### PR TITLE
ci: add release-please and cross-platform binary release workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write      # push version bump commits and tags
+  pull-requests: write # open/update release PRs
 
 jobs:
   release-please:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         include:
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
     steps:
@@ -29,14 +29,17 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: ${{ matrix.target }}
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
       - name: Package
-        run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../orchard-${{ matrix.target }}.tar.gz orchard
-          cd -
+        run: tar czf orchard-${{ matrix.target }}.tar.gz -C target/${{ matrix.target }}/release orchard
+      - name: Checksum
+        run: shasum -a 256 orchard-${{ matrix.target }}.tar.gz > orchard-${{ matrix.target }}.tar.gz.sha256
       - name: Upload
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87422cf08f104dccef957 # v2
         with:
-          files: orchard-${{ matrix.target }}.tar.gz
+          files: |
+            orchard-${{ matrix.target }}.tar.gz
+            orchard-${{ matrix.target }}.tar.gz.sha256


### PR DESCRIPTION
## Summary
- Adds `release-please.yml` workflow using `googleapis/release-please-action@v4` with `release-type: rust` to automate version bumps, changelog generation, and GitHub Release creation from conventional commits
- Adds `release.yml` workflow triggered on release publication that builds cross-platform binaries (macOS arm64, macOS x86_64, Linux x86_64) and attaches them as release assets

Closes #35, closes #40

## Test plan
- [ ] Verify release-please creates a Release PR after merging a `feat:` or `fix:` commit to main
- [ ] Verify merging the Release PR creates a GitHub Release with correct tag
- [ ] Verify release workflow triggers on release publication and builds all 3 targets
- [ ] Verify binary archives are attached to the GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)