### PR TITLE
feat: adopt ratatui ecosystem widgets for TUI polish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,10 +99,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bstr"
@@ -113,16 +158,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -148,6 +193,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -192,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -220,19 +271,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crossterm"
-version = "0.28.1"
+name = "cpufeatures"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
- "bitflags",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
+ "libc",
 ]
 
 [[package]]
@@ -241,13 +285,13 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -263,13 +307,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -282,7 +370,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -291,9 +390,55 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -315,7 +460,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -323,6 +468,16 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -342,7 +497,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -373,7 +528,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -387,16 +551,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "float-cmp"
@@ -408,10 +605,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font8x8"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875488b8711a968268c7cf5d139578713097ca4635a76044e8fe8eedf831d07e"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -426,13 +651,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -455,9 +692,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -465,12 +700,23 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
@@ -541,11 +787,11 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -569,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -591,6 +837,23 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy_static"
@@ -620,10 +883,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -654,11 +920,21 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -666,6 +942,27 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -685,7 +982,30 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -695,12 +1015,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -743,7 +1089,7 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "color-eyre",
- "crossterm 0.29.0",
+ "crossterm",
  "dirs",
  "glob",
  "open",
@@ -754,7 +1100,19 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "tempfile",
+ "throbber-widgets-tui",
  "tokio",
+ "tui-big-text",
+ "tui-scrollview",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -787,22 +1145,123 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "predicates"
@@ -841,7 +1300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -864,29 +1323,114 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "bitflags",
- "cassowary",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.0",
  "compact_str",
- "crossterm 0.28.1",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
+ "line-clipping",
+ "ratatui-core",
  "strum",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -895,7 +1439,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -906,7 +1450,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -955,28 +1499,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1030,7 +1561,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1044,6 +1575,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1102,6 +1644,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,7 +1662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1131,24 +1679,34 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1171,8 +1729,29 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1182,12 +1761,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1198,7 +1839,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1209,6 +1850,36 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "throbber-widgets-tui"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e6941f74491a80911cb8821cb1f55f7e13bca867b28a2b14e5a1daaf691eb3"
