### PR TITLE
fix: correct softprops/action-gh-release SHA

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Checksum
         run: shasum -a 256 orchard-${{ matrix.target }}.tar.gz > orchard-${{ matrix.target }}.tar.gz.sha256
       - name: Upload
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87422cf08f104dccef957 # v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           tag_name: ${{ needs.release-please.outputs.tag_name }}
           files: |


### PR DESCRIPTION
## Why

Build jobs failed because the pinned SHA for softprops/action-gh-release didn't exist. This blocks the release pipeline.

Closes the build failure from the v0.1.0 release attempt.

## What changed

Updated softprops/action-gh-release from invalid SHA c95fe14 to 153bb8e (v2.6.1).

## Test plan

- [ ] Re-run the release workflow — build jobs should pass setup step

# Related issue

- #122