### PR TITLE
ci: add PR automation workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+rust:
+  - changed-files:
+      - any-glob-to-any-file: "src/**/*.rs"
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file: "tests/**/*"
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**/*"
+          - "*.md"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ".github/**/*"

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,0 +1,39 @@
+name: PR Automation
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Auto-link issue from branch name
+        uses: tkt-actions/add-issue-links@v1.8.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          branch-prefix: "issue"
+
+      - name: Auto-label by files changed
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+
+      - name: Auto-assign PR to author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addAssignees({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignees: [context.actor]
+            })


### PR DESCRIPTION
## Summary
- Auto-links PRs to issues based on `issue<N>/` branch prefix
- Auto-labels PRs based on files changed (rust, tests, docs, ci)
- Auto-assigns PRs to their author

Closes #59

## Test plan
- [ ] Open a PR from an `issue<N>/` branch and verify it links to the issue
- [ ] Verify labels are applied based on changed files
- [ ] Verify PR is assigned to the author

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #59