### PR TITLE
feat: auto-create main tmux session at worktree origin

### DIFF
--- a/specs/features/main-session-at-worktree-origin.feature
+++ b/specs/features/main-session-at-worktree-origin.feature
@@ -1,0 +1,162 @@
+Feature: Ensure a main tmux session always exists at the worktree origin
+  As a developer using git-orchard
+  I want a permanent tmux session at the worktree origin (main checkout)
+  So that I always have a session for orchestration, triage, reviews, and non-feature work
+
+  # Design decisions (informed by devil's advocate review):
+  #
+  # 1. Worktree origin = first entry from `git worktree list` (documented stable behavior).
+  #    NOT "first non-bare" — git guarantees the main worktree is listed first.
+  #
+  # 2. Repo name is derived from the worktree origin path, NOT from `get_repo_name()`
+  #    which uses `git rev-parse --show-toplevel` and returns different values per worktree.
+  #    The canonical repo name comes from the origin worktree's directory name.
+  #
+  # 3. Session creation is a SEPARATE pipeline stage (`ensure_main_session`), called
+  #    BEFORE `merge_tmux_sessions`. The merge function stays pure (no side effects).
+  #    The newly created session is included in the session list passed to merge.
+  #
+  # 4. Session creation only happens in TUI mode, NOT in JSON mode. JSON mode is a
+  #    read-only interface — creating tmux sessions as a side effect would surprise
+  #    CI pipelines and scripts piping output to jq.
+  #
+  # 5. Dots in repo names are replaced with underscores in session names to avoid
+  #    tmux target-session parsing issues (`.` is a window/pane separator in tmux).
+
+  Background:
+    Given a git repository with worktree origin at "/home/user/myrepo" on branch "main"
+    And the canonical repo name is "myrepo" (derived from the origin worktree path)
+
+  # -------------------------------------------------------------------------
+  # Happy path: session auto-created on TUI startup
+  # -------------------------------------------------------------------------
+
+  @e2e
+  Scenario: Creates main session on first TUI startup
+    Given no tmux session named "myrepo_main" exists
+    When the TUI starts up
+    Then a tmux session named "myrepo_main" is created at "/home/user/myrepo"
+
+  # -------------------------------------------------------------------------
+  # JSON mode: read-only, no session creation
+  # -------------------------------------------------------------------------
+
+  @integration
+  Scenario: JSON mode does not create a main session
+    Given no tmux session named "myrepo_main" exists
+    When git-orchard runs in JSON mode
+    Then no tmux session is created
+    And the JSON output includes the main worktree without a tmux_session
+
+  # -------------------------------------------------------------------------
+  # Idempotency: session already exists
+  # -------------------------------------------------------------------------
+
+  @unit
+  Scenario: Skips session creation when main session already exists
+    Given a session list containing "myrepo_main"
+    When ensure_main_session checks whether to create
+    Then it returns without creating a new session
+
+  # -------------------------------------------------------------------------
+  # Canonical repo name: derived from worktree origin path
+  # -------------------------------------------------------------------------
+
+  @unit
+  Scenario: Derives repo name from worktree origin path regardless of invocation worktree
+    Given the worktree origin is at "/home/user/my-project"
+    And orchard is invoked from a feature worktree at "/home/user/my-project/.worktrees/issue42"
+    When the canonical repo name is derived
+    Then the repo name is "my-project"
+    And the main session name is "my-project_main"
+
+  @unit
+  Scenario: Sanitizes dots in repo name to avoid tmux parsing issues
+    Given the worktree origin is at "/home/user/my.repo-v2"
+    When the main session name is derived
+    Then the session name is "my_repo-v2_main"
+
+  # -------------------------------------------------------------------------
+  # Pipeline architecture: separate stage, before merge
+  # -------------------------------------------------------------------------
+
+  @integration
+  Scenario: Creates main session in a separate stage before tmux merge
+    Given no tmux session named "myrepo_main" exists
+    When the ensure_main_session stage runs
+    Then a tmux session "myrepo_main" is created at "/home/user/myrepo"
+    And the session is included in the session list passed to merge_tmux_sessions
+
+  # -------------------------------------------------------------------------
+  # TUI visibility: merge maps session to worktree
+  # -------------------------------------------------------------------------
+
+  @unit
+  Scenario: Merge maps main session to the origin worktree row
+    Given a session list containing "myrepo_main" at "/home/user/myrepo"
+    And a worktree at "/home/user/myrepo" on branch "main"
+    When merge_tmux_sessions runs
+    Then the main worktree row has tmux_session "myrepo_main"
+
+  # -------------------------------------------------------------------------
+  # Worktree origin identification
+  # -------------------------------------------------------------------------
+
+  @unit
+  Scenario: Identifies worktree origin as first entry from git worktree list
+    Given worktrees exist at:
+      | path                               | branch         | is_bare |
+      | /home/user/myrepo                  | main           | false   |
+      | /home/user/myrepo/.worktrees/f     | feature/login  | false   |
+    When the worktree origin is identified
+    Then "/home/user/myrepo" is selected as the worktree origin
+
+  @unit
+  Scenario: Derives session name from non-main default branch
+    Given the worktree origin is at "/home/user/myrepo" on branch "develop"
+    When the main session name is derived
+    Then the session name is "myrepo_develop"
+
+  @unit
+  Scenario: Uses HEAD as branch identifier when worktree origin is detached
+    Given the worktree origin is at "/home/user/myrepo" in detached HEAD state
+    When the main session name is derived
+    Then the session name is "myrepo_HEAD"
+
+  # -------------------------------------------------------------------------
+  # Edge cases
+  # -------------------------------------------------------------------------
+
+  @integration
+  Scenario: Creates main session when tmux has no existing sessions
+    Given no tmux sessions exist at all
+    When the ensure_main_session stage runs in TUI mode
+    Then a tmux session named "myrepo_main" is created at "/home/user/myrepo"
+
+  @unit
+  Scenario: Preserves main session across refresh cycles
+    Given a session list containing "myrepo_main" at "/home/user/myrepo"
+    And a worktree at "/home/user/myrepo" on branch "main"
+    When merge_tmux_sessions runs again after a refresh
+    Then the main worktree row still has tmux_session "myrepo_main"
+
+  @integration
+  Scenario: Shows persistent error when tmux new-session fails
+    Given no tmux session named "myrepo_main" exists
+    And tmux new-session will fail with an error
+    When the ensure_main_session stage runs
+    Then a persistent red error is displayed with the failure message
+    And the error remains visible until the user dismisses it
+
+  @integration
+  Scenario: TUI continues functioning after main session creation failure
+    Given no tmux session named "myrepo_main" exists
+    And tmux new-session will fail with an error
+    When the ensure_main_session stage runs
+    Then the main worktree appears in the list without a session indicator
+
+  @unit
+  Scenario: Skips creation when session name already exists at different path
+    Given a session list containing "myrepo_main" at "/tmp/other-path"
+    When ensure_main_session checks whether to create
+    Then it returns without creating a new session

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -29,6 +29,45 @@ pub fn fetch_tmux_and_gh() -> (Vec<TmuxSession>, bool) {
     })
 }
 
+/// Ensures a tmux session exists at the worktree origin (the first entry from
+/// `git worktree list`). Skips creation if a session with the derived name already
+/// exists. Returns the (possibly augmented) session list.
+///
+/// Only call this in TUI mode -- JSON mode is read-only.
+pub fn ensure_main_session(
+    trees: &[Worktree],
+    mut sessions: Vec<TmuxSession>,
+    error_fn: &dyn Fn(&str),
+) -> Vec<TmuxSession> {
+    let origin = match trees.first() {
+        Some(wt) if !wt.is_bare => wt,
+        _ => return sessions,
+    };
+
+    let session_name = tmux::derive_main_session_name(&origin.path, origin.branch.as_deref());
+
+    // Idempotent: skip if session name already exists (regardless of path).
+    if sessions.iter().any(|s| s.name == session_name) {
+        return sessions;
+    }
+
+    match tmux::new_detached_session(&session_name, &origin.path) {
+        Ok(()) => {
+            sessions.push(TmuxSession {
+                name: session_name,
+                path: origin.path.clone(),
+                attached: false,
+                pane_title: None,
+            });
+        }
+        Err(e) => {
+            error_fn(&format!("Failed to create main session: {e}"));
+        }
+    }
+
+    sessions
+}
+
 /// Merges tmux session data into the worktrees slice.
 /// Sets `pr_loading = true` for non-bare worktrees that have a branch and gh available.
 pub fn merge_tmux_sessions(
@@ -186,14 +225,19 @@ pub fn collect_worktree_data() -> anyhow::Result<Vec<Worktree>> {
 }
 
 /// Runs the pipeline in stages, calling `update_fn` after each stage so that
-/// a TUI can display progressively richer data.
-pub fn refresh_worktrees(update_fn: &dyn Fn(&[Worktree])) -> anyhow::Result<()> {
+/// a TUI can display progressively richer data. Non-fatal errors (e.g. session
+/// creation failures) are reported via `error_fn` without aborting the pipeline.
+pub fn refresh_worktrees(
+    update_fn: &dyn Fn(&[Worktree]),
+    error_fn: &dyn Fn(&str),
+) -> anyhow::Result<()> {
     // Stage 1: local worktrees appear immediately.
     let trees = fetch_git_worktrees();
     update_fn(&trees);
 
-    // Stage 2: merge tmux sessions.
+    // Stage 2: ensure main session exists, then merge tmux sessions.
     let (sessions, gh_ok) = fetch_tmux_and_gh();
+    let sessions = ensure_main_session(&trees, sessions, error_fn);
     let with_tmux = merge_tmux_sessions(&trees, &sessions, gh_ok);
     update_fn(&with_tmux);
 
@@ -440,5 +484,93 @@ mod tests {
         let result = apply_issue_states(&[tree], &issue_states);
         assert!(result[0].issue_number.is_none());
         assert!(result[0].issue_state.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // ensure_main_session
+    // -----------------------------------------------------------------------
+
+    fn noop_error(_msg: &str) {}
+
+    #[test]
+    fn ensure_main_session_skips_when_session_already_exists() {
+        let trees = vec![branched_worktree("/home/user/myrepo", "main")];
+        let sessions = vec![TmuxSession {
+            name: "myrepo_main".to_string(),
+            path: "/home/user/myrepo".to_string(),
+            attached: false,
+            pane_title: None,
+        }];
+        let result = ensure_main_session(&trees, sessions.clone(), &noop_error);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "myrepo_main");
+    }
+
+    #[test]
+    fn ensure_main_session_skips_when_session_exists_at_different_path() {
+        let trees = vec![branched_worktree("/home/user/myrepo", "main")];
+        let sessions = vec![TmuxSession {
+            name: "myrepo_main".to_string(),
+            path: "/tmp/other-path".to_string(),
+            attached: false,
+            pane_title: None,
+        }];
+        let result = ensure_main_session(&trees, sessions.clone(), &noop_error);
+        // Should not create a duplicate -- session name already exists
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "myrepo_main");
+    }
+
+    #[test]
+    fn ensure_main_session_returns_unchanged_when_no_worktrees() {
+        let sessions = vec![TmuxSession {
+            name: "other".to_string(),
+            path: "/other".to_string(),
+            attached: false,
+            pane_title: None,
+        }];
+        let result = ensure_main_session(&[], sessions.clone(), &noop_error);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn ensure_main_session_skips_when_first_worktree_is_bare() {
+        let trees = vec![bare_worktree("/home/user/bare.git")];
+        let sessions = vec![];
+        let result = ensure_main_session(&trees, sessions, &noop_error);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn ensure_main_session_merge_maps_created_session_to_origin() {
+        // Simulate the flow: session already in list -> merge maps it to origin worktree
+        let trees = vec![
+            branched_worktree("/home/user/myrepo", "main"),
+            branched_worktree("/home/user/myrepo/.worktrees/feat", "feature/login"),
+        ];
+        let sessions = vec![TmuxSession {
+            name: "myrepo_main".to_string(),
+            path: "/home/user/myrepo".to_string(),
+            attached: false,
+            pane_title: None,
+        }];
+        let result = merge_tmux_sessions(&trees, &sessions, false);
+        assert_eq!(result[0].tmux_session.as_deref(), Some("myrepo_main"));
+        assert!(result[1].tmux_session.is_none());
+    }
+
+    #[test]
+    fn ensure_main_session_preserves_across_refresh() {
+        // Same session exists on re-run -- should stay mapped
+        let trees = vec![branched_worktree("/home/user/myrepo", "main")];
+        let sessions = vec![TmuxSession {
+            name: "myrepo_main".to_string(),
+            path: "/home/user/myrepo".to_string(),
+            attached: false,
+            pane_title: None,
+        }];
+        let result1 = merge_tmux_sessions(&trees, &sessions, false);
+        let result2 = merge_tmux_sessions(&trees, &sessions, false);
+        assert_eq!(result1[0].tmux_session, result2[0].tmux_session);
     }
 }

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -112,6 +112,49 @@ pub fn find_session_for_worktree<'a>(
     None
 }
 
+/// Replaces dots with underscores in a repo name to avoid tmux target-session
+/// parsing issues (`.` is a window/pane separator in tmux).
+pub fn sanitize_repo_name(name: &str) -> String {
+    name.replace('.', "_")
+}
+
+/// Replaces slashes with dashes in a branch name so it is valid as part of a
+/// tmux session name (slashes are path separators in tmux target syntax).
+fn sanitize_branch(branch: &str) -> String {
+    branch.replace('/', "-")
+}
+
+/// Derives the main session name for the worktree origin.
+/// Format: `{sanitized_repo_name}_{branch}`. Uses "HEAD" when detached.
+pub fn derive_main_session_name(origin_path: &str, branch: Option<&str>) -> String {
+    let repo_name = std::path::Path::new(origin_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("orchard");
+    let sanitized = sanitize_repo_name(repo_name);
+    let branch_part = branch.map(sanitize_branch).unwrap_or_else(|| "HEAD".to_string());
+    format!("{sanitized}_{branch_part}")
+}
+
+/// Creates a new detached tmux session with the given name at the given directory.
+pub fn new_detached_session(name: &str, start_dir: &str) -> Result<()> {
+    let output = Command::new("tmux")
+        .args(["new-session", "-d", "-s", name, "-c", start_dir])
+        .output()
+        .context("tmux new-session")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow::anyhow!(
+            "tmux new-session failed: {}",
+            stderr.trim()
+        ));
+    }
+
+    LOG.info(&format!("newDetachedSession: {} at {}", name, start_dir));
+    Ok(())
+}
+
 /// Kills the tmux session with the given name.
 pub fn kill_tmux_session(name: &str) -> Result<()> {
     Command::new("tmux")
@@ -139,7 +182,7 @@ pub fn capture_pane_content(session: &str, lines: u32) -> Result<String> {
 /// Falls back to the last path segment, then "orchard".
 pub fn derive_session_name(repo_name: &str, branch: Option<&str>, worktree_path: &str) -> String {
     let suffix = match branch {
-        Some(b) => b.replace('/', "-"),
+        Some(b) => sanitize_branch(b),
         None => {
             let base = std::path::Path::new(worktree_path)
                 .file_name()
@@ -311,6 +354,81 @@ mod tests {
     fn derive_session_name_fallback_to_orchard() {
         assert_eq!(derive_session_name("myrepo", None, "/"), "myrepo_orchard");
     }
+
+    // -----------------------------------------------------------------------
+    // sanitize_repo_name
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn sanitize_repo_name_replaces_dots_with_underscores() {
+        assert_eq!(sanitize_repo_name("my.repo-v2"), "my_repo-v2");
+    }
+
+    #[test]
+    fn sanitize_repo_name_preserves_names_without_dots() {
+        assert_eq!(sanitize_repo_name("myrepo"), "myrepo");
+    }
+
+    #[test]
+    fn sanitize_repo_name_replaces_multiple_dots() {
+        assert_eq!(sanitize_repo_name("a.b.c"), "a_b_c");
+    }
+
+    // -----------------------------------------------------------------------
+    // derive_main_session_name
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn derive_main_session_name_with_branch() {
+        assert_eq!(
+            derive_main_session_name("/home/user/myrepo", Some("main")),
+            "myrepo_main"
+        );
+    }
+
+    #[test]
+    fn derive_main_session_name_uses_head_when_detached() {
+        assert_eq!(
+            derive_main_session_name("/home/user/myrepo", None),
+            "myrepo_HEAD"
+        );
+    }
+
+    #[test]
+    fn derive_main_session_name_sanitizes_dots() {
+        assert_eq!(
+            derive_main_session_name("/home/user/my.repo-v2", Some("main")),
+            "my_repo-v2_main"
+        );
+    }
+
+    #[test]
+    fn derive_main_session_name_with_non_main_branch() {
+        assert_eq!(
+            derive_main_session_name("/home/user/myrepo", Some("develop")),
+            "myrepo_develop"
+        );
+    }
+
+    #[test]
+    fn derive_main_session_name_derives_repo_from_path() {
+        assert_eq!(
+            derive_main_session_name("/home/user/my-project", Some("main")),
+            "my-project_main"
+        );
+    }
+
+    #[test]
+    fn derive_main_session_name_sanitizes_branch_slashes() {
+        assert_eq!(
+            derive_main_session_name("/home/user/myrepo", Some("feature/login")),
+            "myrepo_feature-login"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // format_status_left
+    // -----------------------------------------------------------------------
 
     #[test]
     fn format_status_left_detached() {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -121,7 +121,11 @@ impl App {
             let update_fn = move |trees: &[Worktree]| {
                 let _ = tx_clone.send(AppMsg::Worktrees(trees.to_vec()));
             };
-            if let Err(e) = collector::refresh_worktrees(&update_fn) {
+            let tx_err = tx.clone();
+            let error_fn = move |msg: &str| {
+                let _ = tx_err.send(AppMsg::Error(msg.to_string()));
+            };
+            if let Err(e) = collector::refresh_worktrees(&update_fn, &error_fn) {
                 let _ = tx.send(AppMsg::Error(e.to_string()));
             }
         });


### PR DESCRIPTION
## Summary

- Auto-creates a `{repo}_{branch}` tmux session at the worktree origin (main checkout) on TUI startup
- Adds `ensure_main_session` as a separate pipeline stage before `merge_tmux_sessions`, keeping the merge function pure
- Derives canonical repo name from the origin worktree path (stable regardless of which worktree invokes orchard)
- Sanitizes dots in repo names and slashes in branch names for tmux target-session safety
- TUI only — JSON mode remains side-effect-free
- Failures surface as persistent red errors via `AppMsg::Error`
- 15 new unit tests (142 total, all passing)

Closes #1

## Test plan

- [ ] Run `cargo test` — all 142 tests pass
- [ ] Launch orchard TUI from the main checkout — verify `{repo}_main` session is auto-created
- [ ] Launch orchard TUI from a feature worktree — verify same `{repo}_main` session is created (not `{worktree}_main`)
- [ ] Kill the main session, refresh TUI — verify session is re-created
- [ ] Run `git-orchard --json` — verify no tmux session is created
- [ ] Verify persistent red error appears if tmux new-session fails (e.g., tmux not running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)