### PR TITLE
docs: add doc comments to all public APIs

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -1,3 +1,7 @@
+//! System browser launcher.
+//!
+//! Thin wrapper around the `open` crate that opens a URL in the default
+//! system browser. Used by the TUI to open PR and issue URLs on keypress.
 /// Opens `url` in the system default browser. Fire-and-forget; errors are silently ignored.
 pub fn open_url(url: &str) {
     let _ = open::that(url);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,3 +1,9 @@
+//! Cache types and read/write helpers for Orchard's on-disk cache.
+//!
+//! Provides strongly-typed entry structs (`CachedIssue`, `CachedPr`, etc.),
+//! atomic JSON file I/O, path conventions under `~/.cache/orchard/`, and
+//! the session manifest that persists worktree-to-session bindings across
+//! cache refreshes.
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -8,44 +14,71 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 // Entry types
 // ---------------------------------------------------------------------------
 
+/// A GitHub issue entry as stored in the issues cache file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedIssue {
+    /// GitHub issue number.
     pub number: u32,
+    /// Issue title.
     pub title: String,
+    /// Issue state string (e.g. `"open"`, `"closed"`).
     pub state: String,
+    /// Labels applied to the issue.
     pub labels: Vec<String>,
 }
 
+/// A GitHub pull request entry as stored in the PRs cache file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedPr {
+    /// GitHub PR number.
     pub number: u32,
+    /// The branch name the PR was opened from.
     pub branch: String,
+    /// The issue number this PR is linked to, if any.
     pub linked_issue: Option<u32>,
+    /// PR state string (e.g. `"open"`, `"merged"`, `"closed"`).
     pub state: String,
+    /// Aggregated review decision string from GitHub (e.g. `"APPROVED"`).
     pub review_decision: Option<String>,
+    /// Aggregated CI checks state string (e.g. `"pass"`, `"fail"`, `"pending"`).
     pub checks_state: Option<String>,
+    /// Whether the PR has merge conflicts with its base branch.
     pub has_conflicts: bool,
+    /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
 }
 
+/// A git worktree entry as stored in the worktrees cache file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedWorktree {
+    /// Absolute filesystem path to the worktree root.
     pub path: String,
+    /// The branch checked out in this worktree.
     pub branch: String,
+    /// Whether this is the bare worktree (the `.git` root).
     pub is_bare: bool,
+    /// Whether the worktree is locked (cannot be pruned by git).
     pub is_locked: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// Remote host identifier if this worktree lives on a remote machine.
     pub host: Option<String>,
 }
 
+/// A tmux session entry as stored in the tmux sessions cache file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CachedTmuxSession {
+    /// The tmux session name.
     pub name: String,
+    /// Working directory of the session's first window.
     pub path: String,
+    /// Titles of all panes in the session.
     pub pane_titles: Vec<String>,
+    /// Commands running in each pane of the session.
     pub pane_commands: Vec<String>,
+    /// Remote host identifier if this session is on a remote machine.
     pub host: Option<String>,
     #[serde(default)]
+    /// Recent output lines from the session's active pane.
     pub last_output_lines: Vec<String>,
 }
 
@@ -53,9 +86,12 @@ pub struct CachedTmuxSession {
 // Cache file wrapper
 // ---------------------------------------------------------------------------
 
+/// Wrapper that pairs a list of cache entries with the timestamp of the last refresh.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheFile<T> {
+    /// UTC timestamp of when this cache was last written.
     pub last_refreshed: DateTime<Utc>,
+    /// The cached entries.
     pub entries: Vec<T>,
 }
 
@@ -162,17 +198,24 @@ pub fn write_cache_if_nonempty<T: Serialize>(path: &Path, entries: &[T]) -> anyh
 /// tmux session at the time of the last cache refresh.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionManifestEntry {
+    /// Name of the tmux session.
     pub session_name: String,
+    /// Absolute path to the worktree the session is rooted in.
     pub worktree_path: String,
+    /// Branch checked out in the worktree at the time of the snapshot.
     pub branch: String,
+    /// Whether a Claude agent session was active in this worktree's tmux session.
     pub had_claude: bool,
+    /// Remote host identifier if this session is on a remote machine.
     pub host: Option<String>,
 }
 
 /// The full session manifest written to `~/.cache/orchard/session_manifest.json`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SessionManifest {
+    /// UTC timestamp of the last manifest write.
     pub last_updated: DateTime<Utc>,
+    /// All recorded session entries.
     pub sessions: Vec<SessionManifestEntry>,
 }
 

--- a/src/cache_sources.rs
+++ b/src/cache_sources.rs
@@ -1,3 +1,8 @@
+//! Imperative shell for populating Orchard's on-disk cache.
+//!
+//! Fetches issues, PRs, worktrees, and tmux sessions from their respective
+//! sources (GitHub CLI, git, SSH remotes) and writes the results to the
+//! cache files consumed by `sources::*` and `derive`.
 use std::process::Command;
 use std::sync::OnceLock;
 

--- a/src/claude_state.rs
+++ b/src/claude_state.rs
@@ -1,3 +1,8 @@
+//! Claude hook-state types and reader.
+//!
+//! Defines `ClaudeStateFile` (the JSON written by the orchard-state.sh hook)
+//! and `ClaudeState` (the parsed working/idle/input enum). Provides helpers to
+//! read all state files from a directory and look up state by tmux session name.
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -5,17 +10,25 @@ use serde::{Deserialize, Serialize};
 /// State written by the orchard-state.sh hook script.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClaudeStateFile {
