### PR TITLE
feat(tui): full tmux session/window/pane hierarchy

### DIFF
--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -13,6 +13,7 @@ use crate::global_config::GlobalConfig;
 use crate::orchard_state::{HostState, OrchardState, RepoState, WorktreeState};
 use crate::session::{
     ClaudeSessionInfo, EnrichedSession, Host, SessionStatus, StandaloneSessionRow, TmuxSessionInfo,
+    build_windows_and_panes,
 };
 use crate::sources;
 
@@ -136,12 +137,14 @@ fn build_standalone_sessions(
                 .filter(|cs| !crate::derive::is_state_stale_default(&cs.timestamp))
                 .and_then(ClaudeSessionInfo::from_state_file);
 
-            let panes = live
+            let (windows, panes) = live
                 .map(|s| {
-                    crate::session::build_pane_infos(
+                    build_windows_and_panes(
                         &s.pane_targets,
                         &s.pane_commands,
                         &s.pane_titles,
+                        &s.window_names,
+                        &s.window_active,
                     )
                 })
                 .unwrap_or_default();
@@ -154,6 +157,7 @@ fn build_standalone_sessions(
                         status,
                     },
                     claude,
+                    windows,
                     panes,
                 },
                 config: cfg.clone(),
@@ -362,6 +366,8 @@ mod tests {
             pane_targets: vec![],
             pane_titles: vec![],
             pane_commands: vec![],
+            window_names: vec![],
+            window_active: vec![],
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
@@ -490,6 +496,8 @@ mod tests {
             pane_targets: vec![],
             pane_titles: vec![],
             pane_commands: vec![],
+            window_names: vec![],
+            window_active: vec![],
             host: Some("ubuntu@10.0.0.1".to_string()),
             last_output_lines: vec![],
             claude_state_raw: Some(make_state_file(state, name, timestamp)),
@@ -569,6 +577,8 @@ mod tests {
             pane_targets: vec![],
             pane_titles: vec![],
             pane_commands: vec![],
+            window_names: vec![],
+            window_active: vec![],
             host: Some("ubuntu@10.0.0.1".to_string()),
             last_output_lines: vec![],
             claude_state_raw: None,

--- a/crates/orchard/src/cache.rs
+++ b/crates/orchard/src/cache.rs
@@ -84,6 +84,18 @@ pub struct CachedTmuxSession {
     pub pane_titles: Vec<String>,
     /// Commands running in each pane of the session.
     pub pane_commands: Vec<String>,
+    /// Window name per pane row, parallel to `pane_targets`.
+    ///
+    /// Uses `serde(default)` so old cache files without this field deserialize
+    /// with an empty vec, triggering synthetic window name fallback.
+    #[serde(default)]
+    pub window_names: Vec<String>,
+    /// Window active flag per pane row, parallel to `pane_targets`.
+    ///
+    /// "1" means the pane's window is the active window in this session;
+    /// anything else means inactive. Uses `serde(default)` for cache upgrade compat.
+    #[serde(default)]
+    pub window_active: Vec<String>,
     /// Remote host identifier if this session is on a remote machine.
     pub host: Option<String>,
     #[serde(default)]
@@ -319,6 +331,8 @@ mod tests {
             pane_targets: vec!["0.0".to_string()],
             pane_titles: vec!["bash".to_string()],
             pane_commands: vec!["vim".to_string()],
+            window_names: vec![],
+            window_active: vec![],
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
@@ -527,6 +541,52 @@ mod tests {
         // by confirming the function doesn't panic.
         let result = std::panic::catch_unwind(read_manifest);
         assert!(result.is_ok());
+    }
+
+    // -- CachedTmuxSession window fields ------------------------------------
+
+    #[test]
+    fn cached_tmux_session_window_fields_roundtrip() {
+        let session = CachedTmuxSession {
+            name: "my-session".to_string(),
+            path: "/home/user/repo".to_string(),
+            pane_targets: vec!["0.0".to_string(), "1.0".to_string()],
+            pane_titles: vec!["bash".to_string(), "nvim".to_string()],
+            pane_commands: vec!["bash".to_string(), "nvim".to_string()],
+            window_names: vec!["main".to_string(), "editor".to_string()],
+            window_active: vec!["1".to_string(), "0".to_string()],
+            host: None,
+            last_output_lines: vec![],
+            claude_state_raw: None,
+        };
+        let json = serde_json::to_string(&session).unwrap();
+        let parsed: CachedTmuxSession = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.window_names, vec!["main", "editor"]);
+        assert_eq!(parsed.window_active, vec!["1", "0"]);
+    }
+
+    #[test]
+    fn cached_tmux_session_missing_window_fields_default_to_empty() {
+        // Old cache format without window_names or window_active fields.
+        let json = r#"{
+            "name": "old-session",
+            "path": "/home/user/repo",
+            "pane_targets": ["0.0"],
+            "pane_titles": ["bash"],
+            "pane_commands": ["bash"],
+            "host": null,
+            "last_output_lines": [],
+            "claude_state_raw": null
+        }"#;
+        let parsed: CachedTmuxSession = serde_json::from_str(json).unwrap();
+        assert!(
+            parsed.window_names.is_empty(),
+            "window_names should default to empty vec"
+        );
+        assert!(
+            parsed.window_active.is_empty(),
+            "window_active should default to empty vec"
+        );
     }
 
     #[test]

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -1215,7 +1215,8 @@ mod tests {
 
     #[test]
     fn parse_pane_lines_new_format_extracts_window_metadata() {
-        let output = "0.0\tmain\t1\tbash:bash\n0.1\tmain\t1\tclaude:claude\n1.0\teditor\t0\tnvim:nvim\n";
+        let output =
+            "0.0\tmain\t1\tbash:bash\n0.1\tmain\t1\tclaude:claude\n1.0\teditor\t0\tnvim:nvim\n";
         let parsed = parse_pane_lines(output);
         assert_eq!(parsed.targets, vec!["0.0", "0.1", "1.0"]);
         assert_eq!(parsed.window_names, vec!["main", "main", "editor"]);

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -242,15 +242,17 @@ pub fn parse_tmux_output(
         };
 
         let pane_output = panes_fn(name);
-        let (pane_targets, pane_titles, pane_commands) = parse_pane_lines(&pane_output);
+        let parsed = parse_pane_lines(&pane_output);
         let last_output_lines = content_fn(name);
 
         sessions.push(CachedTmuxSession {
             name: name.to_string(),
             path: path.to_string(),
-            pane_targets,
-            pane_titles,
-            pane_commands,
+            pane_targets: parsed.targets,
+            pane_titles: parsed.titles,
+            pane_commands: parsed.commands,
+            window_names: parsed.window_names,
+            window_active: parsed.window_active,
             host: host.map(|h| h.to_string()),
             last_output_lines,
             claude_state_raw: None, // populated after parsing remote Claude state
@@ -260,12 +262,32 @@ pub fn parse_tmux_output(
     sessions
 }
 
-/// Parses pane info lines in the format `{window}.{pane}\t{pane_title}:{pane_current_command}`.
+/// Structured output of `parse_pane_lines`.
+struct ParsedPaneData {
+    /// Tmux window.pane addresses (e.g. "0.1").
+    targets: Vec<String>,
+    /// Window names per pane row.
+    window_names: Vec<String>,
+    /// Window active flags per pane row ("1" or "0").
+    window_active: Vec<String>,
+    /// Pane titles per pane row.
+    titles: Vec<String>,
+    /// Commands running in each pane.
+    commands: Vec<String>,
+}
+
+/// Parses pane info lines into structured pane data.
 ///
-/// Returns `(targets, titles, commands)` where `targets` contains tmux
-/// window.pane addresses (e.g., "0.1") for each pane.
-fn parse_pane_lines(output: &str) -> (Vec<String>, Vec<String>, Vec<String>) {
+/// New format: `{window}.{pane}\t{window_name}\t{window_active}\t{pane_title}:{pane_current_command}`
+///
+/// Old format (backward compat): `{window}.{pane}\t{pane_title}:{pane_current_command}`
+///
+/// Old-format lines (only one tab field after the target) are handled gracefully:
+/// `window_name` is set to empty string and `window_active` to "0".
+fn parse_pane_lines(output: &str) -> ParsedPaneData {
     let mut targets = Vec::new();
+    let mut window_names = Vec::new();
+    let mut window_active = Vec::new();
     let mut titles = Vec::new();
     let mut commands = Vec::new();
 
@@ -273,22 +295,48 @@ fn parse_pane_lines(output: &str) -> (Vec<String>, Vec<String>, Vec<String>) {
         if line.is_empty() {
             continue;
         }
-        // Format: "{window_index}.{pane_index}\t{pane_title}:{pane_current_command}"
-        // Split on tab first to separate target from title:command.
-        if let Some((target, rest)) = line.split_once('\t') {
-            targets.push(target.to_string());
-            // Split rest on first colon; title may contain colons.
-            if let Some((title, cmd)) = rest.split_once(':') {
-                titles.push(title.to_string());
-                commands.push(cmd.to_string());
-            } else {
-                titles.push(rest.to_string());
-                commands.push(String::new());
+        // Split on tabs; new format has 4 fields, old format has 2.
+        let parts: Vec<&str> = line.splitn(4, '\t').collect();
+        match parts.as_slice() {
+            [target, win_name, win_active, rest] => {
+                // New format: target, window_name, window_active, title:command
+                targets.push(target.to_string());
+                window_names.push(win_name.to_string());
+                window_active.push(win_active.to_string());
+                if let Some((title, cmd)) = rest.split_once(':') {
+                    titles.push(title.to_string());
+                    commands.push(cmd.to_string());
+                } else {
+                    titles.push(rest.to_string());
+                    commands.push(String::new());
+                }
+            }
+            [target, rest] => {
+                // Old format: target, title:command
+                targets.push(target.to_string());
+                window_names.push(String::new());
+                window_active.push("0".to_string());
+                if let Some((title, cmd)) = rest.split_once(':') {
+                    titles.push(title.to_string());
+                    commands.push(cmd.to_string());
+                } else {
+                    titles.push(rest.to_string());
+                    commands.push(String::new());
+                }
+            }
+            _ => {
+                // Malformed line — skip.
             }
         }
     }
 
-    (targets, titles, commands)
+    ParsedPaneData {
+        targets,
+        window_names,
+        window_active,
+        titles,
+        commands,
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -520,7 +568,7 @@ pub fn refresh_tmux_sessions(host: Option<&str>) -> anyhow::Result<()> {
         |session_name| {
             // -s lists panes across ALL windows in the session.
             // Format: "window.pane\ttitle:command" for parse_pane_lines.
-            let pane_fmt = "#{window_index}.#{pane_index}\t#{pane_title}:#{pane_current_command}";
+            let pane_fmt = "#{window_index}.#{pane_index}\t#{window_name}\t#{window_active}\t#{pane_title}:#{pane_current_command}";
             match host {
                 None => run_local(
                     "tmux",
@@ -1166,37 +1214,47 @@ mod tests {
     // -- parse_pane_lines ---------------------------------------------------
 
     #[test]
-    fn parse_pane_lines_single_window() {
-        let output = "0.0\tbash:bash\n0.1\tvim:vim\n";
-        let (targets, titles, commands) = parse_pane_lines(output);
-        assert_eq!(targets, vec!["0.0", "0.1"]);
-        assert_eq!(titles, vec!["bash", "vim"]);
-        assert_eq!(commands, vec!["bash", "vim"]);
+    fn parse_pane_lines_new_format_extracts_window_metadata() {
+        let output = "0.0\tmain\t1\tbash:bash\n0.1\tmain\t1\tclaude:claude\n1.0\teditor\t0\tnvim:nvim\n";
+        let parsed = parse_pane_lines(output);
+        assert_eq!(parsed.targets, vec!["0.0", "0.1", "1.0"]);
+        assert_eq!(parsed.window_names, vec!["main", "main", "editor"]);
+        assert_eq!(parsed.window_active, vec!["1", "1", "0"]);
+        assert_eq!(parsed.titles, vec!["bash", "claude", "nvim"]);
+        assert_eq!(parsed.commands, vec!["bash", "claude", "nvim"]);
     }
 
     #[test]
-    fn parse_pane_lines_multi_window() {
-        let output = "0.0\tbash:bash\n0.1\tclaude:claude\n1.0\tnvim:nvim\n";
-        let (targets, titles, commands) = parse_pane_lines(output);
-        assert_eq!(targets, vec!["0.0", "0.1", "1.0"]);
-        assert_eq!(titles, vec!["bash", "claude", "nvim"]);
-        assert_eq!(commands, vec!["bash", "claude", "nvim"]);
+    fn parse_pane_lines_old_format_backward_compat() {
+        // Old format: only two tab-separated fields — target and title:command.
+        let output = "0.0\tbash:bash\n0.1\tvim:vim\n";
+        let parsed = parse_pane_lines(output);
+        assert_eq!(parsed.targets, vec!["0.0", "0.1"]);
+        // Old format: window_names empty, window_active defaults to "0".
+        assert_eq!(parsed.window_names, vec!["", ""]);
+        assert_eq!(parsed.window_active, vec!["0", "0"]);
+        assert_eq!(parsed.titles, vec!["bash", "vim"]);
+        assert_eq!(parsed.commands, vec!["bash", "vim"]);
     }
 
     #[test]
     fn parse_pane_lines_empty_input() {
-        let (targets, titles, commands) = parse_pane_lines("");
-        assert!(targets.is_empty());
-        assert!(titles.is_empty());
-        assert!(commands.is_empty());
+        let parsed = parse_pane_lines("");
+        assert!(parsed.targets.is_empty());
+        assert!(parsed.window_names.is_empty());
+        assert!(parsed.window_active.is_empty());
+        assert!(parsed.titles.is_empty());
+        assert!(parsed.commands.is_empty());
     }
 
     #[test]
-    fn parse_pane_lines_title_with_colon() {
-        let output = "0.0\tClaude: my-project:node\n";
-        let (targets, titles, commands) = parse_pane_lines(output);
-        assert_eq!(targets, vec!["0.0"]);
-        assert_eq!(titles, vec!["Claude"]);
-        assert_eq!(commands, vec![" my-project:node"]);
+    fn parse_pane_lines_title_with_colon_new_format() {
+        let output = "0.0\tmain\t1\tClaude: my-project:node\n";
+        let parsed = parse_pane_lines(output);
+        assert_eq!(parsed.targets, vec!["0.0"]);
+        assert_eq!(parsed.window_names, vec!["main"]);
+        assert_eq!(parsed.window_active, vec!["1"]);
+        assert_eq!(parsed.titles, vec!["Claude"]);
+        assert_eq!(parsed.commands, vec![" my-project:node"]);
     }
 }

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -6,7 +6,8 @@
 use crate::cache::{CachedIssue, CachedPr, CachedTmuxSession, CachedWorktree};
 use crate::github;
 use crate::session::{
-    ClaudeSessionInfo, EnrichedSession, Host, SessionStatus, TmuxSessionInfo, build_pane_infos,
+    ClaudeSessionInfo, EnrichedSession, Host, PaneInfo, SessionStatus, TmuxSessionInfo,
+    WindowInfo, build_windows_and_panes,
 };
 
 /// Tuple type for per-repo cache data passed to [`derive_all_repos`].
@@ -245,10 +246,12 @@ fn enrich_session(
         status: SessionStatus::Running { attached: false },
     };
 
-    let panes = build_pane_infos(
+    let (windows, panes) = build_windows_and_panes(
         &session.pane_targets,
         &session.pane_commands,
         &session.pane_titles,
+        &session.window_names,
+        &session.window_active,
     );
 
     // Hook-first: check if a fresh state file exists for this session.
@@ -260,27 +263,24 @@ fn enrich_session(
             return EnrichedSession {
                 tmux,
                 claude,
+                windows,
                 panes,
             };
         }
     }
 
     // Fallback: terminal scraping.
-    enrich_session_from_scraping(session, tmux)
+    enrich_session_from_scraping(session, tmux, windows, panes)
 }
 
 /// Derives session info by scraping terminal output (fallback when no hook state).
 fn enrich_session_from_scraping(
     session: &CachedTmuxSession,
     tmux: TmuxSessionInfo,
+    windows: Vec<WindowInfo>,
+    panes: Vec<PaneInfo>,
 ) -> EnrichedSession {
     use crate::claude_state::ClaudeState;
-
-    let panes = build_pane_infos(
-        &session.pane_targets,
-        &session.pane_commands,
-        &session.pane_titles,
-    );
 
     let has_claude_active = session
         .pane_commands
@@ -341,6 +341,7 @@ fn enrich_session_from_scraping(
     EnrichedSession {
         tmux,
         claude,
+        windows,
         panes,
     }
 }
@@ -470,7 +471,14 @@ mod tests {
             name: session.name.clone(),
             status: SessionStatus::Running { attached: false },
         };
-        enrich_session_from_scraping(session, tmux)
+        let (windows, panes) = build_windows_and_panes(
+            &session.pane_targets,
+            &session.pane_commands,
+            &session.pane_titles,
+            &session.window_names,
+            &session.window_active,
+        );
+        enrich_session_from_scraping(session, tmux, windows, panes)
     }
 
     fn open_issue(number: u32) -> CachedIssue {
@@ -538,6 +546,8 @@ mod tests {
             pane_targets: targets,
             pane_titles: vec![],
             pane_commands: pane_commands.into_iter().map(|s| s.to_string()).collect(),
+            window_names: vec![],
+            window_active: vec![],
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
@@ -1420,6 +1430,8 @@ mod tests {
             pane_targets: targets,
             pane_titles: pane_titles.into_iter().map(|s| s.to_string()).collect(),
             pane_commands: pane_commands.into_iter().map(|s| s.to_string()).collect(),
+            window_names: vec![],
+            window_active: vec![],
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
@@ -1454,6 +1466,8 @@ mod tests {
             pane_targets: vec![],
             pane_titles: vec![],
             pane_commands: vec![],
+            window_names: vec![],
+            window_active: vec![],
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -6,8 +6,8 @@
 use crate::cache::{CachedIssue, CachedPr, CachedTmuxSession, CachedWorktree};
 use crate::github;
 use crate::session::{
-    ClaudeSessionInfo, EnrichedSession, Host, PaneInfo, SessionStatus, TmuxSessionInfo,
-    WindowInfo, build_windows_and_panes,
+    ClaudeSessionInfo, EnrichedSession, Host, PaneInfo, SessionStatus, TmuxSessionInfo, WindowInfo,
+    build_windows_and_panes,
 };
 
 /// Tuple type for per-repo cache data passed to [`derive_all_repos`].

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use crate::claude_state::ClaudeState;
 use crate::derive::DisplayGroup;
 use crate::orchard_state::{
-    IssueInfo, OrchardState, PrState, RepoState, SessionState, WorktreeState,
+    IssueInfo, OrchardState, PrState, RepoState, SessionState, WindowState, WorktreeState,
 };
 use crate::session::StandaloneSessionRow;
 
@@ -109,7 +109,8 @@ pub struct JsonPr {
 
 /// Session information in JSON output using the EnrichedSession shape.
 ///
-/// Contains tmux session identity (name, host, status) and optional Claude enrichment.
+/// Contains tmux session identity (name, host, status), optional Claude enrichment,
+/// and the full window → pane hierarchy.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonSession {
@@ -121,6 +122,42 @@ pub struct JsonSession {
     pub status: String,
     /// Claude enrichment data, or `null` when no Claude process is active.
     pub claude: Option<JsonClaudeInfo>,
+    /// Window hierarchy for this session (window → pane structure).
+    pub windows: Vec<JsonWindow>,
+}
+
+/// Window within a session in JSON output.
+///
+/// Contains window identity and its panes.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JsonWindow {
+    /// Tmux's stable window index.
+    pub index: usize,
+    /// Window name from tmux.
+    pub name: String,
+    /// Whether this is the active window in the session.
+    pub is_active: bool,
+    /// Panes belonging to this window.
+    pub panes: Vec<JsonPane>,
+}
+
+/// Individual pane within a window in JSON output.
+///
+/// Contains pane identity, running command, title, and Claude detection flag.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JsonPane {
+    /// Zero-based sequential index in the flat pane list.
+    pub index: usize,
+    /// Tmux window.pane target address (e.g., "0.1").
+    pub tmux_target: String,
+    /// Command running in this pane.
+    pub command: String,
+    /// Tmux pane title.
+    pub title: String,
+    /// True when the pane is running a Claude process.
+    pub has_claude: bool,
 }
 
 /// Claude enrichment data in JSON output.
@@ -200,8 +237,26 @@ impl From<&PrState> for JsonPr {
     }
 }
 
+impl From<&WindowState> for JsonWindow {
+    /// Converts an internal `WindowState` to JSON output format with nested panes.
+    fn from(w: &WindowState) -> Self {
+        Self {
+            index: w.index,
+            name: w.name.clone(),
+            is_active: w.is_active,
+            panes: w.panes.iter().map(|p| JsonPane {
+                index: p.index,
+                tmux_target: p.tmux_target.clone(),
+                command: p.command.clone(),
+                title: p.title.clone(),
+                has_claude: p.has_claude,
+            }).collect(),
+        }
+    }
+}
+
 impl From<&SessionState> for JsonSession {
-    /// Converts an internal `SessionState` to JSON v3 format with nested `claude` field.
+    /// Converts an internal `SessionState` to JSON v4 format with nested `claude` and `windows` fields.
     fn from(s: &SessionState) -> Self {
         let host = match &s.host {
             Some(h) => h.clone(),
@@ -218,6 +273,7 @@ impl From<&SessionState> for JsonSession {
             host,
             status: "running".to_string(),
             claude,
+            windows: s.windows.iter().map(Into::into).collect(),
         }
     }
 }
@@ -264,17 +320,30 @@ impl From<&StandaloneSessionRow> for JsonSession {
             context_window_pct: c.context_window_pct,
             model: c.model.clone(),
         });
+        let windows = row.session.windows.iter().map(|w| JsonWindow {
+            index: w.index,
+            name: w.name.clone(),
+            is_active: w.is_active,
+            panes: w.panes.iter().map(|p| JsonPane {
+                index: p.index,
+                tmux_target: p.tmux_target.clone(),
+                command: p.command.clone(),
+                title: p.title.clone(),
+                has_claude: p.has_claude,
+            }).collect(),
+        }).collect();
         Self {
             name: row.session.tmux.name.clone(),
             host,
             status: status.to_string(),
             claude,
+            windows,
         }
     }
 }
 
 impl From<&OrchardState> for JsonOutput {
-    /// Converts the unified `OrchardState` to JSON output, setting version to 3.
+    /// Converts the unified `OrchardState` to JSON output, setting version to 4.
     fn from(state: &OrchardState) -> Self {
         let hosts = state
             .hosts
@@ -290,7 +359,7 @@ impl From<&OrchardState> for JsonOutput {
             .collect();
 
         Self {
-            version: 3,
+            version: 4,
             tmux_sessions: state.standalone_sessions.iter().map(Into::into).collect(),
             repos: state.repos.iter().map(Into::into).collect(),
             hosts,
@@ -323,9 +392,9 @@ mod tests {
     }
 
     #[test]
-    fn from_orchard_state_produces_version_3() {
+    fn from_orchard_state_produces_version_4() {
         let output = JsonOutput::from(&empty_state());
-        assert_eq!(output.version, 3);
+        assert_eq!(output.version, 4);
     }
 
     #[test]
@@ -431,6 +500,7 @@ mod tests {
                 context_window_pct: None,
                 model: None,
             }),
+            windows: vec![],
         };
         let js = JsonSession::from(&session);
         assert_eq!(js.host, "local");
@@ -445,8 +515,108 @@ mod tests {
             name: "repo-main".to_string(),
             host: None,
             claude: None,
+            windows: vec![],
         };
         let js = JsonSession::from(&session);
         assert!(js.claude.is_none());
+    }
+
+    // -- Window hierarchy tests (section 9) ----------------------------------
+
+    use crate::orchard_state::{PaneState, WindowState};
+
+    fn make_session_with_windows() -> SessionState {
+        SessionState {
+            name: "test-session".to_string(),
+            host: None,
+            claude: None,
+            windows: vec![
+                WindowState {
+                    index: 0,
+                    name: "main".to_string(),
+                    is_active: true,
+                    panes: vec![
+                        PaneState {
+                            index: 0,
+                            tmux_target: "0.0".to_string(),
+                            command: "bash".to_string(),
+                            title: "bash".to_string(),
+                            has_claude: false,
+                        },
+                    ],
+                },
+                WindowState {
+                    index: 1,
+                    name: "editor".to_string(),
+                    is_active: false,
+                    panes: vec![
+                        PaneState {
+                            index: 1,
+                            tmux_target: "1.0".to_string(),
+                            command: "claude".to_string(),
+                            title: "claude".to_string(),
+                            has_claude: true,
+                        },
+                    ],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn json_version_is_4() {
+        let output = JsonOutput::from(&empty_state());
+        assert_eq!(output.version, 4);
+    }
+
+    #[test]
+    fn json_session_includes_windows_array() {
+        let session = make_session_with_windows();
+        let js = JsonSession::from(&session);
+        assert_eq!(js.windows.len(), 2);
+    }
+
+    #[test]
+    fn json_window_has_index_name_is_active_panes() {
+        let session = make_session_with_windows();
+        let value = serde_json::to_value(JsonSession::from(&session)).unwrap();
+        let win0 = &value["windows"][0];
+        assert!(win0.get("index").is_some(), "expected 'index'");
+        assert!(win0.get("name").is_some(), "expected 'name'");
+        assert!(win0.get("isActive").is_some(), "expected camelCase 'isActive'");
+        assert!(win0.get("panes").is_some(), "expected 'panes'");
+        assert_eq!(win0["index"], 0);
+        assert_eq!(win0["name"], "main");
+        assert_eq!(win0["isActive"], true);
+    }
+
+    #[test]
+    fn json_pane_has_expected_camelcase_fields() {
+        let session = make_session_with_windows();
+        let value = serde_json::to_value(JsonSession::from(&session)).unwrap();
+        let pane = &value["windows"][1]["panes"][0];
+        assert!(pane.get("index").is_some(), "expected 'index'");
+        assert!(pane.get("tmuxTarget").is_some(), "expected camelCase 'tmuxTarget'");
+        assert!(pane.get("command").is_some(), "expected 'command'");
+        assert!(pane.get("title").is_some(), "expected 'title'");
+        assert!(pane.get("hasClaude").is_some(), "expected camelCase 'hasClaude'");
+        assert_eq!(pane["hasClaude"], true);
+    }
+
+    #[test]
+    fn json_single_window_session_still_has_windows_array() {
+        let session = SessionState {
+            name: "single-window".to_string(),
+            host: None,
+            claude: None,
+            windows: vec![WindowState {
+                index: 0,
+                name: "main".to_string(),
+                is_active: true,
+                panes: vec![],
+            }],
+        };
+        let js = JsonSession::from(&session);
+        assert_eq!(js.windows.len(), 1);
     }
 }

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -244,13 +244,17 @@ impl From<&WindowState> for JsonWindow {
             index: w.index,
             name: w.name.clone(),
             is_active: w.is_active,
-            panes: w.panes.iter().map(|p| JsonPane {
-                index: p.index,
-                tmux_target: p.tmux_target.clone(),
-                command: p.command.clone(),
-                title: p.title.clone(),
-                has_claude: p.has_claude,
-            }).collect(),
+            panes: w
+                .panes
+                .iter()
+                .map(|p| JsonPane {
+                    index: p.index,
+                    tmux_target: p.tmux_target.clone(),
+                    command: p.command.clone(),
+                    title: p.title.clone(),
+                    has_claude: p.has_claude,
+                })
+                .collect(),
         }
     }
 }
@@ -320,18 +324,27 @@ impl From<&StandaloneSessionRow> for JsonSession {
             context_window_pct: c.context_window_pct,
             model: c.model.clone(),
         });
-        let windows = row.session.windows.iter().map(|w| JsonWindow {
-            index: w.index,
-            name: w.name.clone(),
-            is_active: w.is_active,
-            panes: w.panes.iter().map(|p| JsonPane {
-                index: p.index,
-                tmux_target: p.tmux_target.clone(),
-                command: p.command.clone(),
-                title: p.title.clone(),
-                has_claude: p.has_claude,
-            }).collect(),
-        }).collect();
+        let windows = row
+            .session
+            .windows
+            .iter()
+            .map(|w| JsonWindow {
+                index: w.index,
+                name: w.name.clone(),
+                is_active: w.is_active,
+                panes: w
+                    .panes
+                    .iter()
+                    .map(|p| JsonPane {
+                        index: p.index,
+                        tmux_target: p.tmux_target.clone(),
+                        command: p.command.clone(),
+                        title: p.title.clone(),
+                        has_claude: p.has_claude,
+                    })
+                    .collect(),
+            })
+            .collect();
         Self {
             name: row.session.tmux.name.clone(),
             host,
@@ -535,29 +548,25 @@ mod tests {
                     index: 0,
                     name: "main".to_string(),
                     is_active: true,
-                    panes: vec![
-                        PaneState {
-                            index: 0,
-                            tmux_target: "0.0".to_string(),
-                            command: "bash".to_string(),
-                            title: "bash".to_string(),
-                            has_claude: false,
-                        },
-                    ],
+                    panes: vec![PaneState {
+                        index: 0,
+                        tmux_target: "0.0".to_string(),
+                        command: "bash".to_string(),
+                        title: "bash".to_string(),
+                        has_claude: false,
+                    }],
                 },
                 WindowState {
                     index: 1,
                     name: "editor".to_string(),
                     is_active: false,
-                    panes: vec![
-                        PaneState {
-                            index: 1,
-                            tmux_target: "1.0".to_string(),
-                            command: "claude".to_string(),
-                            title: "claude".to_string(),
-                            has_claude: true,
-                        },
-                    ],
+                    panes: vec![PaneState {
+                        index: 1,
+                        tmux_target: "1.0".to_string(),
+                        command: "claude".to_string(),
+                        title: "claude".to_string(),
+                        has_claude: true,
+                    }],
                 },
             ],
         }
@@ -583,7 +592,10 @@ mod tests {
         let win0 = &value["windows"][0];
         assert!(win0.get("index").is_some(), "expected 'index'");
         assert!(win0.get("name").is_some(), "expected 'name'");
-        assert!(win0.get("isActive").is_some(), "expected camelCase 'isActive'");
+        assert!(
+            win0.get("isActive").is_some(),
+            "expected camelCase 'isActive'"
+        );
         assert!(win0.get("panes").is_some(), "expected 'panes'");
         assert_eq!(win0["index"], 0);
         assert_eq!(win0["name"], "main");
@@ -596,10 +608,16 @@ mod tests {
         let value = serde_json::to_value(JsonSession::from(&session)).unwrap();
         let pane = &value["windows"][1]["panes"][0];
         assert!(pane.get("index").is_some(), "expected 'index'");
-        assert!(pane.get("tmuxTarget").is_some(), "expected camelCase 'tmuxTarget'");
+        assert!(
+            pane.get("tmuxTarget").is_some(),
+            "expected camelCase 'tmuxTarget'"
+        );
         assert!(pane.get("command").is_some(), "expected 'command'");
         assert!(pane.get("title").is_some(), "expected 'title'");
-        assert!(pane.get("hasClaude").is_some(), "expected camelCase 'hasClaude'");
+        assert!(
+            pane.get("hasClaude").is_some(),
+            "expected camelCase 'hasClaude'"
+        );
         assert_eq!(pane["hasClaude"], true);
     }
 

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -135,6 +135,7 @@ pub struct PrState {
 ///
 /// Mirrors the `EnrichedSession` domain type from `session.rs`.
 /// The `claude` field is `None` when no Claude process is detected.
+/// The `windows` field contains the full session → window → pane hierarchy.
 #[derive(Debug, Clone)]
 pub struct SessionState {
     /// tmux session name.
@@ -143,6 +144,40 @@ pub struct SessionState {
     pub host: Option<String>,
     /// Claude enrichment data, if a Claude process is active.
     pub claude: Option<ClaudeEnrichment>,
+    /// Window hierarchy for this session (window → pane structure).
+    pub windows: Vec<WindowState>,
+}
+
+/// Window within a session, with nested panes.
+///
+/// Mirrors `WindowInfo` from `session.rs` for the state layer.
+#[derive(Debug, Clone)]
+pub struct WindowState {
+    /// Tmux's stable window index.
+    pub index: usize,
+    /// Window name from tmux.
+    pub name: String,
+    /// Whether this is the active window in the session.
+    pub is_active: bool,
+    /// Panes belonging to this window.
+    pub panes: Vec<PaneState>,
+}
+
+/// Individual pane within a window.
+///
+/// Mirrors `PaneInfo` from `session.rs` for the state layer.
+#[derive(Debug, Clone)]
+pub struct PaneState {
+    /// Zero-based sequential index in the flat pane list.
+    pub index: usize,
+    /// Tmux window.pane target address (e.g., "0.1").
+    pub tmux_target: String,
+    /// Command running in this pane.
+    pub command: String,
+    /// Tmux pane title.
+    pub title: String,
+    /// True when the pane is running a Claude process.
+    pub has_claude: bool,
 }
 
 /// Claude enrichment data within a `SessionState`.
@@ -197,10 +232,23 @@ impl From<&EnrichedSession> for SessionState {
             context_window_pct: c.context_window_pct,
             model: c.model.clone(),
         });
+        let windows = s.windows.iter().map(|w| WindowState {
+            index: w.index,
+            name: w.name.clone(),
+            is_active: w.is_active,
+            panes: w.panes.iter().map(|p| PaneState {
+                index: p.index,
+                tmux_target: p.tmux_target.clone(),
+                command: p.command.clone(),
+                title: p.title.clone(),
+                has_claude: p.has_claude,
+            }).collect(),
+        }).collect();
         Self {
             name: s.tmux.name.clone(),
             host,
             claude,
+            windows,
         }
     }
 }
@@ -391,5 +439,70 @@ mod tests {
         };
         let pr_state = PrState::from(&pr_info);
         assert!(pr_state.state.is_none());
+    }
+
+    // -- From<&EnrichedSession> for SessionState tests ----------------------
+
+    use crate::session::{
+        EnrichedSession, Host, PaneInfo, SessionStatus, TmuxSessionInfo, WindowInfo,
+    };
+
+    fn make_enriched_session(windows: Vec<WindowInfo>) -> EnrichedSession {
+        let panes = windows.iter().flat_map(|w| w.panes.clone()).collect();
+        EnrichedSession {
+            tmux: TmuxSessionInfo {
+                host: Host::Local,
+                name: "test-session".to_string(),
+                status: SessionStatus::Running { attached: false },
+            },
+            claude: None,
+            windows,
+            panes,
+        }
+    }
+
+    #[test]
+    fn from_enriched_session_converts_windows_with_panes() {
+        let windows = vec![
+            WindowInfo {
+                index: 0,
+                name: "main".to_string(),
+                is_active: true,
+                panes: vec![
+                    PaneInfo::new(0, "0.0", "bash", "bash"),
+                    PaneInfo::new(1, "0.1", "nvim", "nvim"),
+                ],
+            },
+            WindowInfo {
+                index: 1,
+                name: "editor".to_string(),
+                is_active: false,
+                panes: vec![PaneInfo::new(2, "1.0", "claude", "claude")],
+            },
+        ];
+        let enriched = make_enriched_session(windows);
+        let state = SessionState::from(&enriched);
+
+        assert_eq!(state.name, "test-session");
+        assert!(state.host.is_none());
+        assert_eq!(state.windows.len(), 2);
+        assert_eq!(state.windows[0].index, 0);
+        assert_eq!(state.windows[0].name, "main");
+        assert!(state.windows[0].is_active);
+        assert_eq!(state.windows[0].panes.len(), 2);
+        assert_eq!(state.windows[0].panes[0].tmux_target, "0.0");
+        assert_eq!(state.windows[0].panes[1].tmux_target, "0.1");
+        assert_eq!(state.windows[1].index, 1);
+        assert_eq!(state.windows[1].name, "editor");
+        assert!(!state.windows[1].is_active);
+        assert_eq!(state.windows[1].panes.len(), 1);
+        assert!(state.windows[1].panes[0].has_claude);
+    }
+
+    #[test]
+    fn from_enriched_session_empty_windows_produces_empty_windows() {
+        let enriched = make_enriched_session(vec![]);
+        let state = SessionState::from(&enriched);
+        assert!(state.windows.is_empty());
     }
 }

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -232,18 +232,26 @@ impl From<&EnrichedSession> for SessionState {
             context_window_pct: c.context_window_pct,
             model: c.model.clone(),
         });
-        let windows = s.windows.iter().map(|w| WindowState {
-            index: w.index,
-            name: w.name.clone(),
-            is_active: w.is_active,
-            panes: w.panes.iter().map(|p| PaneState {
-                index: p.index,
-                tmux_target: p.tmux_target.clone(),
-                command: p.command.clone(),
-                title: p.title.clone(),
-                has_claude: p.has_claude,
-            }).collect(),
-        }).collect();
+        let windows = s
+            .windows
+            .iter()
+            .map(|w| WindowState {
+                index: w.index,
+                name: w.name.clone(),
+                is_active: w.is_active,
+                panes: w
+                    .panes
+                    .iter()
+                    .map(|p| PaneState {
+                        index: p.index,
+                        tmux_target: p.tmux_target.clone(),
+                        command: p.command.clone(),
+                        title: p.title.clone(),
+                        has_claude: p.has_claude,
+                    })
+                    .collect(),
+            })
+            .collect();
         Self {
             name: s.tmux.name.clone(),
             host,

--- a/crates/orchard/src/session.rs
+++ b/crates/orchard/src/session.rs
@@ -467,10 +467,6 @@ mod tests {
 
     // -- WindowInfo / build_windows tests -----------------------------------
 
-    fn s(v: &str) -> String {
-        v.to_string()
-    }
-
     fn svec(items: &[&str]) -> Vec<String> {
         items.iter().map(|s| s.to_string()).collect()
     }

--- a/crates/orchard/src/session.rs
+++ b/crates/orchard/src/session.rs
@@ -571,13 +571,9 @@ mod tests {
         let names = svec(&["main", "main", "editor"]);
         let active = svec(&["1", "1", "0"]);
 
-        let (windows, panes) =
-            build_windows_and_panes(&targets, &cmds, &titles, &names, &active);
+        let (windows, panes) = build_windows_and_panes(&targets, &cmds, &titles, &names, &active);
 
-        let expected: Vec<PaneInfo> = windows
-            .iter()
-            .flat_map(|w| w.panes.clone())
-            .collect();
+        let expected: Vec<PaneInfo> = windows.iter().flat_map(|w| w.panes.clone()).collect();
 
         assert_eq!(panes, expected);
         assert_eq!(panes.len(), 3);

--- a/crates/orchard/src/session.rs
+++ b/crates/orchard/src/session.rs
@@ -31,7 +31,7 @@ pub enum Host {
 /// Whether a tmux session is alive and, if so, whether it is attached.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SessionStatus {
-    /// The session is running. `attached` is true when a client is connected.
+    /// The session is running. `attached` is true when a terminal client is connected.
     Running {
         /// True when a terminal client is attached to this session.
         attached: bool,
@@ -157,6 +157,146 @@ pub fn build_pane_infos(
 }
 
 // ---------------------------------------------------------------------------
+// WindowInfo
+// ---------------------------------------------------------------------------
+
+/// Per-window metadata for a tmux session, containing the panes in that window.
+///
+/// Windows group panes in tmux. The `index` field uses tmux's stable window
+/// index (not sequential 0..N), so closing a window doesn't shift indices
+/// for remaining windows and expansion state keys remain stable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowInfo {
+    /// Tmux's stable window index (not sequential — survives window closes).
+    pub index: usize,
+    /// Window name from tmux (e.g., "main", "editor").
+    pub name: String,
+    /// Whether this is the active window in the session.
+    pub is_active: bool,
+    /// Panes belonging to this window.
+    pub panes: Vec<PaneInfo>,
+}
+
+/// Parses the window index from a tmux pane target like "1.2" → 1.
+///
+/// Returns 0 if the target is malformed.
+fn parse_window_index(target: &str) -> usize {
+    target
+        .split_once('.')
+        .and_then(|(w, _)| w.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Builds a `Vec<WindowInfo>` by grouping panes by window index.
+///
+/// - `pane_targets`: tmux window.pane addresses, e.g. `["0.0", "0.1", "1.0"]`
+/// - `pane_commands`: command running in each pane (parallel to targets)
+/// - `pane_titles`: pane title for each pane (parallel to targets)
+/// - `window_names`: window name per pane row (parallel to targets). When empty,
+///   synthetic names like `"window:0"` are derived from the window index.
+/// - `window_active`: "1" means active window, anything else means inactive
+///   (parallel to targets). When empty, all windows are marked inactive.
+///
+/// Windows are returned sorted by their tmux window index. Within each window,
+/// panes appear in the order they were encountered in `pane_targets`.
+pub fn build_windows(
+    pane_targets: &[String],
+    pane_commands: &[String],
+    pane_titles: &[String],
+    window_names: &[String],
+    window_active: &[String],
+) -> Vec<WindowInfo> {
+    if pane_targets.is_empty() {
+        return Vec::new();
+    }
+
+    // Use an ordered vec of (window_index, WindowInfo) to preserve insertion order.
+    // We'll sort by index at the end.
+    let mut window_order: Vec<usize> = Vec::new();
+    let mut window_map: std::collections::HashMap<usize, WindowInfo> =
+        std::collections::HashMap::new();
+
+    let empty = String::new();
+
+    for (flat_idx, target) in pane_targets.iter().enumerate() {
+        let win_idx = parse_window_index(target);
+        let cmd = pane_commands.get(flat_idx).unwrap_or(&empty);
+        let title = pane_titles.get(flat_idx).unwrap_or(&empty);
+
+        let pane = PaneInfo::new(flat_idx, target, cmd, title);
+
+        if let Some(window) = window_map.get_mut(&win_idx) {
+            window.panes.push(pane);
+        } else {
+            // Derive window name: use provided name or synthesize.
+            let name = if window_names.is_empty() {
+                format!("window:{win_idx}")
+            } else {
+                window_names
+                    .get(flat_idx)
+                    .cloned()
+                    .unwrap_or_else(|| format!("window:{win_idx}"))
+            };
+
+            // Active flag: "1" means active.
+            let is_active = window_active
+                .get(flat_idx)
+                .map(|s| s == "1")
+                .unwrap_or(false);
+
+            window_order.push(win_idx);
+            window_map.insert(
+                win_idx,
+                WindowInfo {
+                    index: win_idx,
+                    name,
+                    is_active,
+                    panes: vec![pane],
+                },
+            );
+        }
+    }
+
+    // Return windows sorted by tmux window index.
+    window_order.sort_unstable();
+    window_order.dedup();
+    window_order
+        .into_iter()
+        .filter_map(|idx| window_map.remove(&idx))
+        .collect()
+}
+
+/// Builds both the structured window hierarchy and the denormalized flat pane list.
+///
+/// The flat `panes` vec is kept on `EnrichedSession` for backward compatibility —
+/// it's all panes in window order, concatenated. The 28+ call sites that use
+/// `session.panes` continue working without changes.
+///
+/// # Arguments
+/// - `pane_targets`: tmux window.pane addresses (e.g. "0.0", "1.2")
+/// - `pane_commands`: command running in each pane
+/// - `pane_titles`: title for each pane
+/// - `window_names`: window name per pane row; empty → synthetic names
+/// - `window_active`: "1" or "0" per pane row; empty → all inactive
+pub fn build_windows_and_panes(
+    pane_targets: &[String],
+    pane_commands: &[String],
+    pane_titles: &[String],
+    window_names: &[String],
+    window_active: &[String],
+) -> (Vec<WindowInfo>, Vec<PaneInfo>) {
+    let windows = build_windows(
+        pane_targets,
+        pane_commands,
+        pane_titles,
+        window_names,
+        window_active,
+    );
+    let panes = windows.iter().flat_map(|w| w.panes.clone()).collect();
+    (windows, panes)
+}
+
+// ---------------------------------------------------------------------------
 // EnrichedSession
 // ---------------------------------------------------------------------------
 
@@ -164,14 +304,21 @@ pub fn build_pane_infos(
 ///
 /// This is the primary session type consumed by the TUI and JSON output.
 /// The `claude` field is `None` when no Claude process is detected.
-/// The `panes` field contains per-pane metadata for sub-row rendering.
+/// The `windows` field contains the structured session → window → pane hierarchy.
+/// The `panes` field is a denormalized flat list derived from `windows`, kept
+/// for backward compatibility with the 28+ call sites that access it directly.
 #[derive(Debug, Clone)]
 pub struct EnrichedSession {
     /// Pure tmux session data.
     pub tmux: TmuxSessionInfo,
     /// Claude-specific enrichment, if a Claude process is active.
     pub claude: Option<ClaudeSessionInfo>,
-    /// Per-pane metadata for all panes in this session.
+    /// Structured window hierarchy for this session.
+    pub windows: Vec<WindowInfo>,
+    /// Per-pane metadata for all panes in this session (denormalized flat list).
+    ///
+    /// Derived from `windows` — all panes in window order concatenated.
+    /// Preserved for backward compatibility; use `windows` for hierarchy-aware code.
     pub panes: Vec<PaneInfo>,
 }
 
@@ -316,6 +463,124 @@ mod tests {
         assert_eq!(panes.len(), 2);
         assert_eq!(panes[0].tmux_target, "0.0");
         assert_eq!(panes[1].tmux_target, "0.1");
+    }
+
+    // -- WindowInfo / build_windows tests -----------------------------------
+
+    fn s(v: &str) -> String {
+        v.to_string()
+    }
+
+    fn svec(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn build_windows_groups_panes_by_window_index() {
+        let targets = svec(&["0.0", "0.1", "1.0", "1.1"]);
+        let cmds = svec(&["bash", "vim", "nvim", "cargo"]);
+        let titles = svec(&["bash", "vim", "nvim", "cargo"]);
+        let names = svec(&["main", "main", "editor", "editor"]);
+        let active = svec(&["1", "1", "0", "0"]);
+
+        let windows = build_windows(&targets, &cmds, &titles, &names, &active);
+
+        assert_eq!(windows.len(), 2);
+        assert_eq!(windows[0].index, 0);
+        assert_eq!(windows[0].name, "main");
+        assert!(windows[0].is_active);
+        assert_eq!(windows[0].panes.len(), 2);
+        assert_eq!(windows[1].index, 1);
+        assert_eq!(windows[1].name, "editor");
+        assert!(!windows[1].is_active);
+        assert_eq!(windows[1].panes.len(), 2);
+    }
+
+    #[test]
+    fn build_windows_contains_correct_pane_references() {
+        let targets = svec(&["0.0", "0.1", "1.0"]);
+        let cmds = svec(&["bash", "vim", "nvim"]);
+        let titles = svec(&["bash", "vim", "nvim"]);
+        let names = svec(&["shell", "shell", "code"]);
+        let active = svec(&["1", "1", "0"]);
+
+        let windows = build_windows(&targets, &cmds, &titles, &names, &active);
+
+        assert_eq!(windows[0].panes[0].tmux_target, "0.0");
+        assert_eq!(windows[0].panes[1].tmux_target, "0.1");
+        assert_eq!(windows[1].panes[0].tmux_target, "1.0");
+    }
+
+    #[test]
+    fn build_windows_single_window_produces_one_entry() {
+        let targets = svec(&["0.0", "0.1"]);
+        let cmds = svec(&["bash", "vim"]);
+        let titles = svec(&["bash", "vim"]);
+        let names = svec(&["main", "main"]);
+        let active = svec(&["1", "1"]);
+
+        let windows = build_windows(&targets, &cmds, &titles, &names, &active);
+
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].panes.len(), 2);
+    }
+
+    #[test]
+    fn build_windows_empty_input_returns_empty() {
+        let windows = build_windows(&[], &[], &[], &[], &[]);
+        assert!(windows.is_empty());
+    }
+
+    #[test]
+    fn build_windows_missing_window_names_synthesizes_fallback() {
+        let targets = svec(&["0.0", "0.1", "1.0"]);
+        let cmds = svec(&["bash", "vim", "nvim"]);
+        let titles = svec(&["bash", "vim", "nvim"]);
+
+        // Pass empty window_names and window_active
+        let windows = build_windows(&targets, &cmds, &titles, &[], &[]);
+
+        assert_eq!(windows.len(), 2);
+        assert_eq!(windows[0].name, "window:0");
+        assert_eq!(windows[1].name, "window:1");
+        assert!(!windows[0].is_active);
+        assert!(!windows[1].is_active);
+    }
+
+    #[test]
+    fn build_windows_discontinuous_indices() {
+        let targets = svec(&["0.0", "2.0", "5.0"]);
+        let cmds = svec(&["bash", "vim", "nvim"]);
+        let titles = svec(&["bash", "vim", "nvim"]);
+        let names = svec(&["main", "editor", "logs"]);
+        let active = svec(&["0", "1", "0"]);
+
+        let windows = build_windows(&targets, &cmds, &titles, &names, &active);
+
+        assert_eq!(windows.len(), 3);
+        assert_eq!(windows[0].index, 0);
+        assert_eq!(windows[1].index, 2);
+        assert_eq!(windows[2].index, 5);
+    }
+
+    #[test]
+    fn build_windows_and_panes_denormalized_matches_flattened() {
+        let targets = svec(&["0.0", "0.1", "1.0"]);
+        let cmds = svec(&["bash", "vim", "nvim"]);
+        let titles = svec(&["bash", "vim", "nvim"]);
+        let names = svec(&["main", "main", "editor"]);
+        let active = svec(&["1", "1", "0"]);
+
+        let (windows, panes) =
+            build_windows_and_panes(&targets, &cmds, &titles, &names, &active);
+
+        let expected: Vec<PaneInfo> = windows
+            .iter()
+            .flat_map(|w| w.panes.clone())
+            .collect();
+
+        assert_eq!(panes, expected);
+        assert_eq!(panes.len(), 3);
     }
 }
 

--- a/crates/orchard/src/tmux.rs
+++ b/crates/orchard/src/tmux.rs
@@ -255,6 +255,24 @@ pub fn capture_pane_content_at(
 
 /// Selects a specific pane within a tmux session.
 ///
+/// Switches to a specific window within a tmux session.
+///
+/// Runs `tmux select-window -t session:window_index` to switch
+/// the session's active window.
+pub fn select_window(session: &str, window_index: usize) -> Result<()> {
+    let target = format!("{}:{}", session, window_index);
+    let out = Command::new("tmux")
+        .args(["select-window", "-t", &target])
+        .output()
+        .context("tmux select-window")?;
+
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        anyhow::bail!("tmux select-window failed: {}", stderr.trim());
+    }
+    Ok(())
+}
+
 /// Runs `tmux select-pane -t session:{pane_target}` where `pane_target` is
 /// a window.pane address like "0.1" (window 0, pane 1).
 pub fn select_pane(session: &str, pane_target: &str) -> Result<()> {

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -353,6 +353,7 @@ mod tests {
                 status: SessionStatus::Running { attached: false },
             },
             claude: None,
+            windows: vec![],
             panes: vec![],
         }
     }

--- a/crates/orchard/src/tui/last_selection.rs
+++ b/crates/orchard/src/tui/last_selection.rs
@@ -262,7 +262,8 @@ mod tests {
                     status: SessionStatus::Dead,
                 },
                 claude: None,
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             },
             config: StandaloneConfig {
                 name: name.to_string(),

--- a/crates/orchard/src/tui/last_selection.rs
+++ b/crates/orchard/src/tui/last_selection.rs
@@ -263,7 +263,7 @@ mod tests {
                 },
                 claude: None,
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             },
             config: StandaloneConfig {
                 name: name.to_string(),

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -436,38 +436,38 @@ impl App {
                     &self.filter_text,
                     self.active_repo_slug(),
                 );
-                if let Some(vt) = tasks.get(worktree_cursor) {
-                    if let Some(session) = vt.row.sessions.first() {
-                        let session_name = session.tmux.name.clone();
-                        let worktree_path = vt.row.worktree_path.clone();
-                        let branch = Some(vt.row.branch.clone());
-                        let host = match &session.tmux.host {
-                            crate::session::Host::Local => None,
-                            crate::session::Host::Remote(h) => Some(h.clone()),
+                if let Some(vt) = tasks.get(worktree_cursor)
+                    && let Some(session) = vt.row.sessions.first()
+                {
+                    let session_name = session.tmux.name.clone();
+                    let worktree_path = vt.row.worktree_path.clone();
+                    let branch = Some(vt.row.branch.clone());
+                    let host = match &session.tmux.host {
+                        crate::session::Host::Local => None,
+                        crate::session::Host::Remote(h) => Some(h.clone()),
+                    };
+                    drop(tasks);
+                    // Guard: refuse to join a session on a host not confirmed reachable.
+                    if let Some(ref h) = host
+                        && self.host_reachable.get(h.as_str()) != Some(&true)
+                    {
+                        let msg = if self.host_reachable.contains_key(h.as_str()) {
+                            format!("@{} is unreachable", h)
+                        } else {
+                            format!("@{} -- checking connectivity...", h)
                         };
-                        drop(tasks);
-                        // Guard: refuse to join a session on a host not confirmed reachable.
-                        if let Some(ref h) = host
-                            && self.host_reachable.get(h.as_str()) != Some(&true)
-                        {
-                            let msg = if self.host_reachable.contains_key(h.as_str()) {
-                                format!("@{} is unreachable", h)
-                            } else {
-                                format!("@{} -- checking connectivity...", h)
-                            };
-                            self.warning = Some((msg, Instant::now()));
-                            return false;
-                        }
-                        self.join_or_create_session(
-                            &session_name,
-                            &worktree_path,
-                            branch.as_deref(),
-                            host.as_deref(),
-                            None,
-                        );
-                        let _ = tmux::select_window(&session_name, window_idx);
-                        return self.switch_target.is_some();
+                        self.warning = Some((msg, Instant::now()));
+                        return false;
                     }
+                    self.join_or_create_session(
+                        &session_name,
+                        &worktree_path,
+                        branch.as_deref(),
+                        host.as_deref(),
+                        None,
+                    );
+                    let _ = tmux::select_window(&session_name, window_idx);
+                    return self.switch_target.is_some();
                 }
                 return false;
             }
@@ -980,6 +980,8 @@ struct SubRowContext<'a> {
     show_branch: bool,
     has_remote: bool,
     theme: &'a Theme,
+    bar_color: Color,
+    prefix: &'a str,
 }
 
 impl App {
@@ -1417,12 +1419,13 @@ impl App {
                     show_branch,
                     has_remote,
                     theme,
+                    bar_color: Color::DarkGray,
+                    prefix: "",
                 };
                 if ss.session.windows.len() > 1 {
                     self.push_window_sub_rows(
                         &ss.session,
                         idx,
-                        Color::DarkGray,
                         &sub_ctx,
                         &mut rows,
                         &mut row_heights,
@@ -1434,8 +1437,6 @@ impl App {
                         &ss.session.panes,
                         idx,
                         win_idx,
-                        Color::DarkGray,
-                        "",
                         &sub_ctx,
                         &mut rows,
                         &mut row_heights,
@@ -1648,13 +1649,14 @@ impl App {
                     show_branch,
                     has_remote,
                     theme,
+                    bar_color,
+                    prefix: "",
                 };
                 if let Some(session) = vt.row.sessions.first() {
                     if session.windows.len() > 1 {
                         self.push_window_sub_rows(
                             session,
                             cursor_idx,
-                            bar_color,
                             &sub_ctx,
                             &mut rows,
                             &mut row_heights,
@@ -1666,8 +1668,6 @@ impl App {
                             &session.panes,
                             cursor_idx,
                             win_idx,
-                            bar_color,
-                            "",
                             &sub_ctx,
                             &mut rows,
                             &mut row_heights,
@@ -1692,12 +1692,12 @@ impl App {
         panes: &[crate::session::PaneInfo],
         parent_cursor_idx: usize,
         window_index: usize,
-        bar_color: Color,
-        prefix: &str,
         ctx: &SubRowContext<'_>,
         rows: &mut Vec<Row<'static>>,
         row_heights: &mut Vec<u16>,
     ) {
+        let bar_color = ctx.bar_color;
+        let prefix = ctx.prefix;
         use super::SubCursor;
         let pane_count = panes.len();
         for (pi, pane) in panes.iter().enumerate() {
@@ -1764,11 +1764,11 @@ impl App {
         &self,
         session: &crate::session::EnrichedSession,
         parent_cursor_idx: usize,
-        bar_color: Color,
         ctx: &SubRowContext<'_>,
         rows: &mut Vec<Row<'static>>,
         row_heights: &mut Vec<u16>,
     ) {
+        let bar_color = ctx.bar_color;
         use super::SubCursor;
         let windows = &session.windows;
         let window_count = windows.len();
@@ -1839,13 +1839,12 @@ impl App {
                 } else {
                     "\u{2502} " // │ vertical line continuation
                 };
+                let pane_ctx = SubRowContext { prefix, ..*ctx };
                 self.push_pane_sub_rows(
                     &window.panes,
                     parent_cursor_idx,
                     window.index,
-                    bar_color,
-                    prefix,
-                    ctx,
+                    &pane_ctx,
                     rows,
                     row_heights,
                 );

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -394,14 +394,87 @@ impl App {
     ///
     /// Returns `true` when the TUI should exit (to switch to a session).
     pub(crate) fn handle_enter_action(&mut self) -> bool {
+        use super::SubCursor;
         let standalone_count = self.standalone_sessions.len();
 
-        let pane_idx = self.selected_pane;
+        // Resolve pane target from SubCursor for Enter action.
+        let resolve_pane_target_from_sub_cursor =
+            |sub_cursor: &SubCursor, session: &crate::session::EnrichedSession| -> Option<String> {
+                match sub_cursor {
+                    SubCursor::Pane { window, pane } => {
+                        session
+                            .windows
+                            .iter()
+                            .find(|w| w.index == *window)
+                            .and_then(|w| w.panes.get(*pane))
+                            .map(|p| p.tmux_target.clone())
+                    }
+                    SubCursor::Window(_) => {
+                        // Enter on window → switch to that window (target is "session:window_index").
+                        // Return None; the window switch is handled above.
+                        None
+                    }
+                    SubCursor::None => None,
+                }
+            };
+
+        // Handle Enter on window sub-row: switch to that window.
+        if let SubCursor::Window(w) = &self.sub_cursor {
+            let window_idx = *w;
+            if cursor_is_standalone(self.cursor, standalone_count) {
+                if let Some(ss) = self.standalone_sessions.get(self.cursor) {
+                    let session_name = ss.session.tmux.name.clone();
+                    if tmux::session_exists(&session_name) {
+                        let _ = tmux::select_window(&session_name, window_idx);
+                        self.switch_target = Some(session_name);
+                        return true;
+                    }
+                }
+                return false;
+            } else {
+                let worktree_cursor = self.cursor - standalone_count;
+                let tasks = visible_tasks_filtered(&self.task_rows, &self.filter_text, self.active_repo_slug());
+                if let Some(vt) = tasks.get(worktree_cursor) {
+                    if let Some(session) = vt.row.sessions.first() {
+                        let session_name = session.tmux.name.clone();
+                        let worktree_path = vt.row.worktree_path.clone();
+                        let branch = Some(vt.row.branch.clone());
+                        let host = match &session.tmux.host {
+                            crate::session::Host::Local => None,
+                            crate::session::Host::Remote(h) => Some(h.clone()),
+                        };
+                        drop(tasks);
+                        // Guard: refuse to join a session on a host not confirmed reachable.
+                        if let Some(ref h) = host
+                            && self.host_reachable.get(h.as_str()) != Some(&true)
+                        {
+                            let msg = if self.host_reachable.contains_key(h.as_str()) {
+                                format!("@{} is unreachable", h)
+                            } else {
+                                format!("@{} -- checking connectivity...", h)
+                            };
+                            self.warning = Some((msg, Instant::now()));
+                            return false;
+                        }
+                        self.join_or_create_session(
+                            &session_name,
+                            &worktree_path,
+                            branch.as_deref(),
+                            host.as_deref(),
+                            None,
+                        );
+                        let _ = tmux::select_window(&session_name, window_idx);
+                        return self.switch_target.is_some();
+                    }
+                }
+                return false;
+            }
+        }
+
+        let sub_cursor = self.sub_cursor.clone();
         let action = if cursor_is_standalone(self.cursor, standalone_count) {
             self.standalone_sessions.get(self.cursor).map(|ss| {
-                let pane_target = pane_idx
-                    .and_then(|i| ss.session.panes.get(i))
-                    .map(|p| p.tmux_target.clone());
+                let pane_target = resolve_pane_target_from_sub_cursor(&sub_cursor, &ss.session);
                 TaskEnterAction::JoinStandalone {
                     session_name: ss.session.tmux.name.clone(),
                     command: ss.config.command.clone(),
@@ -419,9 +492,7 @@ impl App {
                         crate::session::Host::Local => None,
                         crate::session::Host::Remote(h) => Some(h.clone()),
                     };
-                    let pane_target = pane_idx
-                        .and_then(|i| session.panes.get(i))
-                        .map(|p| p.tmux_target.clone());
+                    let pane_target = resolve_pane_target_from_sub_cursor(&sub_cursor, session);
                     TaskEnterAction::JoinSession {
                         session_name: session.tmux.name.clone(),
                         worktree_path: vt.row.worktree_path.clone(),
@@ -535,14 +606,31 @@ impl App {
         }
     }
 
-    /// Resolves the tmux pane target string for the selected sub-row pane.
+    /// Resolves the tmux pane target string for the current sub-cursor.
     ///
-    /// Looks up the `PaneInfo.tmux_target` from the session's pane list using
-    /// `self.selected_pane` as the sequential index.
-    fn resolve_pane_target(&self, panes: &[crate::session::PaneInfo]) -> Option<String> {
-        self.selected_pane
-            .and_then(|i| panes.get(i))
-            .map(|p| p.tmux_target.clone())
+    /// For `SubCursor::Pane`, looks up the pane in the matching window.
+    /// For `SubCursor::Window`, returns the active pane target of that window (first pane).
+    /// For `SubCursor::None`, returns `None` (default pane).
+    fn resolve_pane_target(&self, session: &crate::session::EnrichedSession) -> Option<String> {
+        use super::SubCursor;
+        match &self.sub_cursor {
+            SubCursor::Pane { window, pane } => session
+                .windows
+                .iter()
+                .find(|w| w.index == *window)
+                .and_then(|w| w.panes.get(*pane))
+                .map(|p| p.tmux_target.clone()),
+            SubCursor::Window(w) => {
+                // For window-level cursor, capture the active (first) pane of that window.
+                session
+                    .windows
+                    .iter()
+                    .find(|wi| wi.index == *w)
+                    .and_then(|wi| wi.panes.first())
+                    .map(|p| p.tmux_target.clone())
+            }
+            SubCursor::None => None,
+        }
     }
 
     /// Fetches pane content for the task at the current cursor position.
@@ -559,7 +647,7 @@ impl App {
             )
         {
             let session_name = ss.session.tmux.name.clone();
-            let pane_target = self.resolve_pane_target(&ss.session.panes);
+            let pane_target = self.resolve_pane_target(&ss.session);
             let tx = self.tx.clone();
             std::thread::spawn(move || {
                 let content = tmux::capture_pane_content_at(
@@ -590,7 +678,7 @@ impl App {
                     crate::session::Host::Local => None,
                     crate::session::Host::Remote(h) => Some(h.clone()),
                 };
-                let pane_target = self.resolve_pane_target(&session.panes);
+                let pane_target = self.resolve_pane_target(session);
                 let tx = self.tx.clone();
                 std::thread::spawn(move || {
                     let content = if let Some(host) = remote_host {
@@ -1270,7 +1358,7 @@ impl App {
 
         // Render standalone session rows first.
         for (idx, ss) in self.standalone_sessions.iter().enumerate() {
-            let selected = idx == self.cursor && self.selected_pane.is_none();
+            let selected = idx == self.cursor && matches!(self.sub_cursor, super::SubCursor::None);
             if selected {
                 selected_visual_idx = Some(rows.len());
             }
@@ -1286,8 +1374,13 @@ impl App {
 
             // Expand/collapse indicator in CLAUDE cell.
             let pane_count = ss.session.panes.len();
+            let window_count = ss.session.windows.len();
             let is_expanded = self.expanded.contains(&ss.session.tmux.name);
-            let claude_display = expand_indicator(&claude_text, pane_count, is_expanded);
+            let claude_display = if window_count > 1 {
+                expand_indicator_windows(&claude_text, window_count, is_expanded)
+            } else {
+                expand_indicator(&claude_text, pane_count, is_expanded)
+            };
 
             let row_style = if selected {
                 Style::default()
@@ -1316,20 +1409,36 @@ impl App {
             rows.push(Row::new(cells).style(row_style));
             row_heights.push(1);
 
-            // Pane sub-rows for expanded standalone sessions.
+            // Sub-rows for expanded standalone sessions.
             if is_expanded {
-                self.push_pane_sub_rows(
-                    &ss.session.panes,
-                    idx,
-                    Color::DarkGray, // no repo color for standalone
-                    &SubRowContext {
-                        show_branch,
-                        has_remote,
-                        theme,
-                    },
-                    &mut rows,
-                    &mut row_heights,
-                );
+                let sub_ctx = SubRowContext {
+                    show_branch,
+                    has_remote,
+                    theme,
+                };
+                if ss.session.windows.len() > 1 {
+                    self.push_window_sub_rows(
+                        &ss.session,
+                        idx,
+                        Color::DarkGray,
+                        &sub_ctx,
+                        &mut rows,
+                        &mut row_heights,
+                    );
+                } else {
+                    // Single-window auto-flatten: render panes directly.
+                    let win_idx = ss.session.windows.first().map(|w| w.index).unwrap_or(0);
+                    self.push_pane_sub_rows(
+                        &ss.session.panes,
+                        idx,
+                        win_idx,
+                        Color::DarkGray,
+                        "",
+                        &sub_ctx,
+                        &mut rows,
+                        &mut row_heights,
+                    );
+                }
             }
 
             unified_num += 1;
@@ -1340,7 +1449,7 @@ impl App {
 
         for (flat_idx, vt) in tasks.iter().enumerate() {
             let cursor_idx = flat_idx + standalone_count;
-            let selected = cursor_idx == self.cursor && self.selected_pane.is_none();
+            let selected = cursor_idx == self.cursor && matches!(self.sub_cursor, super::SubCursor::None);
 
             // Section header when display group changes
             if last_group != Some(vt.group) {
@@ -1438,8 +1547,13 @@ impl App {
 
             // Expand/collapse indicator in CLAUDE cell.
             let pane_count = vt.row.sessions.first().map(|s| s.panes.len()).unwrap_or(0);
+            let window_count = vt.row.sessions.first().map(|s| s.windows.len()).unwrap_or(0);
             let is_expanded = self.expanded.contains(&vt.row.worktree_path);
-            let claude_display = expand_indicator(&claude_text, pane_count, is_expanded);
+            let claude_display = if window_count > 1 {
+                expand_indicator_windows(&claude_text, window_count, is_expanded)
+            } else {
+                expand_indicator(&claude_text, pane_count, is_expanded)
+            };
 
             // Build title cell with fuzzy highlights when a filter is active.
             // The TITLE field is issue_title (field index 3) or branch (field index 1).
@@ -1520,26 +1634,38 @@ impl App {
             rows.push(Row::new(cells).style(row_style));
             row_heights.push(1);
 
-            // Pane sub-rows for expanded worktree rows.
+            // Sub-rows for expanded worktree rows.
             if is_expanded {
-                let panes = vt
-                    .row
-                    .sessions
-                    .first()
-                    .map(|s| s.panes.as_slice())
-                    .unwrap_or(&[]);
-                self.push_pane_sub_rows(
-                    panes,
-                    cursor_idx,
-                    bar_color,
-                    &SubRowContext {
-                        show_branch,
-                        has_remote,
-                        theme,
-                    },
-                    &mut rows,
-                    &mut row_heights,
-                );
+                let sub_ctx = SubRowContext {
+                    show_branch,
+                    has_remote,
+                    theme,
+                };
+                if let Some(session) = vt.row.sessions.first() {
+                    if session.windows.len() > 1 {
+                        self.push_window_sub_rows(
+                            session,
+                            cursor_idx,
+                            bar_color,
+                            &sub_ctx,
+                            &mut rows,
+                            &mut row_heights,
+                        );
+                    } else {
+                        // Single-window auto-flatten: render panes directly.
+                        let win_idx = session.windows.first().map(|w| w.index).unwrap_or(0);
+                        self.push_pane_sub_rows(
+                            &session.panes,
+                            cursor_idx,
+                            win_idx,
+                            bar_color,
+                            "",
+                            &sub_ctx,
+                            &mut rows,
+                            &mut row_heights,
+                        );
+                    }
+                }
             }
 
             unified_num += 1;
@@ -1548,29 +1674,34 @@ impl App {
         (rows, row_heights, selected_visual_idx)
     }
 
-    /// Appends pane sub-rows for an expanded parent row.
+    /// Appends pane sub-rows for an expanded parent row (single-window auto-flatten).
     ///
     /// Each sub-row shows: tree connector in # cell, claude indicator, command in TITLE,
     /// and empty cells elsewhere. The BAR cell inherits the parent's repo color.
+    /// `window_index` is the tmux window index these panes belong to, used for SubCursor matching.
     fn push_pane_sub_rows(
         &self,
         panes: &[crate::session::PaneInfo],
         parent_cursor_idx: usize,
+        window_index: usize,
         bar_color: Color,
+        prefix: &str,
         ctx: &SubRowContext<'_>,
         rows: &mut Vec<Row<'static>>,
         row_heights: &mut Vec<u16>,
     ) {
+        use super::SubCursor;
         let pane_count = panes.len();
         for (pi, pane) in panes.iter().enumerate() {
             let is_last = pi == pane_count - 1;
-            let selected = self.cursor == parent_cursor_idx && self.selected_pane == Some(pi);
+            let selected = self.cursor == parent_cursor_idx
+                && self.sub_cursor == SubCursor::Pane { window: window_index, pane: pi };
 
             // Tree connector: ├─N for non-last, └─N for last pane.
             let connector = if is_last {
-                format!("\u{2514}\u{2500}{}", pane.index)
+                format!("{}\u{2514}\u{2500}{}", prefix, pane.index)
             } else {
-                format!("\u{251c}\u{2500}{}", pane.index)
+                format!("{}\u{251c}\u{2500}{}", prefix, pane.index)
             };
 
             // Claude indicator for this pane.
@@ -1610,6 +1741,100 @@ impl App {
 
             rows.push(Row::new(cells).style(row_style));
             row_heights.push(1);
+        }
+    }
+
+    /// Appends window and nested pane sub-rows for an expanded multi-window session.
+    ///
+    /// For each window, renders a window sub-row with tree connector. If the window
+    /// is expanded (in `window_expanded`), nested pane sub-rows are rendered beneath it.
+    fn push_window_sub_rows(
+        &self,
+        session: &crate::session::EnrichedSession,
+        parent_cursor_idx: usize,
+        bar_color: Color,
+        ctx: &SubRowContext<'_>,
+        rows: &mut Vec<Row<'static>>,
+        row_heights: &mut Vec<u16>,
+    ) {
+        use super::SubCursor;
+        let windows = &session.windows;
+        let window_count = windows.len();
+        let session_name = &session.tmux.name;
+
+        for (wi, window) in windows.iter().enumerate() {
+            let is_last_window = wi == window_count - 1;
+            let selected = self.cursor == parent_cursor_idx
+                && self.sub_cursor == SubCursor::Window(window.index);
+
+            // Tree connector for window row.
+            let connector = if is_last_window {
+                format!("\u{2514}\u{2500} win:{} {}", window.index, window.name)
+            } else {
+                format!("\u{251c}\u{2500} win:{} {}", window.index, window.name)
+            };
+
+            let is_window_expanded = self
+                .window_expanded
+                .contains(&super::App::window_expansion_key(session_name, window.index));
+
+            // Expand indicator for the window (in STATUS cell).
+            let status_text = if window.panes.len() > 1 {
+                let caret = if is_window_expanded {
+                    "\u{25bc}"
+                } else {
+                    "\u{25b6}"
+                };
+                format!("{}{}", caret, window.panes.len())
+            } else {
+                String::new()
+            };
+
+            let row_style = if selected {
+                Style::default()
+                    .fg(ctx.theme.accent)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(ctx.theme.dimmed)
+            };
+
+            let mut cells = vec![
+                Cell::from("\u{25cf}").style(Style::default().fg(bar_color)),
+                Cell::from(connector),
+                Cell::from(""), // CLAUDE: empty for window row
+                Cell::from(""), // ISSUE: empty
+                Cell::from(""), // TITLE: empty (name is in # cell)
+            ];
+
+            if ctx.show_branch {
+                cells.push(Cell::from(""));
+            }
+            if ctx.has_remote {
+                cells.push(Cell::from(""));
+            }
+            cells.push(Cell::from(status_text));
+
+            rows.push(Row::new(cells).style(row_style));
+            row_heights.push(1);
+
+            // If window is expanded, render nested pane sub-rows.
+            if is_window_expanded {
+                let prefix = if is_last_window {
+                    "  " // no vertical line after last window
+                } else {
+                    "\u{2502} " // │ vertical line continuation
+                };
+                self.push_pane_sub_rows(
+                    &window.panes,
+                    parent_cursor_idx,
+                    window.index,
+                    bar_color,
+                    prefix,
+                    ctx,
+                    rows,
+                    row_heights,
+                );
+            }
         }
     }
 
@@ -1895,6 +2120,27 @@ pub(crate) fn expand_indicator(base_text: &str, pane_count: usize, expanded: boo
     format!("{} {}({})", caret, rest.trim_start(), pane_count)
 }
 
+/// Expand indicator for multi-window sessions, showing window count with "w" suffix.
+///
+/// For multi-window sessions (2+ windows), shows `▶Nw` or `▼Nw`.
+/// Returns the base text unchanged if window_count <= 1.
+pub(crate) fn expand_indicator_windows(
+    base_text: &str,
+    window_count: usize,
+    expanded: bool,
+) -> String {
+    if window_count <= 1 {
+        return base_text.to_string();
+    }
+    let caret = if expanded { "\u{25bc}" } else { "\u{25b6}" }; // ▼ / ▶
+    let rest = base_text
+        .char_indices()
+        .nth(1)
+        .map(|(i, _)| &base_text[i..])
+        .unwrap_or(base_text);
+    format!("{} {}({}w)", caret, rest.trim_start(), window_count)
+}
+
 /// Creates a section header row spanning all columns for a display group.
 ///
 /// `num_columns` is the total number of columns in the table (must match the data rows).
@@ -1987,6 +2233,7 @@ mod tests {
                 status: SessionStatus::Running { attached: false },
             },
             claude: None,
+            windows: vec![],
             panes: vec![],
         }
     }
@@ -2128,7 +2375,8 @@ mod tests {
                     context_window_pct: None,
                     model: None,
                 }),
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             }],
             ..make_task_row(1, DisplayGroup::ClaudeWorking)
         };
@@ -2161,7 +2409,8 @@ mod tests {
                     context_window_pct: None,
                     model: None,
                 }),
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             }],
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2318,6 +2567,7 @@ mod tests {
                 status: SessionStatus::Running { attached: false },
             },
             claude,
+            windows: vec![],
             panes: vec![],
         }
     }
@@ -2427,7 +2677,8 @@ mod tests {
                         context_window_pct: None,
                         model: None,
                     }),
-                    panes: vec![],
+                    windows: vec![],
+            panes: vec![],
                 },
                 EnrichedSession {
                     tmux: TmuxSessionInfo {
@@ -2441,7 +2692,8 @@ mod tests {
                         context_window_pct: Some(45.0),
                         model: None,
                     }),
-                    panes: vec![],
+                    windows: vec![],
+            panes: vec![],
                 },
             ],
             ..make_task_row(1, DisplayGroup::NeedsAttention)

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -401,14 +401,12 @@ impl App {
         let resolve_pane_target_from_sub_cursor =
             |sub_cursor: &SubCursor, session: &crate::session::EnrichedSession| -> Option<String> {
                 match sub_cursor {
-                    SubCursor::Pane { window, pane } => {
-                        session
-                            .windows
-                            .iter()
-                            .find(|w| w.index == *window)
-                            .and_then(|w| w.panes.get(*pane))
-                            .map(|p| p.tmux_target.clone())
-                    }
+                    SubCursor::Pane { window, pane } => session
+                        .windows
+                        .iter()
+                        .find(|w| w.index == *window)
+                        .and_then(|w| w.panes.get(*pane))
+                        .map(|p| p.tmux_target.clone()),
                     SubCursor::Window(_) => {
                         // Enter on window → switch to that window (target is "session:window_index").
                         // Return None; the window switch is handled above.
@@ -433,7 +431,11 @@ impl App {
                 return false;
             } else {
                 let worktree_cursor = self.cursor - standalone_count;
-                let tasks = visible_tasks_filtered(&self.task_rows, &self.filter_text, self.active_repo_slug());
+                let tasks = visible_tasks_filtered(
+                    &self.task_rows,
+                    &self.filter_text,
+                    self.active_repo_slug(),
+                );
                 if let Some(vt) = tasks.get(worktree_cursor) {
                     if let Some(session) = vt.row.sessions.first() {
                         let session_name = session.tmux.name.clone();
@@ -1449,7 +1451,8 @@ impl App {
 
         for (flat_idx, vt) in tasks.iter().enumerate() {
             let cursor_idx = flat_idx + standalone_count;
-            let selected = cursor_idx == self.cursor && matches!(self.sub_cursor, super::SubCursor::None);
+            let selected =
+                cursor_idx == self.cursor && matches!(self.sub_cursor, super::SubCursor::None);
 
             // Section header when display group changes
             if last_group != Some(vt.group) {
@@ -1547,7 +1550,12 @@ impl App {
 
             // Expand/collapse indicator in CLAUDE cell.
             let pane_count = vt.row.sessions.first().map(|s| s.panes.len()).unwrap_or(0);
-            let window_count = vt.row.sessions.first().map(|s| s.windows.len()).unwrap_or(0);
+            let window_count = vt
+                .row
+                .sessions
+                .first()
+                .map(|s| s.windows.len())
+                .unwrap_or(0);
             let is_expanded = self.expanded.contains(&vt.row.worktree_path);
             let claude_display = if window_count > 1 {
                 expand_indicator_windows(&claude_text, window_count, is_expanded)
@@ -1695,7 +1703,11 @@ impl App {
         for (pi, pane) in panes.iter().enumerate() {
             let is_last = pi == pane_count - 1;
             let selected = self.cursor == parent_cursor_idx
-                && self.sub_cursor == SubCursor::Pane { window: window_index, pane: pi };
+                && self.sub_cursor
+                    == SubCursor::Pane {
+                        window: window_index,
+                        pane: pi,
+                    };
 
             // Tree connector: ├─N for non-last, └─N for last pane.
             let connector = if is_last {
@@ -1774,9 +1786,12 @@ impl App {
                 format!("\u{251c}\u{2500} win:{} {}", window.index, window.name)
             };
 
-            let is_window_expanded = self
-                .window_expanded
-                .contains(&super::App::window_expansion_key(session_name, window.index));
+            let is_window_expanded =
+                self.window_expanded
+                    .contains(&super::App::window_expansion_key(
+                        session_name,
+                        window.index,
+                    ));
 
             // Expand indicator for the window (in STATUS cell).
             let status_text = if window.panes.len() > 1 {
@@ -2376,7 +2391,7 @@ mod tests {
                     model: None,
                 }),
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             }],
             ..make_task_row(1, DisplayGroup::ClaudeWorking)
         };
@@ -2410,7 +2425,7 @@ mod tests {
                     model: None,
                 }),
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             }],
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2678,7 +2693,7 @@ mod tests {
                         model: None,
                     }),
                     windows: vec![],
-            panes: vec![],
+                    panes: vec![],
                 },
                 EnrichedSession {
                     tmux: TmuxSessionInfo {
@@ -2693,7 +2708,7 @@ mod tests {
                         model: None,
                     }),
                     windows: vec![],
-            panes: vec![],
+                    panes: vec![],
                 },
             ],
             ..make_task_row(1, DisplayGroup::NeedsAttention)

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -33,8 +33,28 @@ use crate::derive;
 use crate::git;
 use crate::global_config;
 use crate::navigation;
-use crate::session::StandaloneSessionRow;
+use crate::session::{StandaloneSessionRow, WindowInfo};
 use crate::tmux;
+
+// ---------------------------------------------------------------------------
+// SubCursor
+// ---------------------------------------------------------------------------
+
+/// Two-level sub-cursor within an expanded session row.
+///
+/// Replaces the old `selected_pane: Option<usize>` with support for
+/// both window-level and pane-level selection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SubCursor {
+    /// Parent row is selected (no sub-row focus).
+    None,
+    /// A window sub-row is selected (for multi-window sessions).
+    /// Value is the tmux window index.
+    Window(usize),
+    /// A pane sub-row is selected.
+    /// `window` is the tmux window index, `pane` is the vec index within that window.
+    Pane { window: usize, pane: usize },
+}
 
 use message::{Message, UpdateResult};
 use state::{AppMsg, CleanupState, InputPhase, Phase, ViewState};
@@ -133,11 +153,17 @@ pub struct App {
     /// Entries are silently removed on refresh when the row's pane count drops to <= 1.
     expanded: HashSet<String>,
 
-    /// Currently selected pane sub-row within the focused parent row.
+    /// Two-level sub-cursor within an expanded session row.
     ///
-    /// `None` means the parent row itself is selected. `Some(n)` means
-    /// pane sub-row `n` is selected. This does NOT affect `self.cursor`.
-    selected_pane: Option<usize>,
+    /// `SubCursor::None` means the parent row is selected. `SubCursor::Window(w)`
+    /// means a window sub-row is focused. `SubCursor::Pane { window, pane }` means
+    /// a pane within a window is focused. Does NOT affect `self.cursor`.
+    sub_cursor: SubCursor,
+
+    /// Expanded windows keyed by `"session_name:window_index"`.
+    ///
+    /// When a key is present, the window's pane sub-rows are rendered below it.
+    window_expanded: HashSet<String>,
 }
 
 impl App {
@@ -210,7 +236,8 @@ impl App {
             last_click: None,
             preview_scroll_state: std::cell::Cell::new(tui_scrollview::ScrollViewState::default()),
             expanded: HashSet::new(),
-            selected_pane: None,
+            sub_cursor: SubCursor::None,
+            window_expanded: HashSet::new(),
         }
     }
 
@@ -283,11 +310,26 @@ impl App {
 
     /// Returns the pane index to use for preview capture.
     ///
-    /// When the cursor is on a sub-row, returns `Some(pane_index)`.
+    /// When the cursor is on a pane sub-row, returns `Some(pane_flat_index)`.
+    /// When on a window sub-row, returns `None` (active pane of that window).
     /// When on a parent row, returns `None` (default pane 0).
     #[cfg(test)]
     pub(crate) fn preview_pane_index(&self) -> Option<usize> {
-        self.selected_pane
+        match &self.sub_cursor {
+            SubCursor::Pane { window, pane } => {
+                // Find the flat pane index by summing panes in prior windows.
+                let windows = self.windows_at(self.cursor);
+                let mut flat = 0;
+                for w in windows {
+                    if w.index == *window {
+                        return Some(flat + pane);
+                    }
+                    flat += w.panes.len();
+                }
+                Some(*pane)
+            }
+            _ => None,
+        }
     }
 
     /// Returns true if the row at cursor `idx` is currently expanded.
@@ -341,6 +383,134 @@ impl App {
         }
 
         self.expanded.retain(|k| valid_keys.contains(k));
+
+        // Also prune window_expanded: remove entries for sessions that are no longer expanded.
+        let expanded_ref = &self.expanded;
+
+        // Collect session names for currently expanded rows.
+        let mut expanded_session_names: HashSet<String> = HashSet::new();
+        for ss in &self.standalone_sessions {
+            if expanded_ref.contains(&ss.session.tmux.name) {
+                expanded_session_names.insert(ss.session.tmux.name.clone());
+            }
+        }
+        for vt in tasks.iter() {
+            if expanded_ref.contains(&vt.row.worktree_path) {
+                if let Some(s) = vt.row.sessions.first() {
+                    expanded_session_names.insert(s.tmux.name.clone());
+                }
+            }
+        }
+
+        self.window_expanded.retain(|k| {
+            // Key format: "session_name:window_index"
+            if let Some(colon_pos) = k.rfind(':') {
+                let session_name = &k[..colon_pos];
+                expanded_session_names.contains(session_name)
+            } else {
+                false
+            }
+        });
+    }
+
+    // -------------------------------------------------------------------
+    // Window hierarchy helpers
+    // -------------------------------------------------------------------
+
+    /// Returns the windows for the session at cursor position `idx` (cloned).
+    ///
+    /// For standalone sessions, returns the session's windows.
+    /// For worktree rows, returns windows from the first session (if any).
+    /// Returns an owned Vec because the worktree path requires a temporary lookup.
+    fn windows_at(&self, idx: usize) -> Vec<WindowInfo> {
+        let standalone_count = self.standalone_sessions.len();
+        if idx < standalone_count {
+            self.standalone_sessions
+                .get(idx)
+                .map(|ss| ss.session.windows.clone())
+                .unwrap_or_default()
+        } else {
+            let wt_idx = idx - standalone_count;
+            let tasks = list::visible_tasks_filtered(
+                &self.task_rows,
+                &self.filter_text,
+                self.active_repo_slug(),
+            );
+            tasks
+                .get(wt_idx)
+                .and_then(|vt| vt.row.sessions.first())
+                .map(|s| s.windows.clone())
+                .unwrap_or_default()
+        }
+    }
+
+    /// Returns the number of windows for the session at cursor position `idx`.
+    fn window_count_at(&self, idx: usize) -> usize {
+        self.windows_at(idx).len()
+    }
+
+    /// Returns true when the session at cursor `idx` has exactly 1 window.
+    fn is_single_window_session(&self, idx: usize) -> bool {
+        self.window_count_at(idx) == 1
+    }
+
+    /// Returns the expansion key for a window within a session.
+    fn window_expansion_key(session_name: &str, window_index: usize) -> String {
+        format!("{}:{}", session_name, window_index)
+    }
+
+    /// Returns true if the given window is expanded.
+    fn is_window_expanded(&self, session_name: &str, window_index: usize) -> bool {
+        self.window_expanded
+            .contains(&Self::window_expansion_key(session_name, window_index))
+    }
+
+    /// Returns the session name for the row at cursor position `idx`.
+    fn session_name_at(&self, idx: usize) -> Option<String> {
+        let standalone_count = self.standalone_sessions.len();
+        if idx < standalone_count {
+            self.standalone_sessions
+                .get(idx)
+                .map(|ss| ss.session.tmux.name.clone())
+        } else {
+            let wt_idx = idx - standalone_count;
+            let tasks = list::visible_tasks_filtered(
+                &self.task_rows,
+                &self.filter_text,
+                self.active_repo_slug(),
+            );
+            tasks
+                .get(wt_idx)
+                .and_then(|vt| vt.row.sessions.first())
+                .map(|s| s.tmux.name.clone())
+        }
+    }
+
+    /// Clears window expansion state for all windows of a given session.
+    fn clear_window_expansion_for_session(&mut self, session_name: &str) {
+        let prefix = format!("{}:", session_name);
+        self.window_expanded.retain(|k| !k.starts_with(&prefix));
+    }
+
+    /// Total sub-row count for the session at `idx`, considering window and pane expansion.
+    ///
+    /// For single-window sessions (auto-flattened): returns pane count (same as before).
+    /// For multi-window sessions: returns window count + expanded pane counts.
+    fn sub_row_count_at(&self, idx: usize) -> usize {
+        let windows = self.windows_at(idx);
+        if windows.len() <= 1 {
+            // Auto-flatten: sub-rows are panes directly.
+            self.pane_count_at(idx)
+        } else {
+            let session_name = self.session_name_at(idx).unwrap_or_default();
+            let mut count = windows.len();
+            for w in windows {
+                if self.is_window_expanded(&session_name, w.index) {
+                    count += w.panes.len();
+                }
+            }
+            count
+        }
     }
 
     // -------------------------------------------------------------------
@@ -930,7 +1100,7 @@ impl App {
             table_row += 1;
             // Skip sub-rows if expanded.
             if self.expanded.contains(&ss.session.tmux.name) {
-                let sub_count = ss.session.panes.len();
+                let sub_count = self.sub_row_count_at(idx);
                 if visual_row < table_row + sub_count {
                     return None; // clicked on a sub-row
                 }
@@ -950,6 +1120,7 @@ impl App {
         let mut last_group: Option<crate::derive::DisplayGroup> = None;
 
         for (task_idx, vt) in tasks.iter().enumerate() {
+            let cursor_idx = task_idx + standalone_count;
             // Group header inserted when display group changes.
             if last_group != Some(vt.group) {
                 if table_row == visual_row {
@@ -960,13 +1131,13 @@ impl App {
             }
 
             if table_row == visual_row {
-                return Some(task_idx + standalone_count);
+                return Some(cursor_idx);
             }
             table_row += 1;
 
             // Skip sub-rows if expanded.
             if self.expanded.contains(&vt.row.worktree_path) {
-                let sub_count = vt.row.sessions.first().map(|s| s.panes.len()).unwrap_or(0);
+                let sub_count = self.sub_row_count_at(cursor_idx);
                 if visual_row < table_row + sub_count {
                     return None; // clicked on a sub-row
                 }
@@ -1007,25 +1178,78 @@ impl App {
                         }
                     }
                     _ => {
-                        if let Some(pane) = self.selected_pane {
-                            if pane > 0 {
-                                // Move up within sub-rows.
-                                self.selected_pane = Some(pane - 1);
-                            } else {
-                                // First sub-row → back to parent.
-                                self.selected_pane = None;
+                        match self.sub_cursor.clone() {
+                            SubCursor::Pane { window, pane } => {
+                                if pane > 0 {
+                                    self.sub_cursor = SubCursor::Pane { window, pane: pane - 1 };
+                                } else if self.is_single_window_session(self.cursor) {
+                                    // Single-window: up from first pane → parent row.
+                                    self.sub_cursor = SubCursor::None;
+                                } else {
+                                    // Multi-window: up from first pane → window row.
+                                    self.sub_cursor = SubCursor::Window(window);
+                                }
+                                self.fetch_task_pane_content();
                             }
-                            self.fetch_task_pane_content();
-                        } else if self.cursor > 0 {
-                            self.cursor -= 1;
-                            // If moving up onto an expanded row, select the last sub-row.
-                            if self.is_row_expanded(self.cursor) {
-                                let count = self.pane_count_at(self.cursor);
-                                if count > 0 {
-                                    self.selected_pane = Some(count - 1);
+                            SubCursor::Window(w) => {
+                                let windows = self.windows_at(self.cursor);
+                                // Find this window's position in the list.
+                                let pos = windows.iter().position(|wi| wi.index == w);
+                                if let Some(p) = pos {
+                                    if p == 0 {
+                                        // First window → parent row.
+                                        self.sub_cursor = SubCursor::None;
+                                    } else {
+                                        // Previous window. If it's expanded, go to its last pane.
+                                        let prev_win = &windows[p - 1];
+                                        let session_name = self.session_name_at(self.cursor).unwrap_or_default();
+                                        if self.is_window_expanded(&session_name, prev_win.index) && !prev_win.panes.is_empty() {
+                                            self.sub_cursor = SubCursor::Pane {
+                                                window: prev_win.index,
+                                                pane: prev_win.panes.len() - 1,
+                                            };
+                                        } else {
+                                            self.sub_cursor = SubCursor::Window(prev_win.index);
+                                        }
+                                    }
+                                } else {
+                                    self.sub_cursor = SubCursor::None;
+                                }
+                                self.fetch_task_pane_content();
+                            }
+                            SubCursor::None => {
+                                if self.cursor > 0 {
+                                    self.cursor -= 1;
+                                    // If moving up onto an expanded row, select the last sub-row.
+                                    if self.is_row_expanded(self.cursor) {
+                                        let windows = self.windows_at(self.cursor);
+                                        if windows.len() <= 1 {
+                                            // Single-window auto-flatten: last pane.
+                                            let count = self.pane_count_at(self.cursor);
+                                            if count > 0 {
+                                                let win_idx = windows.first().map(|w| w.index).unwrap_or(0);
+                                                self.sub_cursor = SubCursor::Pane {
+                                                    window: win_idx,
+                                                    pane: count - 1,
+                                                };
+                                            }
+                                        } else {
+                                            // Multi-window: land on last window (or last pane if expanded).
+                                            let last_win = &windows[windows.len() - 1];
+                                            let session_name = self.session_name_at(self.cursor).unwrap_or_default();
+                                            if self.is_window_expanded(&session_name, last_win.index) && !last_win.panes.is_empty() {
+                                                self.sub_cursor = SubCursor::Pane {
+                                                    window: last_win.index,
+                                                    pane: last_win.panes.len() - 1,
+                                                };
+                                            } else {
+                                                self.sub_cursor = SubCursor::Window(last_win.index);
+                                            }
+                                        }
+                                    }
+                                    self.fetch_task_pane_content();
                                 }
                             }
-                            self.fetch_task_pane_content();
                         }
                     }
                 }
@@ -1048,26 +1272,86 @@ impl App {
                         .len();
                         let visible_count = standalone_count + worktree_visible_count;
 
-                        if let Some(pane) = self.selected_pane {
-                            let count = self.pane_count_at(self.cursor);
-                            if pane + 1 < count {
-                                // Move down within sub-rows.
-                                self.selected_pane = Some(pane + 1);
-                            } else {
-                                // Last sub-row → next parent row.
-                                self.selected_pane = None;
-                                if visible_count > 0 && self.cursor < visible_count - 1 {
+                        match self.sub_cursor.clone() {
+                            SubCursor::Pane { window, pane } => {
+                                // Check if there's a next pane in this window.
+                                let windows = self.windows_at(self.cursor);
+                                let win = windows.iter().find(|w| w.index == window);
+                                let pane_count = win.map(|w| w.panes.len()).unwrap_or(0);
+                                if pane + 1 < pane_count {
+                                    self.sub_cursor = SubCursor::Pane { window, pane: pane + 1 };
+                                } else if windows.len() <= 1 {
+                                    // Single-window: last pane → next parent row.
+                                    self.sub_cursor = SubCursor::None;
+                                    if visible_count > 0 && self.cursor < visible_count - 1 {
+                                        self.cursor += 1;
+                                    }
+                                } else {
+                                    // Multi-window: find next window after current.
+                                    let pos = windows.iter().position(|w| w.index == window);
+                                    if let Some(p) = pos {
+                                        if p + 1 < windows.len() {
+                                            self.sub_cursor = SubCursor::Window(windows[p + 1].index);
+                                        } else {
+                                            // Last window's last pane → next parent row.
+                                            self.sub_cursor = SubCursor::None;
+                                            if visible_count > 0 && self.cursor < visible_count - 1 {
+                                                self.cursor += 1;
+                                            }
+                                        }
+                                    } else {
+                                        self.sub_cursor = SubCursor::None;
+                                    }
+                                }
+                                self.fetch_task_pane_content();
+                            }
+                            SubCursor::Window(w) => {
+                                // If window is expanded, enter first pane.
+                                let session_name = self.session_name_at(self.cursor).unwrap_or_default();
+                                let windows = self.windows_at(self.cursor);
+                                let win = windows.iter().find(|wi| wi.index == w);
+                                if self.is_window_expanded(&session_name, w) {
+                                    if let Some(win) = win {
+                                        if !win.panes.is_empty() {
+                                            self.sub_cursor = SubCursor::Pane { window: w, pane: 0 };
+                                            self.fetch_task_pane_content();
+                                            return ok();
+                                        }
+                                    }
+                                }
+                                // Window collapsed: go to next window or next parent.
+                                let pos = windows.iter().position(|wi| wi.index == w);
+                                if let Some(p) = pos {
+                                    if p + 1 < windows.len() {
+                                        self.sub_cursor = SubCursor::Window(windows[p + 1].index);
+                                    } else {
+                                        self.sub_cursor = SubCursor::None;
+                                        if visible_count > 0 && self.cursor < visible_count - 1 {
+                                            self.cursor += 1;
+                                        }
+                                    }
+                                } else {
+                                    self.sub_cursor = SubCursor::None;
+                                }
+                                self.fetch_task_pane_content();
+                            }
+                            SubCursor::None => {
+                                if self.is_row_expanded(self.cursor) {
+                                    let windows = self.windows_at(self.cursor);
+                                    if windows.len() <= 1 {
+                                        // Single-window auto-flatten: enter first pane.
+                                        let win_idx = windows.first().map(|w| w.index).unwrap_or(0);
+                                        self.sub_cursor = SubCursor::Pane { window: win_idx, pane: 0 };
+                                    } else {
+                                        // Multi-window: enter first window.
+                                        self.sub_cursor = SubCursor::Window(windows[0].index);
+                                    }
+                                    self.fetch_task_pane_content();
+                                } else if visible_count > 0 && self.cursor < visible_count - 1 {
                                     self.cursor += 1;
+                                    self.fetch_task_pane_content();
                                 }
                             }
-                            self.fetch_task_pane_content();
-                        } else if self.is_row_expanded(self.cursor) {
-                            // Parent of expanded row → enter first sub-row.
-                            self.selected_pane = Some(0);
-                            self.fetch_task_pane_content();
-                        } else if visible_count > 0 && self.cursor < visible_count - 1 {
-                            self.cursor += 1;
-                            self.fetch_task_pane_content();
                         }
                     }
                 }
@@ -1075,7 +1359,7 @@ impl App {
             }
             Message::CursorTo(idx) => {
                 self.cursor = idx;
-                self.selected_pane = None;
+                self.sub_cursor = SubCursor::None;
                 self.fetch_task_pane_content();
                 ok()
             }
@@ -1227,34 +1511,74 @@ impl App {
             Message::PrevRepo => {
                 self.active_repo_index = self.active_repo_index.saturating_sub(1);
                 self.cursor = 0;
-                self.selected_pane = None;
+                self.sub_cursor = SubCursor::None;
                 ok()
             }
             Message::NextRepo => {
                 let repo_count = self.global_config.repos.len();
                 self.active_repo_index = (self.active_repo_index + 1).min(repo_count);
                 self.cursor = 0;
-                self.selected_pane = None;
+                self.sub_cursor = SubCursor::None;
                 ok()
             }
             Message::ExpandRow => {
-                let pane_count = self.pane_count_at(self.cursor);
-                if pane_count > 1
-                    && let Some(key) = self.expansion_key_at(self.cursor)
-                {
-                    self.expanded.insert(key);
+                match &self.sub_cursor {
+                    SubCursor::Window(w) => {
+                        // Expand window: add to window_expanded.
+                        if let Some(session_name) = self.session_name_at(self.cursor) {
+                            let windows = self.windows_at(self.cursor);
+                            let win = windows.iter().find(|wi| wi.index == *w);
+                            if let Some(win) = win {
+                                if win.panes.len() > 1 {
+                                    let key = Self::window_expansion_key(&session_name, *w);
+                                    self.window_expanded.insert(key);
+                                }
+                            }
+                        }
+                    }
+                    _ => {
+                        // Expand session row.
+                        let pane_count = self.pane_count_at(self.cursor);
+                        if pane_count > 1
+                            && let Some(key) = self.expansion_key_at(self.cursor)
+                        {
+                            self.expanded.insert(key);
+                        }
+                    }
                 }
                 ok()
             }
             Message::CollapseRow => {
-                if self.selected_pane.is_some() {
-                    // On a sub-row: collapse parent + clear selected_pane.
-                    if let Some(key) = self.expansion_key_at(self.cursor) {
-                        self.expanded.remove(&key);
+                match &self.sub_cursor {
+                    SubCursor::Pane { window, .. } => {
+                        let w = *window;
+                        if self.is_single_window_session(self.cursor) {
+                            // Single-window: collapse session entirely.
+                            if let Some(key) = self.expansion_key_at(self.cursor) {
+                                self.expanded.remove(&key);
+                            }
+                            self.sub_cursor = SubCursor::None;
+                        } else {
+                            // Multi-window: collapse window, go to window row.
+                            if let Some(session_name) = self.session_name_at(self.cursor) {
+                                let key = Self::window_expansion_key(&session_name, w);
+                                self.window_expanded.remove(&key);
+                            }
+                            self.sub_cursor = SubCursor::Window(w);
+                        }
                     }
-                    self.selected_pane = None;
-                } else if let Some(key) = self.expansion_key_at(self.cursor) {
-                    self.expanded.remove(&key);
+                    SubCursor::Window(_) => {
+                        // Left on window row is no-op (must navigate to session row).
+                    }
+                    SubCursor::None => {
+                        if let Some(key) = self.expansion_key_at(self.cursor) {
+                            self.expanded.remove(&key);
+                            // Clear window expansion state for this session.
+                            if let Some(session_name) = self.session_name_at(self.cursor) {
+                                self.clear_window_expansion_for_session(&session_name);
+                            }
+                        }
+                    }
                 }
                 ok()
             }
@@ -1274,7 +1598,7 @@ impl App {
                         self.expanded.insert(key);
                     }
                 }
-                // Don't clear selected_pane — persists for re-expansion.
+                // Don't clear sub_cursor — persists for re-expansion.
                 ok()
             }
             Message::Refresh => {
@@ -1672,7 +1996,8 @@ impl App {
             last_click: None,
             preview_scroll_state: std::cell::Cell::new(tui_scrollview::ScrollViewState::default()),
             expanded: HashSet::new(),
-            selected_pane: None,
+            sub_cursor: SubCursor::None,
+            window_expanded: HashSet::new(),
         }
     }
 }
@@ -2299,7 +2624,8 @@ mod tests {
                     status: SessionStatus::Running { attached: false },
                 },
                 claude: None,
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             }],
             ..make_task_row(1, DisplayGroup::ClaudeWorking)
         };
@@ -2459,7 +2785,8 @@ mod tests {
                     context_window_pct: None,
                     model: None,
                 }),
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             }],
             ..make_worktree_row("feat/claude-active", DisplayGroup::ClaudeWorking)
         };
@@ -2518,7 +2845,8 @@ mod tests {
                     context_window_pct: None,
                     model: None,
                 }),
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             }],
             ..make_worktree_row("feat/waiting", DisplayGroup::NeedsAttention)
         };
@@ -2587,7 +2915,8 @@ mod tests {
                     status: SessionStatus::Running { attached: false },
                 },
                 claude: None,
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             }],
             ..make_worktree_row("feat/remote", DisplayGroup::Other)
         };
@@ -2829,6 +3158,8 @@ mod tests {
             pane_targets: vec![],
             pane_titles: vec![],
             pane_commands: vec![],
+            window_names: vec![],
+            window_active: vec![],
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
@@ -2986,7 +3317,8 @@ mod tests {
                     context_window_pct: Some(23.0),
                     model: Some("opus".to_string()),
                 }),
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             }],
             ..make_worktree_row("main", DisplayGroup::RepoMain)
         };
@@ -3012,7 +3344,8 @@ mod tests {
                     context_window_pct: Some(67.0),
                     model: Some("sonnet".to_string()),
                 }),
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             }],
             ..make_task_row_with_title(53, "TEA pattern refactor", DisplayGroup::NeedsAttention)
         };
@@ -3038,7 +3371,8 @@ mod tests {
                     context_window_pct: Some(19.0),
                     model: Some("opus".to_string()),
                 }),
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             }],
             ..make_task_row_with_title(
                 47,
@@ -3300,7 +3634,8 @@ mod tests {
                         status: SessionStatus::Dead,
                     },
                     claude: None,
-                    panes: vec![],
+                    windows: vec![],
+            panes: vec![],
                 },
             });
 
@@ -3554,7 +3889,8 @@ mod tests {
                     status: SessionStatus::Dead,
                 },
                 claude: None,
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             },
         }
     }
@@ -3576,7 +3912,8 @@ mod tests {
                     status: SessionStatus::Running { attached: false },
                 },
                 claude: None,
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             }],
             display_group: DisplayGroup::Other,
             is_main_worktree: false,
@@ -3696,6 +4033,12 @@ mod tests {
                 has_claude: i == 0, // first pane has claude
             })
             .collect();
+        let windows = vec![crate::session::WindowInfo {
+            index: 0,
+            name: "main".to_string(),
+            is_active: true,
+            panes: panes.clone(),
+        }];
         WorktreeRow {
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
@@ -3704,7 +4047,52 @@ mod tests {
                     status: SessionStatus::Running { attached: false },
                 },
                 claude: None,
+                windows,
                 panes,
+            }],
+            ..make_task_row(issue, DisplayGroup::Other)
+        }
+    }
+
+    /// Creates a worktree row with multiple windows for testing multi-window navigation.
+    fn make_task_row_with_windows(
+        issue: u32,
+        window_pane_counts: &[(usize, &str)],
+    ) -> WorktreeRow {
+        let mut all_panes = Vec::new();
+        let mut windows = Vec::new();
+        let mut flat_idx = 0;
+        for (wi, (pane_count, name)) in window_pane_counts.iter().enumerate() {
+            let mut win_panes = Vec::new();
+            for pi in 0..*pane_count {
+                let pane = crate::session::PaneInfo {
+                    index: flat_idx,
+                    tmux_target: format!("{wi}.{pi}"),
+                    command: format!("cmd{flat_idx}"),
+                    title: format!("pane{flat_idx}"),
+                    has_claude: flat_idx == 0,
+                };
+                win_panes.push(pane.clone());
+                all_panes.push(pane);
+                flat_idx += 1;
+            }
+            windows.push(crate::session::WindowInfo {
+                index: wi,
+                name: name.to_string(),
+                is_active: wi == 0,
+                panes: win_panes,
+            });
+        }
+        WorktreeRow {
+            sessions: vec![EnrichedSession {
+                tmux: TmuxSessionInfo {
+                    host: Host::Local,
+                    name: format!("sess-{}", issue),
+                    status: SessionStatus::Running { attached: false },
+                },
+                claude: None,
+                windows,
+                panes: all_panes,
             }],
             ..make_task_row(issue, DisplayGroup::Other)
         }
@@ -3766,24 +4154,24 @@ mod tests {
         app.cursor = 1;
         app.update(Message::ToggleExpandAll);
         assert_eq!(app.cursor, 1, "cursor should stay on same logical row");
-        assert_eq!(app.selected_pane, None, "selected_pane should remain None");
+        assert_eq!(app.sub_cursor, SubCursor::None, "sub_cursor should remain None");
     }
 
     #[test]
-    fn collapse_all_preserves_selected_pane() {
+    fn collapse_all_preserves_sub_cursor() {
         let mut app = App::new_test(vec![make_task_row_with_panes(1, 3)]);
         app.expanded.insert("/workspace/repo-1".to_string());
-        app.selected_pane = Some(1);
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 1 };
         app.update(Message::ToggleExpandAll);
         assert_eq!(
-            app.selected_pane,
-            Some(1),
-            "selected_pane should persist across collapse-all"
+            app.sub_cursor,
+            SubCursor::Pane { window: 0, pane: 1 },
+            "sub_cursor should persist across collapse-all"
         );
     }
 
     // -----------------------------------------------------------------------
-    // Navigation with sub-rows
+    // Navigation with sub-rows (single-window auto-flatten)
     // -----------------------------------------------------------------------
 
     #[test]
@@ -3792,7 +4180,11 @@ mod tests {
         app.expanded.insert("/workspace/repo-1".to_string());
         app.update(Message::CursorDown);
         assert_eq!(app.cursor, 0, "cursor stays on parent row");
-        assert_eq!(app.selected_pane, Some(0), "enters first sub-row");
+        assert_eq!(
+            app.sub_cursor,
+            SubCursor::Pane { window: 0, pane: 0 },
+            "enters first sub-row (single-window auto-flatten)"
+        );
     }
 
     #[test]
@@ -3802,50 +4194,50 @@ mod tests {
             make_task_row_with_panes(2, 2),
         ]);
         app.expanded.insert("/workspace/repo-1".to_string());
-        app.selected_pane = Some(2); // last sub-row of row 0
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 2 }; // last sub-row of row 0
         app.update(Message::CursorDown);
         assert_eq!(app.cursor, 1, "cursor moves to next parent");
-        assert_eq!(app.selected_pane, None, "selected_pane cleared");
+        assert_eq!(app.sub_cursor, SubCursor::None, "sub_cursor cleared");
     }
 
     #[test]
     fn up_on_first_sub_row_returns_to_parent() {
         let mut app = App::new_test(vec![make_task_row_with_panes(1, 3)]);
         app.expanded.insert("/workspace/repo-1".to_string());
-        app.selected_pane = Some(0);
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 0 };
         app.update(Message::CursorUp);
         assert_eq!(app.cursor, 0);
-        assert_eq!(app.selected_pane, None, "back to parent row");
+        assert_eq!(app.sub_cursor, SubCursor::None, "back to parent row");
     }
 
     #[test]
     fn up_on_middle_sub_row_moves_up_within_sub_rows() {
         let mut app = App::new_test(vec![make_task_row_with_panes(1, 3)]);
         app.expanded.insert("/workspace/repo-1".to_string());
-        app.selected_pane = Some(2);
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 2 };
         app.update(Message::CursorUp);
-        assert_eq!(app.selected_pane, Some(1));
+        assert_eq!(app.sub_cursor, SubCursor::Pane { window: 0, pane: 1 });
     }
 
     #[test]
-    fn cursor_to_clears_selected_pane() {
+    fn cursor_to_clears_sub_cursor() {
         let mut app = App::new_test(vec![
             make_task_row_with_panes(1, 3),
             make_task_row_with_panes(2, 2),
         ]);
-        app.selected_pane = Some(1);
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 1 };
         app.update(Message::CursorTo(1));
         assert_eq!(app.cursor, 1);
-        assert_eq!(app.selected_pane, None, "digit-jump clears selected_pane");
+        assert_eq!(app.sub_cursor, SubCursor::None, "digit-jump clears sub_cursor");
     }
 
     #[test]
-    fn collapse_from_sub_row_clears_selected_pane() {
+    fn collapse_from_sub_row_clears_sub_cursor() {
         let mut app = App::new_test(vec![make_task_row_with_panes(1, 3)]);
         app.expanded.insert("/workspace/repo-1".to_string());
-        app.selected_pane = Some(1);
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 1 };
         app.update(Message::CollapseRow);
-        assert_eq!(app.selected_pane, None);
+        assert_eq!(app.sub_cursor, SubCursor::None);
         assert!(!app.expanded.contains("/workspace/repo-1"));
     }
 
@@ -3873,7 +4265,7 @@ mod tests {
     #[test]
     fn preview_pane_index_some_for_sub_row() {
         let mut app = App::new_test(vec![make_task_row_with_panes(1, 3)]);
-        app.selected_pane = Some(1);
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 1 };
         assert_eq!(app.preview_pane_index(), Some(1));
     }
 
@@ -3891,7 +4283,11 @@ mod tests {
         app.cursor = 1; // on row 2
         app.update(Message::CursorUp);
         assert_eq!(app.cursor, 0, "cursor moves to expanded row");
-        assert_eq!(app.selected_pane, Some(2), "selects last sub-row");
+        assert_eq!(
+            app.sub_cursor,
+            SubCursor::Pane { window: 0, pane: 2 },
+            "selects last sub-row"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -4068,7 +4464,8 @@ mod tests {
                     status: SessionStatus::Dead,
                 },
                 claude: None,
-                panes: vec![],
+                windows: vec![],
+            panes: vec![],
             },
             config: StandaloneConfig {
                 name: name.to_string(),
@@ -4132,5 +4529,173 @@ mod tests {
         app.cursor = 0;
         let sel = current_selection(&app).unwrap();
         assert_eq!(sel.active_repo_slug, Some("acme/beta".to_string()));
+    }
+
+    // -----------------------------------------------------------------------
+    // SubCursor multi-window navigation tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn multi_window_down_from_session_enters_first_window() {
+        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.update(Message::CursorDown);
+        assert_eq!(app.cursor, 0);
+        assert_eq!(app.sub_cursor, SubCursor::Window(0), "enters first window");
+    }
+
+    #[test]
+    fn multi_window_down_from_collapsed_window_goes_to_next() {
+        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.sub_cursor = SubCursor::Window(0);
+        app.update(Message::CursorDown);
+        assert_eq!(app.sub_cursor, SubCursor::Window(1));
+    }
+
+    #[test]
+    fn multi_window_down_from_expanded_window_enters_first_pane() {
+        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.window_expanded.insert("sess-1:0".to_string());
+        app.sub_cursor = SubCursor::Window(0);
+        app.update(Message::CursorDown);
+        assert_eq!(app.sub_cursor, SubCursor::Pane { window: 0, pane: 0 });
+    }
+
+    #[test]
+    fn multi_window_down_from_last_pane_goes_to_next_window() {
+        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.window_expanded.insert("sess-1:0".to_string());
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 1 };
+        app.update(Message::CursorDown);
+        assert_eq!(app.sub_cursor, SubCursor::Window(1));
+    }
+
+    #[test]
+    fn multi_window_up_from_first_window_returns_to_session() {
+        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.sub_cursor = SubCursor::Window(0);
+        app.update(Message::CursorUp);
+        assert_eq!(app.sub_cursor, SubCursor::None);
+    }
+
+    #[test]
+    fn multi_window_up_from_first_pane_returns_to_window() {
+        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.window_expanded.insert("sess-1:0".to_string());
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 0 };
+        app.update(Message::CursorUp);
+        assert_eq!(app.sub_cursor, SubCursor::Window(0));
+    }
+
+    #[test]
+    fn multi_window_left_from_pane_collapses_window() {
+        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.window_expanded.insert("sess-1:1".to_string());
+        app.sub_cursor = SubCursor::Pane { window: 1, pane: 0 };
+        app.update(Message::CollapseRow);
+        assert_eq!(app.sub_cursor, SubCursor::Window(1));
+        assert!(!app.window_expanded.contains("sess-1:1"));
+    }
+
+    #[test]
+    fn multi_window_left_from_window_is_noop() {
+        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.sub_cursor = SubCursor::Window(0);
+        app.update(Message::CollapseRow);
+        // Left on window row is no-op.
+        assert_eq!(app.sub_cursor, SubCursor::Window(0));
+        assert!(app.expanded.contains("/workspace/repo-1"));
+    }
+
+    #[test]
+    fn multi_window_right_expands_window() {
+        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.sub_cursor = SubCursor::Window(0);
+        app.update(Message::ExpandRow);
+        assert!(app.window_expanded.contains("sess-1:0"));
+    }
+
+    #[test]
+    fn collapse_session_clears_window_expansion() {
+        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.window_expanded.insert("sess-1:0".to_string());
+        app.window_expanded.insert("sess-1:1".to_string());
+        app.sub_cursor = SubCursor::None;
+        app.update(Message::CollapseRow);
+        assert!(!app.expanded.contains("/workspace/repo-1"));
+        assert!(!app.window_expanded.contains("sess-1:0"));
+        assert!(!app.window_expanded.contains("sess-1:1"));
+    }
+
+    #[test]
+    fn window_expansion_key_uses_tmux_window_index() {
+        assert_eq!(App::window_expansion_key("my-session", 5), "my-session:5");
+    }
+
+    #[test]
+    fn single_window_down_skips_window_level() {
+        // Single-window session: Down goes directly to pane, not window.
+        let mut app = App::new_test(vec![make_task_row_with_panes(1, 3)]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.update(Message::CursorDown);
+        assert_eq!(
+            app.sub_cursor,
+            SubCursor::Pane { window: 0, pane: 0 },
+            "single-window skips to pane"
+        );
+    }
+
+    #[test]
+    fn single_window_left_from_pane_collapses_session() {
+        let mut app = App::new_test(vec![make_task_row_with_panes(1, 3)]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 1 };
+        app.update(Message::CollapseRow);
+        assert_eq!(app.sub_cursor, SubCursor::None);
+        assert!(!app.expanded.contains("/workspace/repo-1"));
+    }
+
+    #[test]
+    fn multi_window_up_onto_expanded_row_selects_last_window() {
+        let mut app = App::new_test(vec![
+            make_task_row_with_windows(1, &[(2, "main"), (2, "editor")]),
+            make_task_row_with_panes(2, 2),
+        ]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.cursor = 1;
+        app.update(Message::CursorUp);
+        assert_eq!(app.cursor, 0);
+        assert_eq!(
+            app.sub_cursor,
+            SubCursor::Window(1),
+            "lands on last window of multi-window session"
+        );
+    }
+
+    #[test]
+    fn multi_window_up_onto_expanded_row_with_expanded_last_window() {
+        let mut app = App::new_test(vec![
+            make_task_row_with_windows(1, &[(2, "main"), (2, "editor")]),
+            make_task_row_with_panes(2, 2),
+        ]);
+        app.expanded.insert("/workspace/repo-1".to_string());
+        app.window_expanded.insert("sess-1:1".to_string());
+        app.cursor = 1;
+        app.update(Message::CursorUp);
+        assert_eq!(app.cursor, 0);
+        assert_eq!(
+            app.sub_cursor,
+            SubCursor::Pane { window: 1, pane: 1 },
+            "lands on last pane of expanded last window"
+        );
     }
 }

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -395,10 +395,10 @@ impl App {
             }
         }
         for vt in tasks.iter() {
-            if expanded_ref.contains(&vt.row.worktree_path) {
-                if let Some(s) = vt.row.sessions.first() {
-                    expanded_session_names.insert(s.tmux.name.clone());
-                }
+            if expanded_ref.contains(&vt.row.worktree_path)
+                && let Some(s) = vt.row.sessions.first()
+            {
+                expanded_session_names.insert(s.tmux.name.clone());
             }
         }
 
@@ -1328,15 +1328,13 @@ impl App {
                                     self.session_name_at(self.cursor).unwrap_or_default();
                                 let windows = self.windows_at(self.cursor);
                                 let win = windows.iter().find(|wi| wi.index == w);
-                                if self.is_window_expanded(&session_name, w) {
-                                    if let Some(win) = win {
-                                        if !win.panes.is_empty() {
-                                            self.sub_cursor =
-                                                SubCursor::Pane { window: w, pane: 0 };
-                                            self.fetch_task_pane_content();
-                                            return ok();
-                                        }
-                                    }
+                                if self.is_window_expanded(&session_name, w)
+                                    && let Some(win) = win
+                                    && !win.panes.is_empty()
+                                {
+                                    self.sub_cursor = SubCursor::Pane { window: w, pane: 0 };
+                                    self.fetch_task_pane_content();
+                                    return ok();
                                 }
                                 // Window collapsed: go to next window or next parent.
                                 let pos = windows.iter().position(|wi| wi.index == w);
@@ -1550,11 +1548,11 @@ impl App {
                         if let Some(session_name) = self.session_name_at(self.cursor) {
                             let windows = self.windows_at(self.cursor);
                             let win = windows.iter().find(|wi| wi.index == *w);
-                            if let Some(win) = win {
-                                if win.panes.len() > 1 {
-                                    let key = Self::window_expansion_key(&session_name, *w);
-                                    self.window_expanded.insert(key);
-                                }
+                            if let Some(win) = win
+                                && win.panes.len() > 1
+                            {
+                                let key = Self::window_expansion_key(&session_name, *w);
+                                self.window_expanded.insert(key);
                             }
                         }
                     }

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -1181,7 +1181,10 @@ impl App {
                         match self.sub_cursor.clone() {
                             SubCursor::Pane { window, pane } => {
                                 if pane > 0 {
-                                    self.sub_cursor = SubCursor::Pane { window, pane: pane - 1 };
+                                    self.sub_cursor = SubCursor::Pane {
+                                        window,
+                                        pane: pane - 1,
+                                    };
                                 } else if self.is_single_window_session(self.cursor) {
                                     // Single-window: up from first pane → parent row.
                                     self.sub_cursor = SubCursor::None;
@@ -1202,8 +1205,11 @@ impl App {
                                     } else {
                                         // Previous window. If it's expanded, go to its last pane.
                                         let prev_win = &windows[p - 1];
-                                        let session_name = self.session_name_at(self.cursor).unwrap_or_default();
-                                        if self.is_window_expanded(&session_name, prev_win.index) && !prev_win.panes.is_empty() {
+                                        let session_name =
+                                            self.session_name_at(self.cursor).unwrap_or_default();
+                                        if self.is_window_expanded(&session_name, prev_win.index)
+                                            && !prev_win.panes.is_empty()
+                                        {
                                             self.sub_cursor = SubCursor::Pane {
                                                 window: prev_win.index,
                                                 pane: prev_win.panes.len() - 1,
@@ -1227,7 +1233,8 @@ impl App {
                                             // Single-window auto-flatten: last pane.
                                             let count = self.pane_count_at(self.cursor);
                                             if count > 0 {
-                                                let win_idx = windows.first().map(|w| w.index).unwrap_or(0);
+                                                let win_idx =
+                                                    windows.first().map(|w| w.index).unwrap_or(0);
                                                 self.sub_cursor = SubCursor::Pane {
                                                     window: win_idx,
                                                     pane: count - 1,
@@ -1236,8 +1243,13 @@ impl App {
                                         } else {
                                             // Multi-window: land on last window (or last pane if expanded).
                                             let last_win = &windows[windows.len() - 1];
-                                            let session_name = self.session_name_at(self.cursor).unwrap_or_default();
-                                            if self.is_window_expanded(&session_name, last_win.index) && !last_win.panes.is_empty() {
+                                            let session_name = self
+                                                .session_name_at(self.cursor)
+                                                .unwrap_or_default();
+                                            if self
+                                                .is_window_expanded(&session_name, last_win.index)
+                                                && !last_win.panes.is_empty()
+                                            {
                                                 self.sub_cursor = SubCursor::Pane {
                                                     window: last_win.index,
                                                     pane: last_win.panes.len() - 1,
@@ -1279,7 +1291,10 @@ impl App {
                                 let win = windows.iter().find(|w| w.index == window);
                                 let pane_count = win.map(|w| w.panes.len()).unwrap_or(0);
                                 if pane + 1 < pane_count {
-                                    self.sub_cursor = SubCursor::Pane { window, pane: pane + 1 };
+                                    self.sub_cursor = SubCursor::Pane {
+                                        window,
+                                        pane: pane + 1,
+                                    };
                                 } else if windows.len() <= 1 {
                                     // Single-window: last pane → next parent row.
                                     self.sub_cursor = SubCursor::None;
@@ -1291,11 +1306,13 @@ impl App {
                                     let pos = windows.iter().position(|w| w.index == window);
                                     if let Some(p) = pos {
                                         if p + 1 < windows.len() {
-                                            self.sub_cursor = SubCursor::Window(windows[p + 1].index);
+                                            self.sub_cursor =
+                                                SubCursor::Window(windows[p + 1].index);
                                         } else {
                                             // Last window's last pane → next parent row.
                                             self.sub_cursor = SubCursor::None;
-                                            if visible_count > 0 && self.cursor < visible_count - 1 {
+                                            if visible_count > 0 && self.cursor < visible_count - 1
+                                            {
                                                 self.cursor += 1;
                                             }
                                         }
@@ -1307,13 +1324,15 @@ impl App {
                             }
                             SubCursor::Window(w) => {
                                 // If window is expanded, enter first pane.
-                                let session_name = self.session_name_at(self.cursor).unwrap_or_default();
+                                let session_name =
+                                    self.session_name_at(self.cursor).unwrap_or_default();
                                 let windows = self.windows_at(self.cursor);
                                 let win = windows.iter().find(|wi| wi.index == w);
                                 if self.is_window_expanded(&session_name, w) {
                                     if let Some(win) = win {
                                         if !win.panes.is_empty() {
-                                            self.sub_cursor = SubCursor::Pane { window: w, pane: 0 };
+                                            self.sub_cursor =
+                                                SubCursor::Pane { window: w, pane: 0 };
                                             self.fetch_task_pane_content();
                                             return ok();
                                         }
@@ -1341,7 +1360,10 @@ impl App {
                                     if windows.len() <= 1 {
                                         // Single-window auto-flatten: enter first pane.
                                         let win_idx = windows.first().map(|w| w.index).unwrap_or(0);
-                                        self.sub_cursor = SubCursor::Pane { window: win_idx, pane: 0 };
+                                        self.sub_cursor = SubCursor::Pane {
+                                            window: win_idx,
+                                            pane: 0,
+                                        };
                                     } else {
                                         // Multi-window: enter first window.
                                         self.sub_cursor = SubCursor::Window(windows[0].index);
@@ -2625,7 +2647,7 @@ mod tests {
                 },
                 claude: None,
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             }],
             ..make_task_row(1, DisplayGroup::ClaudeWorking)
         };
@@ -2786,7 +2808,7 @@ mod tests {
                     model: None,
                 }),
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             }],
             ..make_worktree_row("feat/claude-active", DisplayGroup::ClaudeWorking)
         };
@@ -2846,7 +2868,7 @@ mod tests {
                     model: None,
                 }),
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             }],
             ..make_worktree_row("feat/waiting", DisplayGroup::NeedsAttention)
         };
@@ -2916,7 +2938,7 @@ mod tests {
                 },
                 claude: None,
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             }],
             ..make_worktree_row("feat/remote", DisplayGroup::Other)
         };
@@ -3318,7 +3340,7 @@ mod tests {
                     model: Some("opus".to_string()),
                 }),
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             }],
             ..make_worktree_row("main", DisplayGroup::RepoMain)
         };
@@ -3345,7 +3367,7 @@ mod tests {
                     model: Some("sonnet".to_string()),
                 }),
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             }],
             ..make_task_row_with_title(53, "TEA pattern refactor", DisplayGroup::NeedsAttention)
         };
@@ -3372,7 +3394,7 @@ mod tests {
                     model: Some("opus".to_string()),
                 }),
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             }],
             ..make_task_row_with_title(
                 47,
@@ -3635,7 +3657,7 @@ mod tests {
                     },
                     claude: None,
                     windows: vec![],
-            panes: vec![],
+                    panes: vec![],
                 },
             });
 
@@ -3890,7 +3912,7 @@ mod tests {
                 },
                 claude: None,
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             },
         }
     }
@@ -3913,7 +3935,7 @@ mod tests {
                 },
                 claude: None,
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             }],
             display_group: DisplayGroup::Other,
             is_main_worktree: false,
@@ -4055,10 +4077,7 @@ mod tests {
     }
 
     /// Creates a worktree row with multiple windows for testing multi-window navigation.
-    fn make_task_row_with_windows(
-        issue: u32,
-        window_pane_counts: &[(usize, &str)],
-    ) -> WorktreeRow {
+    fn make_task_row_with_windows(issue: u32, window_pane_counts: &[(usize, &str)]) -> WorktreeRow {
         let mut all_panes = Vec::new();
         let mut windows = Vec::new();
         let mut flat_idx = 0;
@@ -4154,7 +4173,11 @@ mod tests {
         app.cursor = 1;
         app.update(Message::ToggleExpandAll);
         assert_eq!(app.cursor, 1, "cursor should stay on same logical row");
-        assert_eq!(app.sub_cursor, SubCursor::None, "sub_cursor should remain None");
+        assert_eq!(
+            app.sub_cursor,
+            SubCursor::None,
+            "sub_cursor should remain None"
+        );
     }
 
     #[test]
@@ -4228,7 +4251,11 @@ mod tests {
         app.sub_cursor = SubCursor::Pane { window: 0, pane: 1 };
         app.update(Message::CursorTo(1));
         assert_eq!(app.cursor, 1);
-        assert_eq!(app.sub_cursor, SubCursor::None, "digit-jump clears sub_cursor");
+        assert_eq!(
+            app.sub_cursor,
+            SubCursor::None,
+            "digit-jump clears sub_cursor"
+        );
     }
 
     #[test]
@@ -4465,7 +4492,7 @@ mod tests {
                 },
                 claude: None,
                 windows: vec![],
-            panes: vec![],
+                panes: vec![],
             },
             config: StandaloneConfig {
                 name: name.to_string(),
@@ -4537,7 +4564,10 @@ mod tests {
 
     #[test]
     fn multi_window_down_from_session_enters_first_window() {
-        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        let mut app = App::new_test(vec![make_task_row_with_windows(
+            1,
+            &[(2, "main"), (2, "editor")],
+        )]);
         app.expanded.insert("/workspace/repo-1".to_string());
         app.update(Message::CursorDown);
         assert_eq!(app.cursor, 0);
@@ -4546,7 +4576,10 @@ mod tests {
 
     #[test]
     fn multi_window_down_from_collapsed_window_goes_to_next() {
-        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        let mut app = App::new_test(vec![make_task_row_with_windows(
+            1,
+            &[(2, "main"), (2, "editor")],
+        )]);
         app.expanded.insert("/workspace/repo-1".to_string());
         app.sub_cursor = SubCursor::Window(0);
         app.update(Message::CursorDown);
@@ -4555,7 +4588,10 @@ mod tests {
 
     #[test]
     fn multi_window_down_from_expanded_window_enters_first_pane() {
-        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        let mut app = App::new_test(vec![make_task_row_with_windows(
+            1,
+            &[(2, "main"), (2, "editor")],
+        )]);
         app.expanded.insert("/workspace/repo-1".to_string());
         app.window_expanded.insert("sess-1:0".to_string());
         app.sub_cursor = SubCursor::Window(0);
@@ -4565,7 +4601,10 @@ mod tests {
 
     #[test]
     fn multi_window_down_from_last_pane_goes_to_next_window() {
-        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        let mut app = App::new_test(vec![make_task_row_with_windows(
+            1,
+            &[(2, "main"), (2, "editor")],
+        )]);
         app.expanded.insert("/workspace/repo-1".to_string());
         app.window_expanded.insert("sess-1:0".to_string());
         app.sub_cursor = SubCursor::Pane { window: 0, pane: 1 };
@@ -4575,7 +4614,10 @@ mod tests {
 
     #[test]
     fn multi_window_up_from_first_window_returns_to_session() {
-        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        let mut app = App::new_test(vec![make_task_row_with_windows(
+            1,
+            &[(2, "main"), (2, "editor")],
+        )]);
         app.expanded.insert("/workspace/repo-1".to_string());
         app.sub_cursor = SubCursor::Window(0);
         app.update(Message::CursorUp);
@@ -4584,7 +4626,10 @@ mod tests {
 
     #[test]
     fn multi_window_up_from_first_pane_returns_to_window() {
-        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        let mut app = App::new_test(vec![make_task_row_with_windows(
+            1,
+            &[(2, "main"), (2, "editor")],
+        )]);
         app.expanded.insert("/workspace/repo-1".to_string());
         app.window_expanded.insert("sess-1:0".to_string());
         app.sub_cursor = SubCursor::Pane { window: 0, pane: 0 };
@@ -4594,7 +4639,10 @@ mod tests {
 
     #[test]
     fn multi_window_left_from_pane_collapses_window() {
-        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        let mut app = App::new_test(vec![make_task_row_with_windows(
+            1,
+            &[(2, "main"), (2, "editor")],
+        )]);
         app.expanded.insert("/workspace/repo-1".to_string());
         app.window_expanded.insert("sess-1:1".to_string());
         app.sub_cursor = SubCursor::Pane { window: 1, pane: 0 };
@@ -4605,7 +4653,10 @@ mod tests {
 
     #[test]
     fn multi_window_left_from_window_is_noop() {
-        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        let mut app = App::new_test(vec![make_task_row_with_windows(
+            1,
+            &[(2, "main"), (2, "editor")],
+        )]);
         app.expanded.insert("/workspace/repo-1".to_string());
         app.sub_cursor = SubCursor::Window(0);
         app.update(Message::CollapseRow);
@@ -4616,7 +4667,10 @@ mod tests {
 
     #[test]
     fn multi_window_right_expands_window() {
-        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        let mut app = App::new_test(vec![make_task_row_with_windows(
+            1,
+            &[(2, "main"), (2, "editor")],
+        )]);
         app.expanded.insert("/workspace/repo-1".to_string());
         app.sub_cursor = SubCursor::Window(0);
         app.update(Message::ExpandRow);
@@ -4625,7 +4679,10 @@ mod tests {
 
     #[test]
     fn collapse_session_clears_window_expansion() {
-        let mut app = App::new_test(vec![make_task_row_with_windows(1, &[(2, "main"), (2, "editor")])]);
+        let mut app = App::new_test(vec![make_task_row_with_windows(
+            1,
+            &[(2, "main"), (2, "editor")],
+        )]);
         app.expanded.insert("/workspace/repo-1".to_string());
         app.window_expanded.insert("sess-1:0".to_string());
         app.window_expanded.insert("sess-1:1".to_string());

--- a/crates/orchard/tests/common/mod.rs
+++ b/crates/orchard/tests/common/mod.rs
@@ -178,6 +178,8 @@ pub fn make_session(name: &str, path: &str, pane_commands: Vec<&str>) -> CachedT
         pane_targets: targets,
         pane_titles: vec![],
         pane_commands: cmds,
+        window_names: vec![],
+        window_active: vec![],
         host: None,
         last_output_lines: vec![],
         claude_state_raw: None,

--- a/specs/features/tmux-window-hierarchy.feature
+++ b/specs/features/tmux-window-hierarchy.feature
@@ -1,0 +1,517 @@
+Feature: Full tmux session/window/pane hierarchy in TUI
+  As an orchard user with multi-window tmux sessions
+  I want to see the full session → window → pane hierarchy when expanding a session
+  So I can navigate to a specific window and pane and understand the structure of my tmux sessions
+
+  # Current state:
+  #   - PaneInfo has tmux_target as "window.pane" (e.g. "1.2") but no WindowInfo struct
+  #   - push_pane_sub_rows() renders panes flat under the session — no window grouping
+  #   - Window names/titles are not captured from tmux
+  #   - No window-level operations exist
+  #   - pane_fmt = "#{window_index}.#{pane_index}\t#{pane_title}:#{pane_current_command}"
+  #   - CachedTmuxSession stores flat pane_targets, pane_titles, pane_commands
+  #   - EnrichedSession has panes: Vec<PaneInfo> (flat)
+  #
+  # What changes:
+  #   1. Data model: add WindowInfo struct, group panes by window
+  #   2. Cache: extend CachedTmuxSession with window_names, window_active flags
+  #   3. Tmux queries: extend pane_fmt to include #{window_name} and #{window_active}
+  #   4. TUI: double nesting — session expands to windows, window expands to panes
+  #   5. JSON output: sessions[].windows[].panes[] hierarchy
+  #   6. Backward compat: single-window sessions auto-flatten to current behavior
+  #
+  # Files affected:
+  #   - src/session.rs — add WindowInfo struct, update EnrichedSession
+  #   - src/cache.rs — add window_names/window_active to CachedTmuxSession
+  #   - src/cache_sources.rs — extend pane_fmt, parse_pane_lines → parse_pane_lines_with_windows
+  #   - src/build_state.rs — group panes into windows when building EnrichedSession
+  #   - src/tui/list.rs — push_window_sub_rows with nested push_pane_sub_rows
+  #   - src/tui/mod.rs — two-level expansion state, window+pane navigation
+  #   - src/json_output.rs — add JsonWindow, nest panes under windows
+  #   - src/orchard_state.rs — add WindowState to SessionState
+  #
+  # Design decisions (from /challenge review):
+  #
+  #   Cursor model: SubCursor enum replaces Option<usize> selected_pane
+  #     SubCursor::None — parent row selected
+  #     SubCursor::Window(usize) — window sub-row selected (tmux window_index)
+  #     SubCursor::Pane { window: usize, pane: usize } — pane selected (window tmux index + pane vec index)
+  #     Auto-flatten: single-window sessions use SubCursor::Pane { window: 0, pane: n }
+  #
+  #   Navigation state transitions:
+  #     Down from session row → SubCursor::Window(first_window) [or SubCursor::Pane(0, 0) if flattened]
+  #     Down from Window(w) [collapsed] → Window(next_w) or None on next row
+  #     Down from Window(w) [expanded] → Pane { w, 0 }
+  #     Down from Pane { w, last } → Window(next_w) or None on next row
+  #     Up from Pane { w, 0 } → Window(w) [or session row if flattened]
+  #     Up from Window(first) → None (session row)
+  #     Left from Pane → collapse window, cursor to Window(w) [or collapse session if flattened]
+  #     Left from Window → no-op (must navigate to session row to collapse session)
+  #     Right from Window → expand window
+  #     Enter from Window → switch tmux to that window (not expand)
+  #     Enter from Pane → select that specific pane + zoom
+  #
+  #   Backward compatibility:
+  #     - EnrichedSession keeps denormalized `panes: Vec<PaneInfo>` alongside `windows`
+  #       (derived from windows in constructor, avoids touching 28 call sites)
+  #     - Cache upgrade: when window_names is empty, derive windows from pane_targets
+  #       by parsing "window.pane" format, synthesize window name as "window:{idx}"
+  #     - WindowInfo.index uses tmux's stable window_index (not sequential 0..N)
+  #       so closing window 1 doesn't break expansion state for window 2
+  #     - Window expansion key format: "session_name:window_index" (tmux index)
+  #
+  #   Mouse click mapping:
+  #     - Visual-to-logical row mapping updated for variable sub-row counts
+  #     - Sub-row count = sum of (1 per window + expanded_panes_per_window)
+  #
+  #   JSON:
+  #     - SessionState in OrchardState gets WindowState for JSON conversion
+  #     - JSON always shows full hierarchy (no auto-flattening)
+  #     - Version bumps to 4
+  #
+  # Non-goals:
+  #   - Window/pane creation and management operations
+  #   - Fork session with Claude support
+  #   - New session creation flow
+
+  Background:
+    Given the TUI is running with at least one repo configured
+    And there are worktree rows with active tmux sessions
+
+  # ===================================================================
+  # 1. WindowInfo data model
+  # ===================================================================
+
+  @unit
+  Scenario: WindowInfo groups panes by window index
+    Given a tmux session with pane targets ["0.0", "0.1", "1.0", "1.1"]
+    And window names ["main", "editor"]
+    And window active flags [true, false]
+    When windows are built from the pane data
+    Then there are 2 WindowInfo entries
+    And window 0 has name "main", is_active true, and 2 panes
+    And window 1 has name "editor", is_active false, and 2 panes
+
+  @unit
+  Scenario: WindowInfo contains correct pane references
+    Given a tmux session with pane targets ["0.0", "0.1", "1.0"]
+    And window names ["shell", "code"]
+    When windows are built from the pane data
+    Then window 0 contains panes with targets "0.0" and "0.1"
+    And window 1 contains pane with target "1.0"
+
+  @unit
+  Scenario: Single-window session produces one WindowInfo
+    Given a tmux session with pane targets ["0.0", "0.1"]
+    And window names ["main"]
+    When windows are built from the pane data
+    Then there is 1 WindowInfo entry with 2 panes
+
+  @unit
+  Scenario: Session with no panes produces empty windows list
+    Given a tmux session with no panes
+    When windows are built from the pane data
+    Then the windows list is empty
+
+  # ===================================================================
+  # 2. EnrichedSession holds windows instead of flat panes
+  # ===================================================================
+
+  @unit
+  Scenario: EnrichedSession contains windows with nested panes
+    Given a CachedTmuxSession with pane targets ["0.0", "0.1", "1.0"]
+    And window names ["main", "code"]
+    When the session is enriched
+    Then EnrichedSession.windows has 2 entries
+    And EnrichedSession.windows[0].panes has 2 PaneInfo entries
+    And EnrichedSession.windows[1].panes has 1 PaneInfo entry
+
+  @unit
+  Scenario: EnrichedSession backward-compat helper returns all panes flat
+    Given an EnrichedSession with 2 windows containing 3 total panes
+    When all_panes() is called
+    Then it returns a flat slice of 3 PaneInfo entries in window order
+
+  # ===================================================================
+  # 3. CachedTmuxSession captures window metadata
+  # ===================================================================
+
+  @unit
+  Scenario: CachedTmuxSession includes window names and active flags
+    Given tmux list-panes output includes window_name and window_active
+    When the output is parsed
+    Then CachedTmuxSession.window_names contains the window names per pane row
+    And CachedTmuxSession.window_active contains "1" or "0" per pane row
+
+  @unit
+  Scenario: CachedTmuxSession serialization roundtrip with window fields
+    Given a CachedTmuxSession with window_names ["main", "editor"]
+    And window_active ["1", "0"]
+    When serialized to JSON and deserialized back
+    Then the window_names and window_active fields are preserved
+
+  @unit
+  Scenario: Missing window fields default to empty on deserialization
+    Given a cached JSON file without window_names or window_active fields
+    When it is deserialized as CachedTmuxSession
+    Then window_names defaults to empty vec
+    And window_active defaults to empty vec
+
+  # ===================================================================
+  # 4. Tmux query format extended
+  # ===================================================================
+
+  @unit
+  Scenario: pane_fmt includes window_name and window_active
+    When the tmux list-panes format string is constructed
+    Then it includes "#{window_name}" and "#{window_active}"
+    And the parse function extracts them into separate fields
+
+  @unit
+  Scenario: parse_pane_lines extracts window metadata alongside pane data
+    Given tmux output "0.0\tmain\t1\tbash:bash\n0.1\tmain\t1\tclaude:claude\n1.0\teditor\t0\tnvim:nvim"
+    When parse_pane_lines is called
+    Then targets are ["0.0", "0.1", "1.0"]
+    And window_names are ["main", "main", "editor"]
+    And window_active are ["1", "1", "0"]
+    And titles are ["bash", "claude", "nvim"]
+    And commands are ["bash", "claude", "nvim"]
+
+  # ===================================================================
+  # 5. TUI display — double nesting
+  # ===================================================================
+
+  @unit
+  Scenario: Expanding a multi-window session shows window sub-rows
+    Given a worktree row with a session having 2 windows (3 total panes)
+    And the session row is expanded
+    When the table renders
+    Then 2 window sub-rows appear immediately after the session row
+    And no pane sub-rows are visible (windows are collapsed by default)
+
+  @unit
+  Scenario: Window sub-row shows window name and index
+    Given an expanded session with window 0 named "main" and window 1 named "editor"
+    When the window sub-rows render
+    Then window sub-row 0 shows "├─ window:0 main" (or similar tree connector)
+    And window sub-row 1 shows "└─ window:1 editor"
+
+  @unit
+  Scenario: Expanding a window sub-row shows its pane sub-rows
+    Given an expanded session with window 0 having 2 panes
+    And window 0 is expanded
+    When the table renders
+    Then 2 pane sub-rows appear nested under window 0
+    And pane sub-rows use deeper tree connectors (e.g. "│ ├─ pane:0 zsh")
+
+  @unit
+  Scenario: Pane sub-rows under window show command and claude indicator
+    Given an expanded window with pane 0 running "claude" and pane 1 running "nvim"
+    When the pane sub-rows render
+    Then pane 0 shows the lightning bolt Claude indicator
+    And pane 1 shows a dash indicator
+    And the TITLE cell shows the pane command
+
+  @unit
+  Scenario: Collapsed window hides its pane sub-rows
+    Given an expanded session with window 0 collapsed
+    When the table renders
+    Then window 0's pane sub-rows are not visible
+    But window 0's sub-row is still visible
+
+  # ===================================================================
+  # 6. Single-window auto-flatten
+  # ===================================================================
+
+  @unit
+  Scenario: Single-window session skips the window level
+    Given a worktree row with a session having only 1 window with 3 panes
+    And the session row is expanded
+    When the table renders
+    Then pane sub-rows appear directly under the session row (no window row)
+    And the tree connectors match the current pane-level format
+
+  @unit
+  Scenario: Multi-window session always shows window level
+    Given a worktree row with a session having 2+ windows
+    And the session row is expanded
+    When the table renders
+    Then window sub-rows appear (not direct pane sub-rows)
+
+  # ===================================================================
+  # 7. Two-level expansion state
+  # ===================================================================
+
+  @unit
+  Scenario: Session expansion tracked by worktree path (existing behavior)
+    Given the user expands a session for worktree at "/workspace/repo/feat-42"
+    When the expansion set is checked
+    Then "/workspace/repo/feat-42" is in the session expanded set
+
+  @unit
+  Scenario: Window expansion tracked by session_name:window_index key
+    Given an expanded session "my-session" and the user expands window 0
+    When the window expansion set is checked
+    Then "my-session:0" is in the window expanded set
+
+  @unit
+  Scenario: Collapsing session clears its window expansion state
+    Given session "my-session" is expanded with windows 0 and 1 expanded
+    When the user collapses the session
+    Then "my-session:0" and "my-session:1" are removed from the window expanded set
+
+  @unit
+  Scenario: Expansion state survives data refresh
+    Given session "my-session" is expanded and window 0 is expanded
+    When a cache refresh completes
+    Then the session and window expansion states are preserved
+
+  # ===================================================================
+  # 8. Navigation into windows and panes
+  # ===================================================================
+
+  @unit
+  Scenario: Down arrow from session row enters window sub-rows
+    Given an expanded multi-window session
+    When the user presses Down
+    Then the cursor moves to the first window sub-row
+
+  @unit
+  Scenario: Down arrow from window row enters pane sub-rows when expanded
+    Given an expanded window sub-row with 2 panes
+    When the user presses Down
+    Then the cursor moves to the first pane sub-row under that window
+
+  @unit
+  Scenario: Down arrow from collapsed window skips to next window
+    Given an expanded session with window 0 collapsed and window 1
+    When the cursor is on window 0 and the user presses Down
+    Then the cursor moves to window 1
+
+  @unit
+  Scenario: Right arrow on window sub-row expands it
+    Given the cursor is on a collapsed window sub-row with 2 panes
+    When the user presses Right (or "l")
+    Then the window expands and pane sub-rows appear
+
+  @unit
+  Scenario: Left arrow on window sub-row collapses it
+    Given the cursor is on an expanded window sub-row
+    When the user presses Left (or "h")
+    Then the window collapses and pane sub-rows disappear
+
+  @unit
+  Scenario: Left arrow on pane sub-row collapses parent window
+    Given the cursor is on a pane sub-row under window 1
+    When the user presses Left
+    Then window 1 collapses
+    And the cursor moves to the window 1 sub-row
+
+  @unit
+  Scenario: Enter on window sub-row switches to that window
+    Given the cursor is on window sub-row for window 1 of session "my-session"
+    When the user presses Enter
+    Then tmux switches to session "my-session" window 1
+
+  @unit
+  Scenario: Enter on pane sub-row switches to that specific pane
+    Given the cursor is on pane sub-row for window 1, pane 0 of session "my-session"
+    When the user presses Enter
+    Then tmux switches to session "my-session" and selects pane at target "1.0"
+
+  # ===================================================================
+  # 9. JSON output with window hierarchy
+  # ===================================================================
+
+  @unit
+  Scenario: JSON output includes windows array in sessions
+    Given an OrchardState with a session having 2 windows
+    When serialized to JSON via --json
+    Then the session object contains a "windows" array with 2 entries
+    And each window has "index", "name", "isActive", and "panes" fields
+
+  @unit
+  Scenario: JSON window panes contain expected fields
+    Given a window with 2 panes including one running "claude"
+    When serialized to JSON
+    Then each pane object has "index", "tmuxTarget", "command", "title", "hasClaude"
+    And the Claude pane has "hasClaude": true
+
+  @unit
+  Scenario: JSON version bumps to 4
+    When OrchardState is serialized to JSON
+    Then the version field is 4
+
+  @unit
+  Scenario: Single-window session still shows windows array in JSON
+    Given a session with only 1 window
+    When serialized to JSON
+    Then the session still contains a "windows" array with 1 entry
+    # JSON always shows the full hierarchy, no auto-flattening
+
+  # ===================================================================
+  # 10. Keybinds
+  # ===================================================================
+
+  @unit
+  Scenario: h/l and Left/Right work at both session and window levels
+    Given a multi-window session is selected
+    When the user presses Right to expand the session
+    Then window sub-rows appear
+    When the user navigates to window 0 and presses Right
+    Then pane sub-rows appear under window 0
+    When the user presses Left
+    Then window 0 collapses
+    When the user presses Left again (on window row)
+    Then it does nothing (session collapse requires moving to session row)
+
+  @unit
+  Scenario: d key on session row kills the session (existing behavior)
+    Given the cursor is on a session row
+    When the user presses d
+    Then the delete confirmation dialog appears for the session
+
+  # ===================================================================
+  # 11. Window-level expand indicator on window sub-rows
+  # ===================================================================
+
+  @unit
+  Scenario: Multi-pane window shows collapsed indicator
+    Given a window sub-row with 3 panes and the window is collapsed
+    When the sub-row renders
+    Then it shows a collapse indicator with pane count (e.g. "▶3")
+
+  @unit
+  Scenario: Multi-pane window shows expanded indicator
+    Given a window sub-row with 3 panes and the window is expanded
+    When the sub-row renders
+    Then it shows an expand indicator (e.g. "▼3")
+
+  @unit
+  Scenario: Single-pane window shows no expand indicator
+    Given a window sub-row with exactly 1 pane
+    When the sub-row renders
+    Then no expand/collapse indicator is shown for the window
+
+  # ===================================================================
+  # 12. Cache upgrade compatibility
+  # ===================================================================
+
+  @unit
+  Scenario: Old cache without window fields degrades gracefully
+    Given a CachedTmuxSession with pane_targets ["0.0", "0.1", "1.0"]
+    And window_names is empty (old cache format)
+    When the session is enriched
+    Then windows are derived from pane_targets by parsing window indices
+    And window 0 gets synthetic name "window:0" with 2 panes
+    And window 1 gets synthetic name "window:1" with 1 pane
+
+  @unit
+  Scenario: Cache with window fields uses real window names
+    Given a CachedTmuxSession with pane_targets ["0.0", "0.1", "1.0"]
+    And window_names ["main", "main", "code"]
+    When the session is enriched
+    Then window 0 has name "main"
+    And window 1 has name "code"
+
+  # ===================================================================
+  # 13. Window index stability (tmux window_index, not sequential)
+  # ===================================================================
+
+  @unit
+  Scenario: WindowInfo.index uses tmux's stable window_index
+    Given a tmux session with windows 0, 2, 5 (1, 3, 4 were closed)
+    When windows are built
+    Then WindowInfo entries have index 0, 2, 5 (not 0, 1, 2)
+
+  @unit
+  Scenario: Window expansion key uses tmux window_index
+    Given a session with windows at indices 0 and 5
+    And the user expands window 5
+    Then the expansion key is "session:5" (not "session:1")
+
+  # ===================================================================
+  # 14. SubCursor state machine
+  # ===================================================================
+
+  @unit
+  Scenario: SubCursor::None represents parent row selection
+    Given the cursor is on a session row
+    Then sub_cursor is SubCursor::None
+
+  @unit
+  Scenario: SubCursor::Window represents window sub-row selection
+    Given the cursor is on window sub-row for window index 2
+    Then sub_cursor is SubCursor::Window(2)
+
+  @unit
+  Scenario: SubCursor::Pane represents pane sub-row selection
+    Given the cursor is on pane 1 within window index 2
+    Then sub_cursor is SubCursor::Pane { window: 2, pane: 1 }
+
+  @unit
+  Scenario: Down from last pane of window lands on next window row
+    Given expanded session with windows [0, 2] both expanded
+    And cursor on last pane of window 0
+    When user presses Down
+    Then sub_cursor becomes SubCursor::Window(2)
+
+  @unit
+  Scenario: Up from first pane of window lands on window row
+    Given cursor on first pane of window 2
+    When user presses Up
+    Then sub_cursor becomes SubCursor::Window(2)
+
+  @unit
+  Scenario: Up from first window lands on session row
+    Given cursor on first window sub-row
+    When user presses Up
+    Then sub_cursor becomes SubCursor::None (session row)
+
+  # ===================================================================
+  # 15. Mouse click mapping with variable sub-row counts
+  # ===================================================================
+
+  @unit
+  Scenario: Mouse click on window sub-row selects correct window
+    Given an expanded session with 3 windows where window 0 is expanded (2 panes)
+    When the user clicks the visual row for window 1
+    Then sub_cursor becomes SubCursor::Window(window_1_index)
+
+  @unit
+  Scenario: Mouse click on pane sub-row selects correct pane
+    Given an expanded session with window 0 expanded showing 2 pane sub-rows
+    When the user clicks the visual row for the second pane
+    Then sub_cursor becomes SubCursor::Pane { window: 0, pane: 1 }
+
+  # ===================================================================
+  # 16. Preview pane content follows cursor level
+  # ===================================================================
+
+  @unit
+  Scenario: Preview shows active pane content when cursor is on window row
+    Given cursor on window sub-row for window 1
+    When preview content is fetched
+    Then it captures from the active pane of window 1
+
+  @unit
+  Scenario: Preview shows specific pane content when cursor is on pane row
+    Given cursor on pane sub-row for window 1, pane 0
+    When preview content is fetched
+    Then it captures from pane target "1.0"
+
+  # ===================================================================
+  # 17. Session-level expand indicator with windows
+  # ===================================================================
+
+  @unit
+  Scenario: Multi-window session shows window count in expand indicator
+    Given a session with 3 windows (5 total panes) and the session is collapsed
+    When the session row renders
+    Then the STATUS cell shows "▶3w" (window count, not pane count)
+
+  @unit
+  Scenario: Single-window session shows pane count in expand indicator
+    Given a session with 1 window and 3 panes, collapsed
+    When the session row renders
+    Then the STATUS cell shows "▶3" (pane count, matching current behavior)


### PR DESCRIPTION
## Summary

Closes #184

- Add three-level tmux hierarchy (session → windows → panes) to replace flat pane list
- Single-window sessions auto-flatten to preserve current UX
- Multi-window sessions show intermediate window level with expand/collapse
- SubCursor enum replaces `Option<usize>` for two-level navigation
- JSON output version 4 with `windows[].panes[]` hierarchy

## Changes

**Data model** (`session.rs`, `cache.rs`, `cache_sources.rs`, `build_state.rs`, `derive.rs`):
- `WindowInfo` struct groups panes by stable tmux window index
- `EnrichedSession` gains `windows` alongside denormalized `panes` for backward compat
- `CachedTmuxSession` extended with `window_names`, `window_active` (serde default for cache upgrade)
- `pane_fmt` extended with `#{window_name}` and `#{window_active}`
- `ParsedPaneData` struct replaces tuple return from `parse_pane_lines`

**TUI** (`tui/mod.rs`, `tui/list.rs`, `tmux.rs`):
- `SubCursor` enum: `None | Window(usize) | Pane { window, pane }`
- Two expansion sets: session-level + window-level (`session_name:window_index`)
- `push_window_sub_rows` renders window sub-rows with nested pane sub-rows
- Full navigation state machine (Down/Up/Left/Right/Enter) across all cursor levels
- `select_window` tmux command for Enter on window rows

**JSON** (`json_output.rs`, `orchard_state.rs`):
- `JsonWindow`, `JsonPane` types with camelCase serialization
- `WindowState`, `PaneState` in OrchardState
- Version bumped from 3 to 4

## Test plan

- [x] `cargo test -p orchard` — all tests pass
- [x] `cargo build --release` — builds successfully
- [ ] Manual: expand multi-window session, verify window sub-rows appear
- [ ] Manual: expand window, verify pane sub-rows appear nested
- [ ] Manual: single-window session auto-flattens to current behavior
- [ ] Manual: `orchard --json` shows `windows[].panes[]` hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #184

# Related issue

- #184