### PR TITLE
fix: shell-escape session name in notification click action

### DIFF
--- a/src/notify.rs
+++ b/src/notify.rs
@@ -6,6 +6,8 @@
 use std::process::Command;
 use std::sync::OnceLock;
 
+use crate::remote;
+
 /// Cached check for terminal-notifier availability.
 fn has_terminal_notifier() -> bool {
     static AVAILABLE: OnceLock<bool> = OnceLock::new();
@@ -44,7 +46,7 @@ pub fn send_notification_with_session(title: &str, message: &str, session_name: 
                 "-activate".to_string(),
                 "dev.warp.Warp-Stable".to_string(),
                 "-execute".to_string(),
-                format!("tmux switch-client -t '{}'", session),
+                format!("tmux switch-client -t {}", remote::shell_escape(session)),
             ]);
         } else {
             args.extend([
@@ -81,5 +83,14 @@ mod tests {
     fn has_terminal_notifier_returns_bool() {
         // Just verify it doesn't panic
         let _ = has_terminal_notifier();
+    }
+
+    #[test]
+    fn session_name_is_shell_escaped() {
+        // Verify the execute arg uses shell_escape (not raw quotes)
+        let session = "test'session";
+        let escaped = crate::remote::shell_escape(session);
+        let cmd = format!("tmux switch-client -t {}", escaped);
+        assert_eq!(cmd, "tmux switch-client -t 'test'\\''session'");
     }
 }


### PR DESCRIPTION
## Summary
- Fixes shell injection in `src/notify.rs` where the tmux session name was interpolated with manual single quotes
- Reuses the existing `remote::shell_escape()` helper which properly handles embedded quotes
- Adds a test verifying that a session name containing a single quote is correctly escaped

Closes #32

## Test plan
- [x] `cargo test` — all pass, including new `session_name_is_shell_escaped` test
- [x] `cargo build --release` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)