### PR TITLE
fix: use correct repository URL format in npm package

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/drewdrewthis/git-orchard-rs"
+    "url": "git+https://github.com/drewdrewthis/git-orchard-rs.git"
   },
   "bin": {
     "git-orchard": "run.js",


### PR DESCRIPTION
## Why

Triggers release-please to create a v0.2.0 release (skipping past old TS package versions). Also fixes the repository URL format in npm/package.json to use the standard git+https format.

## What changed

npm/package.json repository URL: https → git+https with .git suffix

## Test plan

- [ ] Merge, release-please creates v0.2.0 PR, merge that, all builds + npm publish succeed

# Related issue

- #122