### PR TITLE
fix(tui): Enter activates highlighted row even with active filter

### DIFF
--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -1109,8 +1109,8 @@ impl App {
                 ok()
             }
             Message::Enter => {
-                self.filter_text.clear();
                 let quit = self.handle_enter_action();
+                self.filter_text.clear();
                 UpdateResult {
                     quit,
                     next_msg: None,
@@ -3986,6 +3986,29 @@ mod tests {
         app.filter_text = "feat".to_string();
         app.update(Message::Enter);
         assert_eq!(app.filter_text, "", "Enter should clear the filter");
+    }
+
+    #[test]
+    fn enter_activates_highlighted_row_with_active_filter() {
+        // Two rows with sessions: only row 2 matches the filter "issue-2".
+        let rows = vec![
+            make_task_row_with_session("feat/issue-1", "repo_issue-1"),
+            make_task_row_with_session("feat/issue-2", "repo_issue-2"),
+        ];
+        let mut app = App::new_test(rows);
+        app.filter_text = "issue-2".to_string();
+        // Cursor 0 points at the only visible row (issue-2) while filter is active.
+        app.cursor = 0;
+        app.update(Message::Enter);
+        assert_eq!(app.filter_text, "", "Enter should clear the filter");
+        // handle_enter_action resolves cursor 0 against filtered rows and sets
+        // switch_target to the matched session name. With the fix, the filter is
+        // still active during resolution so cursor 0 maps to issue-2.
+        let target = app.switch_target.as_deref().unwrap_or("");
+        assert!(
+            target.contains("issue-2"),
+            "Enter should activate the filtered row (issue-2), not issue-1; got switch_target: {target}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Move `filter_text.clear()` after `handle_enter_action()` so the Enter key resolves cursor position against the filtered row list, not the unfiltered one
- With an active filter, Enter now activates the highlighted (filtered) row and clears the filter as a side effect
- Add regression test `enter_activates_highlighted_row_with_active_filter`

Closes #163

## Test plan
- [x] New test verifies cursor 0 with filter "issue-2" resolves to issue-2 (not issue-1)
- [x] Existing `enter_clears_filter` test still passes
- [x] Full test suite: 690 passed, 0 failed
- [x] Release build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #163

# Related issue

- #163