### PR TITLE
feat: add TUI screenshot test helper (#75)

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2878,7 +2878,11 @@ mod tests {
                     model: Some("opus".to_string()),
                 }),
             }],
-            ..make_task_row_with_title(47, "Shepherd persistent session", DisplayGroup::ClaudeWorking)
+            ..make_task_row_with_title(
+                47,
+                "Shepherd persistent session",
+                DisplayGroup::ClaudeWorking,
+            )
         };
         let ready = WorktreeRow {
             pr: Some(DPrInfo {


### PR DESCRIPTION
## Summary

- Add `render_to_ansi()` helper that maps ratatui Buffer cells (fg, bg, modifiers) to ANSI escape sequences
- Add `#[test] #[ignore] tui_screenshot` test that renders with realistic fake WorktreeRow data and writes an `.ansi` file
- Run manually: `cargo test --lib tui::tests::tui_screenshot -- --ignored --nocapture`
- Pipe through freeze for PNG: `cat /tmp/orchard-tui-screenshot.ansi | freeze -o screenshot.png --language ansi`

## Use Cases

- Visual verification after UI refactors
- Attach screenshots to PRs / send via Telegram
- Future: snapshot testing

Closes #75

## Test plan

- [x] `cargo test` passes (all 16 tests, ignored test excluded)
- [x] `cargo build --release` succeeds
- [x] Ignored screenshot test runs and writes `.ansi` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #75

# Related issue

- #75