### PR TITLE
fix: correct GitHub URLs and add Substack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Built with [Rust](https://www.rust-lang.org/) + [Ratatui](https://ratatui.rs/).
 
 ![License](https://img.shields.io/badge/license-MIT-blue)
 
+📰 **Blog:** [Grow the Orchard](https://growtheorchard.substack.com/)
+
 ## What it does
 
 Orchard gives you a single dashboard showing everything happening across your repos: which worktrees have PRs, what state they're in, which Claude sessions are working/idle/waiting for input, and what needs your attention.

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ fn handle_setup_remote(args: &[String]) {
 fn handle_upgrade() {
     eprintln!("Upgrade not yet implemented for the Rust binary.");
     eprintln!(
-        "Download the latest from: https://github.com/drewdrewthis/orchard-rs/releases/latest"
+        "Download the latest from: https://github.com/drewdrewthis/git-orchard-rs/releases/latest"
     );
 }
 

--- a/src/tui/list.rs
+++ b/src/tui/list.rs
@@ -1182,7 +1182,7 @@ impl App {
         }
     }
 
-    /// Renders the attribution footer: "made with ❤ — https://github.com/drewdrewthis/orchard-rs"
+    /// Renders the attribution footer: "made with ❤ — https://github.com/drewdrewthis/git-orchard-rs"
     ///
     /// The ❤ is rendered in error (red) color; the URL in dimmed + underlined.
     /// The footer area is also used for mouse-click URL detection.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -48,7 +48,7 @@ const POLL_TIMEOUT_MS: u64 = 100;
 const DOUBLE_CLICK_MS: u128 = 400;
 
 /// Attribution URL displayed in the hints bar footer.
-const ATTRIBUTION_URL: &str = "https://github.com/drewdrewthis/orchard-rs";
+const ATTRIBUTION_URL: &str = "https://github.com/drewdrewthis/git-orchard-rs";
 
 // ---------------------------------------------------------------------------
 // Notification snapshot


### PR DESCRIPTION
## Summary

- Fix wrong GitHub repo URL (`orchard-rs` → `git-orchard-rs`) in TUI attribution footer, upgrade message, and doc comment
- Add Substack blog link to README

Closes #147

## Changes

| File | Change |
|------|--------|
| `src/tui/mod.rs:51` | `ATTRIBUTION_URL` const → `git-orchard-rs` |
| `src/main.rs:104` | Upgrade message URL → `git-orchard-rs` |
| `src/tui/list.rs:1185` | Doc comment URL → `git-orchard-rs` |
| `README.md` | Added Substack blog link |

## Test plan

- [x] `cargo test` — all pass
- [x] `cargo build --release` — success
- [x] Grep confirms zero remaining `drewdrewthis/orchard-rs` refs in `.rs` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #147