### PR TITLE
feat: add --version/-V flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,10 @@ fn main() {
     for arg in &args[1..] {
         match arg.as_str() {
             "--json" => json_flag = true,
+            "--version" | "-V" => {
+                println!("orchard {}", env!("CARGO_PKG_VERSION"));
+                return;
+            }
             "--help" | "-h" => {
                 print_usage();
                 return;
@@ -138,7 +142,8 @@ fn print_usage() {
   orchard upgrade      Upgrade to the latest version
 
 Options:
-  --json    Output worktree data as JSON and exit
+  --version, -V  Print version and exit
+  --json         Output worktree data as JSON and exit
 
 Navigation:
   1-9     Jump to worktree by number


### PR DESCRIPTION
## Summary
- Adds `--version` / `-V` flag that prints `orchard {version}` using `CARGO_PKG_VERSION`
- Updates help text to list the new flag

Closes #33

## Test plan
- [x] `cargo test` passes
- [x] `cargo build --release` passes
- [x] `orchard --version` prints `orchard 0.1.0`
- [x] `orchard -V` prints `orchard 0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)