### PR TITLE
fix(tui): align fuzzy highlight offsets and fix window sub-row layout

### DIFF
--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -88,44 +88,45 @@ pub fn row_haystack(row: &WorktreeRow) -> RowHaystack {
 
 /// Returns PR status text without a Theme dependency.
 ///
-/// Mirrors the logic of `pr_status_text` in `list.rs` but returns only
-/// the plain string so it can be included in the fuzzy haystack.
+/// Mirrors the logic of `pr_status_text` in `list.rs` exactly — including the
+/// same Unicode symbols — so that fuzzy match byte offsets align with the
+/// displayed text in each cell.
 fn pr_status_haystack(row: &WorktreeRow) -> String {
     let Some(ref pr) = row.pr else {
         if let Some(ref state) = row.issue_state
             && (state == "closed" || state == "completed")
         {
-            return format!("issue {}", state);
+            return format!("\u{2716} issue {}", state);
         }
         return "no PR".to_string();
     };
 
     let prefix = format!("#{} ", pr.number);
     if pr.state.as_deref() == Some("merged") {
-        return format!("{}merged", prefix);
+        return format!("{}\u{2713} merged", prefix);
     }
     if pr.state.as_deref() == Some("closed") {
-        return format!("{}closed", prefix);
+        return format!("{}\u{2716} closed", prefix);
     }
     if pr.review_decision.as_deref() == Some("approved") {
-        return format!("{}approved", prefix);
+        return format!("{}\u{2713} approved", prefix);
     }
     if pr.review_decision.as_deref() == Some("changes_requested") {
-        return format!("{}changes req", prefix);
+        return format!("{}\u{2716} changes req", prefix);
     }
     if pr.has_conflicts {
-        return format!("{}conflict", prefix);
+        return format!("{}\u{2716} conflict", prefix);
     }
     if pr.unresolved_threads > 0 {
-        return format!("{}unresolved {}", prefix, pr.unresolved_threads);
+        return format!("{}\u{25cb} unresolved ({})", prefix, pr.unresolved_threads);
     }
     if pr.checks_state.as_deref() == Some("failing") {
-        return format!("{}failing", prefix);
+        return format!("{}\u{2716} failing", prefix);
     }
     if pr.checks_state.as_deref() == Some("pending") {
-        return format!("{}pending CI", prefix);
+        return format!("{}\u{25d0} pending CI", prefix);
     }
-    format!("{}needs review", prefix)
+    format!("{}\u{25cb} needs review", prefix)
 }
 
 /// Returns a session status text string for the haystack.
@@ -320,6 +321,72 @@ pub fn highlight_spans(
 }
 
 // ---------------------------------------------------------------------------
+// Span truncation
+// ---------------------------------------------------------------------------
+
+/// Truncates a `Vec<Span>` from the left to fit within `max_width` characters.
+///
+/// Mirrors the behavior of [`crate::paths::truncate_left`] but operates on
+/// styled spans so that highlight styles are preserved after truncation.
+///
+/// If the total character width of all spans is within `max_width`, the spans
+/// are returned unchanged. Otherwise, characters are removed from the left
+/// until the content (plus a leading "…" ellipsis) fits.
+///
+/// Multi-byte Unicode characters are counted by char, not byte.
+pub fn truncate_spans_left(spans: Vec<Span<'static>>, max_width: usize) -> Vec<Span<'static>> {
+    let total_chars: usize = spans.iter().map(|s| s.content.chars().count()).sum();
+    if total_chars <= max_width {
+        return spans;
+    }
+    if max_width <= 1 {
+        return vec![Span::raw("…".to_string())];
+    }
+
+    // We need to keep only the last (max_width - 1) chars, prefixed with "…".
+    let keep = max_width - 1;
+    let skip = total_chars - keep;
+
+    let mut result: Vec<Span<'static>> = Vec::new();
+    let mut skipped = 0usize;
+    let mut ellipsis_prepended = false;
+
+    for span in spans {
+        let span_chars: Vec<char> = span.content.chars().collect();
+        let span_len = span_chars.len();
+
+        if skipped + span_len <= skip {
+            // Skip this span entirely.
+            skipped += span_len;
+            continue;
+        }
+
+        // Partial or full inclusion of this span.
+        let chars_to_skip_in_span = skip.saturating_sub(skipped);
+        skipped += chars_to_skip_in_span;
+
+        let remaining: String = span_chars[chars_to_skip_in_span..].iter().collect();
+        if remaining.is_empty() {
+            continue;
+        }
+
+        if !ellipsis_prepended {
+            // Prepend "…" with the same style as the first kept span.
+            result.push(Span::styled(format!("…{}", remaining), span.style));
+            ellipsis_prepended = true;
+        } else {
+            result.push(Span::styled(remaining, span.style));
+        }
+    }
+
+    if result.is_empty() {
+        result.push(Span::raw("…".to_string()));
+    }
+
+    result
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -422,8 +489,30 @@ mod tests {
         };
         let haystack = row_haystack(&row);
         assert!(
-            haystack.text.contains("approved"),
-            "pr approved status missing from haystack: {}",
+            haystack.text.contains("\u{2713} approved"),
+            "pr approved status with symbol missing from haystack: {}",
+            haystack.text
+        );
+    }
+
+    #[test]
+    fn haystack_includes_pr_status_failing_with_symbol() {
+        let row = WorktreeRow {
+            pr: Some(PrInfo {
+                number: 12,
+                branch: "feat/issue-42".to_string(),
+                state: None,
+                review_decision: None,
+                checks_state: Some("failing".to_string()),
+                has_conflicts: false,
+                unresolved_threads: 0,
+            }),
+            ..base_row()
+        };
+        let haystack = row_haystack(&row);
+        assert!(
+            haystack.text.contains("\u{2716} failing"),
+            "pr failing status with symbol missing from haystack: {}",
             haystack.text
         );
     }
@@ -575,6 +664,68 @@ mod tests {
         );
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].content.as_ref(), "hello");
+    }
+
+    // -------------------------------------------------------------------------
+    // truncate_spans_left
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn truncate_spans_left_within_width_returns_unchanged() {
+        let spans = vec![
+            Span::raw("hello".to_string()),
+            Span::styled(" world".to_string(), Style::default().add_modifier(Modifier::BOLD)),
+        ];
+        let result = truncate_spans_left(spans.clone(), 20);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].content.as_ref(), "hello");
+        assert_eq!(result[1].content.as_ref(), " world");
+    }
+
+    #[test]
+    fn truncate_spans_left_exceeding_width_prepends_ellipsis_and_trims_left() {
+        // "hello world" = 11 chars; max_width = 7 → keep last 6 chars = "world" + 1 more
+        // skip 4 chars: "hell" → keep "o world" but only 6 chars after "…"
+        // Actually: keep = 6, skip = 5 ("hello"), result = "…world"
+        let spans = vec![Span::raw("hello world".to_string())];
+        let result = truncate_spans_left(spans, 7);
+        // total=11, keep=6, skip=5 → skip "hello", keep " world" (6 chars)
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].content.as_ref(), "… world");
+    }
+
+    #[test]
+    fn truncate_spans_left_preserves_style_of_kept_span() {
+        let bold = Style::default().add_modifier(Modifier::BOLD);
+        let spans = vec![
+            Span::raw("prefix".to_string()),
+            Span::styled("suffix".to_string(), bold),
+        ];
+        // total=12, max_width=8, keep=7, skip=5 → skip "prefi", keep "x" + "suffix"
+        // First kept span fragment: "x" from "prefix", styled as raw (no style)
+        // Then full "suffix" span with bold
+        let result = truncate_spans_left(spans, 8);
+        assert!(result.len() >= 2);
+        // Last span should retain bold style.
+        let last = result.last().unwrap();
+        assert_eq!(last.content.as_ref(), "suffix");
+        assert_eq!(last.style, bold);
+    }
+
+    #[test]
+    fn truncate_spans_left_zero_width_returns_ellipsis() {
+        let spans = vec![Span::raw("hello".to_string())];
+        let result = truncate_spans_left(spans, 0);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].content.as_ref(), "…");
+    }
+
+    #[test]
+    fn truncate_spans_left_width_one_returns_ellipsis() {
+        let spans = vec![Span::raw("hello".to_string())];
+        let result = truncate_spans_left(spans, 1);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].content.as_ref(), "…");
     }
 
     // -------------------------------------------------------------------------

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -674,7 +674,10 @@ mod tests {
     fn truncate_spans_left_within_width_returns_unchanged() {
         let spans = vec![
             Span::raw("hello".to_string()),
-            Span::styled(" world".to_string(), Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " world".to_string(),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
         ];
         let result = truncate_spans_left(spans.clone(), 20);
         assert_eq!(result.len(), 2);

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1586,8 +1586,7 @@ impl App {
                         Style::default(),
                         highlight_style,
                     );
-                    let truncated =
-                        crate::tui::fuzzy::truncate_spans_left(spans, title_width);
+                    let truncated = crate::tui::fuzzy::truncate_spans_left(spans, title_width);
                     Cell::from(Line::from(truncated))
                 } else {
                     Cell::from(title_display)
@@ -1791,10 +1790,24 @@ impl App {
                     ));
 
             // Connector cell: tree chars + window index + optional pane count indicator.
-            let connector_chars = if is_last_window { "\u{2514}\u{2500}" } else { "\u{251c}\u{2500}" };
+            let connector_chars = if is_last_window {
+                "\u{2514}\u{2500}"
+            } else {
+                "\u{251c}\u{2500}"
+            };
             let pane_indicator = if window.panes.len() > 1 {
-                let caret = if is_window_expanded { "\u{25bc}" } else { "\u{25b6}" };
-                format!("{} {} {}{}", connector_chars, window.index, caret, window.panes.len())
+                let caret = if is_window_expanded {
+                    "\u{25bc}"
+                } else {
+                    "\u{25b6}"
+                };
+                format!(
+                    "{} {} {}{}",
+                    connector_chars,
+                    window.index,
+                    caret,
+                    window.panes.len()
+                )
             } else {
                 format!("{} {}", connector_chars, window.index)
             };

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1566,25 +1566,29 @@ impl App {
 
             // Build title cell with fuzzy highlights when a filter is active.
             // The TITLE field is issue_title (field index 3) or branch (field index 1).
+            // We highlight against `title_raw` (the untruncated source) because field
+            // offsets are computed from the original haystack text. After highlighting,
+            // we truncate the resulting spans to `title_width` chars.
             let title_cell = if !vt.match_indices.is_empty() && !fo.is_empty() {
-                let (field_idx, source_text) = if vt.row.is_main_worktree {
-                    // Main worktree: repo name shown, no highlighting needed.
-                    (usize::MAX, title_display.clone())
+                let field_idx = if vt.row.is_main_worktree {
+                    usize::MAX
                 } else {
                     match vt.row.issue_title.as_deref() {
-                        Some(t) if !t.is_empty() => (3, title_display.clone()),
-                        _ => (1, title_display.clone()),
+                        Some(t) if !t.is_empty() => 3,
+                        _ => 1,
                     }
                 };
                 if field_idx != usize::MAX && fo.len() > field_idx {
                     let spans = crate::tui::fuzzy::highlight_spans(
-                        &source_text,
+                        title_raw,
                         fo[field_idx],
                         &vt.match_indices,
                         Style::default(),
                         highlight_style,
                     );
-                    Cell::from(Line::from(spans))
+                    let truncated =
+                        crate::tui::fuzzy::truncate_spans_left(spans, title_width);
+                    Cell::from(Line::from(truncated))
                 } else {
                     Cell::from(title_display)
                 }
@@ -1779,13 +1783,6 @@ impl App {
             let selected = self.cursor == parent_cursor_idx
                 && self.sub_cursor == SubCursor::Window(window.index);
 
-            // Tree connector for window row.
-            let connector = if is_last_window {
-                format!("\u{2514}\u{2500} win:{} {}", window.index, window.name)
-            } else {
-                format!("\u{251c}\u{2500} win:{} {}", window.index, window.name)
-            };
-
             let is_window_expanded =
                 self.window_expanded
                     .contains(&super::App::window_expansion_key(
@@ -1793,17 +1790,17 @@ impl App {
                         window.index,
                     ));
 
-            // Expand indicator for the window (in STATUS cell).
-            let status_text = if window.panes.len() > 1 {
-                let caret = if is_window_expanded {
-                    "\u{25bc}"
-                } else {
-                    "\u{25b6}"
-                };
-                format!("{}{}", caret, window.panes.len())
+            // Connector cell: tree chars + window index + optional pane count indicator.
+            let connector_chars = if is_last_window { "\u{2514}\u{2500}" } else { "\u{251c}\u{2500}" };
+            let pane_indicator = if window.panes.len() > 1 {
+                let caret = if is_window_expanded { "\u{25bc}" } else { "\u{25b6}" };
+                format!("{} {} {}{}", connector_chars, window.index, caret, window.panes.len())
             } else {
-                String::new()
+                format!("{} {}", connector_chars, window.index)
             };
+
+            // Window name for TITLE column.
+            let window_title = format!("win:{} {}", window.index, window.name);
 
             let row_style = if selected {
                 Style::default()
@@ -1815,10 +1812,10 @@ impl App {
 
             let mut cells = vec![
                 Cell::from("\u{25cf}").style(Style::default().fg(bar_color)),
-                Cell::from(connector),
-                Cell::from(""), // CLAUDE: empty for window row
-                Cell::from(""), // ISSUE: empty
-                Cell::from(""), // TITLE: empty (name is in # cell)
+                Cell::from(pane_indicator), // # column: connector + pane count
+                Cell::from(""),             // CLAUDE: empty
+                Cell::from(""),             // ISSUE: empty
+                Cell::from(window_title),   // TITLE: window name
             ];
 
             if ctx.show_branch {
@@ -1827,7 +1824,7 @@ impl App {
             if ctx.has_remote {
                 cells.push(Cell::from(""));
             }
-            cells.push(Cell::from(status_text));
+            cells.push(Cell::from("")); // STATUS: empty
 
             rows.push(Row::new(cells).style(row_style));
             row_heights.push(1);

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -290,6 +290,7 @@ mod tests {
                 context_window_pct: None,
                 model: None,
             }),
+            windows: vec![],
         }];
         wt
     }
@@ -559,6 +560,7 @@ mod tests {
                         status: SessionStatus::Running { attached: false },
                     },
                     claude: None,
+                    windows: vec![],
                     panes: vec![],
                 },
                 config: StandaloneConfig {
@@ -596,6 +598,7 @@ mod tests {
                         status: SessionStatus::Running { attached: false },
                     },
                     claude: None,
+                    windows: vec![],
                     panes: vec![],
                 },
                 config: StandaloneConfig {

--- a/crates/orchard/src/watch/threshold.rs
+++ b/crates/orchard/src/watch/threshold.rs
@@ -130,6 +130,7 @@ mod tests {
                 context_window_pct: context_pct,
                 model: None,
             }),
+            windows: vec![],
         };
         let wt = WorktreeState {
             path: path.to_string(),


### PR DESCRIPTION
## Summary

- **Fuzzy highlight alignment (#195)**: Fix title cell highlighting by passing untruncated source text to `highlight_spans` and truncating the resulting styled spans via new `truncate_spans_left()`. Fix PR status highlighting by including Unicode symbols in `pr_status_haystack` to match `pr_status_text`.
- **Window sub-row layout (#196)**: Move window name to TITLE column, put pane count + caret in `#` cell after connector + index, leave STATUS column empty for window rows.
- **Pre-existing fix**: Add missing `windows: vec![]` field to test fixtures in `diff.rs` and `threshold.rs` (broken by #194 merge).

Closes #195
Closes #196

## Test plan

- [x] `truncate_spans_left` - 5 unit tests covering: fits within width, exceeds width, preserves styles, zero width, width=1
- [x] `pr_status_haystack` - updated approved test to verify symbol, added failing-with-symbol test
- [x] `cargo test` passes
- [x] `cargo build --release` succeeds
- [ ] Manual: filter TUI with long issue titles - highlights land on correct chars
- [ ] Manual: expand multi-window session - window name in TITLE, pane count in # cell

Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #195

# Related issue

- #195