### PR TITLE
fix: strip component prefix from release tag for npm version

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Set version from release tag
         run: |
           VERSION="${{ needs.release-please.outputs.tag_name }}"
-          VERSION="${VERSION#v}"
+          VERSION="${VERSION##*v}"
           cd npm
           npm version "$VERSION" --no-git-tag-version
       - name: Publish to npm


### PR DESCRIPTION
## Why

npm publish failed because the tag name is orchard-v0.3.0 (with component prefix), not v0.3.0. The version strip only removed a leading v, leaving orchard-v0.3.0 which is not valid semver.

## What changed

Changed ${VERSION#v} to ${VERSION##*v} to strip everything through the last v, extracting just the semver (0.3.0).

## Test plan

- [ ] Merge, release-please creates next release PR, merge that, npm publish succeeds

# Related issue

- #122