### PR TITLE
feat: add orchard heal command for self-repair and cleanup

### DIFF
--- a/specs/features/orchard-heal.feature
+++ b/specs/features/orchard-heal.feature
@@ -1,0 +1,194 @@
+Feature: Orchard heal command for self-repair and cleanup
+  As an orchard user
+  I want a heal command that audits and repairs drifted state
+  So I can keep my environment clean without manual investigation
+
+  Background:
+    Given a repo with orchard configured
+    And tmux is available
+
+  # --- Dry Run (default mode) ---
+
+  @unit
+  Scenario: Dry run reports what it would do without making changes
+    Given there is an orphaned tmux session "myrepo_old-feature" with no matching worktree
+    And there is a stale claude state file for dead session "myrepo_dead"
+    When the user runs "orchard heal"
+    Then the output shows a health check report
+    And the report lists the orphaned session as a warning
+    And the report lists the stale claude state file as a warning
+    And no sessions are killed
+    And no files are deleted
+    And the output suggests "Run `orchard heal --fix` to repair."
+
+  @unit
+  Scenario: Dry run reports all-healthy when nothing is wrong
+    Given all tmux sessions have matching worktrees
+    And all worktrees have valid branches
+    And no stale cache or claude state files exist
+    When the user runs "orchard heal"
+    Then the output shows only success checkmarks
+    And the output does not suggest running --fix
+
+  # --- Orphaned Tmux Sessions ---
+
+  @unit
+  Scenario: Detect tmux session with no matching worktree
+    Given tmux session "myrepo_old-feature" exists
+    And no worktree path matches that session's directory
+    When the user runs "orchard heal"
+    Then the report warns about orphaned session "myrepo_old-feature"
+
+  @unit
+  Scenario: Fix kills orphaned tmux session
+    Given tmux session "myrepo_old-feature" exists
+    And no worktree path matches that session's directory
+    When the user runs "orchard heal --fix"
+    Then tmux session "myrepo_old-feature" is killed
+    And the report confirms the session was killed
+
+  @unit
+  Scenario: Detect tmux session whose directory doesn't exist on disk
+    Given tmux session "myrepo_gone" points to "/tmp/nonexistent-path"
+    And that path does not exist on disk
+    When the user runs "orchard heal --fix"
+    Then tmux session "myrepo_gone" is killed
+
+  # --- Stale Claude State Files ---
+
+  @unit
+  Scenario: Detect claude state file for dead tmux session
+    Given /tmp/orchard-claude-abc123.json exists with tmux_session "myrepo_dead"
+    And no tmux session named "myrepo_dead" exists
+    When the user runs "orchard heal"
+    Then the report warns about stale claude state file for "myrepo_dead"
+
+  @unit
+  Scenario: Fix deletes claude state file for dead session
+    Given /tmp/orchard-claude-abc123.json exists with tmux_session "myrepo_dead"
+    And no tmux session named "myrepo_dead" exists
+    When the user runs "orchard heal --fix"
+    Then /tmp/orchard-claude-abc123.json is deleted
+    And the report confirms the state file was cleaned up
+
+  # --- Stale Cache Entries ---
+
+  @unit
+  Scenario: Detect cache files for non-existent repo
+    Given cache file "ghost_repo_issues.json" exists in ~/.cache/orchard/
+    And no git remote matches "ghost/repo"
+    When the user runs "orchard heal"
+    Then the report warns about stale cache entry "ghost_repo_issues.json"
+
+  @unit
+  Scenario: Fix deletes stale cache files
+    Given cache file "ghost_repo_issues.json" exists in ~/.cache/orchard/
+    And no git remote matches "ghost/repo"
+    When the user runs "orchard heal --fix"
+    Then "ghost_repo_issues.json" is deleted from ~/.cache/orchard/
+    And the report confirms the cache entry was removed
+
+  # --- Worktrees for Merged PRs ---
+
+  @unit
+  Scenario: Flag worktree whose PR is merged
+    Given worktree ".worktrees/issue3-tests" exists with branch "issue3/tests"
+    And PR #12 for branch "issue3/tests" has state "merged"
+    When the user runs "orchard heal"
+    Then the report flags worktree ".worktrees/issue3-tests" as stale
+    And the message mentions "PR #12 merged"
+
+  @unit
+  Scenario: Flag worktree whose PR is closed
+    Given worktree ".worktrees/issue5-fix" exists with branch "issue5/fix"
+    And PR #15 for branch "issue5/fix" has state "closed"
+    When the user runs "orchard heal"
+    Then the report flags worktree ".worktrees/issue5-fix" as stale
+
+  @unit
+  Scenario: Fix does not auto-delete worktrees for merged PRs
+    Given worktree ".worktrees/issue3-tests" exists with branch "issue3/tests"
+    And PR #12 for branch "issue3/tests" has state "merged"
+    When the user runs "orchard heal --fix"
+    Then worktree ".worktrees/issue3-tests" is NOT deleted
+    And the report flags it for manual cleanup
+
+  # --- Worktrees for Closed Issues ---
+
+  @unit
+  Scenario: Flag worktree whose issue is closed
+    Given worktree ".worktrees/issue8-refactor" exists with branch "issue8/refactor"
+    And issue #8 has state "closed"
+    And no active tmux session exists for that worktree
+    When the user runs "orchard heal"
+    Then the report flags worktree ".worktrees/issue8-refactor" as stale
+
+  # --- Session Naming Mismatches ---
+
+  @unit
+  Scenario: Report session name that doesn't match derived pattern
+    Given repo name is "myrepo" and branch is "feature/login"
+    And tmux session "wrong-name" points to the worktree for that branch
+    When the user runs "orchard heal"
+    Then the report warns about naming mismatch
+    And the message shows expected "myrepo_feature-login" vs actual "wrong-name"
+
+  # --- Multiple Sessions Per Worktree ---
+
+  @unit
+  Scenario: Report multiple sessions pointing to same worktree
+    Given worktree ".worktrees/issue10-api" exists
+    And tmux sessions "myrepo_issue10-api" and "extra-session" both point to that worktree
+    When the user runs "orchard heal"
+    Then the report warns about multiple sessions for the same worktree
+
+  # --- Health Report Format ---
+
+  @unit
+  Scenario: Report uses structured output with icons
+    Given there are 5 healthy sessions and 1 orphaned session
+    And there are 3 healthy worktrees and 1 stale worktree
+    When the user runs "orchard heal"
+    Then the output includes a line like "5 tmux sessions OK" with a checkmark
+    And the output includes a line like "3 worktrees OK" with a checkmark
+    And the output includes warning lines with a warning icon
+    And the output includes error/flag lines with an error icon
+
+  # --- JSON Output ---
+
+  @unit
+  Scenario: Heal supports --json flag for machine-readable output
+    Given there is an orphaned tmux session
+    When the user runs "orchard heal --json"
+    Then the output is valid JSON
+    And the JSON contains a "findings" array
+    And each finding has "category", "severity", "message", and "action" fields
+
+  # --- TUI Integration ---
+
+  @unit
+  Scenario: Press h in list view to run heal
+    Given the TUI is running in list view
+    When the user presses 'h'
+    Then the heal check runs
+    And the results are displayed in a heal view
+
+  @unit
+  Scenario: Heal view shows fix option
+    Given the TUI is showing heal results with warnings
+    When the user presses 'f'
+    Then the fix actions are executed
+    And the heal view updates to show the results
+
+  # --- CLI Entry Point ---
+
+  @unit
+  Scenario: Heal command is accessible as a subcommand
+    When the user runs "orchard heal"
+    Then the heal check executes and prints a report
+
+  @unit
+  Scenario: Heal --fix flag triggers repairs
+    When the user runs "orchard heal --fix"
+    Then the heal check executes and performs repairs
+    And the report shows what was fixed

