### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchard"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 description = "Interactive TUI for managing git worktrees, PR status, and tmux sessions"
 license = "MIT"


### PR DESCRIPTION
## Why

The npm package git-orchard has existing versions 0.1.0-0.1.2 from the archived TypeScript version. Release-please tried to publish 0.1.2 and got a 404/conflict. Bumping to 0.2.0 so the next release publishes above the old versions.

## What changed

Cargo.toml version: 0.1.2 → 0.2.0

## Test plan

- [ ] Merge, let release-please create v0.2.0 PR, merge that, verify npm publish succeeds

# Related issue

- #122