### PR TITLE
docs: update README, architecture, and add ADR-006/007

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Orchard gives you a single dashboard showing everything happening across your re
 - **Remote worktrees** — manage worktrees on remote machines via SSH, with reachability indicators
 - **JSON output** — `orchard --json` returns complete, fresh data for scripting
 - **Auto-refresh** — background refresh with two-phase loading (fast locals, then slow remotes)
+- **Mouse support** — click to select worktrees, scroll to navigate
+- **Transfer** — push/pull worktrees between local and remote machines
+- **Self-healing** — `orchard heal` audits and repairs drifted state
+- **Theme system** — centralized semantic color definitions for consistent styling
 
 ## Install
 
@@ -52,6 +56,9 @@ This will:
 ```
 orchard                    Interactive dashboard
 orchard cleanup            Jump straight to cleanup view
+orchard heal               Audit state for drift (dry-run by default)
+orchard heal --fix         Apply repairs
+orchard setup-remote HOST  Provision a remote host for SSH worktrees
 orchard init               Setup wizard
 orchard --json             Full state as JSON (always fresh, never cached)
 ```
@@ -68,12 +75,16 @@ orchard --json             Full state as JSON (always fresh, never cached)
 | `i` | Open issue in browser |
 | `p` | Toggle priority flag |
 | `d` | Delete worktree |
+| `n` | New worktree |
+| `t` | Transfer worktree (push/pull to remote) |
 | `c` | Cleanup stale worktrees |
 | `f` | Cycle filter mode |
 | `/` | Search |
 | `r` | Refresh |
 | `R` | Reconnect (SSH) |
 | `?` | Help |
+| Mouse click | Select worktree |
+| Mouse scroll | Navigate list |
 | `q` | Quit |
 
 ## Configuration
@@ -96,6 +107,14 @@ orchard --json             Full state as JSON (always fresh, never cached)
           "shell": "ssh"
         }
       ]
+    }
+  ],
+  "tmux_sessions": [
+    {
+      "name": "shepherd",
+      "command": "claude --continue",
+      "cwd": "/path/to/repo",
+      "start_on_launch": true
     }
   ]
 }

--- a/docs/adr/006-tea-pattern.md
+++ b/docs/adr/006-tea-pattern.md
@@ -1,0 +1,69 @@
+# ADR-006: TEA pattern for TUI event handling
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-29
+
+## Context
+
+The TUI previously mixed input handling, state mutation, and rendering in a single event loop. Key handlers directly mutated `App` state and triggered side effects inline, making event flow hard to trace.
+
+Adding mouse support and new dialogs (cleanup, transfer, heal, new worktree) increased the complexity of event routing. Every new interaction required careful ordering of guard clauses and mutations spread across the event loop body.
+
+Testing was difficult because it required simulating full terminal events rather than testing state transitions in isolation. There was no clear boundary between "what the user did" and "what the app does about it."
+
+## Decision
+
+Adopt The Elm Architecture (TEA) — a unidirectional data flow through three distinct phases:
+
+### 1. `handle_event(&self, event) -> Option<Message>`
+
+A pure function mapping raw terminal events (key presses, mouse clicks, resize) to a `Message` enum. No state mutation. Returns `None` for unhandled events.
+
+### 2. `update(&mut self, msg: Message) -> UpdateResult`
+
+The only place state mutation occurs. Takes a `Message`, updates `App` state, and returns an `UpdateResult` indicating whether to continue, quit, or perform a side effect (switch session, open browser, delete worktree).
+
+### 3. `render(&self, frame: &mut Frame)`
+
+A stateless view function. Reads `App` state and draws the UI. No mutation, no side effects.
+
+---
+
+The `Message` enum in `tui/message.rs` defines every user intent:
+
+```
+Quit, CursorUp, CursorDown, CursorTo(usize), Enter, OpenPr, OpenIssue,
+TogglePriority, Delete, NewWorktree, Transfer, CycleFilter, Search,
+Refresh, Reconnect, Help, ...
+```
+
+Mouse events map to the same `Message` variants as their keyboard equivalents — a click maps to `CursorTo` plus a context-dependent action; scroll maps to `CursorUp`/`CursorDown`. This eliminates duplicated state mutation logic between input devices.
+
+`UpdateResult` signals the event loop what to do next: continue polling, quit, or perform an I/O side effect. The event loop itself is a thin driver that calls these three functions in sequence.
+
+## Consequences
+
+**Positive:**
+
+- Input handling is testable without a terminal — construct a `Message`, call `update`, assert state.
+- Mouse and keyboard events share the same state mutation logic, eliminating duplication.
+- New actions require adding a `Message` variant and an `update` match arm — a clear, consistent extension point.
+- Rendering is a pure function of state, making screenshot tests reliable.
+
+**Negative:**
+
+- Indirection — tracing a keypress to its effect requires following the message through `handle_event` → `update`.
+- The `Message` enum grows with every new action and could become large over time.
+
+## Alternatives considered
+
+**Direct mutation in key handlers (prior approach)** — rejected because it mixed concerns and was untestable in isolation.
+
+**Trait-based command pattern** — rejected as over-engineered for a single TUI. The `Message` enum is simpler and sufficient.
+
+**Redux-style with middleware** — rejected as unnecessary complexity for a single-threaded TUI.

--- a/docs/adr/007-session-data-model.md
+++ b/docs/adr/007-session-data-model.md
@@ -1,0 +1,80 @@
+# ADR-007: Session data model
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-29
+
+## Context
+
+Orchard needs to represent tmux sessions enriched with Claude Code state information. Sessions can be local or on remote hosts via SSH.
+
+The previous approach embedded session data directly in worktree types. This worked for the common case — a session attached to a worktree — but made standalone sessions impossible to represent. A "shepherd" session that orchestrates work across repos has no worktree to attach to, and neither do monitoring or utility sessions.
+
+Additional complication: Claude enrichment data (status, cost, context window usage, model) comes from hook state files written to `/tmp/`, not from tmux itself. The enrichment layer must be kept separate from the transport layer to avoid coupling tmux discovery to Claude-specific logic.
+
+## Decision
+
+Define a layered session type system in `src/session.rs`.
+
+### Type hierarchy
+
+**`TmuxSessionInfo`** — pure tmux data only:
+- `host: Host` (enum: `Local` | `Remote(String)`)
+- `name: String`
+- `status: SessionStatus` (enum: `Running { attached: bool }` | `Dead`)
+
+**`ClaudeSessionInfo`** — Claude Code enrichment data:
+- `status: ClaudeState` (working, idle, waiting for input, etc.)
+- `cost_usd: Option<f64>`
+- `context_window_pct: Option<f64>`
+- `model: Option<String>`
+
+**`EnrichedSession`** — composition of tmux + optional Claude data:
+- `tmux: TmuxSessionInfo`
+- `claude: Option<ClaudeSessionInfo>`
+
+**`StandaloneConfig`** — configuration for non-worktree sessions, defined in global config under the `tmux_sessions` array:
+- `name: String`
+- `command: String`
+- `cwd: String`
+- `start_on_launch: bool`
+
+**`StandaloneSessionRow`** — a standalone session matched to its config:
+- `session: EnrichedSession`
+- `config: StandaloneConfig`
+
+**`ListEntry`** — the TUI list's display unit:
+- `Worktree(WorktreeRow)` — a worktree with its enriched sessions
+- `Standalone(StandaloneSessionRow)` — a standalone session
+
+### Join behavior
+
+The composition pattern (`EnrichedSession` = `TmuxSessionInfo` + `Option<ClaudeSessionInfo>`) keeps the tmux discovery layer ignorant of Claude. Claude enrichment is joined at `build_state` time by matching tmux session names to hook state files in `/tmp/orchard-claude-{session}.json`.
+
+`OrchardState.standalone_sessions: Vec<StandaloneSessionRow>` holds sessions that don't belong to any worktree. These are displayed in their own section of the TUI, below the worktree list.
+
+`ListEntry` gives the TUI a single type to iterate over for rendering, handling both worktrees and standalone sessions uniformly without conditional dispatch at the call site.
+
+## Consequences
+
+**Positive:**
+- Clean separation between tmux transport layer and Claude enrichment — neither knows about the other until join time.
+- Standalone sessions (shepherd, monitoring, utilities) are first-class citizens, not afterthoughts.
+- `ListEntry` enum gives the TUI a uniform iteration type for both worktrees and standalone sessions.
+- Adding new enrichment sources (e.g. a different AI assistant) means adding an optional field on `EnrichedSession`, not restructuring the hierarchy.
+
+**Negative:**
+- More types to navigate — session representation spans `session.rs`, `orchard_state.rs` (`SessionState`, `ClaudeEnrichment`), and `sources/tmux.rs`.
+- Two parallel session type hierarchies exist: `session.rs` types for discovery and display, and `orchard_state.rs` types for the unified state model. This is an acknowledged seam, not an oversight.
+
+## Alternatives considered
+
+**Single flat `Session` struct with all fields** — rejected because most fields are optional depending on context, producing a wide struct with many `None` values and a confusing API surface.
+
+**Trait-based polymorphism (`trait Session` with `WorktreeSession` and `StandaloneSession` impls)** — rejected per ADR-002's guidance to avoid traits for non-polymorphic cases. The variant behavior here is display, not behavior — an enum handles it cleanly.
+
+**Embedding Claude data directly in `TmuxSessionInfo`** — rejected because it couples the tmux discovery layer to Claude-specific concerns, making the tmux module harder to test and reason about in isolation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,53 +76,97 @@ ssh probe         ──→  (in-memory only)                     ┘         �
 
 Both modes produce an `OrchardState` — the single unified data model.
 
