### PR TITLE
feat(tui): replace space-leader with search bar

### DIFF
--- a/crates/orchard/src/tui/dialogs.rs
+++ b/crates/orchard/src/tui/dialogs.rs
@@ -353,6 +353,14 @@ impl App {
                 Span::styled("Jump to item", dim),
             ]),
             Line::from(vec![
+                Span::styled("Space    ", key_style),
+                Span::styled("Open search bar", dim),
+            ]),
+            Line::from(vec![
+                Span::styled("type     ", key_style),
+                Span::styled("Filter worktrees (in search bar)", dim),
+            ]),
+            Line::from(vec![
                 Span::styled("o        ", key_style),
                 Span::styled("Open PR in browser", dim),
             ]),
@@ -401,8 +409,8 @@ impl App {
                 Span::styled("Scroll preview pane", dim),
             ]),
             Line::from(vec![
-                Span::styled("q / esc  ", key_style),
-                Span::styled("Quit", dim),
+                Span::styled("q / Esc  ", key_style),
+                Span::styled("Close search bar / quit", dim),
             ]),
             Line::from(vec![
                 Span::styled("?        ", key_style),
@@ -418,7 +426,7 @@ impl App {
             theme.accent,
             theme.background,
             60,
-            20,
+            22,
             Some(" HELP "),
             Padding::new(2, 2, 1, 1),
         );

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -14,7 +14,7 @@ use crate::derive::{DisplayGroup, WorktreeRow};
 use crate::paths;
 use crate::remote;
 use crate::tmux;
-use crate::tui::state::{CleanupState, Phase, ViewState};
+use crate::tui::state::{CleanupState, InputPhase, Phase, ViewState};
 use crate::tui::theme::{Theme, display_group_color, repo_color};
 use crate::tui::{ATTRIBUTION_URL, App, WARNING_DURATION_SECS, filter_stale};
 
@@ -971,13 +971,20 @@ impl App {
             ((area.height as f32 * TABLE_MAX_HEIGHT_FRACTION) as u16).max(TABLE_MIN_HEIGHT);
         let table_height = table_height.min(max_table_height);
 
+        let search_active = self.input_phase == InputPhase::Searching;
+
         let mut constraints = vec![
             Constraint::Length(hdr_height),
             Constraint::Length(3), // tab bar (rounded badges need 3 rows)
+        ];
+        if search_active {
+            constraints.push(Constraint::Length(1)); // search bar
+        }
+        constraints.extend([
             Constraint::Length(table_height),
             Constraint::Length(1), // spacer
             Constraint::Min(4),    // preview fills remaining
-        ];
+        ]);
 
         if has_warning {
             constraints.push(Constraint::Length(1));
@@ -997,6 +1004,11 @@ impl App {
 
         self.render_repo_tabs(f, chunks[idx]);
         idx += 1;
+
+        if search_active {
+            self.render_search_bar(f, chunks[idx]);
+            idx += 1;
+        }
 
         let theme = &self.theme;
 
@@ -1736,23 +1748,23 @@ impl App {
                 Style::default().fg(theme.accent),
             ));
         } else {
-            spans.push(Span::styled("Spc+r", key_style));
+            spans.push(Span::styled("r", key_style));
             spans.push(Span::raw(" refresh"));
         }
 
         let has_unreachable = self.host_reachable.values().any(|&v| !v);
         if has_unreachable {
             spans.push(sep.clone());
-            spans.push(Span::styled("Spc+R", key_style));
+            spans.push(Span::styled("R", key_style));
             spans.push(Span::raw(" reconnect"));
         }
 
         spans.push(sep.clone());
-        spans.push(Span::styled("Spc+q", key_style));
+        spans.push(Span::styled("q", key_style));
         spans.push(Span::raw(format!(" {}", quit_label)));
 
         spans.push(sep.clone());
-        spans.push(Span::styled("Spc+?", key_style));
+        spans.push(Span::styled("?", key_style));
         spans.push(Span::raw(" help"));
     }
 
@@ -1773,10 +1785,10 @@ impl App {
             sep.clone(),
         ];
 
-        // Active filter text indicator — shown inline when filter is non-empty.
-        if !self.filter_text.is_empty() {
+        // Active filter text indicator — shown inline when filter is non-empty and bar is closed.
+        if self.input_phase == InputPhase::Idle && !self.filter_text.is_empty() {
             spans.push(Span::styled(
-                format!("[{}_]", self.filter_text),
+                format!("[filter: {}]", self.filter_text),
                 Style::default().fg(theme.search_highlight),
             ));
             spans.push(sep.clone());
@@ -1793,23 +1805,23 @@ impl App {
                 .is_some_and(|vt| vt.row.pr.is_some())
         };
         if has_pr {
-            spans.push(Span::styled("Spc+o", key_style));
+            spans.push(Span::styled("o", key_style));
             spans.push(Span::raw(" pr"));
         } else {
-            spans.push(Span::styled("Spc+o pr", dim));
+            spans.push(Span::styled("o pr", dim));
         }
         spans.push(sep.clone());
 
         // Dim 'p' (priority) for standalone sessions.
         if is_standalone {
-            spans.push(Span::styled("Spc+p priority", dim));
+            spans.push(Span::styled("p priority", dim));
         } else {
-            spans.push(Span::styled("Spc+p", key_style));
+            spans.push(Span::styled("p", key_style));
             spans.push(Span::raw(" priority"));
         }
         spans.push(sep.clone());
 
-        spans.push(Span::styled("Spc+B", key_style));
+        spans.push(Span::styled("B", key_style));
         spans.push(Span::raw(" branch"));
         spans.push(sep.clone());
 
@@ -1821,14 +1833,36 @@ impl App {
         spans.push(Span::raw(" expand"));
         spans.push(sep.clone());
 
-        spans.push(Span::styled("Spc+c", key_style));
+        spans.push(Span::styled("c", key_style));
         spans.push(Span::raw(" cleanup"));
+        spans.push(sep.clone());
+
+        spans.push(Span::styled("Space", key_style));
+        spans.push(Span::raw(" search"));
         spans.push(sep.clone());
 
         self.append_common_hints(&mut spans, &sep, key_style, "quit");
 
         let hints = Paragraph::new(Line::from(spans)).alignment(Alignment::Center);
         f.render_widget(hints, area);
+    }
+
+    /// Renders the search bar row between the tab bar and the table.
+    fn render_search_bar(&self, f: &mut Frame, area: Rect) {
+        let theme = &self.theme;
+        let spans = vec![
+            Span::styled(" \u{1F50D} ", Style::default().fg(theme.accent)),
+            Span::styled(
+                self.filter_text.clone(),
+                Style::default()
+                    .fg(theme.text)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+            Span::styled("\u{2588}", Style::default().fg(theme.accent)),
+        ];
+        let search_line =
+            Paragraph::new(Line::from(spans)).style(Style::default().bg(theme.background));
+        f.render_widget(search_line, area);
     }
 }
 
@@ -2738,10 +2772,8 @@ mod tests {
         assert!(text.contains("branch"), "must contain 'branch' hint");
         assert!(text.contains("quit"), "must contain 'quit' hint");
         assert!(text.contains("help"), "must contain 'help' hint");
-        assert!(
-            text.contains("Spc+"),
-            "must contain 'Spc+' leader prefix hints"
-        );
+        assert!(text.contains("Space"), "must contain 'Space search' hint");
+        assert!(text.contains("search"), "must contain 'search' hint");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/orchard/src/tui/message.rs
+++ b/crates/orchard/src/tui/message.rs
@@ -60,14 +60,14 @@ pub enum Message {
     ToggleHelp,
 
     // -- Instant filter actions --
-    /// Append a character to the instant filter (bare keystroke in Filtering phase).
+    /// Append a character to the instant filter (keystroke in Searching phase).
     FilterChar(char),
     /// Remove the last character from the instant filter.
     FilterBackspace,
-    /// Space pressed — enter the leader-key phase for action dispatch.
-    LeaderKey,
-    /// Unrecognized key in leader phase — cancel and return to filtering.
-    LeaderCancel,
+    /// Open the search bar.
+    OpenSearch,
+    /// Close the search bar, preserving filter text.
+    CloseSearch,
 
     // -- Dialog actions --
     /// Confirm a yes/no dialog (delete).

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -84,7 +84,7 @@ pub struct App {
     show_branch_column: bool,
     /// Text accumulated by bare keystrokes — filters the visible task list in real time.
     filter_text: String,
-    /// Current input phase: bare keys filter (`Filtering`) or dispatch an action (`AwaitingLeader`).
+    /// Current input phase: bare keys dispatch actions (`Idle`) or feed the search bar (`Searching`).
     input_phase: InputPhase,
 
     // Reachability state keyed by SSH host name
@@ -194,7 +194,7 @@ impl App {
             active_repo_index: initial_repo_index,
             show_branch_column: false,
             filter_text: String::new(),
-            input_phase: InputPhase::Filtering,
+            input_phase: InputPhase::Idle,
             host_reachable: HashMap::new(),
             tx,
             rx,
@@ -720,9 +720,8 @@ impl App {
                 let visible_count = standalone_count + worktree_visible_count;
 
                 match self.input_phase {
-                    InputPhase::AwaitingLeader => {
-                        // Next key dispatches an action; any unrecognized key is ignored
-                        // and returns to Filtering (update() resets the phase for non-leader msgs).
+                    InputPhase::Idle => {
+                        // Bare keys are direct actions. Navigation + special keys.
                         match key.code {
                             KeyCode::Char('o') => Some(Message::OpenPR),
                             KeyCode::Char('i') => Some(Message::OpenIssue),
@@ -745,14 +744,7 @@ impl App {
                                 navigation::cursor_index_from_digit(c, visible_count)
                                     .map(Message::CursorTo)
                             }
-                            // Unrecognized key: cancel leader and return to Filtering.
-                            _ => Some(Message::LeaderCancel),
-                        }
-                    }
-                    InputPhase::Filtering => {
-                        // Direct navigation keys work without a leader prefix.
-                        // Printable chars feed the instant filter.
-                        match key.code {
+                            KeyCode::Char(' ') => Some(Message::OpenSearch),
                             KeyCode::Up => Some(Message::CursorUp),
                             KeyCode::Down => Some(Message::CursorDown),
                             KeyCode::Left => Some(Message::CollapseRow),
@@ -763,9 +755,30 @@ impl App {
                             KeyCode::BackTab => Some(Message::PrevRepo),
                             KeyCode::PageUp => Some(Message::PreviewPageUp),
                             KeyCode::PageDown => Some(Message::PreviewPageDown),
-                            KeyCode::Char(' ') => Some(Message::LeaderKey),
-                            KeyCode::Backspace => Some(Message::FilterBackspace),
-                            KeyCode::Char(c) => Some(Message::FilterChar(c)),
+                            _ => None,
+                        }
+                    }
+                    InputPhase::Searching => {
+                        // Navigation keys work, printable chars go to filter.
+                        match key.code {
+                            KeyCode::Esc => Some(Message::CloseSearch),
+                            KeyCode::Enter => Some(Message::Enter),
+                            KeyCode::Up => Some(Message::CursorUp),
+                            KeyCode::Down => Some(Message::CursorDown),
+                            KeyCode::Left => Some(Message::CollapseRow),
+                            KeyCode::Right => Some(Message::ExpandRow),
+                            KeyCode::Tab => Some(Message::NextRepo),
+                            KeyCode::BackTab => Some(Message::PrevRepo),
+                            KeyCode::PageUp => Some(Message::PreviewPageUp),
+                            KeyCode::PageDown => Some(Message::PreviewPageDown),
+                            KeyCode::Backspace => {
+                                if self.filter_text.is_empty() {
+                                    Some(Message::CloseSearch)
+                                } else {
+                                    Some(Message::FilterBackspace)
+                                }
+                            }
+                            KeyCode::Char(c) => Some(Message::FilterChar(c)), // includes space
                             _ => None,
                         }
                     }
@@ -979,14 +992,6 @@ impl App {
                 quit: false,
                 next_msg: None,
             }
-        }
-
-        // Reset to Filtering phase on any message that is not a filter/leader message.
-        // This ensures that after a leader-dispatched action (or any unrecognized key
-        // that causes update to be called), the input phase returns to baseline.
-        match msg {
-            Message::LeaderKey | Message::FilterChar(_) | Message::FilterBackspace => {}
-            _ => self.input_phase = InputPhase::Filtering,
         }
 
         match msg {
@@ -1289,12 +1294,12 @@ impl App {
                 };
                 ok()
             }
-            Message::LeaderKey => {
-                self.input_phase = InputPhase::AwaitingLeader;
+            Message::OpenSearch => {
+                self.input_phase = InputPhase::Searching;
                 ok()
             }
-            Message::LeaderCancel => {
-                // Phase already reset to Filtering by the reset block above.
+            Message::CloseSearch => {
+                self.input_phase = InputPhase::Idle;
                 ok()
             }
             Message::FilterChar(c) => {
@@ -1651,7 +1656,7 @@ impl App {
             active_repo_index: 0,
             show_branch_column: false,
             filter_text: String::new(),
-            input_phase: InputPhase::Filtering,
+            input_phase: InputPhase::Idle,
             host_reachable: HashMap::new(),
             tx,
             rx,
@@ -2049,15 +2054,9 @@ mod tests {
 
     #[test]
     fn spc_w_key_opens_new_worktree_dialog() {
-        // NewWorktree is a leader-prefixed action: Space then 'w'.
+        // 'w' in Idle phase directly dispatches NewWorktree.
         let mut app = App::new_test(vec![]);
-        // Press Space to enter AwaitingLeader.
-        let space = KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE);
-        let leader_msg = app.handle_event(space);
-        assert_eq!(leader_msg, Some(Message::LeaderKey));
-        app.update(leader_msg.unwrap());
-        assert_eq!(app.input_phase, InputPhase::AwaitingLeader);
-        // Press 'w' to dispatch NewWorktree.
+        assert_eq!(app.input_phase, InputPhase::Idle);
         let key = KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::NewWorktree));
@@ -2220,10 +2219,8 @@ mod tests {
         }
     }
 
-    /// Send Space (leader) then a key — shorthand for leader-prefixed actions.
+    /// Send a key directly — in Idle phase, all action keys dispatch without a leader prefix.
     fn send_leader_key(app: &mut App, key: KeyEvent) -> UpdateResult {
-        let space = KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE);
-        send_key(app, space);
         send_key(app, key)
     }
 
@@ -2692,20 +2689,19 @@ mod tests {
 
     #[test]
     fn handle_event_printable_char_goes_to_filter() {
-        let app = App::new_test(vec![]);
+        let mut app = App::new_test(vec![]);
+        app.input_phase = InputPhase::Searching;
         let key = KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(key), Some(Message::FilterChar('z')));
     }
 
     #[test]
-    fn handle_event_unbound_leader_key_returns_leader_cancel() {
+    fn handle_event_unbound_key_in_searching_returns_none() {
         let mut app = App::new_test(vec![]);
-        // Enter AwaitingLeader phase
-        let space = KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE);
-        send_key(&mut app, space);
-        // F5 is not bound in leader mode — produces LeaderCancel
+        app.input_phase = InputPhase::Searching;
+        // F5 is not bound in Searching phase
         let key = KeyEvent::new(KeyCode::F(5), KeyModifiers::NONE);
-        assert_eq!(app.handle_event(key), Some(Message::LeaderCancel));
+        assert_eq!(app.handle_event(key), None);
     }
 
     #[test]
@@ -2735,37 +2731,37 @@ mod tests {
     }
 
     #[test]
-    fn handle_event_filtering_phase_routes_chars_to_filter() {
-        // In the default Filtering phase, printable chars become FilterChar messages.
-        let app = App::new_test(vec![]);
-        assert_eq!(app.input_phase, InputPhase::Filtering);
+    fn handle_event_searching_phase_routes_chars_to_filter() {
+        // In the Searching phase, printable chars become FilterChar messages.
+        let mut app = App::new_test(vec![]);
+        app.input_phase = InputPhase::Searching;
         let key = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(key), Some(Message::FilterChar('a')));
     }
 
     #[test]
-    fn handle_event_digit_in_filtering_goes_to_filter() {
-        // Digits are printable chars — in Filtering phase they feed the filter.
-        let rows = vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::ClaudeWorking),
-            make_task_row(3, DisplayGroup::Other),
-        ];
-        let app = App::new_test(rows);
-        let key = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE);
-        assert_eq!(app.handle_event(key), Some(Message::FilterChar('1')));
-    }
-
-    #[test]
-    fn handle_event_digit_in_awaiting_leader_returns_cursor_to() {
-        // Digits dispatch CursorTo when behind the leader prefix.
+    fn handle_event_digit_in_searching_goes_to_filter() {
+        // Digits are printable chars — in Searching phase they feed the filter.
         let rows = vec![
             make_task_row(1, DisplayGroup::NeedsAttention),
             make_task_row(2, DisplayGroup::ClaudeWorking),
             make_task_row(3, DisplayGroup::Other),
         ];
         let mut app = App::new_test(rows);
-        app.input_phase = InputPhase::AwaitingLeader;
+        app.input_phase = InputPhase::Searching;
+        let key = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE);
+        assert_eq!(app.handle_event(key), Some(Message::FilterChar('1')));
+    }
+
+    #[test]
+    fn handle_event_digit_in_idle_returns_cursor_to() {
+        // Digits dispatch CursorTo directly in Idle phase.
+        let rows = vec![
+            make_task_row(1, DisplayGroup::NeedsAttention),
+            make_task_row(2, DisplayGroup::ClaudeWorking),
+            make_task_row(3, DisplayGroup::Other),
+        ];
+        let app = App::new_test(rows);
         let key = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(key), Some(Message::CursorTo(0)));
     }
@@ -2798,10 +2794,9 @@ mod tests {
     }
 
     #[test]
-    fn handle_event_spc_p_maps_to_toggle_priority() {
-        // 'p' dispatches TogglePriority only when behind the Space leader prefix.
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
-        app.input_phase = InputPhase::AwaitingLeader;
+    fn handle_event_p_maps_to_toggle_priority() {
+        // 'p' dispatches TogglePriority directly in Idle phase.
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
         let key = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(key), Some(Message::TogglePriority));
     }
@@ -3630,9 +3625,8 @@ mod tests {
 
     #[test]
     fn h_key_maps_to_collapse_behind_leader() {
-        // 'h' dispatches CollapseRow only when behind the Space leader prefix.
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
-        app.input_phase = InputPhase::AwaitingLeader;
+        // 'h' dispatches CollapseRow directly in Idle phase.
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
         let key = KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::CollapseRow));
@@ -3656,9 +3650,8 @@ mod tests {
 
     #[test]
     fn l_key_maps_to_expand_behind_leader() {
-        // 'l' dispatches ExpandRow only when behind the Space leader prefix.
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
-        app.input_phase = InputPhase::AwaitingLeader;
+        // 'l' dispatches ExpandRow directly in Idle phase.
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
         let key = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::ExpandRow));
@@ -3682,9 +3675,8 @@ mod tests {
 
     #[test]
     fn e_key_maps_to_toggle_expand_all_behind_leader() {
-        // 'E' dispatches ToggleExpandAll only when behind the Space leader prefix.
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
-        app.input_phase = InputPhase::AwaitingLeader;
+        // 'E' dispatches ToggleExpandAll directly in Idle phase.
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
         let key = KeyEvent::new(KeyCode::Char('E'), KeyModifiers::SHIFT);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::ToggleExpandAll));
@@ -3964,37 +3956,28 @@ mod tests {
     }
 
     #[test]
-    fn leader_key_sets_awaiting_leader() {
+    fn open_search_sets_searching() {
         let mut app = App::new_test(vec![]);
-        assert_eq!(app.input_phase, InputPhase::Filtering);
-        app.update(Message::LeaderKey);
-        assert_eq!(app.input_phase, InputPhase::AwaitingLeader);
+        assert_eq!(app.input_phase, InputPhase::Idle);
+        app.update(Message::OpenSearch);
+        assert_eq!(app.input_phase, InputPhase::Searching);
     }
 
     #[test]
     fn leader_then_action_dispatches_open_pr() {
-        let mut app = App::new_test(vec![]);
-        // Space sets AwaitingLeader.
-        let space = KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE);
-        let leader_msg = app.handle_event(space).unwrap();
-        app.update(leader_msg);
-        assert_eq!(app.input_phase, InputPhase::AwaitingLeader);
-        // 'o' in AwaitingLeader → OpenPR.
+        // In Idle phase, 'o' directly dispatches OpenPR (no leader needed).
+        let app = App::new_test(vec![]);
+        assert_eq!(app.input_phase, InputPhase::Idle);
         let o_key = KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(o_key), Some(Message::OpenPR));
     }
 
     #[test]
-    fn leader_then_unknown_key_cancels_and_resets_phase() {
+    fn close_search_resets_phase_to_idle() {
         let mut app = App::new_test(vec![]);
-        app.input_phase = InputPhase::AwaitingLeader;
-        // An unrecognized key in AwaitingLeader produces LeaderCancel.
-        let unknown = KeyEvent::new(KeyCode::Char('z'), KeyModifiers::NONE);
-        let msg = app.handle_event(unknown);
-        assert_eq!(msg, Some(Message::LeaderCancel));
-        // Processing LeaderCancel resets phase to Filtering.
-        app.update(msg.unwrap());
-        assert_eq!(app.input_phase, InputPhase::Filtering);
+        app.input_phase = InputPhase::Searching;
+        app.update(Message::CloseSearch);
+        assert_eq!(app.input_phase, InputPhase::Idle);
     }
 
     #[test]
@@ -4006,15 +3989,15 @@ mod tests {
     }
 
     #[test]
-    fn arrow_keys_work_without_leader_in_filtering() {
-        // Up/Down arrow keys dispatch directly without requiring a leader prefix.
+    fn arrow_keys_work_without_leader_in_idle() {
+        // Up/Down arrow keys dispatch directly in Idle phase.
         let rows = vec![
             make_task_row(1, DisplayGroup::NeedsAttention),
             make_task_row(2, DisplayGroup::Other),
         ];
         let mut app = App::new_test(rows);
         app.cursor = 1;
-        assert_eq!(app.input_phase, InputPhase::Filtering);
+        assert_eq!(app.input_phase, InputPhase::Idle);
         let up = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
         assert_eq!(app.handle_event(up), Some(Message::CursorUp));
         let down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
@@ -4022,27 +4005,27 @@ mod tests {
     }
 
     #[test]
-    fn printable_chars_go_to_filter_not_actions() {
-        // In Filtering phase, 'o' becomes FilterChar('o'), not OpenPR.
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
-        assert_eq!(app.input_phase, InputPhase::Filtering);
+    fn printable_chars_go_to_filter_in_searching_not_actions() {
+        // In Searching phase, 'o' becomes FilterChar('o'), not OpenPR.
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        app.input_phase = InputPhase::Searching;
         let key = KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(key), Some(Message::FilterChar('o')));
     }
 
     #[test]
-    fn space_key_produces_leader_key_message_in_filtering() {
+    fn space_key_produces_open_search_message_in_idle() {
         let app = App::new_test(vec![]);
         let key = KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE);
-        assert_eq!(app.handle_event(key), Some(Message::LeaderKey));
+        assert_eq!(app.handle_event(key), Some(Message::OpenSearch));
     }
 
     #[test]
-    fn any_action_message_resets_phase_to_filtering() {
+    fn searching_phase_persists_through_action_messages() {
         let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
-        app.input_phase = InputPhase::AwaitingLeader;
+        app.input_phase = InputPhase::Searching;
         app.update(Message::CursorDown);
-        assert_eq!(app.input_phase, InputPhase::Filtering);
+        assert_eq!(app.input_phase, InputPhase::Searching);
     }
 
     // -----------------------------------------------------------------------

--- a/crates/orchard/src/tui/state.rs
+++ b/crates/orchard/src/tui/state.rs
@@ -74,16 +74,17 @@ pub struct NewWorktreeState {
 
 /// Input phase for the main list view.
 ///
-/// There are no modes — only phases. The default `Filtering` phase routes
-/// bare printable keystrokes directly into the instant filter. `AwaitingLeader`
-/// is entered by pressing Space and routes the *next* key to an action.
+/// `Idle` is the default: bare keys dispatch actions directly (no prefix required).
+/// `Searching` means the search bar is open; all printable keystrokes feed the
+/// fuzzy filter. Only `Message::CloseSearch` and `Message::Quit` transition from
+/// `Searching` back to `Idle`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum InputPhase {
-    /// Bare keystrokes append to the filter. This is the default state.
+    /// Bare keys dispatch actions directly. This is the default state.
     #[default]
-    Filtering,
-    /// Space was pressed; the next key dispatches an action.
-    AwaitingLeader,
+    Idle,
+    /// Search bar is open; printable keystrokes feed the filter.
+    Searching,
 }
 
 // ---------------------------------------------------------------------------

--- a/specs/features/tui-search-bar.feature
+++ b/specs/features/tui-search-bar.feature
@@ -1,0 +1,317 @@
+Feature: TUI search bar replaces space-leader key
+  The space key now opens a dedicated search bar between the tab bar and the
+  table instead of entering a leader-key dispatch mode. When the search bar is
+  closed, bare keys are direct actions (no Spc+ prefix). When it is open, all
+  printable characters feed the fuzzy filter.
+
+  Phase reset rule: Searching persists through ALL messages. Only
+  Message::CloseSearch and Message::Quit transition from Searching to Idle.
+  This is the inverse of the old blanket-reset pattern.
+
+  Background:
+    Given the TUI is running with worktree rows loaded
+
+  # --- State model ---
+
+  @unit
+  Scenario: InputPhase has Idle and Searching variants
+    Then InputPhase has variants Idle and Searching
+    And InputPhase::AwaitingLeader does not exist
+    And InputPhase::Filtering does not exist
+
+  @unit
+  Scenario: Default input phase is Idle
+    Then the default InputPhase is Idle
+
+  # --- Message enum ---
+
+  @unit
+  Scenario: Message enum replaces leader messages with search messages
+    Then Message::OpenSearch exists
+    And Message::CloseSearch exists
+    And Message::LeaderKey does not exist
+    And Message::LeaderCancel does not exist
+
+  # --- Opening the search bar ---
+
+  @unit
+  Scenario: Space opens the search bar from Idle
+    Given the input phase is Idle
+    When the user presses Space
+    Then the message OpenSearch is dispatched
+    And the input phase changes to Searching
+
+  @unit
+  Scenario: Space reopens search bar preserving existing filter text
+    Given the filter text is "deploy"
+    And the input phase is Idle
+    When the user presses Space
+    Then the input phase changes to Searching
+    And the filter text is still "deploy"
+
+  @unit
+  Scenario: Space while Searching inserts a space character
+    Given the input phase is Searching
+    And the filter text is "my"
+    When the user presses Space
+    Then the filter text is "my "
+
+  # --- Typing in the search bar ---
+
+  @unit
+  Scenario: Printable characters feed the filter when searching
+    Given the input phase is Searching
+    When the user types "abc"
+    Then the filter text is "abc"
+    And the cursor resets to 0
+
+  @unit
+  Scenario: Backspace removes last character in search bar
+    Given the input phase is Searching
+    And the filter text is "abc"
+    When the user presses Backspace
+    Then the filter text is "ab"
+
+  @unit
+  Scenario: Backspace on empty filter closes the search bar
+    Given the input phase is Searching
+    And the filter text is ""
+    When the user presses Backspace
+    Then the message CloseSearch is dispatched
+    And the input phase changes to Idle
+
+  # --- Closing the search bar ---
+
+  @unit
+  Scenario: Esc while Searching closes the search bar and preserves filter text
+    Given the input phase is Searching
+    And the filter text is "deploy"
+    When the user presses Esc
+    Then the message CloseSearch is dispatched
+    And the input phase changes to Idle
+    And the filter text is still "deploy"
+
+  @unit
+  Scenario: Esc in Idle phase quits the application
+    Given the input phase is Idle
+    When the user presses Esc
+    Then the application quits
+
+  # --- Enter behavior ---
+
+  @unit
+  Scenario: Enter activates the selected session (quits TUI for tmux switch)
+    Given a worktree row is selected
+    When the user presses Enter
+    Then the selected session is activated
+    And UpdateResult.quit is true
+
+  @unit
+  Scenario: Enter works identically in both Idle and Searching phases
+    Given the input phase is Searching
+    And a worktree row is selected
+    When the user presses Enter
+    Then the selected session is activated
+    And UpdateResult.quit is true
+
+  # --- Navigation works in both phases ---
+
+  @unit
+  Scenario: Up/Down arrow keys navigate in Idle phase
+    Given the input phase is Idle
+    When the user presses Down
+    Then the cursor moves down
+
+  @unit
+  Scenario: Up/Down arrow keys navigate in Searching phase
+    Given the input phase is Searching
+    When the user presses Down
+    Then the cursor moves down
+    And the input phase is still Searching
+
+  @unit
+  Scenario: Tab switches repo tab in Searching phase
+    Given the input phase is Searching
+    When the user presses Tab
+    Then the active repo tab advances
+    And the input phase is still Searching
+
+  @unit
+  Scenario: PageUp/PageDown scroll preview in both phases
+    Given the input phase is Searching
+    When the user presses PageDown
+    Then the preview pane scrolls down
+    And the input phase is still Searching
+
+  @unit
+  Scenario: j/k are direct navigation in Idle phase
+    Given the input phase is Idle
+    When the user presses 'j'
+    Then the cursor moves down
+
+  @unit
+  Scenario: j/k feed filter text in Searching phase
+    Given the input phase is Searching
+    When the user presses 'j'
+    Then the filter text contains "j"
+    And the input phase is still Searching
+
+  @unit
+  Scenario: Digit keys 1-9 jump to row in Idle phase
+    Given the input phase is Idle
+    When the user presses '3'
+    Then the cursor jumps to row 3
+
+  @unit
+  Scenario: Digit keys feed filter text in Searching phase
+    Given the input phase is Searching
+    When the user presses '3'
+    Then the filter text contains "3"
+
+  # --- Direct action keys in Idle phase ---
+
+  @unit
+  Scenario Outline: Bare action keys dispatch in Idle phase
+    Given the input phase is Idle
+    When the user presses '<key>'
+    Then the message <message> is dispatched
+
+    Examples:
+      | key | message          |
+      | o   | OpenPR           |
+      | d   | Delete           |
+      | p   | TogglePriority   |
+      | B   | ToggleBranchCol  |
+      | c   | Cleanup          |
+      | r   | Refresh          |
+      | R   | ReconnectHosts   |
+      | ?   | ToggleHelp       |
+      | q   | Quit             |
+      | n   | NewSession       |
+      | w   | NewWorktree      |
+      | i   | OpenIssue        |
+      | h   | CollapseRow      |
+      | l   | ExpandRow        |
+      | E   | ToggleExpandAll  |
+
+  @unit
+  Scenario: Action keys are consumed as filter chars when Searching
+    Given the input phase is Searching
+    When the user presses 'o'
+    Then the filter text contains "o"
+    And no action message is dispatched
+    And the input phase is still Searching
+
+  # --- Phase persistence rule ---
+
+  @unit
+  Scenario: Searching phase persists through navigation messages
+    Given the input phase is Searching
+    When CursorDown is dispatched
+    Then the input phase is still Searching
+
+  @unit
+  Scenario: Searching phase persists through CacheRefreshed
+    Given the input phase is Searching
+    When CacheRefreshed is dispatched
+    Then the input phase is still Searching
+
+  @unit
+  Scenario: Searching phase persists through Refresh
+    Given the input phase is Searching
+    When Refresh is dispatched
+    Then the input phase is still Searching
+
+  @unit
+  Scenario: Only CloseSearch transitions from Searching to Idle
+    Given the input phase is Searching
+    When CloseSearch is dispatched
+    Then the input phase changes to Idle
+
+  # --- Layout ---
+
+  @unit
+  Scenario: Search bar row appears in layout when Searching
+    Given the input phase is Searching
+    Then the layout has a Length(1) constraint between the tab bar and the table
+
+  @unit
+  Scenario: Search bar row absent from layout when Idle
+    Given the input phase is Idle
+    Then the layout has no search bar constraint between tab bar and table
+
+  # --- Search bar rendering ---
+
+  @unit
+  Scenario: Search bar displays magnifying glass icon and filter text
+    Given the input phase is Searching
+    And the filter text is "deploy"
+    Then the search bar renders a magnifying glass icon followed by "deploy"
+
+  @unit
+  Scenario: Search bar shows empty input field when no filter text
+    Given the input phase is Searching
+    And the filter text is ""
+    Then the search bar renders a magnifying glass icon with empty input
+
+  # --- Filter active indicator when bar is closed ---
+
+  @unit
+  Scenario: Hint bar shows filter indicator when filter active and bar closed
+    Given the input phase is Idle
+    And the filter text is "deploy"
+    Then the hint bar shows a filter-active indicator with the text "deploy"
+
+  @unit
+  Scenario: No filter indicator when filter text is empty
+    Given the input phase is Idle
+    And the filter text is ""
+    Then the hint bar does not show a filter-active indicator
+
+  # --- Hint bar ---
+
+  @unit
+  Scenario: Hint bar shows bare key labels without Spc+ prefix
+    Then the hint bar contains "o pr" not "Spc+o pr"
+    And the hint bar contains "r refresh" not "Spc+r refresh"
+    And the hint bar contains "Space search"
+
+  # --- Help overlay ---
+
+  @unit
+  Scenario: Help overlay documents search bar
+    When the help overlay is displayed
+    Then it includes "Space" with description "Open search bar"
+    And it includes "Esc" with description "Close search bar / quit"
+    And it does not mention leader key
+
+  # --- Filter persistence ---
+
+  @unit
+  Scenario: Filter text persists across search bar open/close cycles
+    Given the input phase is Searching
+    And the user types "api"
+    When the user presses Esc
+    Then the input phase is Idle
+    And the filter text is "api"
+    When the user presses Space
+    Then the input phase is Searching
+    And the filter text is "api"
+
+  # --- Clearing filter text ---
+
+  @unit
+  Scenario: Enter clears filter text when activating a session
+    Given the input phase is Idle
+    And the filter text is "deploy"
+    And a worktree row is selected
+    When the user presses Enter
+    Then the filter text is cleared
+    And the selected session is activated
+
+  # --- Build verification ---
+
+  @unit
+  Scenario: All existing tests compile and pass after refactor
+    Then cargo test passes
+    And cargo build --release succeeds


### PR DESCRIPTION
## Summary
- Replaces the `Space+key` leader-key pattern with direct action keys (`o`, `p`, `r`, `q`, `?`, etc.) that work without a prefix
- `Space` now toggles a dedicated search bar between the tab bar and table for fuzzy filtering
- `Esc` or `Backspace` on empty input closes the search bar; filter text persists when closed and shows inline
- Updates help dialog, status bar hints, and all related tests

Closes #183

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo test` — all pass
- [x] `cargo clippy --all-targets` — no warnings
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #183