### PR TITLE
feat: add `y` keybinding to copy branch name to clipboard

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,0 +1,73 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+/// Copies `text` to the system clipboard.
+///
+/// On macOS, uses `pbcopy`. On Linux, tries `xclip`, then `xsel`, then `wl-copy`.
+/// Returns `Err` with a human-readable message if no clipboard tool is available
+/// or if writing to it fails.
+pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        return run_clipboard_cmd("pbcopy", &[], text);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let linux_tools: &[(&str, &[&str])] = &[
+            ("xclip", &["-selection", "clipboard"]),
+            ("xsel", &["--clipboard", "--input"]),
+            ("wl-copy", &[]),
+        ];
+
+        for (cmd, args) in linux_tools {
+            if run_clipboard_cmd(cmd, args, text).is_ok() {
+                return Ok(());
+            }
+        }
+
+        Err("no clipboard tool found (tried xclip, xsel, wl-copy)".to_string())
+    }
+}
+
+fn run_clipboard_cmd(program: &str, args: &[&str], text: &str) -> Result<(), String> {
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("{program}: {e}"))?;
+
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|e| format!("{program}: write error: {e}"))?;
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("{program}: wait error: {e}"))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("{program}: exited with {status}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copy_empty_string_succeeds() {
+        // On CI/systems without clipboard, this may fail, so just verify it doesn't panic.
+        let _ = copy_to_clipboard("");
+    }
+
+    #[test]
+    fn copy_text_returns_result() {
+        let result = copy_to_clipboard("test-branch-name");
+        // Result is Ok on systems with clipboard tools, Err on those without.
+        assert!(result.is_ok() || result.is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod browser;
+mod clipboard;
 mod collector;
 pub mod events;
 mod config;

--- a/src/tui/list.rs
+++ b/src/tui/list.rs
@@ -304,6 +304,25 @@ impl App {
                 });
                 false
             }
+            KeyCode::Char('y') => {
+                let text = self
+                    .selected_worktree()
+                    .map(|wt| {
+                        wt.branch
+                            .clone()
+                            .unwrap_or_else(|| wt.path.clone())
+                    })
+                    .unwrap_or_default();
+                match crate::clipboard::copy_to_clipboard(&text) {
+                    Ok(()) => {
+                        self.warning = Some((format!("copied: {}", text), Instant::now()));
+                    }
+                    Err(err) => {
+                        self.warning = Some((format!("clipboard error: {}", err), Instant::now()));
+                    }
+                }
+                false
+            }
             KeyCode::Char('r') => {
                 self.refreshing = true;
                 self.start_refresh();
@@ -410,6 +429,25 @@ impl App {
             KeyCode::Char('c') => {
                 // Cleanup: enter cleanup view for done/stale worktrees.
                 self.enter_cleanup_view();
+                false
+            }
+            KeyCode::Char('y') => {
+                let (visible, _) = visible_tasks(&self.app_state.tasks, &self.worktrees, self.backlog_page);
+                let text = visible.get(self.cursor).and_then(|vt| {
+                    vt.task.worktree.as_ref().and_then(|wt_path| {
+                        self.worktrees.iter().find(|w| &w.path == wt_path).map(|wt| {
+                            wt.branch.clone().unwrap_or_else(|| wt.path.clone())
+                        })
+                    })
+                }).unwrap_or_default();
+                match crate::clipboard::copy_to_clipboard(&text) {
+                    Ok(()) => {
+                        self.warning = Some((format!("copied: {}", text), Instant::now()));
+                    }
+                    Err(err) => {
+                        self.warning = Some((format!("clipboard error: {}", err), Instant::now()));
+                    }
+                }
                 false
             }
             KeyCode::Char('r') => {
@@ -968,6 +1006,15 @@ impl App {
         spans.push(Span::raw(" new"));
 
         spans.push(sep.clone());
+        spans.push(Span::styled(
+            "y",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(" copy"));
+
+        spans.push(sep.clone());
         if self.refreshing {
             let spinner = SPINNER_FRAMES[self.spinner_frame];
             spans.push(Span::styled(
@@ -1409,6 +1456,8 @@ impl App {
             Span::styled(":open PR  ", dim_style),
             Span::styled("c", key_style),
             Span::styled(":cleanup  ", dim_style),
+            Span::styled("y", key_style),
+            Span::styled(":copy  ", dim_style),
         ];
 
         if self.refreshing {


### PR DESCRIPTION
## Summary

- Adds `y` (yank) keybinding that copies the selected worktree's branch name to the system clipboard
- Works in both worktree list view and task list view
- Cross-platform: uses `pbcopy` on macOS, falls back through `xclip` / `xsel` / `wl-copy` on Linux
- Shows a 3-second confirmation ("copied: branch-name") or error message via the existing warning toast

## Why

The TUI runs in alternate screen + raw mode, which makes native mouse text selection unreliable across terminal emulators and tmux configurations. Rather than fighting terminal quirks, a dedicated yank keybinding gives reliable, instant access to copy branch names — the most commonly needed text from the dashboard.

## Changes

| File | What |
|------|------|
| `src/clipboard.rs` | New module — `copy_to_clipboard()` with platform detection and fallback chain |
| `src/main.rs` | Register `mod clipboard` |
| `src/tui/list.rs` | `y` handler in both `handle_list_key` and `handle_task_list_key`; hint bar updates |

## Test plan

- [x] `cargo test` — 232 passed, 0 failed
- [x] `cargo build --release` — clean (only pre-existing warnings)
- [ ] Manual: launch TUI, press `y` on a worktree row → branch name appears in clipboard
- [ ] Manual: press `y` when no worktrees loaded → no crash, empty copy

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)