+### TUI Event Architecture (TEA Pattern)
+
+The TUI follows The Elm Architecture (TEA) — a unidirectional data flow:
+
+1. **`handle_event(key/mouse) → Option<Message>`** — pure mapping from input to intent
+2. **`update(msg) → UpdateResult`** — all state mutation happens here
+3. **`render(frame)`** — stateless view function, reads App state
+
+The `Message` enum in `tui/message.rs` defines every possible user intent (navigation,
+actions, dialog interactions). This separates input handling from state mutation,
+making the event loop testable and predictable. Mouse events (click, scroll) are
+mapped to the same `Message` variants as their keyboard equivalents.
+
 ## Module Structure
 
 ```
 src/
-├── main.rs              # Entry point: CLI args, mode dispatch
-├── state.rs             # OrchardState and all sub-types (data models)
-├── build_state.rs       # Pure compositor: joins source data → OrchardState
+├── main.rs                # Entry point: CLI args, mode dispatch
+├── lib.rs                 # Crate root: module declarations
 │
-├── sources/             # Shell layer: fetching + caching (one file per source)
-│   ├── mod.rs           # Re-exports, shared helpers
-│   ├── github.rs        # Issues, PRs, check runs via gh CLI / GraphQL
-│   ├── worktrees.rs     # Local git worktree list
-│   ├── remote.rs        # Remote worktrees via SSH
-│   ├── tmux.rs          # Tmux session listing (local + remote)
-│   ├── claude.rs        # Claude Code hook state files
-│   └── hosts.rs         # SSH reachability probes
+├── orchard_state.rs       # OrchardState and sub-types (unified data model)
+├── build_state.rs         # Pure compositor: joins source data → OrchardState
+├── state.rs               # Persistent task state (AppState, Task)
+├── session.rs             # Session domain types: TmuxSessionInfo, ClaudeSessionInfo,
+│                          #   EnrichedSession, StandaloneConfig, ListEntry
+├── session_discovery.rs   # Tmux session discovery and task reconciliation
+├── derive.rs              # Display group derivation logic
+├── types.rs               # Shared type definitions (OrchardConfig, RemoteConfig)
 │
-├── tui/                 # TUI rendering and interaction
-│   ├── mod.rs           # App struct, event loop, refresh orchestration
-│   ├── list.rs          # Task list view rendering
-│   ├── dialogs.rs       # Cleanup, new session, transfer dialogs
-│   ├── state.rs         # View state enums
-│   └── widgets.rs       # Reusable badge/status widgets
+├── config.rs              # Per-repo config loader (.orchard.json + .git/orchard.json)
+├── global_config.rs       # Global config (~/.config/orchard/config.json)
+├── cache.rs               # Generic cache read/write helpers
+├── cache_sources.rs       # Orchestrates multi-source cache refresh
 │
-├── json.rs              # JsonOutput mapping from OrchardState (versioned)
+├── json_output.rs         # JsonOutput mapping from OrchardState (versioned)
+├── heal.rs                # Self-repair: diagnose() → HealReport → apply_fixes()
+├── setup_remote.rs        # Remote host provisioning (orchard setup-remote)
+├── transfer.rs            # Worktree transfer between local and remote machines
 │
-├── config/              # Configuration loading
-│   ├── global.rs        # ~/.config/orchard/config.json + CWD auto-discovery
-│   └── repo.rs          # .orchard.json + .git/orchard.json (two-layer merge)
+├── navigation.rs          # Cursor and selection navigation logic
+├── priority.rs            # Priority flag persistence
+├── events.rs              # Structured event logging (events.jsonl)
+├── status.rs              # Tmux status bar segment writer
+├── shell.rs               # Shell integration (rc files, tmux keybindings)
+├── browser.rs             # Open URLs in browser
 │
-└── util/                # Shared utilities
-    ├── paths.rs         # Path manipulation (tildify, truncate_left)
-    ├── logger.rs        # File-based logging
-    └── notify.rs        # Desktop notifications
+├── claude_state.rs        # Claude Code hook state file parsing
+├── git.rs                 # Git operations (worktree create/delete, branch ops)
+├── github.rs              # GitHub API helpers (issue/PR queries)
+├── remote.rs              # Remote operations over SSH
+├── tmux.rs                # Tmux session management (create, switch, kill)
+│
+├── logger.rs              # File-based logging
+├── notify.rs              # Desktop notifications
+├── paths.rs               # Path manipulation (tildify, truncate_left)
+│
+├── sources/               # Shell layer: fetching + caching (one file per source)
+│   ├── mod.rs             # Re-exports, shared helpers
+│   ├── github.rs          # Issues, PRs, check runs via gh CLI / GraphQL
+│   ├── worktrees.rs       # Local git worktree list
+│   ├── tmux.rs            # Tmux session listing (local + remote)
+│   ├── claude.rs          # Claude Code hook state files
+│   └── hosts.rs           # SSH reachability probes
+│
+└── tui/                   # TUI rendering and interaction (TEA pattern)
+    ├── mod.rs             # App struct, event loop, refresh orchestration
+    ├── list.rs            # Task list view rendering
+    ├── dialogs.rs         # Cleanup, new worktree, transfer, heal dialogs
+    ├── message.rs         # Message enum (TEA: event → message → update)
+    ├── state.rs           # View state enums (ViewState, FilterMode, Phase)
+    ├── theme.rs           # Centralized semantic color theme
+    └── widgets.rs         # Reusable badge/status widgets
 ```
 
 ### What goes where
 
 | I need to... | Look in... |
 |---|---|