-    pub state: String, // "working", "idle", "input"
+    /// Raw state string from the hook script: `"working"`, `"idle"`, or `"input"`.
+    pub state: String,
+    /// Unique Claude session identifier.
     pub session_id: String,
+    /// Name of the tmux session this Claude process is running inside.
     pub tmux_session: String,
+    /// Working directory of the Claude process.
     pub cwd: String,
+    /// Hook event that triggered the state write (e.g. `"Stop"`, `"PreToolUse"`).
     pub event: String,
-    pub timestamp: String, // ISO 8601
-    // Optional enrichment from statusline
+    /// ISO 8601 timestamp of the last state write.
+    pub timestamp: String,
+    /// Context window utilization percentage (0–100), if available from the statusline.
     #[serde(default)]
     pub context_window_pct: Option<f64>,
+    /// Cumulative cost in USD for this session, if available from the statusline.
     #[serde(default)]
     pub cost_usd: Option<f64>,
+    /// Model identifier in use (e.g. `"opus"`, `"sonnet"`), if available from the statusline.
     #[serde(default)]
     pub model: Option<String>,
 }
@@ -24,9 +37,13 @@ pub struct ClaudeStateFile {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ClaudeState {
+    /// Claude is actively executing a tool or generating a response.
     Working,
+    /// Claude has finished its turn and is waiting for the next prompt.
     Idle,
+    /// Claude is paused and waiting for user input.
     Input,
+    /// No Claude state file was found, or the state string was unrecognised.
     None,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,8 @@
+//! Per-repository configuration loader for Orchard.
+//!
+//! Reads `orchard.json` from the `.git` directory of the current repo,
+//! supporting both the current single-remote format and a legacy multi-remote
+//! array format. Used by the imperative shell at startup to discover remote hosts.
 use std::path::PathBuf;
 use std::process::Command;
 

--- a/src/derive.rs
+++ b/src/derive.rs
@@ -1,3 +1,8 @@
+//! Pure functional core: derives display-ready rows from cached data.
+//!
+//! `derive_all_repos` joins cached issues, PRs, worktrees, and tmux sessions
+//! into `TaskRow` values with computed `DisplayGroup` sort keys. No I/O occurs
+//! here — all input comes from the cache layer, making this fully testable.
 use crate::cache::{CachedIssue, CachedPr, CachedTmuxSession, CachedWorktree};
 use crate::github;
 
@@ -28,31 +33,47 @@ const HOOK_STATE_STALENESS_SECS: u64 = 300;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DisplayGroup {
-    Shepherd,       // 0th — always first (the repo_main session)
-    Prioritized,    // 1st — user-flagged as priority
-    NeedsAttention, // 2nd
-    ClaudeWorking,  // 3rd
-    ReadyToMerge,   // 4th
-    Other,          // 5th (worktrees without PRs, misc)
+    /// Always first — the repo's main/shepherd session.
+    Shepherd,
+    /// User-flagged as priority work.
+    Prioritized,
+    /// Requires human action (blocked, conflicts, review requested).
+    NeedsAttention,
+    /// A Claude session is actively working in this worktree.
+    ClaudeWorking,
+    /// PR is approved and checks pass — ready to merge.
+    ReadyToMerge,
+    /// Worktrees without PRs or other misc work.
+    Other,
 }
 
 /// Lightweight PR summary attached to a worktree row.
 #[derive(Debug, Clone)]
 pub struct PrInfo {
+    /// GitHub PR number.
     pub number: u32,
+    /// Head branch name for this PR.
     pub branch: String,
+    /// PR state: "OPEN", "CLOSED", or "MERGED".
     pub state: Option<String>,
+    /// Review decision: "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", etc.
     pub review_decision: Option<String>,
+    /// Aggregate CI checks state: "SUCCESS", "FAILURE", "PENDING", etc.
     pub checks_state: Option<String>,
+    /// True when the PR has merge conflicts.
     pub has_conflicts: bool,
+    /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
 }
 
 /// Lightweight tmux session summary attached to a worktree row.
 #[derive(Debug, Clone)]
 pub struct SessionInfo {
+    /// tmux session name.
     pub name: String,
+    /// Remote SSH host this session runs on, or `None` for local.
     pub host: Option<String>,
+    /// True when a Claude process is running in this session.
     pub has_claude_active: bool,
     /// True when Claude is actively working (spinner/activity indicator visible).
     pub claude_is_working: bool,
@@ -72,18 +93,28 @@ pub struct SessionInfo {
 /// enriched with PR/issue metadata and tmux session info.
 #[derive(Debug, Clone)]
 pub struct WorktreeRow {
+    /// Repository slug in `owner/repo` format.
     pub repo_slug: String,
+    /// Absolute path to the worktree on disk.
     pub worktree_path: String,
+    /// Git branch checked out in this worktree.
     pub branch: String,
+    /// Remote SSH host this worktree lives on, or `None` for local.
     pub worktree_host: Option<String>,
+    /// GitHub issue number extracted from the branch name, if any.
     pub issue_number: Option<u32>,
+    /// Title of the linked GitHub issue, if resolved.
     pub issue_title: Option<String>,
     /// State of the linked issue ("open", "closed", "completed"), if any.
     /// Used to detect stale worktrees whose issue has been resolved without a PR.
     pub issue_state: Option<String>,
+    /// Linked pull request, if one exists for this branch.
     pub pr: Option<PrInfo>,
+    /// Active tmux sessions associated with this worktree path.
     pub sessions: Vec<SessionInfo>,
+    /// Display group controlling sort order and TUI section.
     pub display_group: DisplayGroup,
+    /// True when this is the repo's main/shepherd worktree.
     pub is_shepherd: bool,
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,3 +1,8 @@
+//! Append-only structured event log.
+//!
+//! Writes task and session lifecycle events as JSON lines to
+//! `~/.local/state/git-orchard/events.jsonl`. Rotates at 50 MB, keeping
+//! at most three archived files. Used for auditing and retrospective analysis.
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::Value;
@@ -12,8 +17,11 @@ const MAX_ROTATED_FILES: u32 = 3;
 /// A structured event written as a single JSON line to events.jsonl.
 #[derive(Debug, Clone, Serialize)]
 pub struct Event {
+    /// UTC timestamp of when the event was recorded.
     pub ts: DateTime<Utc>,
+    /// Event type identifier (e.g. `"task.created"`, `"session.switch"`).
     pub event: String,
+    /// Arbitrary key-value payload specific to the event type.
     #[serde(flatten)]
     pub fields: HashMap<String, Value>,
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,3 +1,8 @@
+//! Git worktree introspection and manipulation.
+//!
+//! Wraps `git worktree list --porcelain`, conflict detection, and worktree
+//! removal. This is part of the imperative shell — all functions spawn
+//! subprocess calls to `git`.
 use std::path::Path;
 use std::process::Command;
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,3 +1,8 @@
+//! GitHub API client built on the `gh` CLI.
+//!
+//! Fetches PR lists, enriches them via batched GraphQL queries, extracts
+//! issue numbers from branch names, and resolves issue states. All network
+//! I/O goes through `gh` subprocesses rather than a direct HTTP client.
 use std::collections::HashMap;
 use std::process::Command;
 use std::sync::{Arc, Condvar, Mutex, OnceLock};

--- a/src/issue_sync.rs
+++ b/src/issue_sync.rs
@@ -1,3 +1,9 @@
+//! GitHub issue-to-task synchronisation.
+//!
+//! Queries `gh issue list` for issues assigned to the current user, then
+//! creates new `Task` entries for open issues and marks tasks done when their
+//! linked issue is closed. Part of the imperative shell; pure logic is in
+//! the inner `sync_issues_with_data` helper to enable unit testing.
 use std::process::Command;
 
 use chrono::Utc;

--- a/src/json_output.rs
+++ b/src/json_output.rs
@@ -24,8 +24,11 @@ use crate::orchard_state::{
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonOutput {
+    /// Schema version number for forward compatibility.
     pub version: u32,
+    /// All repositories in the output.
     pub repos: Vec<JsonRepo>,
+    /// Reachability state keyed by SSH host name.
     pub hosts: HashMap<String, JsonHostState>,
 }
 
@@ -35,7 +38,9 @@ pub struct JsonOutput {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonRepo {
+    /// Repository slug in `owner/repo` format.
     pub slug: String,
+    /// All worktrees belonging to this repository.
     pub worktrees: Vec<JsonWorktree>,
 }
 
@@ -45,13 +50,21 @@ pub struct JsonRepo {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonWorktree {
+    /// Absolute path to the worktree on disk.
     pub path: String,
+    /// Git branch checked out in this worktree.
     pub branch: String,
+    /// Remote SSH host this worktree lives on, or `null` for local.
     pub host: Option<String>,
+    /// Linked GitHub issue, if any.
     pub issue: Option<JsonIssue>,
+    /// Linked pull request, if any.
     pub pr: Option<JsonPr>,
+    /// Active Claude sessions associated with this worktree.
     pub sessions: Vec<JsonSession>,
+    /// Display group as a snake_case string (e.g., "needs_attention").
     pub display_group: String,
+    /// True when this is the repo's main/shepherd worktree.
     pub is_shepherd: bool,
 }
 
@@ -61,8 +74,11 @@ pub struct JsonWorktree {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonIssue {
+    /// GitHub issue number.
     pub number: u32,
+    /// Issue title.
     pub title: String,
+    /// Issue state: "open", "closed", or "completed".
     pub state: String,
 }
 
@@ -72,12 +88,19 @@ pub struct JsonIssue {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonPr {
+    /// GitHub PR number.
     pub number: u32,
+    /// Head branch name for this PR.
     pub branch: String,
+    /// PR state: "OPEN", "CLOSED", or "MERGED".
     pub state: Option<String>,
+    /// Review decision: "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", etc.
     pub review_decision: Option<String>,
+    /// Aggregate CI checks state: "SUCCESS", "FAILURE", "PENDING", etc.
     pub checks_state: Option<String>,
+    /// True when the PR has merge conflicts.
     pub has_conflicts: bool,
+    /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
 }
 
@@ -88,11 +111,17 @@ pub struct JsonPr {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonSession {
+    /// tmux session name.
     pub name: String,
+    /// Remote SSH host this session runs on, or `null` for local.
     pub host: Option<String>,
+    /// Claude state as a string: "working", "idle", "input", or "none".
     pub claude_state: String,
+    /// Context window usage percentage, if available.
     pub context_window_pct: Option<f64>,
+    /// Cumulative session cost in USD, if available.
     pub cost_usd: Option<f64>,
+    /// Model name (e.g., "opus", "sonnet"), if available.
     pub model: Option<String>,
 }
 
@@ -101,6 +130,7 @@ pub struct JsonSession {
 /// Simple boolean indicating whether an SSH host is reachable.
 #[derive(Serialize)]
 pub struct JsonHostState {
+    /// True when the SSH host responded to the last reachability check.
     pub reachable: bool,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+//! Root library crate for Orchard.
+//!
+//! Re-exports all public modules that make up the functional core and imperative
+//! shell of the application. Consumers should import from the top-level module
+//! rather than reaching into sub-modules directly.
+#![warn(missing_docs)]
+
 mod browser;
 pub mod build_state;
 pub mod cache;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,3 +1,9 @@
+//! File-based diagnostic logger and timing utilities.
+//!
+//! Provides the global `LOG` singleton (writing to
+//! `~/.local/state/git-orchard/debug.log`, rotating at 10 MB), a `TimingGuard`
+//! RAII helper, and the `timed!` macro used throughout the codebase to
+//! measure and log the duration of key operations.
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
@@ -102,6 +108,7 @@ pub struct TimingGuard<'a> {
 }
 
 impl<'a> TimingGuard<'a> {
+    /// Starts timing `label` via `LOG.time` and returns the guard.
     pub fn new(label: &'a str) -> Self {
         Self { label }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+//! Binary entry point for the `orchard` CLI.
+//!
+//! Parses CLI flags (`--json`, `--version`, `--help`), handles the `init` and
+//! `upgrade` sub-commands, and dispatches to either the JSON output path or the
+//! Ratatui TUI (re-launching itself inside a tmux popup when appropriate).
 use std::env;
 use std::io::IsTerminal;
 

--- a/src/navigation.rs
+++ b/src/navigation.rs
@@ -1,3 +1,8 @@
+//! Keyboard navigation helpers for the TUI list view.
+//!
+//! Provides the `cursor_index_from_digit` function that maps digit keypresses
+//! (`1`–`9`) to 0-based list indices, used by the TUI to jump directly to a
+//! worktree row by number.
 /// Maps a digit character `'1'`–`'9'` to a 0-based list index.
 /// Returns `None` if the character is not in `'1'`–`'9'` or if the resulting
 /// index is out of bounds for a list of `item_count` items.

--- a/src/orchard_state.rs
+++ b/src/orchard_state.rs
@@ -16,7 +16,9 @@ use crate::derive::DisplayGroup;
 /// The unified state model for Orchard. Contains all repos and host reachability.
 #[derive(Debug, Clone)]
 pub struct OrchardState {
+    /// All repositories known to Orchard.
     pub repos: Vec<RepoState>,
+    /// Reachability state keyed by SSH host name.
     pub hosts: HashMap<String, HostState>,
 }
 
@@ -66,61 +68,92 @@ impl Default for OrchardState {
 /// State for a single repository.
 #[derive(Debug, Clone)]
 pub struct RepoState {
+    /// Repository slug in `owner/repo` format.
     pub slug: String,
+    /// All worktrees belonging to this repository.
     pub worktrees: Vec<WorktreeState>,
 }
 
 /// State for a single worktree, enriched with issue/PR/session metadata.
 #[derive(Debug, Clone)]
 pub struct WorktreeState {
+    /// Absolute path to the worktree on disk.
     pub path: String,
+    /// Git branch checked out in this worktree.
     pub branch: String,
+    /// True when this is a bare worktree (no working tree).
     pub is_bare: bool,
+    /// Remote SSH host this worktree lives on, or `None` for local.
     pub host: Option<String>,
+    /// Linked GitHub issue, if any.
     pub issue: Option<IssueInfo>,
+    /// Linked pull request, if any.
     pub pr: Option<PrState>,
+    /// Active tmux sessions associated with this worktree.
     pub sessions: Vec<SessionState>,
+    /// Display group controlling sort order and TUI section.
     pub display_group: DisplayGroup,
+    /// True when this is the repo's main/shepherd worktree.
     pub is_shepherd: bool,
 }
 
 /// Lightweight issue summary attached to a worktree.
 #[derive(Debug, Clone)]
 pub struct IssueInfo {
+    /// GitHub issue number.
     pub number: u32,
+    /// Issue title.
     pub title: String,
+    /// Issue state: "open", "closed", or "completed".
     pub state: String,
 }
 
 /// Lightweight PR summary attached to a worktree.
 #[derive(Debug, Clone)]
 pub struct PrState {
+    /// GitHub PR number.
     pub number: u32,
+    /// Head branch name for this PR.
     pub branch: String,
+    /// PR state: "OPEN", "CLOSED", or "MERGED".
     pub state: Option<String>,
+    /// Review decision: "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", etc.
     pub review_decision: Option<String>,
+    /// Aggregate CI checks state: "SUCCESS", "FAILURE", "PENDING", etc.
     pub checks_state: Option<String>,
+    /// True when the PR has merge conflicts.
     pub has_conflicts: bool,
+    /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
 }
 
 /// Lightweight tmux session summary attached to a worktree.
 #[derive(Debug, Clone)]
 pub struct SessionState {
+    /// tmux session name.
     pub name: String,
+    /// Remote SSH host this session runs on, or `None` for local.
     pub host: Option<String>,
+    /// True when a Claude process is running in this session.
     pub has_claude_active: bool,
+    /// True when Claude is actively working (spinner/activity indicator visible).
     pub claude_is_working: bool,
+    /// True when Claude appears to be waiting for user input.
     pub claude_needs_input: bool,
+    /// Structured Claude state from hook files (replaces booleans when available).
     pub claude_state: ClaudeState,
+    /// Context window usage percentage from hook state enrichment.
     pub context_window_pct: Option<f64>,
+    /// Cumulative session cost in USD from hook state enrichment.
     pub cost_usd: Option<f64>,
+    /// Model name from hook state enrichment (e.g., "opus", "sonnet").
     pub model: Option<String>,
 }
 
 /// Reachability state for a remote host.
 #[derive(Debug, Clone)]
 pub struct HostState {
+    /// True when the SSH host responded to the last reachability check.
     pub reachable: bool,
 }
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,3 +1,8 @@
+//! Path display utilities for the TUI.
+//!
+//! `tildify` shortens absolute paths by replacing the home directory prefix
+//! with `~`; `truncate_left` caps display width by eliding from the left with
+//! a `…` character.
 /// Replaces the user's home directory prefix in `path` with `~`.
 /// Returns the path unchanged if it does not start with `$HOME`.
 pub fn tildify(path: &str) -> String {

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,3 +1,9 @@
+//! SSH-based remote worktree and tmux session access.
+//!
+//! Provides helpers to run commands on a remote host over SSH with multiplexed
+//! connections, list remote git worktrees and tmux sessions, and create or
+//! attach to sessions on the remote machine. Consumed by `cache_sources` and
+//! the TUI transfer flow.
 use std::path::Path;
 use std::process::Command;
 

--- a/src/session_discovery.rs
+++ b/src/session_discovery.rs
@@ -1,3 +1,8 @@
+//! Tmux session discovery and task reconciliation.
+//!
+//! Reconciles live tmux sessions with the persisted `AppState` task list:
+//! binds sessions to tasks by worktree path, identifies orphaned sessions
+//! (no matching task), and flags dead sessions (in state but not in tmux).
 use crate::events;
 use crate::state::AppState;
 use crate::types::TmuxSession;
@@ -11,8 +16,11 @@ use std::process::Command;
 /// Rich detail for a single tmux pane.
 #[derive(Debug, Clone)]
 pub struct PaneDetail {
+    /// tmux pane identifier (e.g. `"%0"`).
     pub pane_id: String,
+    /// Name of the foreground command running in the pane.
     pub command: String,
+    /// Current terminal title set by the running process.
     pub title: String,
     /// `true` when the pane title contains "claude" (case-insensitive).
     pub is_agent: bool,
@@ -21,7 +29,9 @@ pub struct PaneDetail {
 /// Rich detail for a tmux session, including all its panes.
 #[derive(Debug, Clone)]
 pub struct SessionDetail {
+    /// tmux session name.
     pub name: String,
+    /// All panes belonging to this session.
     pub panes: Vec<PaneDetail>,
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,3 +1,9 @@
+//! Persistent task state for Orchard.
+//!
+//! Defines `AppState` and its contained `Task`, `TaskSource`, and `TaskStatus`
+//! types, together with JSON serialisation, a versioned on-disk format, and
+//! atomic read/write helpers. This is the single source of truth for task
+//! lifecycle data between invocations.
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
@@ -8,9 +14,12 @@ use serde::{Deserialize, Serialize};
 // Types
 // ---------------------------------------------------------------------------
 
+/// Persistent application state serialized to `~/.local/state/git-orchard/state.json`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AppState {
+    /// Schema version; currently always `1`.
     pub version: u32,
+    /// All tracked tasks.
     pub tasks: Vec<Task>,
 }
 
@@ -23,40 +32,65 @@ impl Default for AppState {
     }
 }
 
+/// A unit of work tracked by Orchard, derived from a GitHub issue.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Task {
+    /// Stable unique identifier for this task (e.g. `"acme/webapp#47"`).
     pub id: String,
     #[serde(default)]
+    /// Human-readable title, synced from the issue title.
     pub title: String,
+    /// Where this task originated (currently always a GitHub issue).
     pub source: TaskSource,
+    /// Current workflow status of the task.
     pub status: TaskStatus,
+    /// Relative priority; lower numbers are higher priority.
     pub priority: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Absolute path of the worktree associated with this task, if any.
     pub worktree: Option<String>,
     #[serde(default)]
+    /// Names of tmux sessions associated with this task.
     pub sessions: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// GitHub PR number linked to this task, if a PR has been opened.
     pub pr: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Remote host for this task's worktree, if it is on a remote machine.
     pub remote_host: Option<String>,
+    /// UTC timestamp when this task was first created.
     pub created_at: DateTime<Utc>,
+    /// UTC timestamp of the most recent update to this task.
     pub updated_at: DateTime<Utc>,
 }
 
+/// The origin system that produced a task.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum TaskSource {
     #[serde(rename = "github_issue")]
-    GithubIssue { repo: String, number: u32 },
+    /// Task was created from a GitHub issue.
+    GithubIssue {
+        /// Repository slug in `owner/name` format.
+        repo: String,
+        /// GitHub issue number.
+        number: u32,
+    },
 }
 
+/// Workflow stage of a task, modelled as a simple kanban column.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum TaskStatus {
+    /// Task is queued but not yet ready to start.
     Backlog,
+    /// Task is ready to be picked up.
     Ready,
+    /// Work is actively in progress on this task.
     InProgress,
+    /// A PR has been opened and is awaiting review.
     InReview,
+    /// The task is complete and the PR has been merged (or work is discarded).
     Done,
 }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,3 +1,8 @@
+//! Tmux status-bar writer.
+//!
+//! After each data refresh, formats a summary string (active worktree count,
+//! Claude session count, failing CI count) and writes it to
+//! `~/.local/state/git-orchard/status.txt` for use in the tmux status bar.
 /// Writes tmux-formatted status text to `~/.local/state/git-orchard/status.txt`
 /// after each data refresh, so the tmux status bar can display orchard state.
 use crate::types::{ChecksStatus, Worktree};

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -1,3 +1,8 @@
+//! Tmux session management for Orchard.
+//!
+//! Lists active sessions, resolves pane titles, creates new sessions for
+//! worktrees, switches the current client to a session, and orchestrates the
+//! full "switch to worktree" flow including PR-aware notification banners.
 use std::process::Command;
 
 use anyhow::{Context, Result};

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1,3 +1,9 @@
+//! Worktree transfer between local and remote machines.
+//!
+//! Provides the `push_to_remote` and `pull_from_remote` operations that
+//! commit a WIP stash, create or update a remote worktree over SSH, and
+//! create a matching tmux session on the remote host. Used by the TUI
+//! transfer dialog.
 use std::path::Path;
 use std::process::Command;
 

--- a/src/tui/dialogs.rs
+++ b/src/tui/dialogs.rs
@@ -1,3 +1,8 @@
+//! TUI confirmation and progress dialogs.
+//!
+//! Implements keyboard handlers and Ratatui rendering for the delete,
+//! cleanup, new-session, and transfer dialogs shown as modal overlays
+//! over the main worktree list.
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::prelude::*;
 use ratatui::widgets::Padding;

--- a/src/tui/list.rs
+++ b/src/tui/list.rs
@@ -1,3 +1,8 @@
+//! Worktree list view: rendering and keyboard handling.
+//!
+//! Draws the main task/worktree table, the detail pane, and the header;
+//! handles keypresses (navigate, select, open browser, start session, etc.);
+//! and formats row labels. This is the primary interactive surface of the TUI.
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::prelude::*;
 use ratatui::widgets::*;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,3 +1,8 @@
+//! Ratatui-based terminal user interface.
+//!
+//! Drives the interactive worktree list, handles keyboard events, manages
+//! background cache refreshes via a worker thread, and delegates rendering
+//! to the `list`, `dialogs`, and `widgets` sub-modules.
 mod dialogs;
 mod list;
 mod state;
@@ -52,6 +57,7 @@ struct WorktreeSnapshot {
 // App
 // ---------------------------------------------------------------------------
 
+/// Root TUI application state. Owns all display data, background channels, and dialog state.
 pub struct App {
     cursor: usize,
     loading: bool,

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,3 +1,9 @@
+//! TUI application state types.
+//!
+//! Defines `ViewState` (which screen is active), `FilterMode`, `Phase`,
+//! `AppMsg` (messages from the background worker), and the various dialog
+//! state structs (`DeleteState`, `CleanupState`, etc.). Consumed by the
+//! main TUI event loop, `list`, and `dialogs` modules.
 use std::collections::HashSet;
 use std::fmt;
 
@@ -11,9 +17,13 @@ use crate::types::Worktree;
 /// Determines which rows are shown in the task list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FilterMode {
+    /// Show all worktrees regardless of state.
     All,
+    /// Show only worktrees that have an active tmux session.
     HasSession,
+    /// Show only worktrees where a Claude agent is running.
     HasClaude,
+    /// Show only worktrees with an open pull request.
     HasPR,
 }
 
@@ -45,38 +55,63 @@ impl fmt::Display for FilterMode {
 // View state (sum type carrying dialog state)
 // ---------------------------------------------------------------------------
 
+/// The active screen or dialog the TUI is currently rendering.
 pub enum ViewState {
+    /// The main worktree task list.
     List,
+    /// A confirmation dialog for deleting a worktree.
     ConfirmDelete(DeleteState),
+    /// A dialog for transferring a worktree to a remote host.
     Transfer(TransferState),
+    /// A multi-select dialog for cleaning up stale worktrees.
     Cleanup(CleanupState),
+    /// A text-entry dialog for creating a new tmux session.
     NewSession(NewSessionState),
+    /// The keybinding help overlay.
     Help,
 }
 
+/// State carried while the delete-worktree confirmation dialog is open.
 pub struct DeleteState {
+    /// The worktree that the user has chosen to delete.
     pub target: Worktree,
+    /// Current progress phase of the delete operation.
     pub phase: Phase,
+    /// Error message to display if the operation failed.
     pub error: Option<String>,
 }
 
+/// State carried while the remote-transfer dialog is open.
 pub struct TransferState {
+    /// The worktree being transferred to a remote host.
     pub target: Worktree,
+    /// Current progress phase of the transfer operation.
     pub phase: Phase,
+    /// Error message to display if the operation failed.
     pub error: Option<String>,
 }
 
+/// State carried while the stale-worktree cleanup dialog is open.
 pub struct CleanupState {
+    /// The list of stale task rows eligible for deletion.
     pub stale: Vec<TaskRow>,
+    /// Set of worktree paths the user has toggled for deletion.
     pub selected: HashSet<String>,
+    /// Index of the currently highlighted row in the cleanup list.
     pub cursor: usize,
+    /// Current progress phase of the cleanup operation.
     pub phase: Phase,
+    /// Paths successfully deleted during this cleanup pass.
     pub deleted: Vec<String>,
+    /// Error messages collected during the cleanup pass.
     pub errors: Vec<String>,
 }
 
+/// State carried while the new-session name-entry dialog is open.
 pub struct NewSessionState {
+    /// The session name being typed by the user.
     pub name: String,
+    /// Byte offset of the cursor within `name`.
     pub cursor: usize,
 }
 
@@ -84,12 +119,18 @@ pub struct NewSessionState {
 // Phase enum
 // ---------------------------------------------------------------------------
 
+/// Progress phase for async dialog operations (delete, transfer, cleanup).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Phase {
+    /// Waiting for user confirmation before starting.
     Idle,
+    /// User has confirmed; ready to begin execution.
     Confirm,
+    /// The background operation is currently running.
     InProgress,
+    /// The operation completed successfully.
     Done,
+    /// The operation failed; an error message is available.
     Error,
 }
 
@@ -97,16 +138,27 @@ pub enum Phase {
 // Messages from background threads
 // ---------------------------------------------------------------------------
 
+/// Messages sent from background threads to the main TUI event loop.
 pub enum AppMsg {
-    PaneContent(String, String), // (session_name, content)
+    /// Pane output captured for display; carries `(session_name, content)`.
+    PaneContent(String, String),
+    /// The cache refresh cycle completed; the TUI should re-derive task rows.
     CacheRefreshed,
-    HostReachability(String, bool), // (host, is_reachable)
+    /// SSH reachability result for a host; carries `(host, is_reachable)`.
+    HostReachability(String, bool),
+    /// The delete operation finished successfully.
     DeleteDone,
+    /// The delete operation failed with the given error message.
     DeleteErr(String),
+    /// The transfer operation finished successfully.
     TransferDone,
+    /// The transfer operation failed with the given error message.
     TransferErr(String),
+    /// The cleanup batch operation finished; reports per-path outcomes.
     CleanupDone {
-        deleted: Vec<String>, // paths successfully deleted
-        errors: Vec<String>,  // error messages
+        /// Paths that were successfully deleted.
+        deleted: Vec<String>,
+        /// Error messages for paths that could not be deleted.
+        errors: Vec<String>,
     },
 }

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -1,3 +1,8 @@
+//! Reusable Ratatui widget primitives.
+//!
+//! Currently exposes `render_popup`, a helper that centres a bordered,
+//! padded popup block over the terminal area. Used by both the list view
+//! and the dialog module to render modal overlays.
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -5,6 +10,10 @@ use ratatui::widgets::*;
 // Popup rendering helper
 // ---------------------------------------------------------------------------
 
+/// Renders a centered rounded-border popup over the current frame.
+///
+/// `percent_x` controls popup width as a percentage of the terminal width.
+/// `height` is the absolute row count; it is clamped to the terminal height.
 pub fn render_popup(
     f: &mut Frame,
     lines: Vec<Line>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,54 +1,93 @@
+//! Shared domain types used throughout Orchard.
+//!
+//! Defines the core data structures (`Worktree`, `PrInfo`, `TmuxSession`, etc.)
+//! and the `resolve_pr_status` helper that maps raw PR fields to a displayable
+//! `PrStatus`. Both the TUI and JSON output paths consume these types.
 use serde::{Deserialize, Serialize};
 
+/// A single git worktree, enriched with PR, tmux, and issue data.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Worktree {
+    /// Absolute filesystem path to the worktree root.
     pub path: String,
+    /// The branch checked out in this worktree, if any.
     pub branch: Option<String>,
+    /// The short commit SHA at HEAD.
     pub head: String,
+    /// Whether this is the bare worktree (the `.git` root).
     pub is_bare: bool,
+    /// Whether the worktree has unresolved merge conflicts.
     pub has_conflicts: bool,
+    /// The associated pull request, if one exists for this branch.
     pub pr: Option<PrInfo>,
+    /// True while PR data is being fetched asynchronously.
     pub pr_loading: bool,
+    /// Name of the tmux session attached to this worktree, if any.
     pub tmux_session: Option<String>,
+    /// Whether the tmux session is currently attached to a terminal.
     pub tmux_attached: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Title of the active tmux pane in this worktree's session.
     pub tmux_pane_title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Remote host identifier if this worktree lives on a remote machine.
     pub remote: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// GitHub issue number linked to this worktree's branch, if any.
     pub issue_number: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Current state of the linked GitHub issue.
     pub issue_state: Option<IssueState>,
 }
 
+/// Snapshot of a GitHub pull request's status and review state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PrInfo {
+    /// GitHub PR number.
     pub number: u32,
-    pub state: String, // "open", "merged", "closed"
+    /// PR lifecycle state: `"open"`, `"merged"`, or `"closed"`.
+    pub state: String,
+    /// PR title as shown on GitHub.
     pub title: String,
+    /// URL to the PR on GitHub.
     pub url: String,
+    /// The overall review decision (approved, changes requested, etc.).
     pub review_decision: ReviewDecision,
+    /// Number of review threads that have not been resolved.
     pub unresolved_threads: u32,
+    /// Aggregated status of all CI checks on the PR.
     pub checks_status: ChecksStatus,
+    /// Whether the PR branch has merge conflicts with its base.
     pub has_conflicts: bool,
 }
 
+/// Derived single-value status for a PR, used to drive display and sorting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum PrStatus {
+    /// The branch has merge conflicts with its base.
     Conflict,
+    /// One or more CI checks have failed.
     Failing,
+    /// There are unresolved review threads.
     Unresolved,
+    /// A reviewer has requested changes.
     ChangesRequested,
+    /// A review has been requested but not yet submitted.
     ReviewNeeded,
+    /// CI checks are still running.
     PendingCi,
+    /// The PR is approved and CI is passing.
     Approved,
+    /// The PR has been merged.
     Merged,
+    /// The PR was closed without merging.
     Closed,
 }
 
 impl PrStatus {
+    /// Returns the icon and label used to render this status in the TUI.
     pub fn display(self) -> StatusDisplay {
         match self {
             Self::Conflict => StatusDisplay {
@@ -91,11 +130,17 @@ impl PrStatus {
     }
 }
 
+/// Icon and text label pair used to render a `PrStatus` in the TUI.
 pub struct StatusDisplay {
+    /// Single-character (or short) symbol representing the status visually.
     pub icon: &'static str,
+    /// Short human-readable label for the status.
     pub label: &'static str,
 }
 
+/// Derives the canonical `PrStatus` from a `PrInfo` by applying a priority-ordered
+/// set of rules (merged > closed > conflict > unresolved > changes requested > failing
+/// > review needed > pending CI > approved).
 pub fn resolve_pr_status(pr: &PrInfo) -> PrStatus {
     if pr.state == "merged" {
         return PrStatus::Merged;
@@ -128,51 +173,74 @@ pub fn resolve_pr_status(pr: &PrInfo) -> PrStatus {
     PrStatus::ReviewNeeded
 }
 
+/// The aggregated review decision returned by the GitHub API for a pull request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum ReviewDecision {
     #[default]
     #[serde(rename = "")]
+    /// No review has been requested or submitted yet.
     None,
     #[serde(rename = "APPROVED")]
+    /// All required reviewers have approved the PR.
     Approved,
     #[serde(rename = "CHANGES_REQUESTED")]
+    /// At least one reviewer has requested changes.
     ChangesRequested,
     #[serde(rename = "REVIEW_REQUIRED")]
+    /// A review is required before the PR can be merged.
     ReviewRequired,
 }
 
+/// Aggregated result of all CI checks associated with a pull request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum ChecksStatus {
+    /// All checks completed successfully.
     Pass,
+    /// One or more checks failed.
     Fail,
+    /// Checks are queued or currently running.
     Pending,
     #[default]
+    /// No checks are configured or data is unavailable.
     None,
 }
 
+/// The lifecycle state of a GitHub issue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum IssueState {
+    /// The issue is open and active.
     Open,
+    /// The issue was closed without being completed (e.g., won't fix).
     Closed,
+    /// The issue was closed as completed.
     Completed,
 }
 
+/// A live tmux session discovered on the local or remote host.
 #[derive(Debug, Clone)]
 pub struct TmuxSession {
+    /// The tmux session name.
     pub name: String,
+    /// The working directory of the session's first window.
     pub path: String,
+    /// Whether a client is currently attached to this session.
     pub attached: bool,
+    /// Title of the active pane, if available.
     pub pane_title: Option<String>,
 }
 
+/// Connection details for a remote machine that hosts worktrees.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoteConfig {
+    /// SSH target in `user@host` format.
     pub host: String,
+    /// Absolute path to the repository root on the remote machine.
     pub repo_path: String,
     #[serde(default = "default_shell")]
+    /// Shell command used to connect (defaults to `"ssh"`).
     pub shell: String,
 }
 
@@ -180,15 +248,22 @@ fn default_shell() -> String {
     "ssh".to_string()
 }
 
+/// Project-level Orchard configuration, loaded from `.orchard.json`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct OrchardConfig {
+    /// Optional remote machine configuration for SSH-backed worktrees.
     pub remote: Option<RemoteConfig>,
 }
 
+/// Parameters for switching the terminal to an existing or new tmux session.
 pub struct SwitchToSessionOptions {
+    /// Name of the tmux session to switch to or create.
     pub session_name: String,
+    /// Filesystem path of the worktree the session is rooted in.
     pub worktree_path: String,
+    /// Branch associated with the session, used for display purposes.
     pub branch: Option<String>,
+    /// PR associated with the worktree, passed through for context display.
     pub pr: Option<PrInfo>,
 }
 


### PR DESCRIPTION
## Summary
- Add `//!` module-level docs to all 27 files that were missing them
- Add `///` doc comments to all public structs, enums, fields, variants, and functions across 29 files
- Add `#![warn(missing_docs)]` to `lib.rs` to enforce doc coverage going forward
- `cargo doc` generates clean, navigable docs with zero warnings

## Test plan
- [x] `cargo test` — all 12 tests pass
- [x] `cargo build --release` — clean build
- [x] `cargo doc` — no warnings
- [x] `#![warn(missing_docs)]` catches any future regressions

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #39