### PR TITLE
feat(tui): expand all session rows by default

### DIFF
--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -384,6 +384,11 @@ impl App {
 
         self.expanded.retain(|k| valid_keys.contains(k));
 
+        // Auto-expand all expandable rows so hierarchy is visible by default.
+        for key in &valid_keys {
+            self.expanded.insert(key.clone());
+        }
+
         // Also prune window_expanded: remove entries for sessions that are no longer expanded.
         let expanded_ref = &self.expanded;
 
@@ -411,6 +416,28 @@ impl App {
                 false
             }
         });
+
+        // Auto-expand windows for sessions with >1 window.
+        for ss in &self.standalone_sessions {
+            if self.expanded.contains(&ss.session.tmux.name) && ss.session.windows.len() > 1 {
+                for (i, _) in ss.session.windows.iter().enumerate() {
+                    self.window_expanded
+                        .insert(Self::window_expansion_key(&ss.session.tmux.name, i));
+                }
+            }
+        }
+        for vt in tasks.iter() {
+            if self.expanded.contains(&vt.row.worktree_path) {
+                if let Some(s) = vt.row.sessions.first() {
+                    if s.windows.len() > 1 {
+                        for (i, _) in s.windows.iter().enumerate() {
+                            self.window_expanded
+                                .insert(Self::window_expansion_key(&s.tmux.name, i));
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // -------------------------------------------------------------------
@@ -4263,6 +4290,28 @@ mod tests {
         assert!(
             app.expanded.contains("/workspace/repo-1"),
             "multi-pane row should remain in expanded set"
+        );
+    }
+
+    #[test]
+    fn prune_expansion_state_auto_expands_new_multi_pane_rows() {
+        let mut app = App::new_test(vec![make_task_row_with_panes(1, 3)]);
+        // expanded starts empty
+        assert!(app.expanded.is_empty());
+        app.prune_expansion_state();
+        assert!(
+            app.expanded.contains("/workspace/repo-1"),
+            "multi-pane row should be auto-expanded after prune"
+        );
+    }
+
+    #[test]
+    fn prune_expansion_state_does_not_expand_single_pane_rows() {
+        let mut app = App::new_test(vec![make_task_row_with_panes(1, 1)]);
+        app.prune_expansion_state();
+        assert!(
+            app.expanded.is_empty(),
+            "single-pane row should not be auto-expanded"
         );
     }
 

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -427,14 +427,13 @@ impl App {
             }
         }
         for vt in tasks.iter() {
-            if self.expanded.contains(&vt.row.worktree_path) {
-                if let Some(s) = vt.row.sessions.first() {
-                    if s.windows.len() > 1 {
-                        for (i, _) in s.windows.iter().enumerate() {
-                            self.window_expanded
-                                .insert(Self::window_expansion_key(&s.tmux.name, i));
-                        }
-                    }
+            if self.expanded.contains(&vt.row.worktree_path)
+                && let Some(s) = vt.row.sessions.first()
+                && s.windows.len() > 1
+            {
+                for (i, _) in s.windows.iter().enumerate() {
+                    self.window_expanded
+                        .insert(Self::window_expansion_key(&s.tmux.name, i));
                 }
             }
         }

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -290,6 +290,7 @@ mod tests {
                 context_window_pct: None,
                 model: None,
             }),
+            windows: vec![],
         }];
         wt
     }
@@ -559,6 +560,7 @@ mod tests {
                         status: SessionStatus::Running { attached: false },
                     },
                     claude: None,
+                    windows: vec![],
                     panes: vec![],
                 },
                 config: StandaloneConfig {
@@ -596,6 +598,7 @@ mod tests {
                         status: SessionStatus::Running { attached: false },
                     },
                     claude: None,
+                    windows: vec![],
                     panes: vec![],
                 },
                 config: StandaloneConfig {

--- a/crates/orchard/src/watch/threshold.rs
+++ b/crates/orchard/src/watch/threshold.rs
@@ -130,6 +130,7 @@ mod tests {
                 context_window_pct: context_pct,
                 model: None,
             }),
+            windows: vec![],
         };
         let wt = WorktreeState {
             path: path.to_string(),


### PR DESCRIPTION
## Summary
- Session nesting (windows/panes) now starts fully expanded so the hierarchy is visible immediately
- Auto-expand runs after every cache refresh, including window-level expansion for multi-window sessions
- Also fixes missing `windows` field in watch test fixtures (broken by #189)

Closes #197

## Test plan
- [x] `prune_expansion_state_auto_expands_new_multi_pane_rows` — verifies multi-pane rows auto-expand
- [x] `prune_expansion_state_does_not_expand_single_pane_rows` — verifies single-pane rows stay collapsed
- [x] Existing prune tests still pass (retain/remove behavior unchanged)
- [ ] Manual: launch TUI, verify session rows show expanded hierarchy on first render

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #197

# Related issue

- #197