--- a/src/heal.rs
+++ b/src/heal.rs
@@ -1,0 +1,1053 @@
+//! Heal command: audits and repairs drifted Orchard state.
+//!
+//! The heal command inspects tmux sessions, worktrees, Claude state files, and
+//! cache files to find inconsistencies and stale data. It can operate in dry-run
+//! mode (default) or apply fixes with `--fix`.
+//!
+//! Architecture follows the functional core / imperative shell pattern:
+//! - `diagnose()` is a pure function that computes a `HealReport` from its inputs.
+//! - `apply_fixes()` performs the actual I/O side effects.
+//! - `format_report()` formats a human-readable text output.
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use crate::cache;
+use crate::tmux;
+use crate::types::TmuxSession;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// The category of a heal finding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HealCategory {
+    /// A tmux session with no matching worktree path on disk.
+    OrphanedSession,
+    /// A tmux session whose working directory no longer exists on disk.
+    DeadSessionDirectory,
+    /// A `/tmp/orchard-claude-*.json` file for a tmux session that no longer exists.
+    StaleClaudeState,
+    /// A `~/.cache/orchard/` file whose repo slug is not in the active config.
+    StaleCache,
+    /// A worktree whose associated PR has been merged.
+    MergedPrWorktree,
+    /// A worktree whose associated PR has been closed without merging.
+    ClosedPrWorktree,
+    /// A worktree whose linked GitHub issue is closed.
+    ClosedIssueWorktree,
+    /// A tmux session whose name does not match the Orchard naming convention.
+    SessionNamingMismatch,
+    /// Multiple tmux sessions pointing to the same worktree path.
+    MultipleSessionsPerWorktree,
+}
+
+/// Severity level for a heal finding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    /// Everything looks healthy — no action needed.
+    Ok,
+    /// Something looks off but is not immediately broken.
+    Warning,
+    /// A clear problem that should be fixed.
+    Error,
+}
+
+/// The action associated with a heal finding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+pub enum HealAction {
+    /// Kill the named tmux session.
+    KillSession(String),
+    /// Delete the file at the given path.
+    DeleteFile(String),
+    /// Flag the item for manual cleanup; no automatic action.
+    FlagForCleanup(String),
+    /// Informational only — report but take no action.
+    ReportOnly(String),
+    /// No action needed; item is healthy.
+    None,
+}
+
+/// A single finding from the heal diagnosis.
+#[derive(Debug, Clone, Serialize)]
+pub struct HealFinding {
+    /// Category of the problem.
+    pub category: HealCategory,
+    /// Severity of the problem.
+    pub severity: Severity,
+    /// Human-readable description of the finding.
+    pub message: String,
+    /// The action to take, if any.
+    pub action: HealAction,
+}
+
+/// The complete output of a heal diagnosis run.
+#[derive(Debug, Serialize)]
+pub struct HealReport {
+    /// All findings, both healthy and problematic.
+    pub findings: Vec<HealFinding>,
+}
+
+impl HealReport {
+    /// Returns true when every finding is healthy (severity == Ok).
+    pub fn is_all_ok(&self) -> bool {
+        self.findings.iter().all(|f| f.severity == Severity::Ok)
+    }
+
+    /// Returns only the findings that have an actionable fix.
+    pub fn actionable(&self) -> impl Iterator<Item = &HealFinding> {
+        self.findings
+            .iter()
+            .filter(|f| !matches!(f.action, HealAction::None))
+    }
+}
+
+/// Result of applying a single heal action.
+#[derive(Debug, Serialize)]
+pub struct FixResult {
+    /// The finding that was addressed.
+    pub message: String,
+    /// Whether the fix succeeded.
+    pub success: bool,
+    /// Error detail when `success` is false.
+    pub error: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Inputs for diagnose()
+// ---------------------------------------------------------------------------
+
+/// Describes a worktree to the healer (lightweight, no PR/issue enrichment needed at this layer).
+#[derive(Debug, Clone)]
+pub struct HealWorktree {
+    /// Absolute filesystem path to the worktree root.
+    pub path: String,
+    /// The branch checked out in this worktree.
+    pub branch: String,
+    /// The expected Orchard session name derived from this worktree.
+    pub expected_session_name: Option<String>,
+    /// PR state for this worktree's branch ("open", "merged", "closed"), if any.
+    pub pr_state: Option<String>,
+    /// PR number, if any.
+    pub pr_number: Option<u32>,
+    /// Linked GitHub issue state ("open", "closed"), if any.
+    pub issue_state: Option<String>,
+}
+
+/// Describes a Claude state file to the healer.
+#[derive(Debug, Clone)]
+pub struct HealClaudeState {
+    /// Absolute path to the state file.
+    pub path: String,
+    /// The tmux session name recorded in the file.
+    pub tmux_session: String,
+}
+
+// ---------------------------------------------------------------------------
+// Core diagnostic function (pure)
+// ---------------------------------------------------------------------------
+
+/// Diagnoses the health of the Orchard environment.
+///
+/// This is a pure function: all I/O is performed by callers who gather the
+/// inputs. The function only analyzes and classifies findings.
+///
+/// # Parameters
+/// - `sessions`: live tmux sessions from `tmux::list_tmux_sessions()`
+/// - `worktrees`: enriched worktrees to check
+/// - `claude_states`: stale-check candidates from `/tmp/orchard-claude-*.json`
+/// - `cache_files`: cache file names from `~/.cache/orchard/`
+/// - `known_repo_slugs`: repo slugs from global config (e.g. `["owner/repo"]`)
+pub fn diagnose(
+    sessions: &[TmuxSession],
+    worktrees: &[HealWorktree],
+    claude_states: &[HealClaudeState],
+    cache_files: &[String],
+    known_repo_slugs: &[String],
+) -> HealReport {
+    let mut findings = Vec::new();
+
+    check_sessions(sessions, worktrees, &mut findings);
+    check_claude_states(claude_states, sessions, &mut findings);
+    check_cache_files(cache_files, known_repo_slugs, &mut findings);
+    check_worktree_pr_states(worktrees, &mut findings);
+    check_worktree_issue_states(worktrees, &mut findings);
+    check_session_naming(sessions, worktrees, &mut findings);
+    check_multiple_sessions_per_worktree(sessions, worktrees, &mut findings);
+
+    HealReport { findings }
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+fn check_sessions(
+    sessions: &[TmuxSession],
+    worktrees: &[HealWorktree],
+    findings: &mut Vec<HealFinding>,
+) {
+    let worktree_paths: Vec<&str> = worktrees.iter().map(|w| w.path.as_str()).collect();
+
+    for session in sessions {
+        let path_exists = Path::new(&session.path).exists();
+        let path_has_worktree = worktree_paths.contains(&session.path.as_str());
+
+        if !path_exists {
+            findings.push(HealFinding {
+                category: HealCategory::DeadSessionDirectory,
+                severity: Severity::Error,
+                message: format!(
+                    "Session \"{}\" points to non-existent path \"{}\"",
+                    session.name, session.path
+                ),
+                action: HealAction::KillSession(session.name.clone()),
+            });
+        } else if !path_has_worktree {
+            findings.push(HealFinding {
+                category: HealCategory::OrphanedSession,
+                severity: Severity::Warning,
+                message: format!(
+                    "Session \"{}\" has no matching worktree (path: {})",
+                    session.name, session.path
+                ),
+                action: HealAction::KillSession(session.name.clone()),
+            });
+        }
+    }
+}
+
+fn check_claude_states(
+    claude_states: &[HealClaudeState],
+    sessions: &[TmuxSession],
+    findings: &mut Vec<HealFinding>,
+) {
+    let session_names: Vec<&str> = sessions.iter().map(|s| s.name.as_str()).collect();
+
+    for cs in claude_states {
+        if !session_names.contains(&cs.tmux_session.as_str()) {
+            findings.push(HealFinding {
+                category: HealCategory::StaleClaudeState,
+                severity: Severity::Warning,
+                message: format!(
+                    "Stale Claude state file for dead session \"{}\" ({})",
+                    cs.tmux_session, cs.path
+                ),
+                action: HealAction::DeleteFile(cs.path.clone()),
+            });
+        }
+    }
+}
+
+fn check_cache_files(
+    cache_files: &[String],
+    known_repo_slugs: &[String],
+    findings: &mut Vec<HealFinding>,
+) {
+    for filename in cache_files {
+        // Cache files follow the pattern: {owner}_{repo}_{source}.json
+        // Skip files that don't follow the per-repo naming convention.
+        if let Some(repo_slug) = extract_repo_slug_from_cache_filename(filename)
+            && !known_repo_slugs.contains(&repo_slug)
+        {
+            let cache_path = cache::cache_dir().join(filename);
+            findings.push(HealFinding {
+                category: HealCategory::StaleCache,
+                severity: Severity::Warning,
+                message: format!(
+                    "Stale cache file \"{}\" for unknown repo \"{}\"",
+                    filename, repo_slug
+                ),
+                action: HealAction::DeleteFile(cache_path.to_string_lossy().to_string()),
+            });
+        }
+    }
+}
+
+fn check_worktree_pr_states(worktrees: &[HealWorktree], findings: &mut Vec<HealFinding>) {
+    for wt in worktrees {
+        let Some(pr_state) = &wt.pr_state else {
+            continue;
+        };
+        let pr_label = wt
+            .pr_number
+            .map(|n| format!("PR #{n}"))
+            .unwrap_or_else(|| "PR".to_string());
+
+        if pr_state.eq_ignore_ascii_case("merged") {
+            findings.push(HealFinding {
+                category: HealCategory::MergedPrWorktree,
+                severity: Severity::Warning,
+                message: format!("Worktree \"{}\" is stale: {} merged", wt.path, pr_label),
+                action: HealAction::FlagForCleanup(wt.path.clone()),
+            });
+        } else if pr_state.eq_ignore_ascii_case("closed") {
+            findings.push(HealFinding {
+                category: HealCategory::ClosedPrWorktree,
+                severity: Severity::Warning,
+                message: format!(
+                    "Worktree \"{}\" is stale: {} closed without merge",
+                    wt.path, pr_label
+                ),
+                action: HealAction::FlagForCleanup(wt.path.clone()),
+            });
+        }
+    }
+}
+
+fn check_worktree_issue_states(worktrees: &[HealWorktree], findings: &mut Vec<HealFinding>) {
+    for wt in worktrees {
+        let Some(issue_state) = &wt.issue_state else {
+            continue;
+        };
+        // Only flag when the issue is closed and there's no PR (otherwise the PR check covers it).
+        if issue_state.eq_ignore_ascii_case("closed") && wt.pr_state.is_none() {
+            findings.push(HealFinding {
+                category: HealCategory::ClosedIssueWorktree,
+                severity: Severity::Warning,
+                message: format!("Worktree \"{}\" is stale: linked issue is closed", wt.path),
+                action: HealAction::FlagForCleanup(wt.path.clone()),
+            });
+        }
+    }
+}
+
+fn check_session_naming(
+    sessions: &[TmuxSession],
+    worktrees: &[HealWorktree],
+    findings: &mut Vec<HealFinding>,
+) {
+    for session in sessions {
+        // Find the worktree this session is associated with (by path).
+        let Some(wt) = worktrees.iter().find(|w| w.path == session.path) else {
+            continue;
+        };
+        let Some(expected) = &wt.expected_session_name else {
+            continue;
+        };
+        if &session.name != expected {
+            findings.push(HealFinding {
+                category: HealCategory::SessionNamingMismatch,
+                severity: Severity::Warning,
+                message: format!(
+                    "Session naming mismatch: expected \"{}\" but found \"{}\"",
+                    expected, session.name
+                ),
+                action: HealAction::ReportOnly(format!(
+                    "Rename session \"{}\" to \"{}\"",
+                    session.name, expected
+                )),
+            });
+        }
+    }
+}
+
+fn check_multiple_sessions_per_worktree(
+    sessions: &[TmuxSession],
+    worktrees: &[HealWorktree],
+    findings: &mut Vec<HealFinding>,
+) {
+    for wt in worktrees {
+        let matching: Vec<&TmuxSession> = sessions.iter().filter(|s| s.path == wt.path).collect();
+
+        if matching.len() > 1 {
+            let names: Vec<&str> = matching.iter().map(|s| s.name.as_str()).collect();
+            findings.push(HealFinding {
+                category: HealCategory::MultipleSessionsPerWorktree,
+                severity: Severity::Warning,
+                message: format!(
+                    "Multiple sessions for worktree \"{}\": {}",
+                    wt.path,
+                    names.join(", ")
+                ),
+                action: HealAction::ReportOnly(format!(
+                    "Worktree \"{}\" has {} sessions",
+                    wt.path,
+                    matching.len()
+                )),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fix application (imperative shell)
+// ---------------------------------------------------------------------------
+
+/// Applies the actions from a set of findings.
+///
+/// Kills sessions and deletes files as directed. Worktrees flagged with
+/// `FlagForCleanup` are never deleted automatically — they require manual action.
+pub fn apply_fixes(findings: &[HealFinding]) -> Vec<FixResult> {
+    let mut results = Vec::new();
+
+    for finding in findings {
+        match &finding.action {
+            HealAction::KillSession(name) => {
+                let result = tmux::kill_tmux_session(name);
+                results.push(FixResult {
+                    message: format!("Killed session \"{}\"", name),
+                    success: result.is_ok(),
+                    error: result.err().map(|e| e.to_string()),
+                });
+            }
+            HealAction::DeleteFile(path) => {
+                let p = Path::new(path);
+                let in_cache = p.starts_with(cache::cache_dir());
+                let in_tmp = p.starts_with("/tmp")
+                    && p.file_name()
+                        .is_some_and(|n| n.to_string_lossy().starts_with("orchard-claude-"));
+                if !in_cache && !in_tmp {
+                    results.push(FixResult {
+                        message: format!("Skipped file outside expected directories: \"{}\"", path),
+                        success: false,
+                        error: Some("path not in ~/.cache/orchard/ or /tmp/orchard-*".to_string()),
+                    });
+                    continue;
+                }
+                let result = std::fs::remove_file(path);
+                results.push(FixResult {
+                    message: format!("Deleted file \"{}\"", path),
+                    success: result.is_ok(),
+                    error: result.err().map(|e| e.to_string()),
+                });
+            }
+            HealAction::FlagForCleanup(desc) => {
+                results.push(FixResult {
+                    message: format!("Flagged for manual cleanup: {}", desc),
+                    success: true,
+                    error: None,
+                });
+            }
+            HealAction::ReportOnly(_) | HealAction::None => {
+                // No action to apply.
+            }
+        }
+    }
+
+    results
+}
+
+// ---------------------------------------------------------------------------
+// Text report formatting
+// ---------------------------------------------------------------------------
+
+/// Formats a heal report as a human-readable string with icons.
+///
+/// Healthy items use a checkmark (`✓`), warnings use `⚠`, and errors use `✗`.
+/// When there are actionable findings, a suggestion to run `--fix` is appended.
+pub fn format_report(report: &HealReport, fix_results: Option<&[FixResult]>) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    let ok_sessions = report
+        .findings
+        .iter()
+        .filter(|f| {
+            matches!(
+                f.category,
+                HealCategory::OrphanedSession | HealCategory::DeadSessionDirectory
+            ) && f.severity == Severity::Ok
+        })
+        .count();
+
+    let bad_sessions = report
+        .findings
+        .iter()
+        .filter(|f| {
+            matches!(
+                f.category,
+                HealCategory::OrphanedSession | HealCategory::DeadSessionDirectory
+            ) && f.severity != Severity::Ok
+        })
+        .count();
+
+    // Summary lines.
+    let total_session_issues = bad_sessions;
+    let session_names: Vec<String> = report
+        .findings
+        .iter()
+        .filter(|f| {
+            matches!(
+                f.category,
+                HealCategory::OrphanedSession | HealCategory::DeadSessionDirectory
+            )
+        })
+        .map(|f| f.message.clone())
+        .collect();
+
+    // Build a summary of session health.
+    let total_sessions_checked = ok_sessions + bad_sessions;
+    if (total_sessions_checked > 0 || session_names.is_empty()) && total_session_issues == 0 {
+        lines.push(format!(
+            "\u{2713} {} tmux session{} OK",
+            total_sessions_checked,
+            if total_sessions_checked == 1 { "" } else { "s" }
+        ));
+    }
+
+    // Print all session-related findings.
+    for finding in report.findings.iter().filter(|f| {
+        matches!(
+            f.category,
+            HealCategory::OrphanedSession | HealCategory::DeadSessionDirectory
+        )
+    }) {
+        let icon = severity_icon(&finding.severity);
+        lines.push(format!("{} {}", icon, finding.message));
+    }
+
+    // Print all non-session findings.
+    for finding in report.findings.iter().filter(|f| {
+        !matches!(
+            f.category,
+            HealCategory::OrphanedSession | HealCategory::DeadSessionDirectory
+        )
+    }) {
+        let icon = severity_icon(&finding.severity);
+        lines.push(format!("{} {}", icon, finding.message));
+    }
+
+    // Fix results section.
+    if let Some(results) = fix_results
+        && !results.is_empty()
+    {
+        lines.push(String::new());
+        lines.push("Applied fixes:".to_string());
+        for r in results {
+            let icon = if r.success { "\u{2713}" } else { "\u{2716}" };
+            if let Some(err) = &r.error {
+                lines.push(format!("  {} {} ({})", icon, r.message, err));
+            } else {
+                lines.push(format!("  {} {}", icon, r.message));
+            }
+        }
+    }
+
+    // Suggest --fix when there are actionable findings and we're not in fix mode.
+    let has_actionable = report.actionable().any(|f| {
+        matches!(
+            f.action,
+            HealAction::KillSession(_) | HealAction::DeleteFile(_)
+        )
+    });
+    if fix_results.is_none() && has_actionable {
+        lines.push(String::new());
+        lines.push("Run `orchard heal --fix` to repair.".to_string());
+    }
+
+    lines.join("\n")
+}
+
+fn severity_icon(severity: &Severity) -> &'static str {
+    match severity {
+        Severity::Ok => "\u{2713}",      // ✓
+        Severity::Warning => "\u{26a0}", // ⚠
+        Severity::Error => "\u{2716}",   // ✗
+    }
+}
+
+// ---------------------------------------------------------------------------
+// I/O helpers for gathering heal inputs
+// ---------------------------------------------------------------------------
+
+/// Reads all Claude state files from `/tmp` and returns them as `HealClaudeState` entries.
+pub fn gather_claude_states() -> Vec<HealClaudeState> {
+    let tmp = PathBuf::from("/tmp");
+    let pattern = format!("{}/orchard-claude-*.json", tmp.display());
+    let mut results = Vec::new();
+
+    for path in glob::glob(&pattern).into_iter().flatten().flatten() {
+        if path.to_string_lossy().contains(".tmp.") {
+            continue;
+        }
+        if let Ok(data) = std::fs::read(&path)
+            && let Ok(state) = serde_json::from_slice::<crate::claude_state::ClaudeStateFile>(&data)
+        {
+            results.push(HealClaudeState {
+                path: path.to_string_lossy().to_string(),
+                tmux_session: state.tmux_session,
+            });
+        }
+    }
+
+    results
+}
+
+/// Reads all files from the orchard cache directory and returns their filenames.
+pub fn gather_cache_files() -> Vec<String> {
+    let dir = cache::cache_dir();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+
+    entries
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            if name.ends_with(".json") {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Cache filename parsing
+// ---------------------------------------------------------------------------
+
+/// Extracts a `owner/repo` slug from a cache filename like `owner_repo_issues.json`.
+///
+/// Returns `None` for filenames that don't follow the per-repo naming pattern
+/// (e.g. `tmux_sessions.json`, `config.json`).
+fn extract_repo_slug_from_cache_filename(filename: &str) -> Option<String> {
+    // Per-repo files follow: {owner}_{repo}_{source}.json
+    // We need at least 3 underscore-separated parts before the extension.
+    let without_ext = filename.strip_suffix(".json")?;
+
+    // Known non-repo files.
+    let non_repo_prefixes = ["tmux_sessions", "config", "session_manifest"];
+    if non_repo_prefixes.iter().any(|p| without_ext.starts_with(p)) {
+        return None;
+    }
+
+    // Must have at least 3 parts: owner_repo_source
+    let parts: Vec<&str> = without_ext.splitn(3, '_').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+
+    Some(format!("{}/{}", parts[0], parts[1]))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::TmuxSession;
+
+    fn make_session(name: &str, path: &str) -> TmuxSession {
+        TmuxSession {
+            name: name.to_string(),
+            path: path.to_string(),
+            attached: false,
+            pane_title: None,
+        }
+    }
+
+    fn make_worktree(path: &str, branch: &str) -> HealWorktree {
+        HealWorktree {
+            path: path.to_string(),
+            branch: branch.to_string(),
+            expected_session_name: None,
+            pr_state: None,
+            pr_number: None,
+            issue_state: None,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Orphaned session detection
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detect_orphaned_session_no_matching_worktree() {
+        let sessions = vec![make_session(
+            "myrepo_old-feature",
+            "/tmp/nonexistent-worktree",
+        )];
+        let worktrees = vec![make_worktree("/workspace/main", "main")];
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+
+        // Path doesn't exist → DeadSessionDirectory, not orphaned
+        let finding = &report.findings[0];
+        assert_eq!(finding.category, HealCategory::DeadSessionDirectory);
+        assert_eq!(finding.severity, Severity::Error);
+    }
+
+    #[test]
+    fn detect_orphaned_session_path_exists_but_no_worktree() {
+        // Use a real path that exists but is not a worktree.
+        let sessions = vec![make_session("myrepo_old-feature", "/tmp")];
+        let worktrees = vec![make_worktree("/workspace/main", "main")];
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::OrphanedSession);
+        assert!(finding.is_some(), "should detect orphaned session");
+        assert_eq!(finding.unwrap().severity, Severity::Warning);
+        assert!(
+            matches!(&finding.unwrap().action, HealAction::KillSession(name) if name == "myrepo_old-feature")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Dead session directory
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detect_dead_session_directory() {
+        let sessions = vec![make_session("myrepo_gone", "/tmp/nonexistent-path-xyz")];
+        let worktrees = vec![];
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::DeadSessionDirectory);
+        assert!(finding.is_some());
+        assert!(
+            matches!(&finding.unwrap().action, HealAction::KillSession(n) if n == "myrepo_gone")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Stale claude state files
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detect_stale_claude_state_for_dead_session() {
+        let sessions = vec![];
+        let claude_states = vec![HealClaudeState {
+            path: "/tmp/orchard-claude-abc123.json".to_string(),
+            tmux_session: "myrepo_dead".to_string(),
+        }];
+        let report = diagnose(&sessions, &[], &claude_states, &[], &[]);
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::StaleClaudeState);
+        assert!(finding.is_some(), "should detect stale claude state");
+        assert!(
+            matches!(&finding.unwrap().action, HealAction::DeleteFile(p) if p == "/tmp/orchard-claude-abc123.json")
+        );
+    }
+
+    #[test]
+    fn no_finding_when_claude_state_session_is_alive() {
+        let sessions = vec![make_session("myrepo_live", "/workspace/main")];
+        let claude_states = vec![HealClaudeState {
+            path: "/tmp/orchard-claude-abc123.json".to_string(),
+            tmux_session: "myrepo_live".to_string(),
+        }];
+        let report = diagnose(&sessions, &[], &claude_states, &[], &[]);
+
+        let stale = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::StaleClaudeState);
+        assert!(
+            stale.is_none(),
+            "should not flag live session's claude state"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Stale cache files
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detect_stale_cache_file_for_unknown_repo() {
+        let cache_files = vec!["ghost_repo_issues.json".to_string()];
+        let known_slugs = vec!["owner/my-project".to_string()];
+        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs);
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::StaleCache);
+        assert!(finding.is_some(), "should detect stale cache file");
+        assert!(matches!(finding.unwrap().action, HealAction::DeleteFile(_)));
+    }
+
+    #[test]
+    fn no_stale_cache_finding_for_known_repo() {
+        let cache_files = vec!["owner_myproject_issues.json".to_string()];
+        let known_slugs = vec!["owner/myproject".to_string()];
+        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs);
+
+        let stale = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::StaleCache);
+        assert!(stale.is_none());
+    }
+
+    #[test]
+    fn tmux_sessions_cache_file_ignored() {
+        let cache_files = vec!["tmux_sessions.json".to_string()];
+        let known_slugs: Vec<String> = vec![];
+        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs);
+
+        let stale = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::StaleCache);
+        assert!(stale.is_none(), "tmux_sessions.json is not a repo cache");
+    }
+
+    // -----------------------------------------------------------------------
+    // Merged/closed PR worktrees
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn flag_worktree_with_merged_pr() {
+        let mut wt = make_worktree(".worktrees/issue3-tests", "issue3/tests");
+        wt.pr_state = Some("merged".to_string());
+        wt.pr_number = Some(12);
+        let report = diagnose(&[], &[wt], &[], &[], &[]);
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::MergedPrWorktree);
+        assert!(finding.is_some());
+        assert!(finding.unwrap().message.contains("PR #12 merged"));
+        // Must not delete automatically.
+        assert!(matches!(
+            finding.unwrap().action,
+            HealAction::FlagForCleanup(_)
+        ));
+    }
+
+    #[test]
+    fn flag_worktree_with_closed_pr() {
+        let mut wt = make_worktree(".worktrees/issue5-fix", "issue5/fix");
+        wt.pr_state = Some("closed".to_string());
+        wt.pr_number = Some(15);
+        let report = diagnose(&[], &[wt], &[], &[], &[]);
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::ClosedPrWorktree);
+        assert!(finding.is_some());
+    }
+
+    #[test]
+    fn merged_pr_worktree_is_not_deleted_by_fix() {
+        let mut wt = make_worktree(".worktrees/issue3-tests", "issue3/tests");
+        wt.pr_state = Some("merged".to_string());
+        wt.pr_number = Some(12);
+        let report = diagnose(&[], &[wt], &[], &[], &[]);
+
+        let results = apply_fixes(&report.findings);
+        // FlagForCleanup produces a result but does not kill/delete anything.
+        for r in &results {
+            assert!(r.message.starts_with("Flagged for manual cleanup"));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Closed issue worktrees
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn flag_worktree_with_closed_issue_no_pr() {
+        let mut wt = make_worktree(".worktrees/issue8-refactor", "issue8/refactor");
+        wt.issue_state = Some("closed".to_string());
+        let report = diagnose(&[], &[wt], &[], &[], &[]);
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::ClosedIssueWorktree);
+        assert!(finding.is_some());
+    }
+
+    #[test]
+    fn closed_issue_not_flagged_when_pr_exists() {
+        // When there's a PR, the PR check takes precedence; issue check is skipped.
+        let mut wt = make_worktree(".worktrees/issue8-refactor", "issue8/refactor");
+        wt.issue_state = Some("closed".to_string());
+        wt.pr_state = Some("open".to_string());
+        let report = diagnose(&[], &[wt], &[], &[], &[]);
+
+        let issue_finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::ClosedIssueWorktree);
+        assert!(
+            issue_finding.is_none(),
+            "issue check skipped when PR exists"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Session naming mismatch
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detect_session_naming_mismatch() {
+        let sessions = vec![make_session("wrong-name", "/workspace/feature-login")];
+        let mut wt = make_worktree("/workspace/feature-login", "feature/login");
+        wt.expected_session_name = Some("myrepo_feature-login".to_string());
+        let report = diagnose(&sessions, &[wt], &[], &[], &[]);
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::SessionNamingMismatch);
+        assert!(finding.is_some());
+        assert!(finding.unwrap().message.contains("myrepo_feature-login"));
+        assert!(finding.unwrap().message.contains("wrong-name"));
+    }
+
+    #[test]
+    fn no_mismatch_when_session_name_matches() {
+        let sessions = vec![make_session(
+            "myrepo_feature-login",
+            "/workspace/feature-login",
+        )];
+        let mut wt = make_worktree("/workspace/feature-login", "feature/login");
+        wt.expected_session_name = Some("myrepo_feature-login".to_string());
+        let report = diagnose(&sessions, &[wt], &[], &[], &[]);
+
+        let mismatch = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::SessionNamingMismatch);
+        assert!(mismatch.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Multiple sessions per worktree
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detect_multiple_sessions_for_same_worktree() {
+        let sessions = vec![
+            make_session("myrepo_issue10-api", "/workspace/issue10-api"),
+            make_session("extra-session", "/workspace/issue10-api"),
+        ];
+        let wt = make_worktree("/workspace/issue10-api", "issue10/api");
+        let report = diagnose(&sessions, &[wt], &[], &[], &[]);
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::MultipleSessionsPerWorktree);
+        assert!(finding.is_some(), "should detect multiple sessions");
+        assert!(finding.unwrap().message.contains("myrepo_issue10-api"));
+        assert!(finding.unwrap().message.contains("extra-session"));
+    }
+
+    // -----------------------------------------------------------------------
+    // All-healthy
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn all_ok_when_everything_matches() {
+        // Use a real path that exists on disk so the directory check passes.
+        let tmp = std::env::temp_dir();
+        let path = tmp.to_string_lossy().to_string();
+        let sessions = vec![make_session("myrepo_main", &path)];
+        let worktrees = vec![make_worktree(&path, "main")];
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+
+        assert!(report.is_all_ok(), "should report all-ok");
+        assert_eq!(report.findings.len(), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // format_report
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_report_suggests_fix_when_actionable() {
+        let sessions = vec![make_session("orphan", "/tmp")];
+        let worktrees = vec![];
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+        let text = format_report(&report, None);
+
+        assert!(
+            text.contains("orchard heal --fix"),
+            "should suggest --fix: {text}"
+        );
+    }
+
+    #[test]
+    fn format_report_no_fix_suggestion_when_all_ok() {
+        // Use a real path so the directory check passes.
+        let tmp = std::env::temp_dir();
+        let path = tmp.to_string_lossy().to_string();
+        let sessions = vec![make_session("myrepo_main", &path)];
+        let worktrees = vec![make_worktree(&path, "main")];
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+        let text = format_report(&report, None);
+
+        assert!(
+            !text.contains("orchard heal --fix"),
+            "should not suggest --fix when healthy: {text}"
+        );
+    }
+
+    #[test]
+    fn format_report_shows_fix_results() {
+        let fix_results = vec![FixResult {
+            message: "Killed session \"orphan\"".to_string(),
+            success: true,
+            error: None,
+        }];
+        let report = HealReport { findings: vec![] };
+        let text = format_report(&report, Some(&fix_results));
+
+        assert!(text.contains("Killed session"), "{text}");
+    }
+
+    // -----------------------------------------------------------------------
+    // Cache filename parsing
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn extract_repo_slug_from_standard_filename() {
+        let slug = extract_repo_slug_from_cache_filename("owner_myrepo_issues.json");
+        assert_eq!(slug, Some("owner/myrepo".to_string()));
+    }
+
+    #[test]
+    fn extract_repo_slug_returns_none_for_tmux_cache() {
+        let slug = extract_repo_slug_from_cache_filename("tmux_sessions.json");
+        assert!(slug.is_none());
+    }
+
+    #[test]
+    fn extract_repo_slug_returns_none_for_too_few_parts() {
+        let slug = extract_repo_slug_from_cache_filename("something.json");
+        assert!(slug.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // HealReport helpers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn heal_report_is_all_ok_with_no_findings() {
+        let report = HealReport { findings: vec![] };
+        assert!(report.is_all_ok());
+    }
+
+    #[test]
+    fn heal_report_is_not_all_ok_with_warning_finding() {
+        let report = HealReport {
+            findings: vec![HealFinding {
+                category: HealCategory::OrphanedSession,
+                severity: Severity::Warning,
+                message: "orphaned".to_string(),
+                action: HealAction::KillSession("orphan".to_string()),
+            }],
+        };
+        assert!(!report.is_all_ok());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod events;
 pub mod git;
 pub mod github;
 pub mod global_config;
+pub mod heal;
 pub mod json_output;
 pub mod logger;
 mod navigation;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use crossterm::{
 };
 use orchard::build_state;
 use orchard::global_config;
+use orchard::heal;
 use orchard::json_output::JsonOutput;
 use orchard::logger;
 use orchard::setup_remote;
@@ -24,11 +25,13 @@ fn main() {
     let args: Vec<String> = env::args().collect();
 
     let mut json_flag = false;
+    let mut fix_flag = false;
     let mut command = String::new();
 
     for arg in &args[1..] {
         match arg.as_str() {
             "--json" => json_flag = true,
+            "--fix" => fix_flag = true,
             "--version" | "-V" => {
                 println!("orchard {}", env!("CARGO_PKG_VERSION"));
                 return;
@@ -55,6 +58,7 @@ fn main() {
         "init" => handle_init(),
         "upgrade" => handle_upgrade(),
         "setup-remote" => handle_setup_remote(&args),
+        "heal" => handle_heal(fix_flag, json_flag),
         _ => {
             if json_flag {
                 handle_json();
@@ -99,6 +103,85 @@ fn handle_upgrade() {
     eprintln!(
         "Download the latest from: https://github.com/drewdrewthis/orchard-rs/releases/latest"
     );
+}
+
+/// Runs the heal command in CLI mode (non-TUI).
+///
+/// Gathers live state, diagnoses the environment, and prints a report.
+/// When `fix` is true, applies all actionable fixes. When `json` is true,
+/// outputs machine-readable JSON instead of the formatted report.
+fn handle_heal(fix: bool, json: bool) {
+    let config = global_config::load_global_config();
+    let sessions = orchard::tmux::list_tmux_sessions();
+    let claude_states = heal::gather_claude_states();
+    let cache_files = heal::gather_cache_files();
+    let known_slugs: Vec<String> = config.repos.iter().map(|r| r.slug.clone()).collect();
+
+    // Build HealWorktree entries from all configured repo caches.
+    let worktrees = build_heal_worktrees_for_cli(&config);
+
+    let report = heal::diagnose(
+        &sessions,
+        &worktrees,
+        &claude_states,
+        &cache_files,
+        &known_slugs,
+    );
+
+    if json {
+        let output = serde_json::to_string_pretty(&report).unwrap_or_else(|e| {
+            eprintln!("Error serializing JSON: {e}");
+            std::process::exit(1);
+        });
+        println!("{output}");
+        return;
+    }
+
+    let fix_results = if fix {
+        Some(heal::apply_fixes(&report.findings))
+    } else {
+        None
+    };
+
+    println!("{}", heal::format_report(&report, fix_results.as_deref()));
+}
+
+/// Builds `HealWorktree` entries for the CLI path (no TUI app state available).
+fn build_heal_worktrees_for_cli(config: &global_config::GlobalConfig) -> Vec<heal::HealWorktree> {
+    let mut result = Vec::new();
+    for repo in &config.repos {
+        let worktrees = orchard::cache::read_cache::<orchard::cache::CachedWorktree>(
+            &orchard::cache::cache_path(repo.owner(), repo.repo_name(), "worktrees"),
+        )
+        .entries;
+        let prs = orchard::cache::read_cache::<orchard::cache::CachedPr>(
+            &orchard::cache::cache_path(repo.owner(), repo.repo_name(), "prs"),
+        )
+        .entries;
+        let issues = orchard::cache::read_cache::<orchard::cache::CachedIssue>(
+            &orchard::cache::cache_path(repo.owner(), repo.repo_name(), "issues"),
+        )
+        .entries;
+
+        for wt in worktrees.iter().filter(|w| !w.is_bare) {
+            let pr = prs.iter().find(|p| p.branch == wt.branch);
+            let issue_number = orchard::github::extract_issue_number(&wt.branch);
+            let issue_state = issue_number
+                .and_then(|n| issues.iter().find(|i| i.number == n))
+                .map(|i| i.state.clone());
+            let expected_session_name =
+                orchard::tmux::derive_main_session_name(&wt.path, Some(&wt.branch));
+            result.push(heal::HealWorktree {
+                path: wt.path.clone(),
+                branch: wt.branch.clone(),
+                expected_session_name: Some(expected_session_name),
+                pr_state: pr.map(|p| p.state.clone()),
+                pr_number: pr.map(|p| p.number),
+                issue_state,
+            });
+        }
+    }
+    result
 }
 
 fn handle_json() {
@@ -188,6 +271,9 @@ fn print_usage() {
   orchard init                   Interactive setup wizard for popup mode
   orchard setup-remote <host>    Provision a remote host for orchard
   orchard upgrade                Upgrade to the latest version
+  orchard heal                   Audit and repair drifted state (dry run)
+  orchard heal --fix             Apply all safe automatic repairs
+  orchard heal --json            Output health check results as JSON
 
 Options:
   --version, -V  Print version and exit
@@ -199,6 +285,7 @@ Navigation:
   Enter/t tmux into worktree (creates session if needed, then exits)
   d       Delete selected worktree
   c       Cleanup merged worktrees
+  h       Run heal check
   r       Refresh list
   q/Esc   Close popup (no switch)"#
     );

--- a/src/tui/dialogs.rs
+++ b/src/tui/dialogs.rs
@@ -6,11 +6,12 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Padding;
 
+use crate::heal::{HealAction, Severity};
 use crate::paths;
 use crate::tui::App;
 use crate::tui::SPINNER_FRAMES;
 use crate::tui::state::{
-    CleanupState, DeleteState, NewSessionState, NewWorktreeState, Phase, TransferState,
+    CleanupState, DeleteState, HealState, NewSessionState, NewWorktreeState, Phase, TransferState,
 };
 use crate::tui::widgets::render_popup;
 
@@ -453,6 +454,10 @@ impl App {
                 Span::styled("Cleanup stale worktrees", dim),
             ]),
             Line::from(vec![
+                Span::styled("h        ", key_style),
+                Span::styled("Run heal check", dim),
+            ]),
+            Line::from(vec![
                 Span::styled("n        ", key_style),
                 Span::styled("New tmux session", dim),
             ]),
@@ -488,6 +493,109 @@ impl App {
             60,
             20,
             Some(" HELP "),
+            Padding::new(2, 2, 1, 1),
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Heal dialog
+// ---------------------------------------------------------------------------
+
+impl App {
+    /// Renders the heal results view as a popup dialog.
+    pub(crate) fn render_heal(&self, state: &HealState, f: &mut Frame) {
+        let theme = &self.theme;
+        let mut lines: Vec<Line> = Vec::new();
+
+        if state.findings.is_empty() && state.fix_results.is_none() {
+            lines.push(Line::styled(
+                "\u{2713} All healthy — nothing to repair.",
+                Style::default()
+                    .fg(theme.success)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        } else {
+            for (i, finding) in state.findings.iter().enumerate() {
+                let (icon, color) = match finding.severity {
+                    Severity::Ok => ("\u{2713}", theme.success),
+                    Severity::Warning => ("\u{26a0}", theme.warning),
+                    Severity::Error => ("\u{2716}", theme.error),
+                };
+                let prefix = if i == state.cursor { "> " } else { "  " };
+                let action_hint = match &finding.action {
+                    HealAction::KillSession(n) => format!(" [kill: {n}]"),
+                    HealAction::DeleteFile(p) => format!(" [delete: {p}]"),
+                    HealAction::FlagForCleanup(_) => " [manual cleanup]".to_string(),
+                    HealAction::ReportOnly(_) | HealAction::None => String::new(),
+                };
+                lines.push(Line::from(vec![
+                    Span::raw(format!("{prefix}{icon} ")),
+                    Span::styled(
+                        format!("{}{}", finding.message, action_hint),
+                        Style::default().fg(color),
+                    ),
+                ]));
+            }
+        }
+
+        // Fix results section.
+        if let Some(results) = &state.fix_results {
+            lines.push(Line::from(""));
+            lines.push(Line::styled(
+                "Applied fixes:",
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
+            for r in results {
+                let (icon, color) = if r.success {
+                    ("\u{2713}", theme.success)
+                } else {
+                    ("\u{2716}", theme.error)
+                };
+                let msg = if let Some(ref e) = r.error {
+                    format!("{} ({})", r.message, e)
+                } else {
+                    r.message.clone()
+                };
+                lines.push(Line::styled(
+                    format!("  {icon} {msg}"),
+                    Style::default().fg(color),
+                ));
+            }
+        }
+
+        lines.push(Line::from(""));
+        if state.fixing {
+            let spinner = crate::tui::SPINNER_FRAMES[self.spinner_frame];
+            lines.push(Line::styled(
+                format!("{spinner} Applying fixes..."),
+                Style::default().fg(theme.accent),
+            ));
+        } else if state.fix_results.is_none() && !state.findings.is_empty() {
+            lines.push(Line::styled(
+                "f apply fixes  q/esc go back",
+                Style::default()
+                    .fg(theme.dimmed)
+                    .add_modifier(Modifier::DIM),
+            ));
+        } else {
+            lines.push(Line::styled(
+                "q / esc to go back",
+                Style::default()
+                    .fg(theme.dimmed)
+                    .add_modifier(Modifier::DIM),
+            ));
+        }
+
+        let height = (lines.len() + 4).min(30) as u16;
+        render_popup(
+            f,
+            lines,
+            theme.accent,
+            theme.background,
+            80,
+            height,
+            Some(" Heal "),
             Padding::new(2, 2, 1, 1),
         );
     }

--- a/src/tui/list.rs
+++ b/src/tui/list.rs
@@ -818,6 +818,14 @@ impl App {
             errors: Vec::new(),
         });
     }
+
+    /// Starts a background heal diagnosis and transitions to a loading state.
+    ///
+    /// The `HealDone` message will arrive asynchronously and trigger the
+    /// transition to `ViewState::Heal`.
+    pub(crate) fn enter_heal_view(&mut self) {
+        self.start_heal();
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tui/message.rs
+++ b/src/tui/message.rs
@@ -94,6 +94,18 @@ pub enum Message {
     ConfirmNewWorktree,
     /// Dismiss a Done/Error phase dialog (any-key screens).
     DismissDialog,
+
+    // -- Heal actions --
+    /// Open the heal diagnosis view.
+    Heal,
+    /// Move the cursor up in the heal results view.
+    HealUp,
+    /// Move the cursor down in the heal results view.
+    HealDown,
+    /// Apply fixes from the heal results view.
+    HealFix,
+    /// Return from the heal results view to the list.
+    HealBack,
 }
 
 /// Result of processing a [`Message`] through the `update` function.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -32,7 +32,7 @@ use crate::transfer;
 use crate::types::Worktree;
 
 use message::{Message, UpdateResult};
-use state::{AppMsg, CleanupState, FilterMode, Phase, ViewState};
+use state::{AppMsg, CleanupState, FilterMode, HealState, Phase, ViewState};
 use std::path::Path;
 use std::process::Command;
 
@@ -460,6 +460,22 @@ impl App {
                     }
                     self.start_refresh();
                 }
+                AppMsg::HealDone(report) => {
+                    let findings = report.findings.clone();
+                    self.view = ViewState::Heal(HealState {
+                        report,
+                        findings,
+                        cursor: 0,
+                        fixing: false,
+                        fix_results: None,
+                    });
+                }
+                AppMsg::HealFixDone(fix_results) => {
+                    if let ViewState::Heal(ref mut hs) = self.view {
+                        hs.fixing = false;
+                        hs.fix_results = Some(fix_results);
+                    }
+                }
             }
         }
     }
@@ -523,6 +539,7 @@ impl App {
                     KeyCode::Char('f') => Some(Message::CycleFilter),
                     KeyCode::Char('/') => Some(Message::StartSearch),
                     KeyCode::Char('c') => Some(Message::Cleanup),
+                    KeyCode::Char('h') => Some(Message::Heal),
                     KeyCode::Left => Some(Message::PrevRepo),
                     KeyCode::Right => Some(Message::NextRepo),
                     KeyCode::Char('r') => Some(Message::Refresh),
@@ -594,6 +611,18 @@ impl App {
                 KeyCode::Esc | KeyCode::Char('q') => Some(Message::Cancel),
                 _ => None,
             },
+            ViewState::Heal(hs) => {
+                if hs.fixing {
+                    return None;
+                }
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => Some(Message::HealUp),
+                    KeyCode::Down | KeyCode::Char('j') => Some(Message::HealDown),
+                    KeyCode::Char('f') => Some(Message::HealFix),
+                    KeyCode::Char('q') | KeyCode::Esc => Some(Message::HealBack),
+                    _ => None,
+                }
+            }
         }
     }
 
@@ -962,6 +991,37 @@ impl App {
                 }
                 ok()
             }
+            Message::Heal => {
+                self.enter_heal_view();
+                ok()
+            }
+            Message::HealUp => {
+                if let ViewState::Heal(hs) = &mut self.view {
+                    hs.cursor = hs.cursor.saturating_sub(1);
+                }
+                ok()
+            }
+            Message::HealDown => {
+                if let ViewState::Heal(hs) = &mut self.view
+                    && !hs.findings.is_empty()
+                    && hs.cursor < hs.findings.len() - 1
+                {
+                    hs.cursor += 1;
+                }
+                ok()
+            }
+            Message::HealFix => {
+                if let ViewState::Heal(hs) = &mut self.view {
+                    let findings = hs.findings.clone();
+                    hs.fixing = true;
+                    self.start_heal_fix(findings);
+                }
+                ok()
+            }
+            Message::HealBack => {
+                self.view = ViewState::List;
+                ok()
+            }
         }
     }
 
@@ -986,6 +1046,7 @@ impl App {
             ViewState::NewSession(_) => "NewSession",
             ViewState::NewWorktree(_) => "NewWorktree",
             ViewState::Help => "Help",
+            ViewState::Heal(_) => "Heal",
         }
     }
 
@@ -1012,6 +1073,7 @@ impl App {
                 self.render_new_worktree(nw, f);
             }
             ViewState::Help => self.render_help(f),
+            ViewState::Heal(hs) => self.render_heal(hs, f),
         }
     }
 
@@ -1199,6 +1261,39 @@ impl App {
                     let _ = tx.send(AppMsg::CreateWorktreeDone { session_name });
                 }
             }
+        });
+    }
+
+    /// Starts a background heal diagnosis run and transitions to a loading state.
+    pub(crate) fn start_heal(&self) {
+        let tx = self.tx.clone();
+        let config = self.global_config.clone();
+        std::thread::spawn(move || {
+            let sessions = crate::tmux::list_tmux_sessions();
+            let claude_states = crate::heal::gather_claude_states();
+            let cache_files = crate::heal::gather_cache_files();
+            let known_slugs: Vec<String> = config.repos.iter().map(|r| r.slug.clone()).collect();
+
+            // Build HealWorktree list from the cache.
+            let worktrees = build_heal_worktrees(&config);
+
+            let report = crate::heal::diagnose(
+                &sessions,
+                &worktrees,
+                &claude_states,
+                &cache_files,
+                &known_slugs,
+            );
+            let _ = tx.send(AppMsg::HealDone(report));
+        });
+    }
+
+    /// Applies fixes from the current heal state in a background thread.
+    pub(crate) fn start_heal_fix(&self, findings: Vec<crate::heal::HealFinding>) {
+        let tx = self.tx.clone();
+        std::thread::spawn(move || {
+            let results = crate::heal::apply_fixes(&findings);
+            let _ = tx.send(AppMsg::HealFixDone(results));
         });
     }
 
@@ -1552,6 +1647,58 @@ fn ensure_standalone_sessions(config: &global_config::GlobalConfig) -> anyhow::R
 /// authoritative cache-reading and derivation logic.
 fn derive_from_all_caches(config: &global_config::GlobalConfig) -> Vec<derive::WorktreeRow> {
     crate::build_state::build_task_rows(config)
+}
+
+// ---------------------------------------------------------------------------
+// Heal worktree builder
+// ---------------------------------------------------------------------------
+
+/// Builds `HealWorktree` entries from all configured repo caches.
+///
+/// Reads the worktrees and PRs cache for each repo to produce the lightweight
+/// `HealWorktree` structs needed by `heal::diagnose`.
+fn build_heal_worktrees(config: &global_config::GlobalConfig) -> Vec<crate::heal::HealWorktree> {
+    let mut result = Vec::new();
+    for repo in &config.repos {
+        let worktrees = cache::read_cache::<cache::CachedWorktree>(&cache::cache_path(
+            repo.owner(),
+            repo.repo_name(),
+            "worktrees",
+        ))
+        .entries;
+        let prs = cache::read_cache::<cache::CachedPr>(&cache::cache_path(
+            repo.owner(),
+            repo.repo_name(),
+            "prs",
+        ))
+        .entries;
+        let issues = cache::read_cache::<cache::CachedIssue>(&cache::cache_path(
+            repo.owner(),
+            repo.repo_name(),
+            "issues",
+        ))
+        .entries;
+
+        for wt in worktrees.iter().filter(|w| !w.is_bare) {
+            let pr = prs.iter().find(|p| p.branch == wt.branch);
+            let issue_number = crate::github::extract_issue_number(&wt.branch);
+            let issue_state = issue_number
+                .and_then(|n| issues.iter().find(|i| i.number == n))
+                .map(|i| i.state.clone());
+
+            let expected_session_name = tmux::derive_main_session_name(&wt.path, Some(&wt.branch));
+
+            result.push(crate::heal::HealWorktree {
+                path: wt.path.clone(),
+                branch: wt.branch.clone(),
+                expected_session_name: Some(expected_session_name),
+                pr_state: pr.map(|p| p.state.clone()),
+                pr_number: pr.map(|p| p.number),
+                issue_state,
+            });
+        }
+    }
+    result
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -8,6 +8,7 @@ use std::collections::HashSet;
 use std::fmt;
 
 use crate::derive::WorktreeRow;
+use crate::heal::{FixResult, HealFinding, HealReport};
 use crate::types::Worktree;
 
 // ---------------------------------------------------------------------------
@@ -71,6 +72,8 @@ pub enum ViewState {
     NewWorktree(NewWorktreeState),
     /// The keybinding help overlay.
     Help,
+    /// The heal results view.
+    Heal(HealState),
 }
 
 /// State carried while the delete-worktree confirmation dialog is open.
@@ -121,6 +124,24 @@ pub struct NewSessionState {
 pub struct NewWorktreeState {
     /// The branch name being typed by the user.
     pub branch: String,
+}
+
+/// State carried while the heal results view is displayed.
+pub struct HealState {
+    /// The full report from the last heal diagnosis.
+    ///
+    /// Retained for potential export or re-display logic; the `findings` field
+    /// contains a clone of `report.findings` for cursor-indexed rendering.
+    #[allow(dead_code)]
+    pub report: HealReport,
+    /// All findings as a flat list for cursor navigation.
+    pub findings: Vec<HealFinding>,
+    /// Index of the currently highlighted finding.
+    pub cursor: usize,
+    /// Whether a fix pass is currently running.
+    pub fixing: bool,
+    /// Results from the last `--fix` pass, if one has run.
+    pub fix_results: Option<Vec<FixResult>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -184,4 +205,8 @@ pub enum AppMsg {
         /// Warning message to display (e.g., setup script error details).
         warning: String,
     },
+    /// The heal diagnosis finished; carries the computed report.
+    HealDone(HealReport),
+    /// The heal fix pass finished; carries the per-action results.
+    HealFixDone(Vec<FixResult>),
 }

--- a/tests/heal_test.rs
+++ b/tests/heal_test.rs
@@ -1,0 +1,415 @@
+/// Integration tests for the `orchard heal` command.
+///
+/// These tests exercise the `heal::diagnose` pure function with realistic inputs,
+/// corresponding to acceptance criteria from `specs/features/orchard-heal.feature`.
+use orchard::heal::{
+    HealAction, HealCategory, HealClaudeState, HealWorktree, Severity, diagnose, format_report,
+};
+use orchard::types::TmuxSession;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn session(name: &str, path: &str) -> TmuxSession {
+    TmuxSession {
+        name: name.to_string(),
+        path: path.to_string(),
+        attached: false,
+        pane_title: None,
+    }
+}
+
+fn worktree(path: &str, branch: &str) -> HealWorktree {
+    HealWorktree {
+        path: path.to_string(),
+        branch: branch.to_string(),
+        expected_session_name: None,
+        pr_state: None,
+        pr_number: None,
+        issue_state: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run: reports what it would do without making changes
+// ---------------------------------------------------------------------------
+
+/// Scenario: Dry run reports orphaned session and stale claude state as warnings.
+/// No sessions are killed or files deleted.
+#[test]
+fn dry_run_reports_findings_without_applying_fixes() {
+    let sessions = vec![session("myrepo_old-feature", "/tmp")]; // /tmp exists but no matching wt
+    let worktrees = vec![worktree("/workspace/main", "main")];
+    let claude_states = vec![HealClaudeState {
+        path: "/tmp/orchard-claude-abc123.json".to_string(),
+        tmux_session: "myrepo_dead".to_string(),
+    }];
+
+    let report = diagnose(&sessions, &worktrees, &claude_states, &[], &[]);
+
+    // Orphaned session finding.
+    let orphan = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::OrphanedSession);
+    assert!(orphan.is_some(), "should find orphaned session");
+    assert_eq!(orphan.unwrap().severity, Severity::Warning);
+
+    // Stale claude state finding.
+    let stale = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::StaleClaudeState);
+    assert!(stale.is_some(), "should find stale claude state");
+    assert_eq!(stale.unwrap().severity, Severity::Warning);
+
+    // Suggest fix in report.
+    let text = format_report(&report, None);
+    assert!(
+        text.contains("orchard heal --fix"),
+        "dry run should suggest --fix: {text}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// All-healthy scenario
+// ---------------------------------------------------------------------------
+
+/// Scenario: When everything matches, no findings are generated and no --fix is suggested.
+#[test]
+fn all_healthy_when_sessions_match_worktrees() {
+    // Use a real path that exists on disk so the directory-existence check passes.
+    let tmp = std::env::temp_dir().to_string_lossy().to_string();
+    let sessions = vec![session("myrepo_main", &tmp)];
+    let worktrees = vec![worktree(&tmp, "main")];
+
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+
+    assert_eq!(report.findings.len(), 0, "should have no findings");
+    assert!(report.is_all_ok());
+
+    let text = format_report(&report, None);
+    assert!(
+        !text.contains("orchard heal --fix"),
+        "should not suggest --fix when healthy"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Orphaned tmux sessions
+// ---------------------------------------------------------------------------
+
+/// Scenario: tmux session with no matching worktree path is flagged.
+#[test]
+fn orphaned_session_detected_when_path_exists_but_no_worktree_matches() {
+    // /tmp always exists but is not a worktree.
+    let sessions = vec![session("myrepo_old-feature", "/tmp")];
+    let worktrees = vec![worktree("/workspace/other", "main")];
+
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::OrphanedSession);
+    assert!(
+        finding.is_some(),
+        "should detect orphaned session: {:?}",
+        report.findings
+    );
+    assert_eq!(finding.unwrap().severity, Severity::Warning);
+    assert!(
+        matches!(&finding.unwrap().action, HealAction::KillSession(n) if n == "myrepo_old-feature")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Dead session directory
+// ---------------------------------------------------------------------------
+
+/// Scenario: Session pointing to a non-existent path gets an Error-severity finding.
+#[test]
+fn dead_session_directory_detected_for_nonexistent_path() {
+    let sessions = vec![session(
+        "myrepo_gone",
+        "/tmp/nonexistent-path-xyz-heal-test",
+    )];
+    let worktrees = vec![];
+
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::DeadSessionDirectory);
+    assert!(finding.is_some(), "should detect dead session directory");
+    assert_eq!(finding.unwrap().severity, Severity::Error);
+    assert!(matches!(&finding.unwrap().action, HealAction::KillSession(n) if n == "myrepo_gone"));
+}
+
+// ---------------------------------------------------------------------------
+// Stale claude state files
+// ---------------------------------------------------------------------------
+
+/// Scenario: Claude state file for dead session is flagged.
+#[test]
+fn stale_claude_state_detected_for_dead_session() {
+    let sessions = vec![];
+    let claude_states = vec![HealClaudeState {
+        path: "/tmp/orchard-claude-abc123.json".to_string(),
+        tmux_session: "myrepo_dead".to_string(),
+    }];
+
+    let report = diagnose(&sessions, &[], &claude_states, &[], &[]);
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::StaleClaudeState);
+    assert!(finding.is_some(), "should detect stale claude state");
+    assert!(
+        matches!(&finding.unwrap().action, HealAction::DeleteFile(p) if p == "/tmp/orchard-claude-abc123.json")
+    );
+    // Report warns about "myrepo_dead".
+    assert!(finding.unwrap().message.contains("myrepo_dead"));
+}
+
+/// Scenario: Claude state file for a live session is NOT flagged.
+#[test]
+fn no_stale_claude_state_when_session_is_alive() {
+    // Use /tmp so the path-exists check passes.
+    let sessions = vec![session("myrepo_live", "/tmp")];
+    let claude_states = vec![HealClaudeState {
+        path: "/tmp/orchard-claude-xyz.json".to_string(),
+        tmux_session: "myrepo_live".to_string(),
+    }];
+
+    let report = diagnose(&sessions, &[], &claude_states, &[], &[]);
+
+    let stale = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::StaleClaudeState);
+    assert!(
+        stale.is_none(),
+        "live session's claude state should not be flagged"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Stale cache files
+// ---------------------------------------------------------------------------
+
+/// Scenario: Cache file for unknown repo slug is flagged.
+#[test]
+fn stale_cache_file_flagged_for_unknown_repo() {
+    let cache_files = vec!["ghost_repo_issues.json".to_string()];
+    let known_slugs = vec!["owner/known-project".to_string()];
+
+    let report = diagnose(&[], &[], &[], &cache_files, &known_slugs);
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::StaleCache);
+    assert!(finding.is_some(), "should detect stale cache file");
+    assert!(matches!(finding.unwrap().action, HealAction::DeleteFile(_)));
+    assert!(finding.unwrap().message.contains("ghost_repo_issues.json"));
+}
+
+/// Scenario: Cache file for a known repo slug is NOT flagged.
+#[test]
+fn no_stale_cache_for_known_repo() {
+    let cache_files = vec!["owner_myrepo_issues.json".to_string()];
+    let known_slugs = vec!["owner/myrepo".to_string()];
+
+    let report = diagnose(&[], &[], &[], &cache_files, &known_slugs);
+
+    let stale = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::StaleCache);
+    assert!(stale.is_none(), "known repo cache should not be flagged");
+}
+
+// ---------------------------------------------------------------------------
+// Merged/closed PR worktrees
+// ---------------------------------------------------------------------------
+
+/// Scenario: Worktree whose PR is merged is flagged (not auto-deleted).
+#[test]
+fn merged_pr_worktree_flagged_for_manual_cleanup() {
+    let mut wt = worktree(".worktrees/issue3-tests", "issue3/tests");
+    wt.pr_state = Some("merged".to_string());
+    wt.pr_number = Some(12);
+
+    let report = diagnose(&[], &[wt], &[], &[], &[]);
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::MergedPrWorktree);
+    assert!(finding.is_some(), "should flag merged PR worktree");
+    assert!(finding.unwrap().message.contains("PR #12 merged"));
+    assert!(matches!(
+        finding.unwrap().action,
+        HealAction::FlagForCleanup(_)
+    ));
+}
+
+/// Scenario: Worktree with closed PR is flagged.
+#[test]
+fn closed_pr_worktree_flagged() {
+    let mut wt = worktree(".worktrees/issue5-fix", "issue5/fix");
+    wt.pr_state = Some("closed".to_string());
+    wt.pr_number = Some(15);
+
+    let report = diagnose(&[], &[wt], &[], &[], &[]);
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::ClosedPrWorktree);
+    assert!(finding.is_some(), "should flag closed PR worktree");
+}
+
+/// Scenario: --fix does NOT delete worktrees for merged PRs.
+#[test]
+fn fix_does_not_auto_delete_merged_pr_worktrees() {
+    let mut wt = worktree(".worktrees/issue3-tests", "issue3/tests");
+    wt.pr_state = Some("merged".to_string());
+    wt.pr_number = Some(12);
+
+    let report = diagnose(&[], &[wt], &[], &[], &[]);
+    let fix_results = orchard::heal::apply_fixes(&report.findings);
+
+    // All results should be FlagForCleanup (not KillSession or DeleteFile).
+    for r in &fix_results {
+        assert!(
+            r.message.starts_with("Flagged for manual cleanup"),
+            "merged PR worktree should only be flagged, not deleted: {}",
+            r.message
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Closed issue worktrees
+// ---------------------------------------------------------------------------
+
+/// Scenario: Worktree whose linked issue is closed (and no PR) is flagged.
+#[test]
+fn closed_issue_worktree_flagged_when_no_pr() {
+    let mut wt = worktree(".worktrees/issue8-refactor", "issue8/refactor");
+    wt.issue_state = Some("closed".to_string());
+
+    let report = diagnose(&[], &[wt], &[], &[], &[]);
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::ClosedIssueWorktree);
+    assert!(
+        finding.is_some(),
+        "should flag closed-issue worktree: {:?}",
+        report.findings
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Session naming mismatch
+// ---------------------------------------------------------------------------
+
+/// Scenario: Session whose name doesn't match the expected convention is warned.
+#[test]
+fn session_naming_mismatch_detected() {
+    let sessions = vec![session("wrong-name", "/workspace/feature-login")];
+    let mut wt = worktree("/workspace/feature-login", "feature/login");
+    wt.expected_session_name = Some("myrepo_feature-login".to_string());
+
+    let report = diagnose(&sessions, &[wt], &[], &[], &[]);
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::SessionNamingMismatch);
+    assert!(finding.is_some(), "should detect naming mismatch");
+    assert!(finding.unwrap().message.contains("myrepo_feature-login"));
+    assert!(finding.unwrap().message.contains("wrong-name"));
+}
+
+// ---------------------------------------------------------------------------
+// Multiple sessions per worktree
+// ---------------------------------------------------------------------------
+
+/// Scenario: Two sessions pointing to the same worktree path triggers a warning.
+#[test]
+fn multiple_sessions_per_worktree_detected() {
+    let sessions = vec![
+        session("myrepo_issue10-api", "/workspace/issue10-api"),
+        session("extra-session", "/workspace/issue10-api"),
+    ];
+    let wt = worktree("/workspace/issue10-api", "issue10/api");
+
+    let report = diagnose(&sessions, &[wt], &[], &[], &[]);
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::MultipleSessionsPerWorktree);
+    assert!(finding.is_some(), "should detect multiple sessions");
+    assert!(finding.unwrap().message.contains("myrepo_issue10-api"));
+    assert!(finding.unwrap().message.contains("extra-session"));
+}
+
+// ---------------------------------------------------------------------------
+// Report format
+// ---------------------------------------------------------------------------
+
+/// Scenario: Report uses structured output with icons.
+#[test]
+fn report_format_includes_icons() {
+    let sessions = vec![session("orphan", "/tmp")]; // /tmp is a real path but not a worktree
+    let worktrees = vec![];
+
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+    let text = format_report(&report, None);
+
+    // Should contain at least one icon character.
+    let has_icon =
+        text.contains('\u{2713}') || text.contains('\u{26a0}') || text.contains('\u{2716}');
+    assert!(has_icon, "report should contain icon characters: {text}");
+}
+
+/// Scenario: JSON output contains a "findings" array with required fields.
+#[test]
+fn json_output_contains_findings_array() {
+    let sessions = vec![session("orphan", "/tmp")];
+    let worktrees = vec![];
+
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+    let json_str = serde_json::to_string(&report).expect("serialize report");
+    let json: serde_json::Value = serde_json::from_str(&json_str).expect("parse json");
+
+    let findings = json.get("findings").expect("should have findings field");
+    assert!(findings.is_array(), "findings should be an array");
+
+    let arr = findings.as_array().unwrap();
+    if !arr.is_empty() {
+        let first = &arr[0];
+        assert!(
+            first.get("category").is_some(),
+            "finding should have category"
+        );
+        assert!(
+            first.get("severity").is_some(),
+            "finding should have severity"
+        );
+        assert!(
+            first.get("message").is_some(),
+            "finding should have message"
+        );
+        assert!(first.get("action").is_some(), "finding should have action");
+    }
+}


### PR DESCRIPTION
## Summary

- Implements `orchard heal` command that audits tmux sessions, worktrees, cache files, and Claude state files for drift and staleness (#16)
- Supports three modes: dry-run (default), `--fix` (apply repairs), and `--json` (machine-readable output)
- Integrates into TUI via `h` key with interactive heal view and `f` to apply fixes

### Checks implemented

| Check | Action |
|-------|--------|
| Orphaned tmux sessions (no matching worktree) | Kill with `--fix` |
| Dead session directories (path does not exist) | Kill with `--fix` |
| Stale Claude state files (`/tmp/orchard-claude-*.json`) | Delete with `--fix` |
| Stale cache files (unknown repo slugs) | Delete with `--fix` |
| Merged PR worktrees | Flag only (no auto-delete) |
| Closed PR worktrees | Flag only |
| Closed issue worktrees | Flag only |
| Session naming mismatches | Report only |
| Multiple sessions per worktree | Report only |

## Test plan

- [x] `cargo test` -- 454 unit tests + 16 integration tests pass
- [x] `cargo build --release` -- clean build
- [ ] Run `orchard heal` in a repo with active worktrees -- verify report format
- [ ] Run `orchard heal --fix` with a stale `/tmp/orchard-claude-*.json` file -- verify deletion
- [ ] Run `orchard heal --json` -- verify valid JSON output
- [ ] Press `h` in TUI -- verify heal view renders findings
- [ ] Press `f` in heal view -- verify fixes apply and view updates

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #16

# Related issue

- #16

# Related issue

- #16