### PR TITLE
fix: replace hardcoded /tmp paths with system temp directory

### DIFF
--- a/hooks/orchard-state.sh
+++ b/hooks/orchard-state.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Orchard state hook — writes Claude session state to /tmp for orchard to read.
+# Orchard state hook — writes Claude session state to $TMPDIR for orchard to read.
 # Registered for: PreToolUse, PostToolUse, Stop, Notification, SessionEnd, SessionStart
 
 set -euo pipefail
@@ -17,7 +17,7 @@ cwd=$(echo "$input" | jq -r '.cwd // empty')
 tmux_session=$(tmux display-message -p '#S' 2>/dev/null || true)
 [ -z "$tmux_session" ] && exit 0
 
-state_file="/tmp/orchard-claude-${tmux_session}.json"
+state_file="${TMPDIR:-/tmp}/orchard-claude-${tmux_session}.json"
 
 case "$event" in
   PreToolUse|PostToolUse)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -75,7 +75,7 @@ impl<T> CacheFile<T> {
 /// Returns the cache directory: `~/.cache/orchard/`.
 pub fn cache_dir() -> PathBuf {
     dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .unwrap_or_else(std::env::temp_dir)
         .join(".cache/orchard")
 }
 

--- a/src/claude_state.rs
+++ b/src/claude_state.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use serde::{Deserialize, Serialize};
 
 /// State written by the orchard-state.sh hook script.
@@ -45,8 +47,8 @@ impl std::str::FromStr for ClaudeState {
 ///
 /// Only files matching `{dir}/orchard-claude-*.json` are read.
 /// Malformed files and in-progress writes (`.tmp.`) are silently skipped.
-pub fn read_all_state_files(dir: &str) -> Vec<ClaudeStateFile> {
-    let pattern = format!("{}/orchard-claude-*.json", dir);
+pub fn read_all_state_files(dir: &Path) -> Vec<ClaudeStateFile> {
+    let pattern = format!("{}/orchard-claude-*.json", dir.display());
     let mut results = Vec::new();
 
     for entry in glob::glob(&pattern).into_iter().flatten() {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -19,23 +19,30 @@ pub fn shell_escape(s: &str) -> String {
     format!("'{}'", s.replace('\'', "'\\''"))
 }
 
-// SSH flags used for all orchard remote connections.
-const SSH_FLAGS: &[&str] = &[
-    "-o",
-    "ConnectTimeout=5",
-    "-o",
-    "BatchMode=yes",
-    "-o",
-    "ControlMaster=auto",
-    "-o",
-    "ControlPath=/tmp/orchard-ssh-%r@%h:%p",
-    "-o",
-    "ControlPersist=600",
-];
+/// Returns the SSH flags used for all orchard remote connections.
+///
+/// The ControlPath is placed under the system temp directory (`$TMPDIR` / `std::env::temp_dir`)
+/// rather than a hardcoded `/tmp`.
+fn ssh_flags() -> Vec<String> {
+    let control_path = std::env::temp_dir().join("orchard-ssh-%r@%h:%p");
+    vec![
+        "-o".to_string(),
+        "ConnectTimeout=5".to_string(),
+        "-o".to_string(),
+        "BatchMode=yes".to_string(),
+        "-o".to_string(),
+        "ControlMaster=auto".to_string(),
+        "-o".to_string(),
+        format!("ControlPath={}", control_path.display()),
+        "-o".to_string(),
+        "ControlPersist=600".to_string(),
+    ]
+}
 
 /// Runs a shell command on a remote host over SSH and returns stdout.
 pub fn ssh_exec(host: &str, command: &str) -> anyhow::Result<String> {
-    let mut args: Vec<&str> = SSH_FLAGS.to_vec();
+    let flags = ssh_flags();
+    let mut args: Vec<&str> = flags.iter().map(|s| s.as_str()).collect();
     args.push(host);
     args.push(command);
 

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 /// Returns the orchard popup wrapper script content.
 pub fn get_wrapper_script() -> &'static str {
     r#"#!/bin/sh
-errfile=$(mktemp /tmp/orchard-err.XXXXXX)
+errfile=$(mktemp "${TMPDIR:-/tmp}/orchard-err.XXXXXX")
 session=$(orchard 2>"$errfile")
 rc=$?
 if [ $rc -ne 0 ]; then

--- a/src/sources/claude.rs
+++ b/src/sources/claude.rs
@@ -1,9 +1,10 @@
 //! Claude Code hook state file reader.
 //!
-//! Reads `/tmp/orchard-claude-*.json` files written by the orchard-state.sh tmux hook.
-//! Provides Claude session state (working/idle/input) merged into the workspace model.
+//! Reads `orchard-claude-*.json` files from the system temp directory, written by the
+//! orchard-state.sh tmux hook. Provides Claude session state (working/idle/input) merged
+//! into the workspace model.
 
-/// Reads all orchard hook state files from /tmp.
+/// Reads all orchard hook state files from the system temp directory.
 pub fn read_state_files() -> Vec<crate::claude_state::ClaudeStateFile> {
-    crate::claude_state::read_all_state_files("/tmp")
+    crate::claude_state::read_all_state_files(&std::env::temp_dir())
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -67,7 +67,7 @@ pub enum TaskStatus {
 /// Returns the state directory path (~/.local/state/git-orchard/).
 pub fn state_dir() -> PathBuf {
     dirs::home_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .unwrap_or_else(std::env::temp_dir)
         .join(".local/state/git-orchard")
 }
 


### PR DESCRIPTION
## Summary
- Replace all hardcoded `/tmp` references with `std::env::temp_dir()` (Rust) and `${TMPDIR:-/tmp}` (shell scripts)
- Change `read_all_state_files` signature from `&str` to `&Path`
- Convert SSH `ControlPath` from a static const to a `ssh_flags()` function that builds the path dynamically

## Test plan
- [x] `cargo test` — all tests pass
- [x] `cargo build --release` — builds cleanly
- [ ] Verify on macOS where `$TMPDIR` is a per-user directory under `/var/folders`

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)