### PR TITLE
feat: render standalone shepherd sessions in TUI

### DIFF
--- a/src/tui/list.rs
+++ b/src/tui/list.rs
@@ -66,6 +66,32 @@ pub(crate) fn cursor_is_standalone(cursor: usize, standalone_count: usize) -> bo
     cursor < standalone_count
 }
 
+/// Returns whether the preview pane should be shown for the current cursor position.
+///
+/// For worktree rows: preview is shown when there is pane content and the row has sessions.
+/// For standalone rows: preview is shown when the session is Running and there is pane content.
+pub(crate) fn preview_visible(
+    cursor: usize,
+    standalone_sessions: &[crate::session::StandaloneSessionRow],
+    selected_task: Option<&VisibleTask>,
+    pane_content_empty: bool,
+) -> bool {
+    let standalone_count = standalone_sessions.len();
+    if cursor_is_standalone(cursor, standalone_count) {
+        standalone_sessions
+            .get(cursor)
+            .is_some_and(|ss| {
+                matches!(
+                    ss.session.tmux.status,
+                    crate::session::SessionStatus::Running { .. }
+                )
+            })
+            && !pane_content_empty
+    } else {
+        selected_task.is_some_and(|vt| !pane_content_empty && !vt.row.sessions.is_empty())
+    }
+}
+
 impl DisplayGroup {
     fn label(self) -> &'static str {
         match self {
@@ -894,11 +920,15 @@ impl App {
         let body_height: u16 = row_heights.iter().sum::<u16>();
         let table_height = body_height.saturating_add(3); // +2 borders +1 header row
 
-        // Check if selected task has a preview (only worktree rows have previews)
+        // Check if selected task has a preview (worktree rows and running standalone sessions).
         let worktree_cursor = self.cursor.checked_sub(standalone_count);
         let selected_task = worktree_cursor.and_then(|wc| tasks.get(wc));
-        let has_preview = selected_task
-            .is_some_and(|vt| !self.pane_content.is_empty() && !vt.row.sessions.is_empty());
+        let has_preview = preview_visible(
+            self.cursor,
+            &self.standalone_sessions,
+            selected_task,
+            self.pane_content.is_empty(),
+        );
 
         let mut constraints = vec![
             Constraint::Length(hdr_height),
@@ -1005,7 +1035,10 @@ impl App {
         // Preview
         if has_preview {
             idx += 1; // spacer
-            self.render_task_preview(f, chunks[idx], selected_task);
+            let standalone_at_cursor = cursor_is_standalone(self.cursor, standalone_count)
+                .then(|| self.standalone_sessions.get(self.cursor))
+                .flatten();
+            self.render_task_preview(f, chunks[idx], selected_task, standalone_at_cursor);
             idx += 1;
         }
 
@@ -1052,9 +1085,10 @@ impl App {
             url_span,
         ];
 
-        // Compute URL click area.
-        let prefix_width = "made with \u{2764} \u{2014} ".len();
-        let url_len = ATTRIBUTION_URL.len();
+        // Compute URL click area using display widths (not byte lengths)
+        // so that multi-byte characters like ❤ and — are measured correctly.
+        let prefix_width: usize = spans.iter().take(3).map(|s| s.width()).sum();
+        let url_len = spans.last().map_or(0, |s| s.width());
         let total_width = prefix_width + url_len;
         let left_pad = if (area.width as usize) > total_width {
             ((area.width as usize) - total_width) / 2
@@ -1233,35 +1267,48 @@ impl App {
     }
 
     /// Renders the preview pane with task metadata in the border title.
-    fn render_task_preview(&self, f: &mut Frame, area: Rect, selected_task: Option<&VisibleTask>) {
+    ///
+    /// Either `selected_task` (worktree row) or `standalone_session` must be `Some`.
+    /// When `standalone_session` is provided, the session name is used as the title.
+    fn render_task_preview(
+        &self,
+        f: &mut Frame,
+        area: Rect,
+        selected_task: Option<&VisibleTask>,
+        standalone_session: Option<&crate::session::StandaloneSessionRow>,
+    ) {
         if self.pane_content.is_empty() {
             return;
         }
-        let Some(vt) = selected_task else { return };
 
-        let issue_part = match vt.row.issue_number {
-            Some(num) => format!("#{}", num),
-            None => branch_tail(&vt.row.branch).to_string(),
+        let title = if let Some(ss) = standalone_session {
+            format!("\u{2500}\u{2500} {} \u{2500}\u{2500}", ss.session.tmux.name)
+        } else if let Some(vt) = selected_task {
+            let issue_part = match vt.row.issue_number {
+                Some(num) => format!("#{}", num),
+                None => branch_tail(&vt.row.branch).to_string(),
+            };
+            let title_part = match vt.row.issue_title.as_deref() {
+                Some(t) if !t.is_empty() => format!(" {}", t),
+                _ => String::new(),
+            };
+            let wt_part = {
+                let short = paths::tildify(&vt.row.worktree_path);
+                format!(" \u{2502} wt: {}", short)
+            };
+            let pr_part = vt
+                .row
+                .pr
+                .as_ref()
+                .map(|p| format!(" \u{2502} pr: #{}", p.number))
+                .unwrap_or_default();
+            format!(
+                "\u{2500}\u{2500} {}{}{}{} \u{2500}\u{2500}",
+                issue_part, title_part, wt_part, pr_part
+            )
+        } else {
+            return;
         };
-        let title_part = match vt.row.issue_title.as_deref() {
-            Some(t) if !t.is_empty() => format!(" {}", t),
-            _ => String::new(),
-        };
-        let wt_part = {
-            let short = paths::tildify(&vt.row.worktree_path);
-            format!(" \u{2502} wt: {}", short)
-        };
-        let pr_part = vt
-            .row
-            .pr
-            .as_ref()
-            .map(|p| format!(" \u{2502} pr: #{}", p.number))
-            .unwrap_or_default();
-
-        let title = format!(
-            "\u{2500}\u{2500} {}{}{}{} \u{2500}\u{2500}",
-            issue_part, title_part, wt_part, pr_part
-        );
 
         let theme = &self.theme;
         let block = Block::default()
@@ -2067,5 +2114,64 @@ mod tests {
         let state = tui_scrollview::ScrollViewState::default();
         let _copy = state; // Copy trait in action
         let _another = state; // Still valid after copy
+    }
+
+    // -----------------------------------------------------------------------
+    // preview_visible — standalone session preview logic
+    // -----------------------------------------------------------------------
+
+    fn make_standalone(name: &str, status: SessionStatus) -> crate::session::StandaloneSessionRow {
+        crate::session::StandaloneSessionRow {
+            session: EnrichedSession {
+                tmux: TmuxSessionInfo {
+                    host: Host::Local,
+                    name: name.to_string(),
+                    status,
+                },
+                claude: None,
+            },
+            config: crate::session::StandaloneConfig {
+                name: name.to_string(),
+                command: "bash".to_string(),
+                cwd: "/workspace".to_string(),
+                start_on_launch: false,
+            },
+        }
+    }
+
+    #[test]
+    fn preview_visible_true_for_running_standalone_with_content() {
+        let sessions = vec![make_standalone("shepherd", SessionStatus::Running { attached: false })];
+        assert!(preview_visible(0, &sessions, None, false));
+    }
+
+    #[test]
+    fn preview_visible_false_for_standalone_when_pane_content_empty() {
+        let sessions = vec![make_standalone("shepherd", SessionStatus::Running { attached: false })];
+        assert!(!preview_visible(0, &sessions, None, true));
+    }
+
+    #[test]
+    fn preview_visible_false_for_dead_standalone_with_content() {
+        // Dead sessions never show preview even when pane_content is present.
+        let sessions = vec![make_standalone("shepherd", SessionStatus::Dead)];
+        assert!(!preview_visible(0, &sessions, None, false));
+    }
+
+    #[test]
+    fn preview_visible_false_for_dead_standalone_without_content() {
+        let sessions = vec![make_standalone("shepherd", SessionStatus::Dead)];
+        assert!(!preview_visible(0, &sessions, None, true));
+    }
+
+    #[test]
+    fn preview_visible_false_when_cursor_between_standalone_and_worktree() {
+        // Cursor 5 is past standalone (len 3) but selected_task is None.
+        let sessions = vec![
+            make_standalone("a", SessionStatus::Running { attached: false }),
+            make_standalone("b", SessionStatus::Running { attached: false }),
+            make_standalone("c", SessionStatus::Running { attached: false }),
+        ];
+        assert!(!preview_visible(5, &sessions, None, true));
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -275,6 +275,13 @@ impl App {
                     self.task_rows = derive_from_all_caches(&self.global_config);
                     let state = crate::build_state::build_state(&self.global_config);
                     self.standalone_sessions = state.standalone_sessions;
+                    // Warn on refresh (not fatal) — a new worktree may have
+                    // introduced a collision after boot. Don't crash the TUI.
+                    if let Err(e) =
+                        check_standalone_collisions(&self.standalone_sessions, &self.task_rows)
+                    {
+                        crate::logger::LOG.warn(&format!("{e}"));
+                    }
                     self.loading = false;
                     self.refreshing = false;
                     self.error = None;
@@ -1513,6 +1520,9 @@ pub fn run(command: &str) -> anyhow::Result<Option<String>> {
 
     let mut app = App::new(command);
 
+    // Guard: standalone session names must not collide with worktree-derived names.
+    check_standalone_collisions(&app.standalone_sessions, &app.task_rows)?;
+
     // Start standalone sessions with start_on_launch = true.
     ensure_standalone_sessions(&app.global_config)?;
 
@@ -1792,6 +1802,42 @@ fn ensure_standalone_sessions(config: &global_config::GlobalConfig) -> anyhow::R
                 e
             )
         })?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Collision detection
+// ---------------------------------------------------------------------------
+
+/// Checks that no standalone session name collides with a worktree-derived session name.
+///
+/// Returns `Err` with a descriptive message if a collision is found. The error
+/// identifies the standalone config name and the worktree branch that owns the
+/// conflicting session, so the user knows exactly what to fix.
+fn check_standalone_collisions(
+    standalone: &[StandaloneSessionRow],
+    task_rows: &[derive::WorktreeRow],
+) -> anyhow::Result<()> {
+    use std::collections::HashMap;
+
+    // Build a map from session name → owning worktree branch for fast lookup.
+    let mut wt_sessions: HashMap<&str, &str> = HashMap::new();
+    for row in task_rows {
+        for s in &row.sessions {
+            wt_sessions.insert(s.tmux.name.as_str(), row.branch.as_str());
+        }
+    }
+
+    for row in standalone {
+        let name = &row.config.name;
+        if let Some(branch) = wt_sessions.get(name.as_str()) {
+            return Err(anyhow::anyhow!(
+                "Standalone session '{}' collides with worktree session on branch '{}'",
+                name,
+                branch,
+            ));
+        }
     }
     Ok(())
 }
@@ -3466,5 +3512,87 @@ mod tests {
             output.contains("Git Orchard"),
             "compact header should show 'Git Orchard' text"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // check_standalone_collisions tests
+    // -----------------------------------------------------------------------
+
+    fn make_standalone_row(name: &str) -> crate::session::StandaloneSessionRow {
+        crate::session::StandaloneSessionRow {
+            config: crate::session::StandaloneConfig {
+                name: name.to_string(),
+                command: "bash".to_string(),
+                cwd: "/tmp".to_string(),
+                start_on_launch: false,
+            },
+            session: EnrichedSession {
+                tmux: TmuxSessionInfo {
+                    name: name.to_string(),
+                    host: Host::Local,
+                    status: SessionStatus::Dead,
+                },
+                claude: None,
+            },
+        }
+    }
+
+    fn make_task_row_with_session(branch: &str, session_name: &str) -> WorktreeRow {
+        WorktreeRow {
+            repo_slug: "owner/repo".to_string(),
+            worktree_path: format!("/workspace/{}", branch),
+            branch: branch.to_string(),
+            worktree_host: None,
+            issue_number: None,
+            issue_title: None,
+            issue_state: None,
+            pr: None,
+            sessions: vec![EnrichedSession {
+                tmux: TmuxSessionInfo {
+                    name: session_name.to_string(),
+                    host: Host::Local,
+                    status: SessionStatus::Running { attached: false },
+                },
+                claude: None,
+            }],
+            display_group: DisplayGroup::Other,
+            is_main_worktree: false,
+        }
+    }
+
+    #[test]
+    fn no_collision_returns_ok() {
+        let standalone = vec![make_standalone_row("shepherd")];
+        let task_rows = vec![make_task_row_with_session("feat/issue-1", "repo_1")];
+        assert!(check_standalone_collisions(&standalone, &task_rows).is_ok());
+    }
+
+    #[test]
+    fn collision_with_worktree_session_returns_error() {
+        let standalone = vec![make_standalone_row("repo_1")];
+        let task_rows = vec![make_task_row_with_session("feat/issue-1", "repo_1")];
+        let err = check_standalone_collisions(&standalone, &task_rows).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("repo_1"),
+            "error should mention the colliding session name, got: {msg}"
+        );
+        assert!(
+            msg.contains("feat/issue-1"),
+            "error should mention the owning worktree branch, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn no_false_positive_when_names_differ() {
+        let standalone = vec![
+            make_standalone_row("shepherd"),
+            make_standalone_row("monitor"),
+        ];
+        let task_rows = vec![
+            make_task_row_with_session("feat/issue-1", "repo_1"),
+            make_task_row_with_session("feat/issue-2", "repo_2"),
+        ];
+        assert!(check_standalone_collisions(&standalone, &task_rows).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Closes #81. Completes Part 2 of the standalone (shepherd) session feature:

- **Preview pane** for standalone sessions — running standalone sessions now show tmux pane output in the preview area, matching worktree row behavior
- **Collision detection** — standalone session names are validated against worktree-derived session names at boot (hard error) and on cache refresh (warning log)
- **Unicode width fix** — attribution footer click target uses display-width calculation instead of byte length for correct mouse targeting

### Already implemented (Part 1 / prior commits)

The bulk of the standalone session infrastructure was already in place:
- `ListEntry::Standalone` type and TUI rendering (`build_task_table_rows_with_standalone`)
- Key handler bifurcation (`guard_requires_worktree`, `JoinStandalone` action)
- `start_on_launch` auto-creation (`ensure_standalone_sessions`)
- Init wizard shepherd suggestion (step 9)
- JSON v3 `tmuxSessions` output
- Hint bar dimming for `o` and `p` on standalone rows
- Duplicate standalone name detection at config parse time

## Test plan

- [x] `cargo test` — 593 tests pass (544 unit + integration, 3 ignored)
- [x] `cargo build --release` — clean
- [x] 8 new tests: `preview_visible` (5 cases), `check_standalone_collisions` (3 cases)
- [ ] Manual: configure a `tmux_sessions` entry and verify it renders in TUI
- [ ] Manual: verify Enter key attaches to standalone session
- [ ] Manual: verify `d`/`o`/`i`/`p` keys show flash warning on standalone row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #81