### PR TITLE
fix: upgrade to Node 24 for npm trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Set version from release tag
         run: |
@@ -94,3 +94,5 @@ jobs:
           npm version "$VERSION" --no-git-tag-version
       - name: Publish to npm
         run: npm publish ./npm --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ''


### PR DESCRIPTION
## Why

npm publish fails with 404 because Node 20 ships npm v10, which cannot perform the OIDC token exchange for trusted publishing. The registry returns 404 instead of 401.

## What changed

- Node 20 → 24 (ships npm v11.5+ which supports OIDC)
- Explicitly blank NODE_AUTH_TOKEN so setup-node's .npmrc does not override OIDC with token-based auth

## Test plan

- [ ] Merge, release-please creates next release PR, merge that, npm publish succeeds

# Related issue

- #122