+dependencies = [
+ "ratatui",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tokio"
@@ -1224,7 +1895,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1235,7 +1906,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1280,6 +1951,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "tui-big-text"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3524088df83a9214c4a84648c5812d6aa9f930a4172a1604706468e8b98bed1"
+dependencies = [
+ "derive_builder",
+ "font8x8",
+ "itertools",
+ "ratatui-core",
+]
+
+[[package]]
+name = "tui-scrollview"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ada5290cf63e5e718a13111020398979975d4df556a55ae88014aa8850f171"
+dependencies = [
+ "indoc",
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,20 +1999,14 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -1321,10 +2021,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -1391,7 +2124,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1432,10 +2165,82 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -1481,7 +2286,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1492,7 +2297,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1521,85 +2326,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1631,7 +2363,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1647,7 +2379,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1659,7 +2391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["git", "worktree", "tui", "tmux", "terminal"]
 categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
-ratatui = "0.29"
+ratatui = "0.30"
 crossterm = "0.29"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -23,6 +23,9 @@ chrono = { version = "0.4", features = ["serde"] }
 glob = "0.3"
 open = "5"
 shellexpand = "3.1.2"
+throbber-widgets-tui = "0.11.0"
+tui-scrollview = "0.6.2"
+tui-big-text = "0.8.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/specs/features/ui-polish-ratatui-widgets.feature
+++ b/specs/features/ui-polish-ratatui-widgets.feature
@@ -1,0 +1,98 @@
+Feature: UI polish with ratatui ecosystem widgets
+  As an orchard user
+  I want a polished, modern terminal UI using ratatui ecosystem widgets
+  So that the TUI feels more refined and informative
+
+  # Issue: #56
+  #
+  # Current state:
+  #   - Uses only: Block, Paragraph, Table, Row, Clear, Layout, Line, Span
+  #   - No third-party widget crates
+  #   - Hand-rolled braille spinner (SPINNER_FRAMES cycling every render)
+  #   - Filter modes cycle with 'f' key, no visual indicator of current mode
+  #   - No scrollbar on worktree table
+  #   - No progress indication beyond spinner for async operations
+  #   - Preview pane shows fixed last-N-lines, not scrollable
+  #   - FULL_HEADER_MIN_HEIGHT = 30 controls header size threshold
+  #
+  # Dependencies to add (actual compatible versions TBD via cargo add):
+  #   throbber-widgets-tui  # spinner widget with multiple styles
+  #   tui-scrollview        # scrollable viewports for preview pane
+  #   tui-big-text          # large text rendering for header
+  #
+  # Descoped from original issue (moved to separate issues):
+  #   - tachyonfx animations (Phase 2) -> requires architecture changes (#53)
+  #   - Sparkline commit activity -> new data pipeline, not visual polish
+  #   - tui-term evaluation -> research task, not feature work
+  #   - LineGauge for progress -> no ops report progress; use labeled throbber
+  #
+  # Non-goals:
+  #   - No architecture changes (that's #53)
+  #   - No theme system (that's #54)
+  #   - No new features -- purely visual polish on existing functionality
+  #   - No new data gathering (e.g., git log for sparklines)
+  #   - No render loop changes or animation state management
+
+  Background:
+    Given the orchard TUI is running inside tmux
+    And a repository with multiple worktrees
+
+  # ===================================================================
+  # Widget upgrades: replace DIY implementations with ecosystem widgets
+  # ===================================================================
+
+  @integration
+  Scenario: Throbber widget replaces DIY spinner
+    Given the TUI is performing an async operation (refresh, cleanup, transfer)
+    When the spinner is rendered
+    Then it uses throbber-widgets-tui instead of manual SPINNER_FRAMES
+    And the spinner animates through its configured style
+    # Constraint: SPINNER_FRAMES constant and manual cycling logic must be removed
+
+  @integration
+  Scenario: Labeled throbber for async operations
+    Given an async operation is in progress (refresh, cleanup, transfer)
+    When the status area is rendered
+    Then a throbber widget displays with a label describing the operation
+    And the label indicates what operation is running (e.g., "Refreshing...", "Deleting...")
+
+  @integration
+  Scenario: Vertical scrollbar renders when worktree list overflows visible area
+    Given the worktree list has more items than visible rows
+    When the table is rendered
+    Then a vertical scrollbar is visible on the right side of the table
+    And the scrollbar position reflects the current scroll offset
+    And the scrollbar thumb size reflects the ratio of visible to total items
+
+  @integration
+  Scenario: Scrollbar is not rendered when all worktree rows fit within visible area
+    Given the worktree list has fewer items than visible rows
+    When the table is rendered
+    Then no scrollbar is displayed
+
+  @integration
+  Scenario: Tabs widget shows filter modes
+    Given the TUI is displaying the worktree table
+    When the header area is rendered
+    Then a tab bar is visible showing filter options (All, Active, Mine, etc.)
+    And the currently active filter tab is visually highlighted
+    And pressing 'f' advances to the next tab (existing behavior preserved)
+
+  # ===================================================================
+  # Rich content: enhanced display using ecosystem widgets
+  # ===================================================================
+
+  @integration
+  Scenario: Scrollable preview pane with tui-scrollview
+    Given a worktree row is selected with a tmux pane preview
+    When the preview pane is rendered
+    Then it uses tui-scrollview for scrollable content
+    And the user can scroll through the full pane capture
+    And a scrollbar indicates position within the preview
+
+  @integration
+  Scenario: Big text header when terminal is tall enough
+    Given the terminal height meets FULL_HEADER_MIN_HEIGHT threshold (30+ rows)
+    When the header area is rendered
+    Then the repository name is displayed using tui-big-text
+    And when the terminal is shorter than the threshold, the header falls back to normal text

--- a/src/tui/dialogs.rs
+++ b/src/tui/dialogs.rs
@@ -9,7 +9,6 @@ use ratatui::widgets::Padding;
 use crate::heal::{HealAction, Severity};
 use crate::paths;
 use crate::tui::App;
-use crate::tui::SPINNER_FRAMES;
 use crate::tui::state::{
     CleanupState, DeleteState, HealState, NewSessionState, NewWorktreeState, Phase, TransferState,
 };
@@ -52,8 +51,10 @@ impl App {
                 ]));
             }
             Phase::InProgress => {
-                let spinner = SPINNER_FRAMES[self.spinner_frame];
-                lines.push(Line::from(format!("{} Removing worktree...", spinner)));
+                let throbber = throbber_widgets_tui::Throbber::default()
+                    .label("Deleting worktree...")
+                    .throbber_style(Style::default().fg(theme.accent));
+                lines.push(throbber.to_line(&self.throbber_state));
             }
             Phase::Done => {
                 lines.push(Line::styled(
@@ -134,8 +135,10 @@ impl App {
                 ]));
             }
             Phase::InProgress => {
-                let spinner = SPINNER_FRAMES[self.spinner_frame];
-                lines.push(Line::from(format!("{} Transferring...", spinner)));
+                let throbber = throbber_widgets_tui::Throbber::default()
+                    .label("Transferring worktree...")
+                    .throbber_style(Style::default().fg(theme.accent));
+                lines.push(throbber.to_line(&self.throbber_state));
             }
             Phase::Done => {
                 lines.push(Line::styled(
@@ -229,11 +232,13 @@ impl App {
                 ));
             }
             Phase::InProgress => {
-                let spinner = SPINNER_FRAMES[self.spinner_frame];
+                let throbber = throbber_widgets_tui::Throbber::default()
+                    .throbber_style(Style::default().fg(theme.accent));
+                let symbol = throbber.to_symbol_span(&self.throbber_state);
                 lines.push(Line::styled(
                     format!(
-                        "{} Deleting {} worktree(s)...",
-                        spinner,
+                        "{}Cleaning up {} worktree(s)...",
+                        symbol.content,
                         state.selected.len()
                     ),
                     Style::default()
@@ -245,7 +250,7 @@ impl App {
                     if state.selected.contains(&row.worktree_path) {
                         let short = paths::truncate_left(&paths::tildify(&row.worktree_path), 50);
                         lines.push(Line::styled(
-                            format!("  {} {}", spinner, short),
+                            format!("  {}{}", symbol.content, short),
                             Style::default().fg(theme.dimmed),
                         ));
                     }
@@ -474,6 +479,10 @@ impl App {
                 Span::styled("Push / pull worktree", dim),
             ]),
             Line::from(vec![
+                Span::styled("PgUp/Dn  ", key_style),
+                Span::styled("Scroll preview pane", dim),
+            ]),
+            Line::from(vec![
                 Span::styled("q / esc  ", key_style),
                 Span::styled("Quit", dim),
             ]),
@@ -566,11 +575,10 @@ impl App {
 
         lines.push(Line::from(""));
         if state.fixing {
-            let spinner = crate::tui::SPINNER_FRAMES[self.spinner_frame];
-            lines.push(Line::styled(
-                format!("{spinner} Applying fixes..."),
-                Style::default().fg(theme.accent),
-            ));
+            let throbber = throbber_widgets_tui::Throbber::default()
+                .label("Applying fixes...")
+                .throbber_style(Style::default().fg(theme.accent));
+            lines.push(throbber.to_line(&self.throbber_state));
         } else if state.fix_results.is_none() && !state.findings.is_empty() {
             lines.push(Line::styled(
                 "f apply fixes  q/esc go back",
@@ -631,6 +639,52 @@ mod tests {
         assert!(
             text.contains("w") && text.contains("New worktree"),
             "help overlay must include 'w' keybinding mapped to 'New worktree', got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn delete_dialog_uses_throbber_label() {
+        let mut app = App::new_test(vec![]);
+        // Advance throbber state so it renders a symbol.
+        app.throbber_state.calc_next();
+        let state = DeleteState {
+            target: crate::types::Worktree {
+                path: "/test/wt".to_string(),
+                branch: Some("feat/test".to_string()),
+                head: "abc1234".to_string(),
+                is_bare: false,
+                has_conflicts: false,
+                pr: None,
+                pr_loading: false,
+                tmux_session: None,
+                tmux_attached: false,
+                tmux_pane_title: None,
+                remote: None,
+                issue_number: None,
+                issue_state: None,
+            },
+            phase: Phase::InProgress,
+            error: None,
+        };
+        let backend = TestBackend::new(80, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                app.render_delete(&state, f);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer().clone();
+        let mut text = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                text.push(buffer[(x, y)].symbol().chars().next().unwrap_or(' '));
+            }
+        }
+
+        assert!(
+            text.contains("Deleting worktree..."),
+            "delete dialog InProgress must show labeled throbber, got:\n{text}"
         );
     }
 }

--- a/src/tui/list.rs
+++ b/src/tui/list.rs
@@ -5,6 +5,7 @@
 //! Key-to-message mapping lives in `mod.rs` (`handle_event`).
 use ratatui::prelude::*;
 use ratatui::widgets::*;
+use tui_scrollview::{ScrollView, ScrollbarVisibility};
 
 use std::collections::HashSet;
 use std::time::Instant;
@@ -15,7 +16,7 @@ use crate::remote;
 use crate::tmux;
 use crate::tui::state::{CleanupState, FilterMode, Phase, ViewState};
 use crate::tui::theme::{Theme, display_group_color};
-use crate::tui::{ATTRIBUTION_URL, App, SPINNER_FRAMES, WARNING_DURATION_SECS, filter_stale};
+use crate::tui::{ATTRIBUTION_URL, App, WARNING_DURATION_SECS, filter_stale};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -630,12 +631,11 @@ impl App {
 
         // Loading or empty state
         if self.loading {
-            let spinner = SPINNER_FRAMES[self.spinner_frame];
-            let loading_text = format!("{} Loading worktrees...", spinner);
-            let para = Paragraph::new(loading_text)
+            let throbber = throbber_widgets_tui::Throbber::default()
+                .label("Loading worktrees...")
                 .style(Style::default().fg(theme.accent))
-                .alignment(Alignment::Center);
-            f.render_widget(para, chunks[2]);
+                .throbber_style(Style::default().fg(theme.accent));
+            f.render_stateful_widget(throbber, chunks[2], &mut self.throbber_state.clone());
         } else {
             let empty =
                 Paragraph::new("No worktrees found. Run `orchard init` to configure a repo.")
@@ -673,9 +673,11 @@ impl App {
 
         // Build timestamp span.
         let timestamp_span = if self.refreshing {
-            let spinner = SPINNER_FRAMES[self.spinner_frame];
+            let throbber = throbber_widgets_tui::Throbber::default()
+                .throbber_style(Style::default().fg(theme.accent));
+            let symbol = throbber.to_symbol_span(&self.throbber_state);
             Span::styled(
-                format!("  {} refreshing...", spinner),
+                format!("  {}refreshing...", symbol.content),
                 Style::default().fg(theme.accent),
             )
         } else {
@@ -726,33 +728,75 @@ impl App {
         let logo_style = Style::default()
             .fg(theme.success)
             .add_modifier(Modifier::BOLD);
-        let mut header_text = vec![
-            Line::from("🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴"),
-            Line::from(Span::styled("┌─┐┬┌┬┐╔═╗╦═╗╔═╗╦ ╦╔═╗╦═╗╔╦╗", logo_style)),
-            Line::from(Span::styled("│ ┬│ │ ║ ║╠╦╝║  ╠═╣╠═╣╠╦╝ ║║", logo_style)),
-            Line::from(Span::styled("└─┘┴ ┴ ╚═╝╩╚═╚═╝╩ ╩╩ ╩╩╚══╩╝", logo_style)),
-            Line::from("🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴"),
-        ];
-        if !host_line_spans.is_empty() {
-            header_text.push(Line::from(host_line_spans).alignment(Alignment::Center));
-        }
-        if !self.host_reachable.is_empty() || self.refreshing {
-            header_text.push(Line::from(vec![timestamp_span]).alignment(Alignment::Center));
-        }
-        let header = Paragraph::new(header_text)
-            .alignment(Alignment::Center)
-            .style(
-                Style::default()
-                    .fg(theme.success)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(Style::default().fg(theme.success))
-                    .border_type(BorderType::Rounded),
+
+        let header_block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(theme.success))
+            .border_type(BorderType::Rounded);
+        let inner = header_block.inner(area);
+        f.render_widget(header_block, area);
+
+        // Check if the repo name fits in BigText (HalfHeight: 4 rows, 8 cols/char).
+        let bigtext_char_width = 8_u16;
+        let bigtext_height = 4_u16;
+        let repo_name_width = self.repo_name.len() as u16 * bigtext_char_width;
+        let use_bigtext = repo_name_width > 0 && repo_name_width <= inner.width;
+
+        if use_bigtext {
+            // Layout: BigText (4 rows) + tree line (1 row) + optional host + timestamp
+            let big_text = tui_big_text::BigText::builder()
+                .pixel_size(tui_big_text::PixelSize::HalfHeight)
+                .style(logo_style)
+                .lines(vec![Line::from(self.repo_name.clone())])
+                .centered()
+                .build();
+            let bigtext_area = Rect::new(
+                inner.x,
+                inner.y,
+                inner.width,
+                bigtext_height.min(inner.height),
             );
-        f.render_widget(header, area);
+            f.render_widget(big_text, bigtext_area);
+
+            // Render remaining lines below the BigText.
+            let remaining_y = inner.y + bigtext_height;
+            let remaining_height = inner.height.saturating_sub(bigtext_height);
+            if remaining_height > 0 {
+                let mut info_lines = vec![Line::from("🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴")];
+                if !host_line_spans.is_empty() {
+                    info_lines.push(Line::from(host_line_spans).alignment(Alignment::Center));
+                }
+                if !self.host_reachable.is_empty() || self.refreshing {
+                    info_lines.push(Line::from(vec![timestamp_span]).alignment(Alignment::Center));
+                }
+                let info_area = Rect::new(inner.x, remaining_y, inner.width, remaining_height);
+                let info = Paragraph::new(info_lines).alignment(Alignment::Center);
+                f.render_widget(info, info_area);
+            }
+        } else {
+            // Fallback: original ASCII art header.
+            let mut header_text = vec![
+                Line::from("🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴"),
+                Line::from(Span::styled("┌─┐┬┌┬┐╔═╗╦═╗╔═╗╦ ╦╔═╗╦═╗╔╦╗", logo_style)),
+                Line::from(Span::styled("│ ┬│ │ ║ ║╠╦╝║  ╠═╣╠═╣╠╦╝ ║║", logo_style)),
+                Line::from(Span::styled("└─┘┴ ┴ ╚═╝╩╚═╚═╝╩ ╩╩ ╩╩╚══╩╝", logo_style)),
+                Line::from("🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴🌲🌳🌴"),
+            ];
+            if !host_line_spans.is_empty() {
+                header_text.push(Line::from(host_line_spans).alignment(Alignment::Center));
+            }
+            if !self.host_reachable.is_empty() || self.refreshing {
+                header_text.push(Line::from(vec![timestamp_span]).alignment(Alignment::Center));
+            }
+            let header = Paragraph::new(header_text)
+                .alignment(Alignment::Center)
+                .style(
+                    Style::default()
+                        .fg(theme.success)
+                        .add_modifier(Modifier::BOLD),
+                );
+            f.render_widget(header, inner);
+        }
     }
 
     /// Joins or creates a tmux session. Returns `true` if the TUI should exit
@@ -941,7 +985,10 @@ impl App {
         let mut idx = 0;
         self.render_header(f, chunks[idx]);
         idx += 1;
-        idx += 1; // spacer
+
+        // Render filter tabs in the spacer row.
+        self.render_filter_tabs(f, chunks[idx]);
+        idx += 1;
 
         let theme = &self.theme;
 
@@ -991,6 +1038,27 @@ impl App {
             height: table_chunk.height.saturating_sub(TABLE_CHROME_HEIGHT),
         };
         self.table_area.set(body_rect);
+
+        // Render scrollbar only when total rows exceed visible area.
+        // The visible inner height = table area height - 3 (borders + header row).
+        let total_rows = standalone_count + tasks.len();
+        let visible_rows = table_chunk.height.saturating_sub(3) as usize;
+        if total_rows > visible_rows {
+            let mut scrollbar_state =
+                ratatui::widgets::ScrollbarState::new(total_rows).position(self.cursor);
+            let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(Some("\u{25b2}"))
+                .end_symbol(Some("\u{25bc}"));
+            // Render scrollbar in the table area (inside the border).
+            f.render_stateful_widget(
+                scrollbar,
+                table_chunk.inner(ratatui::layout::Margin {
+                    vertical: 1,
+                    horizontal: 0,
+                }),
+                &mut scrollbar_state,
+            );
+        }
         idx += 1;
 
         // Preview
@@ -1219,20 +1287,53 @@ impl App {
             .border_style(Style::default().fg(theme.border))
             .border_type(BorderType::Double);
 
-        // Truncate content lines to fit
-        let inner_height = area.height.saturating_sub(2) as usize;
-        let all_lines: Vec<&str> = self.pane_content.lines().collect();
-        let display_lines = if all_lines.len() > inner_height {
-            &all_lines[all_lines.len() - inner_height..]
-        } else {
-            &all_lines
-        };
-        let content = display_lines.join("\n");
+        let inner = block.inner(area);
+        f.render_widget(block, area);
 
-        let preview = Paragraph::new(content)
-            .style(Style::default().fg(theme.preview_content))
-            .block(block);
-        f.render_widget(preview, area);
+        // Build a ScrollView containing the full pane content.
+        let line_count = self.pane_content.lines().count() as u16;
+        let content_height = line_count.max(1);
+        let content_width = inner.width.saturating_sub(1); // leave room for scrollbar
+
+        let mut scroll_view = ScrollView::new(Size::new(content_width, content_height))
+            .vertical_scrollbar_visibility(ScrollbarVisibility::Automatic)
+            .horizontal_scrollbar_visibility(ScrollbarVisibility::Never);
+
+        let paragraph = Paragraph::new(self.pane_content.as_str())
+            .style(Style::default().fg(theme.preview_content));
+        scroll_view.render_widget(paragraph, Rect::new(0, 0, content_width, content_height));
+
+        let mut state = self.preview_scroll_state.get();
+        f.render_stateful_widget(scroll_view, inner, &mut state);
+        self.preview_scroll_state.set(state);
+    }
+
+    /// Renders the filter mode tabs bar.
+    ///
+    /// Shows "All | Sessions | Claude | PRs" with the active filter highlighted.
+    /// Placed between the header and the task table.
+    fn render_filter_tabs(&self, f: &mut Frame, area: Rect) {
+        let theme = &self.theme;
+        let titles: Vec<&str> = vec!["All", "Sessions", "Claude", "PRs"];
+        let selected = match self.filter_mode {
+            FilterMode::All => 0,
+            FilterMode::HasSession => 1,
+            FilterMode::HasClaude => 2,
+            FilterMode::HasPR => 3,
+        };
+        let tabs = Tabs::new(titles)
+            .select(selected)
+            .style(Style::default().fg(theme.dimmed))
+            .highlight_style(
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .divider(Span::styled(
+                " \u{2502} ",
+                Style::default().fg(theme.dimmed),
+            ));
+        f.render_widget(tabs, area);
     }
 
     /// Appends the common trailing hint keys: refresh, reconnect, quit, help.
@@ -1245,9 +1346,11 @@ impl App {
     ) {
         let theme = &self.theme;
         if self.refreshing {
-            let spinner = SPINNER_FRAMES[self.spinner_frame];
+            let throbber = throbber_widgets_tui::Throbber::default()
+                .throbber_style(Style::default().fg(theme.accent));
+            let symbol = throbber.to_symbol_span(&self.throbber_state);
             spans.push(Span::styled(
-                format!("{} refreshing...", spinner),
+                format!("{}refreshing...", symbol.content),
                 Style::default().fg(theme.accent),
             ));
         } else {
@@ -1465,11 +1568,14 @@ fn group_header_row(group: DisplayGroup, num_columns: usize, theme: &Theme) -> R
 /// Returns the height (in terminal rows) to allocate for the header.
 ///
 /// When the terminal is tall enough (>= 30 rows), the full header is
-/// shown in a bordered block (7 rows). On shorter terminals a single compact
+/// shown in a bordered block. On shorter terminals a single compact
 /// line is used instead so the task list gets as much vertical space as possible.
+///
+/// The full header reserves 10 rows to accommodate BigText rendering (4 rows)
+/// of the repo name alongside decorative lines and optional host/timestamp info.
 pub(crate) fn header_height(terminal_height: u16) -> u16 {
     if terminal_height >= FULL_HEADER_MIN_HEIGHT {
-        9
+        10
     } else {
         1
     }
@@ -1512,12 +1618,12 @@ mod tests {
 
     #[test]
     fn full_logo_at_threshold() {
-        assert_eq!(header_height(30), 9);
+        assert_eq!(header_height(30), 10);
     }
 
     #[test]
     fn full_logo_above_threshold() {
-        assert_eq!(header_height(50), 9);
+        assert_eq!(header_height(50), 10);
     }
 
     #[test]
@@ -2074,5 +2180,105 @@ mod tests {
         let visible = visible_tasks(&rows, &FilterMode::HasSession, "target");
         assert_eq!(visible.len(), 1);
         assert_eq!(visible[0].row.issue_number, Some(1));
+    }
+
+    // -----------------------------------------------------------------------
+    // filter tabs rendering
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_tabs_renders_all_modes() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let backend = TestBackend::new(80, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                app.render_filter_tabs(f, f.area());
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer().clone();
+        let mut text = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                text.push(buffer[(x, y)].symbol().chars().next().unwrap_or(' '));
+            }
+        }
+
+        assert!(text.contains("All"), "tabs must include 'All' label");
+        assert!(
+            text.contains("Sessions"),
+            "tabs must include 'Sessions' label"
+        );
+        assert!(text.contains("Claude"), "tabs must include 'Claude' label");
+        assert!(text.contains("PRs"), "tabs must include 'PRs' label");
+    }
+
+    #[test]
+    fn throbber_renders_loading_state() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut app = App::new_test(vec![]);
+        app.loading = true;
+        let backend = TestBackend::new(80, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                app.render_list(f);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer().clone();
+        let mut text = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                text.push(buffer[(x, y)].symbol().chars().next().unwrap_or(' '));
+            }
+        }
+
+        assert!(
+            text.contains("Loading worktrees..."),
+            "loading state must show throbber label, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn bigtext_threshold_uses_full_header_for_tall_terminal() {
+        // At 30+ rows, header_height returns the full header size (10 rows).
+        assert_eq!(header_height(FULL_HEADER_MIN_HEIGHT), 10);
+        assert_eq!(header_height(FULL_HEADER_MIN_HEIGHT + 10), 10);
+    }
+
+    #[test]
+    fn bigtext_threshold_uses_compact_header_for_short_terminal() {
+        // Below 30 rows, the compact 1-line header is used (no BigText).
+        assert_eq!(header_height(FULL_HEADER_MIN_HEIGHT - 1), 1);
+        assert_eq!(header_height(15), 1);
+    }
+
+    #[test]
+    fn bigtext_requires_repo_name_fits_in_width() {
+        // BigText with HalfHeight uses 8 columns per character.
+        // A repo name of 10 chars needs 80 columns.
+        let name = "short-repo";
+        let bigtext_char_width: u16 = 8;
+        let needed = name.len() as u16 * bigtext_char_width;
+        assert_eq!(needed, 80);
+        // Fits in 100-column terminal (inner = 98 after borders).
+        assert!(needed <= 98);
+        // Does NOT fit in 60-column terminal (inner = 58 after borders).
+        assert!(needed > 58);
+    }
+
+    #[test]
+    fn preview_scroll_state_is_copy() {
+        // ScrollViewState must be Copy so Cell<ScrollViewState> works.
+        let state = tui_scrollview::ScrollViewState::default();
+        let _copy = state; // Copy trait in action
+        let _another = state; // Still valid after copy
     }
 }

--- a/src/tui/message.rs
+++ b/src/tui/message.rs
@@ -99,6 +99,12 @@ pub enum Message {
     /// Open the attribution URL in the browser.
     OpenAttribution,
 
+    // -- Preview scroll actions --
+    /// Scroll the preview pane up by one page.
+    PreviewPageUp,
+    /// Scroll the preview pane down by one page.
+    PreviewPageDown,
+
     // -- Heal actions --
     /// Open the heal diagnosis view.
     Heal,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -41,11 +41,6 @@ use std::process::Command;
 // Constants
 // ---------------------------------------------------------------------------
 
-const SPINNER_FRAMES: &[&str] = &[
-    "\u{280b}", "\u{2819}", "\u{2839}", "\u{2838}", "\u{283c}", "\u{2834}", "\u{2826}", "\u{2827}",
-    "\u{2807}", "\u{280f}",
-];
-
 const AUTO_REFRESH_SECS: u64 = 60;
 const WARNING_DURATION_SECS: u64 = 3;
 const POLL_TIMEOUT_MS: u64 = 100;
@@ -111,7 +106,8 @@ pub struct App {
 
     // Auto-refresh
     last_refresh: Instant,
-    spinner_frame: usize,
+    /// Throbber animation state — advanced each frame via `calc_next()`.
+    throbber_state: throbber_widgets_tui::ThrobberState,
 
     // Previous snapshots used to detect state transitions between cache refreshes.
     previous_worktree_states: HashMap<String, WorktreeSnapshot>,
@@ -123,6 +119,12 @@ pub struct App {
     url_area: Cell<Rect>,
     /// Row index and timestamp of last mouse click, for double-click detection.
     last_click: Option<(usize, Instant)>,
+
+    /// Scroll state for the preview pane (tui-scrollview).
+    ///
+    /// Uses `Cell` for interior mutability so `render_task_preview` (which takes
+    /// `&self`) can update the state via `StatefulWidget::render`.
+    preview_scroll_state: std::cell::Cell<tui_scrollview::ScrollViewState>,
 }
 
 impl App {
@@ -171,12 +173,13 @@ impl App {
             tx,
             rx,
             last_refresh: Instant::now(),
-            spinner_frame: 0,
+            throbber_state: throbber_widgets_tui::ThrobberState::default(),
             switch_target: None,
             previous_worktree_states: HashMap::new(),
             table_area: Cell::new(Rect::default()),
             url_area: Cell::new(Rect::default()),
             last_click: None,
+            preview_scroll_state: std::cell::Cell::new(tui_scrollview::ScrollViewState::default()),
         }
     }
 
@@ -425,6 +428,11 @@ impl App {
                     };
                     if matches {
                         self.pane_content = content;
+                        // Reset scroll to bottom so most recent output is visible.
+                        // We set a max-offset; the ScrollView render will clamp it.
+                        let mut state = tui_scrollview::ScrollViewState::default();
+                        state.scroll_to_bottom();
+                        self.preview_scroll_state.set(state);
                     }
                 }
                 AppMsg::DeleteDone => {
@@ -563,6 +571,8 @@ impl App {
                     KeyCode::Char('r') => Some(Message::Refresh),
                     KeyCode::Char('R') => Some(Message::ReconnectHosts),
                     KeyCode::Char('?') => Some(Message::ToggleHelp),
+                    KeyCode::PageUp => Some(Message::PreviewPageUp),
+                    KeyCode::PageDown => Some(Message::PreviewPageDown),
                     KeyCode::Char('q') | KeyCode::Esc => Some(Message::Quit),
                     _ => None,
                 }
@@ -818,6 +828,18 @@ impl App {
             Message::CursorTo(idx) => {
                 self.cursor = idx;
                 self.fetch_task_pane_content();
+                ok()
+            }
+            Message::PreviewPageUp => {
+                let mut state = self.preview_scroll_state.get();
+                state.scroll_page_up();
+                self.preview_scroll_state.set(state);
+                ok()
+            }
+            Message::PreviewPageDown => {
+                let mut state = self.preview_scroll_state.get();
+                state.scroll_page_down();
+                self.preview_scroll_state.set(state);
                 ok()
             }
             Message::Enter => {
@@ -1196,6 +1218,7 @@ impl App {
     ///
     /// This is a read-only operation: it borrows `&self` and dispatches
     /// to the appropriate render method based on the current [`ViewState`].
+    /// The preview scroll state uses `Cell` for interior mutability.
     fn render(&self, f: &mut Frame) {
         match &self.view {
             ViewState::List => self.render_list(f),
@@ -1463,12 +1486,13 @@ impl App {
             tx,
             rx,
             last_refresh: Instant::now(),
-            spinner_frame: 0,
+            throbber_state: throbber_widgets_tui::ThrobberState::default(),
             switch_target: None,
             previous_worktree_states: HashMap::new(),
             table_area: Cell::new(Rect::default()),
             url_area: Cell::new(Rect::default()),
             last_click: None,
+            preview_scroll_state: std::cell::Cell::new(tui_scrollview::ScrollViewState::default()),
         }
     }
 }
@@ -1530,8 +1554,8 @@ fn run_loop(
     app: &mut App,
 ) -> anyhow::Result<Option<String>> {
     loop {
-        // Advance spinner before drawing so animation progresses each frame.
-        app.spinner_frame = (app.spinner_frame + 1) % SPINNER_FRAMES.len();
+        // Advance throbber animation before drawing so spinner progresses each frame.
+        app.throbber_state.calc_next();
 
         terminal.draw(|f| app.render(f))?;
 
@@ -3386,5 +3410,96 @@ mod tests {
         let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Right), 10, 6);
         assert_eq!(app.handle_mouse_event(event), None);
+    }
+
+    // Rich content widget tests (ScrollView preview, BigText header)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn handle_event_page_up_returns_preview_scroll() {
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let key = KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE);
+        let msg = app.handle_event(key);
+        assert_eq!(msg, Some(Message::PreviewPageUp));
+    }
+
+    #[test]
+    fn handle_event_page_down_returns_preview_scroll() {
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let key = KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE);
+        let msg = app.handle_event(key);
+        assert_eq!(msg, Some(Message::PreviewPageDown));
+    }
+
+    #[test]
+    fn preview_page_down_advances_scroll_state() {
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let initial = app.preview_scroll_state.get();
+        app.update(Message::PreviewPageDown);
+        let after = app.preview_scroll_state.get();
+        // After scrolling down, the y offset should have advanced.
+        assert!(
+            after.offset().y >= initial.offset().y,
+            "scroll_page_down should advance y offset"
+        );
+    }
+
+    #[test]
+    fn preview_page_up_decrements_scroll_state() {
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        // First scroll down, then back up.
+        app.update(Message::PreviewPageDown);
+        app.update(Message::PreviewPageDown);
+        let before = app.preview_scroll_state.get();
+        app.update(Message::PreviewPageUp);
+        let after = app.preview_scroll_state.get();
+        assert!(
+            after.offset().y <= before.offset().y,
+            "scroll_page_up should decrease y offset"
+        );
+    }
+
+    #[test]
+    fn bigtext_renders_repo_name_in_tall_terminal() {
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        app.repo_name = "orchard".to_string();
+        // Use a tall terminal (40 rows) with enough width for BigText.
+        // "orchard" = 7 chars * 8 cols = 56 cols needed.
+        let output = render_to_string(&mut app, 120, 40);
+        // The BigText rendering uses block characters (half-height pixels).
+        // Verify the repo name does NOT appear as plain text "orchard" in the header
+        // (it should be rendered as pixel blocks instead).
+        // The ASCII art "GIT ORCHARD" should NOT be present since BigText takes over.
+        assert!(
+            !output.contains("╔═╗╦═╗╔═╗"),
+            "ASCII art logo should not appear when BigText is used"
+        );
+    }
+
+    #[test]
+    fn ascii_art_renders_when_repo_name_too_wide() {
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        // A very long repo name that won't fit in BigText.
+        app.repo_name = "a-very-long-repository-name-that-exceeds-width".to_string();
+        // Use a narrow terminal: 46 chars * 8 = 368 cols needed > 80 available.
+        let output = render_to_string(&mut app, 80, 40);
+        // Should fall back to ASCII art header.
+        assert!(
+            output.contains("╔═╗╦═╗╔═╗"),
+            "ASCII art logo should appear when repo name is too wide for BigText"
+        );
+    }
+
+    #[test]
+    fn compact_header_on_short_terminal() {
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        app.repo_name = "orchard".to_string();
+        // Short terminal: 20 rows, well below FULL_HEADER_MIN_HEIGHT.
+        let output = render_to_string(&mut app, 120, 20);
+        // Compact header shows "Git Orchard" as plain text.
+        assert!(
+            output.contains("Git Orchard"),
+            "compact header should show 'Git Orchard' text"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #56 (Phase 1 + partial Phase 3; animations descoped to #53)

- **Replace DIY spinner** with throbber-widgets-tui -- proper spinner widget with labeled throbbers in dialogs
- **Add scrollbar** to worktree table (ratatui built-in) -- appears only when rows overflow visible area
- **Add filter mode tabs** -- visible tab bar showing All / Sessions / Claude / PRs, replacing invisible cycling
- **Scrollable preview pane** with tui-scrollview -- PageUp/PageDown to scroll tmux capture output
- **BigText header** with tui-big-text -- repo name in large text when terminal height >= 30 rows
- **Upgrade ratatui** from 0.29 to 0.30 for ecosystem crate compatibility

### Descoped from original issue

Per devil's-advocate review, the following were moved out of scope:
- **tachyonfx animations** (fade-in, slide transitions, highlight-on-change) -> requires architecture changes, belongs in #53
- **Sparkline commit activity** -> new data pipeline (git log per worktree), not visual polish
- **tui-term evaluation** -> research task, not feature work
- **LineGauge progress** -> no operations report progress; labeled throbber used instead

## Test plan

- [x] cargo test -- all tests pass (existing + new)
- [x] cargo build --release -- clean build
- [ ] Manual: verify spinner animates in refresh, delete, transfer, cleanup, heal dialogs
- [ ] Manual: verify scrollbar appears when worktree list overflows
- [ ] Manual: verify filter tabs render and f key cycles through them
- [ ] Manual: verify PageUp/PageDown scrolls preview pane
- [ ] Manual: verify BigText header on terminals >= 30 rows

# Related issue

- #56

# Related issue

- #56