### PR TITLE
fix: guard macOS-only notification code with cfg attrs

### DIFF
--- a/src/notify.rs
+++ b/src/notify.rs
@@ -103,12 +103,7 @@ pub fn send_notification_with_session(title: &str, message: &str, _session_name:
 
 /// No-op on unsupported platforms.
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-pub fn send_notification_with_session(
-    _title: &str,
-    _message: &str,
-    _session_name: Option<&str>,
-) {
-}
+pub fn send_notification_with_session(_title: &str, _message: &str, _session_name: Option<&str>) {}
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds `#[cfg(target_os)]` gates to `src/notify.rs` so `terminal-notifier` and `osascript` only compile on macOS
- Adds Linux `notify-send` (libnotify) fallback — session_name is ignored since notify-send does not support click actions
- Other platforms get a silent no-op instead of failing at runtime
- Platform-gates the macOS-specific tests; adds a Linux smoke test

Closes #37

## Test plan
- [x] `cargo test` — all 372 tests pass (macOS)
- [x] `cargo build --release` — clean build
- [ ] Verify on Linux: `notify-send` path compiles and sends notifications
- [ ] Verify on unsupported platform: no-op compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)