-| Understand the full data model | `state.rs` |
+| Understand the full data model | `orchard_state.rs` |
 | See how data sources are joined | `build_state.rs` |
+| Understand session types | `session.rs` (TmuxSessionInfo, EnrichedSession, ListEntry) |
 | Fix a GitHub API issue | `sources/github.rs` |
 | Change how worktrees are detected | `sources/worktrees.rs` |
 | Modify the TUI layout | `tui/list.rs` |
-| Change JSON output format | `json.rs` |
-| Add per-repo config options | `config/repo.rs` |
+| Understand TUI event flow | `tui/message.rs` (TEA pattern) |
+| Change colors/styling | `tui/theme.rs` |
+| Change JSON output format | `json_output.rs` |
+| Add per-repo config options | `config.rs` |
+| Add global config options | `global_config.rs` |
+| Fix self-healing/repair | `heal.rs` |
+| Fix worktree transfer | `transfer.rs` |
 
 ## Data Model
 
@@ -133,14 +177,14 @@ knows, fully joined and enriched.
 OrchardState
 ├── repos: Vec<RepoState>
 │   ├── slug: "owner/repo"
-│   ├── config: RepoLocalConfig (CI filters, etc.)
 │   └── worktrees: Vec<WorktreeState>
-│       ├── path, branch, is_bare, host
+│       ├── path, branch, is_bare, host, is_main_worktree
 │       ├── issue: Option<IssueInfo>      # number, title, state
-│       ├── pr: Option<PrInfo>            # number, state, checks, review
-│       ├── sessions: Vec<SessionInfo>    # tmux name, claude state, cost
+│       ├── pr: Option<PrState>           # number, state, checks, review, conflicts
+│       ├── sessions: Vec<SessionState>   # name, host, claude enrichment
 │       └── display_group: DisplayGroup   # derived from joined data
-└── hosts: HashMap<String, HostInfo>      # reachability per remote host
+├── standalone_sessions: Vec<StandaloneSessionRow>  # non-worktree sessions (e.g. shepherd)
+└── hosts: HashMap<String, HostState>     # reachability per remote host
 ```
 
 Display-only fields (like `display_group`) are computed by `build_state`, not
@@ -187,3 +231,5 @@ caching layer.
 - **ADR-002**: No OOP service layers (superseded by ADR-004 for scope)
 - **ADR-003**: Per-repo config — `.orchard.json` + `.git/orchard.json`
 - **ADR-004**: Unified data model with functional core, imperative shell
+- **ADR-006**: TEA pattern for TUI event handling
+- **ADR-007**: Session data model (TmuxSessionInfo → EnrichedSession composition)


### PR DESCRIPTION
## Summary

- **README**: added `heal`, `setup-remote`, `transfer` commands; `n`/`t`/mouse keybindings; `tmux_sessions` config example; new feature bullets (mouse support, transfer, self-healing, theme system)
- **Architecture**: fixed module structure to match flat `src/` layout (removed non-existent `config/`, `util/` subdirs), updated data model with `standalone_sessions`, documented TEA pattern, expanded "what goes where" table
- **ADR-006**: TEA pattern for TUI event handling (`handle_event → Message → update → render`)
- **ADR-007**: Session data model (`TmuxSessionInfo` + `ClaudeSessionInfo` → `EnrichedSession`, `StandaloneConfig`, `ListEntry`)

Closes #79

## Test plan

- [x] `cargo build --release` passes
- [x] `cargo test` passes
- [ ] Verify README commands match `orchard --help` output
- [ ] Verify module structure in architecture.md matches `find src -name '*.rs'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #79