### PR TITLE
feat: include CI failure details and labels in core state model

### DIFF
--- a/crates/orchard/src/cache.rs
+++ b/crates/orchard/src/cache.rs
@@ -52,7 +52,16 @@ pub struct CachedPr {
     /// the GraphQL `closingIssuesReferences` nodes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub linked_issue_state: Option<String>,
+    /// Individual non-passing CI checks (ALL non-passing, before exclusion filtering).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failing_checks: Vec<crate::orchard_state::FailedCheck>,
+    /// Labels applied to this PR.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
 }
+
+// Re-export FailedCheck for convenience in tests and other modules.
+pub use crate::orchard_state::FailedCheck;
 
 /// A git worktree entry as stored in the worktrees cache file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -311,6 +320,8 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            failing_checks: vec![],
+            labels: vec![],
         }
     }
 
@@ -635,5 +646,53 @@ mod tests {
         // Also verify the JSON on disk contains the field name.
         let json = std::fs::read_to_string(&path).unwrap();
         assert!(json.contains("\"last_refreshed\""));
+    }
+
+    // -- CachedPr backward compat -------------------------------------------
+
+    #[test]
+    fn cached_pr_missing_failing_checks_defaults_to_empty() {
+        // Old cache format without failing_checks field.
+        let json = r#"{
+            "number": 7,
+            "branch": "feat/my-branch",
+            "linked_issue": 42,
+            "state": "open",
+            "review_decision": "approved",
+            "checks_state": "passing",
+            "has_conflicts": false,
+            "unresolved_threads": 0
+        }"#;
+        let parsed: CachedPr = serde_json::from_str(json).unwrap();
+        assert!(
+            parsed.failing_checks.is_empty(),
+            "failing_checks should default to empty vec when missing from JSON"
+        );
+    }
+
+    #[test]
+    fn cached_pr_failing_checks_roundtrip() {
+        let pr = CachedPr {
+            failing_checks: vec![FailedCheck {
+                name: "e2e-tests".to_string(),
+                conclusion: "FAILURE".to_string(),
+            }],
+            ..make_pr()
+        };
+        let json = serde_json::to_string(&pr).unwrap();
+        let parsed: CachedPr = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.failing_checks.len(), 1);
+        assert_eq!(parsed.failing_checks[0].name, "e2e-tests");
+        assert_eq!(parsed.failing_checks[0].conclusion, "FAILURE");
+    }
+
+    #[test]
+    fn cached_pr_empty_failing_checks_not_serialized() {
+        let pr = make_pr(); // failing_checks: vec![]
+        let json = serde_json::to_string(&pr).unwrap();
+        assert!(
+            !json.contains("failing_checks"),
+            "empty failing_checks should be omitted from JSON"
+        );
     }
 }

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -232,6 +232,7 @@ pub fn extract_failing_checks(pr: &serde_json::Value) -> Vec<FailedCheck> {
                 _ => None,
             }
         })
+        .filter(|c| !c.name.is_empty())
         .collect()
 }
 
@@ -1439,6 +1440,43 @@ mod tests {
         let checks = extract_failing_checks(&pr);
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].conclusion, "TIMED_OUT");
+    }
+
+    #[test]
+    fn extract_failing_checks_action_required_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "deploy-gate",
+            "conclusion": "ACTION_REQUIRED"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "deploy-gate");
+        assert_eq!(checks[0].conclusion, "ACTION_REQUIRED");
+    }
+
+    #[test]
+    fn extract_failing_checks_startup_failure_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "build",
+            "conclusion": "STARTUP_FAILURE"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "build");
+        assert_eq!(checks[0].conclusion, "STARTUP_FAILURE");
+    }
+
+    #[test]
+    fn extract_failing_checks_empty_name_filtered() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "",
+            "conclusion": "FAILURE"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
     }
 
     #[test]

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -6,6 +6,7 @@
 use std::process::Command;
 
 use crate::cache::{self, CachedIssue, CachedPr, CachedTmuxSession, CachedWorktree};
+use crate::orchard_state::FailedCheck;
 use crate::global_config::RepoConfig;
 use crate::logger::LOG;
 use crate::remote;
@@ -126,6 +127,17 @@ pub fn parse_prs_graphql(json: &str) -> Vec<CachedPr> {
                 Some(normalised.to_string())
             });
 
+            let failing_checks = extract_failing_checks(v);
+
+            let labels: Vec<String> = v["labels"]["nodes"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|n| n["name"].as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
             Some(CachedPr {
                 number,
                 branch,
@@ -136,6 +148,8 @@ pub fn parse_prs_graphql(json: &str) -> Vec<CachedPr> {
                 has_conflicts,
                 unresolved_threads,
                 linked_issue_state,
+                failing_checks,
+                labels,
             })
         })
         .collect()
@@ -154,6 +168,71 @@ fn derive_checks_state_graphql(pr: &serde_json::Value) -> Option<String> {
         "PENDING" => Some("pending".to_string()),
         _ => None,
     }
+}
+
+/// Extracts individual failing CI check details from the GraphQL PR response.
+///
+/// Navigates to `commits.nodes[last].commit.statusCheckRollup.contexts.nodes`
+/// and collects all non-passing, actionable checks. Logs a warning when the
+/// contexts list is paginated (more than 100 checks — extremely rare).
+///
+/// Filters applied:
+/// - **Included** conclusions: `FAILURE`, `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`
+/// - **Excluded** (transient / not actionable): `CANCELLED`, `STALE`, `SUCCESS`, `NEUTRAL`, `SKIPPED`
+/// - `StatusContext` states `FAILURE` and `ERROR` are mapped to conclusion `FAILURE`.
+pub fn extract_failing_checks(pr: &serde_json::Value) -> Vec<FailedCheck> {
+    let rollup = match pr["commits"]["nodes"]
+        .as_array()
+        .and_then(|nodes| nodes.last())
+    {
+        Some(node) => &node["commit"]["statusCheckRollup"],
+        None => return Vec::new(),
+    };
+
+    let contexts = match rollup["contexts"]["nodes"].as_array() {
+        Some(c) => c,
+        None => return Vec::new(),
+    };
+
+    // Warn if there are more than 100 checks (pagination not supported).
+    if rollup["contexts"]["pageInfo"]["hasNextPage"]
+        .as_bool()
+        .unwrap_or(false)
+    {
+        LOG.warn("cache_sources: PR has more than 100 CI checks; some may be missing from failing_checks");
+    }
+
+    contexts
+        .iter()
+        .filter_map(|node| {
+            match node["__typename"].as_str()? {
+                "CheckRun" => {
+                    let name = node["name"].as_str().unwrap_or("").to_string();
+                    let conclusion = node["conclusion"].as_str().unwrap_or("").to_string();
+                    // Include only actionable failures.
+                    match conclusion.as_str() {
+                        "FAILURE" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE" => {
+                            Some(FailedCheck { name, conclusion })
+                        }
+                        _ => None,
+                    }
+                }
+                "StatusContext" => {
+                    let name = node["context"].as_str().unwrap_or("").to_string();
+                    let state = node["state"].as_str().unwrap_or("");
+                    // Map FAILURE/ERROR states to conclusion FAILURE; skip everything else.
+                    match state {
+                        "FAILURE" | "ERROR" => Some(FailedCheck {
+                            name,
+                            conclusion: "FAILURE".to_string(),
+                        }),
+                        _ => None,
+                    }
+                }
+                _ => None,
+            }
+        })
+        .collect()
 }
 
 /// Parses the output of `git worktree list --porcelain` into `Vec<CachedWorktree>`.
@@ -428,6 +507,11 @@ pub fn refresh_prs(config: &RepoConfig) -> anyhow::Result<()> {
         state
         reviewDecision
         mergeable
+        labels(first: 20) {{
+          nodes {{
+            name
+          }}
+        }}
         reviewThreads(first: 100) {{
           nodes {{
             isResolved
@@ -445,6 +529,22 @@ pub fn refresh_prs(config: &RepoConfig) -> anyhow::Result<()> {
             commit {{
               statusCheckRollup {{
                 state
+                contexts(last: 100) {{
+                  pageInfo {{
+                    hasNextPage
+                  }}
+                  nodes {{
+                    __typename
+                    ... on CheckRun {{
+                      name
+                      conclusion
+                    }}
+                    ... on StatusContext {{
+                      context
+                      state
+                    }}
+                  }}
+                }}
               }}
             }}
           }}
@@ -1257,5 +1357,198 @@ mod tests {
         assert_eq!(parsed.window_active, vec!["1"]);
         assert_eq!(parsed.titles, vec!["Claude"]);
         assert_eq!(parsed.commands, vec![" my-project:node"]);
+    }
+
+    // -- extract_failing_checks -----------------------------------------------
+
+    /// Builds a minimal PR value with a statusCheckRollup contexts array.
+    fn pr_with_check_nodes(nodes: serde_json::Value) -> serde_json::Value {
+        json!({
+            "commits": {
+                "nodes": [{
+                    "commit": {
+                        "statusCheckRollup": {
+                            "state": "FAILURE",
+                            "contexts": {
+                                "pageInfo": {"hasNextPage": false},
+                                "nodes": nodes
+                            }
+                        }
+                    }
+                }]
+            }
+        })
+    }
+
+    #[test]
+    fn extract_failing_checks_checkrun_failure_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "e2e-tests",
+            "conclusion": "FAILURE"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "e2e-tests");
+        assert_eq!(checks[0].conclusion, "FAILURE");
+    }
+
+    #[test]
+    fn extract_failing_checks_checkrun_success_excluded() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "unit-tests",
+            "conclusion": "SUCCESS"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn extract_failing_checks_status_context_failure_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "StatusContext",
+            "context": "ci/travis",
+            "state": "FAILURE"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "ci/travis");
+        assert_eq!(checks[0].conclusion, "FAILURE");
+    }
+
+    #[test]
+    fn extract_failing_checks_status_context_error_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "StatusContext",
+            "context": "ci/circle",
+            "state": "ERROR"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].conclusion, "FAILURE");
+    }
+
+    #[test]
+    fn extract_failing_checks_timed_out_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "integration-tests",
+            "conclusion": "TIMED_OUT"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].conclusion, "TIMED_OUT");
+    }
+
+    #[test]
+    fn extract_failing_checks_cancelled_excluded() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "deploy",
+            "conclusion": "CANCELLED"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn extract_failing_checks_stale_excluded() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "stale-job",
+            "conclusion": "STALE"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn extract_failing_checks_pagination_warning_does_not_panic() {
+        // When hasNextPage is true, a warning is logged but no panic occurs.
+        let pr = json!({
+            "commits": {
+                "nodes": [{
+                    "commit": {
+                        "statusCheckRollup": {
+                            "state": "FAILURE",
+                            "contexts": {
+                                "pageInfo": {"hasNextPage": true},
+                                "nodes": [{
+                                    "__typename": "CheckRun",
+                                    "name": "test",
+                                    "conclusion": "FAILURE"
+                                }]
+                            }
+                        }
+                    }
+                }]
+            }
+        });
+        // Must not panic; result should still include the visible checks.
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+    }
+
+    #[test]
+    fn extract_failing_checks_empty_when_no_commits() {
+        let pr = json!({"commits": {"nodes": []}});
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn extract_failing_checks_empty_when_rollup_null() {
+        let pr = json!({
+            "commits": {
+                "nodes": [{"commit": {"statusCheckRollup": null}}]
+            }
+        });
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn parse_prs_graphql_includes_failing_checks() {
+        // Integration: parse_prs_graphql should populate failing_checks from check nodes.
+        let pr_node = json!({
+            "number": 42,
+            "headRefName": "feat/fix",
+            "baseRefName": "main",
+            "state": "OPEN",
+            "reviewDecision": null,
+            "mergeable": "MERGEABLE",
+            "reviewThreads": {"nodes": []},
+            "closingIssuesReferences": {"nodes": []},
+            "commits": {
+                "nodes": [{
+                    "commit": {
+                        "statusCheckRollup": {
+                            "state": "FAILURE",
+                            "contexts": {
+                                "pageInfo": {"hasNextPage": false},
+                                "nodes": [
+                                    {
+                                        "__typename": "CheckRun",
+                                        "name": "unit-tests",
+                                        "conclusion": "FAILURE"
+                                    },
+                                    {
+                                        "__typename": "CheckRun",
+                                        "name": "lint",
+                                        "conclusion": "SUCCESS"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }]
+            }
+        });
+        let json = graphql_prs(json!([pr_node]));
+        let prs = parse_prs_graphql(&json);
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].failing_checks.len(), 1);
+        assert_eq!(prs[0].failing_checks[0].name, "unit-tests");
     }
 }

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -6,9 +6,9 @@
 use std::process::Command;
 
 use crate::cache::{self, CachedIssue, CachedPr, CachedTmuxSession, CachedWorktree};
-use crate::orchard_state::FailedCheck;
 use crate::global_config::RepoConfig;
 use crate::logger::LOG;
+use crate::orchard_state::FailedCheck;
 use crate::remote;
 
 // ---------------------------------------------------------------------------

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -154,9 +154,7 @@ pub fn derive_worktree_rows(
         let linked_issue = issue_number.and_then(|num| issues.iter().find(|i| i.number == num));
         let issue_title = linked_issue.map(|i| i.title.clone());
         let issue_state = linked_issue.map(|i| i.state.clone());
-        let issue_labels = linked_issue
-            .map(|i| i.labels.clone())
-            .unwrap_or_default();
+        let issue_labels = linked_issue.map(|i| i.labels.clone()).unwrap_or_default();
 
         let is_main_worktree =
             is_first_non_bare || session_infos.iter().any(|s| s.tmux.name.ends_with("_main"));

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -68,6 +68,10 @@ pub struct PrInfo {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Individual non-passing CI checks, before non-blocking exclusion filtering.
+    pub failing_checks: Vec<crate::orchard_state::FailedCheck>,
+    /// Labels applied to this PR.
+    pub labels: Vec<String>,
 }
 
 /// One row in the derived worktree view. Corresponds to one non-bare worktree,
@@ -89,6 +93,8 @@ pub struct WorktreeRow {
     /// State of the linked issue ("open", "closed", "completed"), if any.
     /// Used to detect stale worktrees whose issue has been resolved without a PR.
     pub issue_state: Option<String>,
+    /// Labels applied to the linked issue, if any.
+    pub issue_labels: Vec<String>,
     /// Linked pull request, if one exists for this branch.
     pub pr: Option<PrInfo>,
     /// Active tmux sessions associated with this worktree path.
@@ -148,6 +154,9 @@ pub fn derive_worktree_rows(
         let linked_issue = issue_number.and_then(|num| issues.iter().find(|i| i.number == num));
         let issue_title = linked_issue.map(|i| i.title.clone());
         let issue_state = linked_issue.map(|i| i.state.clone());
+        let issue_labels = linked_issue
+            .map(|i| i.labels.clone())
+            .unwrap_or_default();
 
         let is_main_worktree =
             is_first_non_bare || session_infos.iter().any(|s| s.tmux.name.ends_with("_main"));
@@ -168,6 +177,7 @@ pub fn derive_worktree_rows(
             issue_number,
             issue_title,
             issue_state,
+            issue_labels,
             pr: pr_info,
             sessions: session_infos,
             display_group,
@@ -227,6 +237,8 @@ fn pr_info_from(pr: &CachedPr) -> PrInfo {
         checks_state: pr.checks_state.clone(),
         has_conflicts: pr.has_conflicts,
         unresolved_threads: pr.unresolved_threads,
+        failing_checks: pr.failing_checks.clone(),
+        labels: pr.labels.clone(),
     }
 }
 
@@ -501,6 +513,8 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            failing_checks: vec![],
+            labels: vec![],
         }
     }
 
@@ -515,6 +529,8 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            failing_checks: vec![],
+            labels: vec![],
         }
     }
 

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -668,12 +668,10 @@ mod tests {
     fn json_pr_includes_failing_checks_field() {
         use crate::orchard_state::FailedCheck;
         let pr = PrState {
-            failing_checks: vec![
-                FailedCheck {
-                    name: "e2e-tests".to_string(),
-                    conclusion: "FAILURE".to_string(),
-                },
-            ],
+            failing_checks: vec![FailedCheck {
+                name: "e2e-tests".to_string(),
+                conclusion: "FAILURE".to_string(),
+            }],
             ..make_pr_state()
         };
         let jp = JsonPr::from(&pr);

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -11,7 +11,8 @@ use serde::Serialize;
 use crate::claude_state::ClaudeState;
 use crate::derive::DisplayGroup;
 use crate::orchard_state::{
-    IssueInfo, OrchardState, PrState, RepoState, SessionState, WindowState, WorktreeState,
+    FailedCheck, IssueInfo, OrchardState, PrState, RepoState, SessionState, WindowState,
+    WorktreeState,
 };
 use crate::session::StandaloneSessionRow;
 
@@ -73,7 +74,7 @@ pub struct JsonWorktree {
 
 /// Issue information in JSON output.
 ///
-/// Subset of GitHub issue data: number, title, and state (open/closed).
+/// Subset of GitHub issue data: number, title, state (open/closed), and labels.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonIssue {
@@ -83,11 +84,13 @@ pub struct JsonIssue {
     pub title: String,
     /// Issue state: "open", "closed", or "completed".
     pub state: String,
+    /// Labels applied to this issue.
+    pub labels: Vec<String>,
 }
 
 /// Pull request information in JSON output.
 ///
-/// Includes PR metadata: number, branch, state, review decision, CI checks, conflicts, and unresolved review threads.
+/// Includes PR metadata: number, branch, state, review decision, CI checks, conflicts, unresolved review threads, and failing check details.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonPr {
@@ -105,6 +108,10 @@ pub struct JsonPr {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Individual failing CI checks (name + conclusion).
+    pub failing_checks: Vec<FailedCheck>,
+    /// Labels applied to this PR.
+    pub labels: Vec<String>,
 }
 
 /// Session information in JSON output using the EnrichedSession shape.
@@ -218,6 +225,7 @@ impl From<&IssueInfo> for JsonIssue {
             number: i.number,
             title: i.title.clone(),
             state: i.state.clone(),
+            labels: i.labels.clone(),
         }
     }
 }
@@ -233,6 +241,8 @@ impl From<&PrState> for JsonPr {
             checks_state: pr.checks_state.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            failing_checks: pr.failing_checks.clone(),
+            labels: pr.labels.clone(),
         }
     }
 }
@@ -356,7 +366,7 @@ impl From<&StandaloneSessionRow> for JsonSession {
 }
 
 impl From<&OrchardState> for JsonOutput {
-    /// Converts the unified `OrchardState` to JSON output, setting version to 4.
+    /// Converts the unified `OrchardState` to JSON output, setting version to 5.
     fn from(state: &OrchardState) -> Self {
         let hosts = state
             .hosts
@@ -372,7 +382,7 @@ impl From<&OrchardState> for JsonOutput {
             .collect();
 
         Self {
-            version: 4,
+            version: 5,
             tmux_sessions: state.standalone_sessions.iter().map(Into::into).collect(),
             repos: state.repos.iter().map(Into::into).collect(),
             hosts,
@@ -405,9 +415,9 @@ mod tests {
     }
 
     #[test]
-    fn from_orchard_state_produces_version_4() {
+    fn from_orchard_state_produces_version_5() {
         let output = JsonOutput::from(&empty_state());
-        assert_eq!(output.version, 4);
+        assert_eq!(output.version, 5);
     }
 
     #[test]
@@ -573,9 +583,9 @@ mod tests {
     }
 
     #[test]
-    fn json_version_is_4() {
+    fn json_version_is_5() {
         let output = JsonOutput::from(&empty_state());
-        assert_eq!(output.version, 4);
+        assert_eq!(output.version, 5);
     }
 
     #[test]
@@ -636,5 +646,102 @@ mod tests {
         };
         let js = JsonSession::from(&session);
         assert_eq!(js.windows.len(), 1);
+    }
+
+    // -- JsonPr failing_checks and labels tests -------------------------------
+
+    fn make_pr_state() -> PrState {
+        PrState {
+            number: 99,
+            branch: "feat/test".to_string(),
+            state: Some("OPEN".to_string()),
+            review_decision: None,
+            checks_state: Some("failing".to_string()),
+            has_conflicts: false,
+            unresolved_threads: 0,
+            failing_checks: vec![],
+            labels: vec![],
+        }
+    }
+
+    #[test]
+    fn json_pr_includes_failing_checks_field() {
+        use crate::orchard_state::FailedCheck;
+        let pr = PrState {
+            failing_checks: vec![
+                FailedCheck {
+                    name: "e2e-tests".to_string(),
+                    conclusion: "FAILURE".to_string(),
+                },
+            ],
+            ..make_pr_state()
+        };
+        let jp = JsonPr::from(&pr);
+        assert_eq!(jp.failing_checks.len(), 1);
+        assert_eq!(jp.failing_checks[0].name, "e2e-tests");
+        assert_eq!(jp.failing_checks[0].conclusion, "FAILURE");
+    }
+
+    #[test]
+    fn json_pr_failing_checks_empty_by_default() {
+        let pr = make_pr_state();
+        let jp = JsonPr::from(&pr);
+        assert!(jp.failing_checks.is_empty());
+    }
+
+    #[test]
+    fn json_pr_failing_checks_serializes_to_camelcase() {
+        use crate::orchard_state::FailedCheck;
+        let pr = PrState {
+            failing_checks: vec![FailedCheck {
+                name: "unit-tests".to_string(),
+                conclusion: "TIMED_OUT".to_string(),
+            }],
+            ..make_pr_state()
+        };
+        let value = serde_json::to_value(JsonPr::from(&pr)).unwrap();
+        assert!(
+            value.get("failingChecks").is_some(),
+            "expected camelCase 'failingChecks'"
+        );
+        let checks = &value["failingChecks"];
+        assert_eq!(checks[0]["name"], "unit-tests");
+        assert_eq!(checks[0]["conclusion"], "TIMED_OUT");
+    }
+
+    #[test]
+    fn json_pr_includes_labels_field() {
+        let pr = PrState {
+            labels: vec!["bug".to_string(), "priority:high".to_string()],
+            ..make_pr_state()
+        };
+        let jp = JsonPr::from(&pr);
+        assert_eq!(jp.labels, vec!["bug", "priority:high"]);
+    }
+
+    // -- JsonIssue labels test ------------------------------------------------
+
+    #[test]
+    fn json_issue_includes_labels_field() {
+        let issue = IssueInfo {
+            number: 1,
+            title: "Test issue".to_string(),
+            state: "open".to_string(),
+            labels: vec!["enhancement".to_string()],
+        };
+        let ji = JsonIssue::from(&issue);
+        assert_eq!(ji.labels, vec!["enhancement"]);
+    }
+
+    #[test]
+    fn json_issue_labels_empty_by_default() {
+        let issue = IssueInfo {
+            number: 2,
+            title: "Another issue".to_string(),
+            state: "open".to_string(),
+            labels: vec![],
+        };
+        let ji = JsonIssue::from(&issue);
+        assert!(ji.labels.is_empty());
     }
 }

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -6,6 +6,8 @@
 
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::claude_state::ClaudeState;
 use crate::derive::DisplayGroup;
 use crate::session::{EnrichedSession, Host, StandaloneSessionRow};
@@ -110,6 +112,17 @@ pub struct IssueInfo {
     pub title: String,
     /// Issue state: "open", "closed", or "completed".
     pub state: String,
+    /// Labels applied to this issue.
+    pub labels: Vec<String>,
+}
+
+/// A single non-passing CI check.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FailedCheck {
+    /// Check name (e.g. "e2e-tests", "ci/travis").
+    pub name: String,
+    /// GitHub conclusion string (e.g. "FAILURE", "TIMED_OUT").
+    pub conclusion: String,
 }
 
 /// Lightweight PR summary attached to a worktree.
@@ -129,6 +142,10 @@ pub struct PrState {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Individual failing CI checks (filtered: excludes non-blocking checks).
+    pub failing_checks: Vec<FailedCheck>,
+    /// Labels applied to this PR.
+    pub labels: Vec<String>,
 }
 
 /// Lightweight tmux session summary attached to a worktree.
@@ -206,8 +223,17 @@ pub struct HostState {
 // From conversions from derive types
 // ---------------------------------------------------------------------------
 
+/// CI checks that are informational-only and should not surface as actionable failures.
+const NON_BLOCKING_CHECKS: &[&str] = &["check-approval-or-label"];
+
 impl From<&crate::derive::PrInfo> for PrState {
     fn from(pr: &crate::derive::PrInfo) -> Self {
+        let failing_checks = pr
+            .failing_checks
+            .iter()
+            .filter(|c| !NON_BLOCKING_CHECKS.contains(&c.name.as_str()))
+            .cloned()
+            .collect();
         Self {
             number: pr.number,
             branch: pr.branch.clone(),
@@ -216,6 +242,8 @@ impl From<&crate::derive::PrInfo> for PrState {
             checks_state: pr.checks_state.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            failing_checks,
+            labels: pr.labels.clone(),
         }
     }
 }
@@ -270,6 +298,7 @@ impl From<&crate::derive::WorktreeRow> for WorktreeState {
                 .issue_state
                 .clone()
                 .unwrap_or_else(|| "open".to_string()),
+            labels: row.issue_labels.clone(),
         });
 
         Self {
@@ -306,6 +335,7 @@ mod tests {
             issue_number,
             issue_title: issue_number.map(|n| format!("Issue {}", n)),
             issue_state: issue_state.map(|s| s.to_string()),
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group,
@@ -429,6 +459,8 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            failing_checks: vec![],
+            labels: vec![],
         };
         let pr_state = PrState::from(&pr_info);
         assert_eq!(pr_state.state, Some("open".to_string()));
@@ -444,9 +476,60 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            failing_checks: vec![],
+            labels: vec![],
         };
         let pr_state = PrState::from(&pr_info);
         assert!(pr_state.state.is_none());
+    }
+
+    #[test]
+    fn from_pr_info_filters_non_blocking_check() {
+        let pr_info = PrInfo {
+            number: 1,
+            branch: "feat/branch".to_string(),
+            state: None,
+            review_decision: None,
+            checks_state: Some("failing".to_string()),
+            has_conflicts: false,
+            unresolved_threads: 0,
+            failing_checks: vec![
+                FailedCheck {
+                    name: "check-approval-or-label".to_string(),
+                    conclusion: "FAILURE".to_string(),
+                },
+                FailedCheck {
+                    name: "e2e-tests".to_string(),
+                    conclusion: "FAILURE".to_string(),
+                },
+            ],
+            labels: vec![],
+        };
+        let pr_state = PrState::from(&pr_info);
+        assert_eq!(pr_state.failing_checks.len(), 1);
+        assert_eq!(pr_state.failing_checks[0].name, "e2e-tests");
+    }
+
+    #[test]
+    fn from_pr_info_passes_through_failing_checks() {
+        let pr_info = PrInfo {
+            number: 1,
+            branch: "feat/branch".to_string(),
+            state: None,
+            review_decision: None,
+            checks_state: Some("failing".to_string()),
+            has_conflicts: false,
+            unresolved_threads: 0,
+            failing_checks: vec![FailedCheck {
+                name: "unit-tests".to_string(),
+                conclusion: "TIMED_OUT".to_string(),
+            }],
+            labels: vec![],
+        };
+        let pr_state = PrState::from(&pr_info);
+        assert_eq!(pr_state.failing_checks.len(), 1);
+        assert_eq!(pr_state.failing_checks[0].name, "unit-tests");
+        assert_eq!(pr_state.failing_checks[0].conclusion, "TIMED_OUT");
     }
 
     // -- From<&EnrichedSession> for SessionState tests ----------------------

--- a/crates/orchard/src/tui/dialogs.rs
+++ b/crates/orchard/src/tui/dialogs.rs
@@ -480,6 +480,7 @@ mod tests {
                 issue_number: None,
                 issue_title: None,
                 issue_state: None,
+                issue_labels: vec![],
                 pr: None,
                 sessions: vec![],
                 display_group: crate::derive::DisplayGroup::Other,

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -405,6 +405,7 @@ mod tests {
             issue_number: Some(42),
             issue_title: Some("Fix Azure integration bug".to_string()),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: DisplayGroup::NeedsAttention,
@@ -484,6 +485,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..base_row()
         };
@@ -539,6 +542,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..base_row()
         };

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -121,7 +121,11 @@ fn pr_status_haystack(row: &WorktreeRow) -> String {
         return format!("{}\u{25cb} unresolved ({})", prefix, pr.unresolved_threads);
     }
     if pr.checks_state.as_deref() == Some("failing") {
-        return format!("{}\u{2716} failing", prefix);
+        let names: Vec<&str> = pr.failing_checks.iter().map(|c| c.name.as_str()).collect();
+        if names.is_empty() {
+            return format!("{}\u{2716} failing", prefix);
+        }
+        return format!("{}\u{2716} failing {}", prefix, names.join(" "));
     }
     if pr.checks_state.as_deref() == Some("pending") {
         return format!("{}\u{25d0} pending CI", prefix);
@@ -509,6 +513,8 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..base_row()
         };

--- a/crates/orchard/src/tui/last_selection.rs
+++ b/crates/orchard/src/tui/last_selection.rs
@@ -284,6 +284,7 @@ mod tests {
             issue_number: Some(issue_number),
             issue_title: Some(format!("Test task {issue_number}")),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: DisplayGroup::Other,

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -283,7 +283,11 @@ fn pr_status_text(row: &WorktreeRow, theme: &Theme) -> (String, Style) {
                 .take(3)
                 .map(|c| c.name.as_str())
                 .collect();
-            format!(": {} +{} more", shown.join(", "), pr.failing_checks.len() - 3)
+            format!(
+                ": {} +{} more",
+                shown.join(", "),
+                pr.failing_checks.len() - 3
+            )
         };
         return (
             format!("{}\u{2716} failing{}", prefix, detail),
@@ -2600,10 +2604,22 @@ mod tests {
     fn pr_status_failing_ci_truncates_at_four_checks() {
         use crate::orchard_state::FailedCheck;
         let failing_checks = vec![
-            FailedCheck { name: "check-a".to_string(), conclusion: "FAILURE".to_string() },
-            FailedCheck { name: "check-b".to_string(), conclusion: "FAILURE".to_string() },
-            FailedCheck { name: "check-c".to_string(), conclusion: "FAILURE".to_string() },
-            FailedCheck { name: "check-d".to_string(), conclusion: "FAILURE".to_string() },
+            FailedCheck {
+                name: "check-a".to_string(),
+                conclusion: "FAILURE".to_string(),
+            },
+            FailedCheck {
+                name: "check-b".to_string(),
+                conclusion: "FAILURE".to_string(),
+            },
+            FailedCheck {
+                name: "check-c".to_string(),
+                conclusion: "FAILURE".to_string(),
+            },
+            FailedCheck {
+                name: "check-d".to_string(),
+                conclusion: "FAILURE".to_string(),
+            },
         ];
         let row = WorktreeRow {
             pr: Some(PrInfo {

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -265,8 +265,28 @@ fn pr_status_text(row: &WorktreeRow, theme: &Theme) -> (String, Style) {
         );
     }
     if pr.checks_state.as_deref() == Some("failing") {
+        let detail = if pr.failing_checks.is_empty() {
+            String::new()
+        } else if pr.failing_checks.len() <= 3 {
+            format!(
+                ": {}",
+                pr.failing_checks
+                    .iter()
+                    .map(|c| c.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        } else {
+            let shown: Vec<&str> = pr
+                .failing_checks
+                .iter()
+                .take(3)
+                .map(|c| c.name.as_str())
+                .collect();
+            format!(": {} +{} more", shown.join(", "), pr.failing_checks.len() - 3)
+        };
         return (
-            format!("{}\u{2716} failing", prefix),
+            format!("{}\u{2716} failing{}", prefix, detail),
             Style::default().fg(theme.error),
         );
     }
@@ -2242,6 +2262,7 @@ mod tests {
             issue_number: Some(issue_number),
             issue_title: Some(format!("Test task {}", issue_number)),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: group,
@@ -2361,6 +2382,8 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::ReadyToMerge)
         };
@@ -2460,6 +2483,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2482,6 +2507,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: true,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2504,6 +2531,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 3,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2518,6 +2547,7 @@ mod tests {
 
     #[test]
     fn pr_status_failing_ci() {
+        use crate::orchard_state::FailedCheck;
         let row = WorktreeRow {
             pr: Some(PrInfo {
                 number: 1,
@@ -2527,11 +2557,80 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![FailedCheck {
+                    name: "e2e-tests".to_string(),
+                    conclusion: "FAILURE".to_string(),
+                }],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert!(text.contains("failing"), "expected 'failing' in: {}", text);
+        assert!(
+            text.contains("e2e-tests"),
+            "expected check name 'e2e-tests' in: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn pr_status_failing_ci_no_checks_shows_no_detail() {
+        let row = WorktreeRow {
+            pr: Some(PrInfo {
+                number: 1,
+                branch: "feat/branch".to_string(),
+                state: None,
+                review_decision: None,
+                checks_state: Some("failing".to_string()),
+                has_conflicts: false,
+                unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
+            }),
+            ..make_task_row(1, DisplayGroup::NeedsAttention)
+        };
+        let (text, _) = pr_status_text(&row, &Theme::default());
+        assert!(text.contains("failing"), "expected 'failing' in: {}", text);
+        // No colon-separated detail when failing_checks is empty.
+        assert!(!text.contains(':'), "unexpected colon in: {}", text);
+    }
+
+    #[test]
+    fn pr_status_failing_ci_truncates_at_four_checks() {
+        use crate::orchard_state::FailedCheck;
+        let failing_checks = vec![
+            FailedCheck { name: "check-a".to_string(), conclusion: "FAILURE".to_string() },
+            FailedCheck { name: "check-b".to_string(), conclusion: "FAILURE".to_string() },
+            FailedCheck { name: "check-c".to_string(), conclusion: "FAILURE".to_string() },
+            FailedCheck { name: "check-d".to_string(), conclusion: "FAILURE".to_string() },
+        ];
+        let row = WorktreeRow {
+            pr: Some(PrInfo {
+                number: 2,
+                branch: "feat/branch".to_string(),
+                state: None,
+                review_decision: None,
+                checks_state: Some("failing".to_string()),
+                has_conflicts: false,
+                unresolved_threads: 0,
+                failing_checks,
+                labels: vec![],
+            }),
+            ..make_task_row(2, DisplayGroup::NeedsAttention)
+        };
+        let (text, _) = pr_status_text(&row, &Theme::default());
+        assert!(text.contains("failing"), "expected 'failing' in: {}", text);
+        assert!(
+            text.contains("+1 more"),
+            "expected '+1 more' truncation in: {}",
+            text
+        );
+        assert!(
+            text.contains("check-a"),
+            "expected first check name in: {}",
+            text
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -2678,6 +2777,8 @@ mod tests {
                 checks_state: Some("pending".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::Other)
         };
@@ -2787,6 +2888,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::ReadyToMerge)
         };

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -2150,6 +2150,7 @@ mod tests {
             issue_number: Some(issue_number),
             issue_title: Some(format!("Test task {}", issue_number)),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: group,
@@ -2278,6 +2279,8 @@ mod tests {
                     checks_state: None,
                     has_conflicts: false,
                     unresolved_threads: 0,
+                    failing_checks: vec![],
+                    labels: vec![],
                 }),
                 ..make_task_row(1, DisplayGroup::Other)
             },
@@ -2308,6 +2311,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::Other)
         }];
@@ -2337,6 +2342,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::Other)
         }];
@@ -2575,6 +2582,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(42, DisplayGroup::ReadyToMerge)
         };
@@ -2672,6 +2681,7 @@ mod tests {
             issue_number: None,
             issue_title: None,
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: group,
@@ -2740,6 +2750,8 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_worktree_row("feat/needs-attn", DisplayGroup::NeedsAttention)
         };
@@ -2770,6 +2782,8 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_worktree_row("feat/approved", DisplayGroup::ReadyToMerge)
         };
@@ -2845,6 +2859,8 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_worktree_row("feat/branch", DisplayGroup::NeedsAttention)
         };
@@ -3302,6 +3318,8 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 2,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
@@ -3329,6 +3347,8 @@ mod tests {
                 checks_state: Some("pending".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
@@ -3360,6 +3380,8 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row_with_title(54, "Add Theme struct", DisplayGroup::ReadyToMerge)
         };
@@ -3875,6 +3897,7 @@ mod tests {
             issue_number: None,
             issue_title: None,
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -1437,11 +1437,11 @@ impl App {
                     self.active_repo_slug(),
                 );
                 if let Some(vt) = visible.get(worktree_cursor) {
-                    self.view = ViewState::ConfirmDelete(state::DeleteState {
+                    self.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
                         target: vt.row.clone(),
                         phase: Phase::Confirm,
                         error: None,
-                    });
+                    }));
                 }
                 ok()
             }
@@ -3085,11 +3085,11 @@ mod tests {
     #[test]
     fn handle_event_delete_confirm_y() {
         let mut app = App::new_test(vec![]);
-        app.view = ViewState::ConfirmDelete(state::DeleteState {
+        app.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
             target: make_task_row(1, DisplayGroup::Other),
             phase: Phase::Confirm,
             error: None,
-        });
+        }));
         let key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(key), Some(Message::ConfirmYes));
     }
@@ -3557,11 +3557,11 @@ mod tests {
     #[test]
     fn mouse_events_ignored_in_confirm_delete_view() {
         let mut app = app_with_table_area(vec![]);
-        app.view = ViewState::ConfirmDelete(state::DeleteState {
+        app.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
             target: make_task_row(1, DisplayGroup::Other),
             phase: Phase::Confirm,
             error: None,
-        });
+        }));
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 7);
         assert_eq!(app.handle_mouse_event(event), None);
     }

--- a/crates/orchard/src/tui/state.rs
+++ b/crates/orchard/src/tui/state.rs
@@ -17,7 +17,7 @@ pub enum ViewState {
     /// The main worktree task list.
     List,
     /// A confirmation dialog for deleting a worktree.
-    ConfirmDelete(DeleteState),
+    ConfirmDelete(Box<DeleteState>),
     /// A multi-select dialog for cleaning up stale worktrees.
     Cleanup(CleanupState),
     /// A text-entry dialog for creating a new tmux session.

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -154,6 +154,7 @@ pub fn diff(old: &OrchardState, new: &OrchardState) -> Vec<WatchEvent> {
                         worktree: path.to_string(),
                         pr_number,
                         label: label.clone(),
+                        failing_checks: new_pr.failing_checks.clone(),
                     }));
                 }
 
@@ -320,6 +321,8 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            failing_checks: vec![],
+            labels: vec![],
         }
     }
 
@@ -421,6 +424,38 @@ mod tests {
             .filter(|e| matches!(&e.kind, EventKind::CiFailed { .. }))
             .collect();
         assert_eq!(ci_events.len(), 1);
+    }
+
+    #[test]
+    fn diff_ci_failed_event_carries_failing_checks() {
+        use crate::orchard_state::FailedCheck;
+        let path = "/workspace/repo/feat-1";
+        let old_pr = make_pr(10);
+        let new_pr = PrState {
+            checks_state: Some("failing".to_string()),
+            failing_checks: vec![FailedCheck {
+                name: "e2e-tests".to_string(),
+                conclusion: "FAILURE".to_string(),
+            }],
+            ..make_pr(10)
+        };
+
+        let old_wt = with_pr(make_worktree(path, "feat/issue-1"), old_pr);
+        let new_wt = with_pr(make_worktree(path, "feat/issue-1"), new_pr);
+
+        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+
+        let ci_event = events
+            .iter()
+            .find(|e| matches!(&e.kind, EventKind::CiFailed { .. }))
+            .expect("expected a CiFailed event");
+
+        if let EventKind::CiFailed { failing_checks, .. } = &ci_event.kind {
+            assert_eq!(failing_checks.len(), 1);
+            assert_eq!(failing_checks[0].name, "e2e-tests");
+        } else {
+            panic!("unexpected event kind");
+        }
     }
 
     #[test]

--- a/crates/orchard/src/watch/event.rs
+++ b/crates/orchard/src/watch/event.rs
@@ -64,6 +64,8 @@ pub enum EventKind {
         pr_number: u32,
         /// Human-readable label (issue title or branch name).
         label: String,
+        /// Individual failing CI checks (name + conclusion).
+        failing_checks: Vec<crate::orchard_state::FailedCheck>,
     },
     /// CI checks transitioned to passing for a PR.
     CiPassed {
@@ -232,6 +234,7 @@ mod tests {
                 worktree: "/wt/c".to_string(),
                 pr_number: 42,
                 label: "Branch".to_string(),
+                failing_checks: vec![],
             },
             EventKind::Heartbeat {
                 worktree_count: 5,
@@ -272,5 +275,44 @@ mod tests {
             session_count: 1,
         };
         assert!(kind.notification().is_none());
+    }
+
+    #[test]
+    fn ci_failed_event_includes_failing_checks_in_roundtrip() {
+        use crate::orchard_state::FailedCheck;
+        let kind = EventKind::CiFailed {
+            worktree: "/wt/x".to_string(),
+            pr_number: 10,
+            label: "Fix CI".to_string(),
+            failing_checks: vec![FailedCheck {
+                name: "e2e-tests".to_string(),
+                conclusion: "FAILURE".to_string(),
+            }],
+        };
+        let event = WatchEvent::now(kind);
+        let json = serde_json::to_string(&event).unwrap();
+        let decoded: WatchEvent = serde_json::from_str(&json).unwrap();
+        let json2 = serde_json::to_string(&decoded).unwrap();
+        assert_eq!(json, json2, "CiFailed with failing_checks must round-trip");
+        assert!(
+            json.contains("e2e-tests"),
+            "failing_checks must appear in serialized output"
+        );
+    }
+
+    #[test]
+    fn ci_failed_notification_returns_pr_label() {
+        let kind = EventKind::CiFailed {
+            worktree: "/wt/x".to_string(),
+            pr_number: 42,
+            label: "My Feature".to_string(),
+            failing_checks: vec![],
+        };
+        let notif = kind.notification();
+        assert!(notif.is_some());
+        let (title, msg, _) = notif.unwrap();
+        assert_eq!(title, "CI Failed");
+        assert!(msg.contains("42"));
+        assert!(msg.contains("My Feature"));
     }
 }

--- a/crates/orchard/tests/common/mod.rs
+++ b/crates/orchard/tests/common/mod.rs
@@ -141,6 +141,8 @@ pub fn make_pr(number: u32, branch: &str) -> CachedPr {
         has_conflicts: false,
         unresolved_threads: 0,
         linked_issue_state: None,
+        failing_checks: vec![],
+        labels: vec![],
     }
 }
 

--- a/specs/features/ci-failure-details.feature
+++ b/specs/features/ci-failure-details.feature
@@ -1,0 +1,346 @@
+Feature: CI failure details and labels in core state model
+  As a developer using orchard
+  I want to see which CI checks failed and what labels are on issues/PRs
+  So that I can decide whether to investigate, ignore, or prioritize at a glance
+
+  Background:
+    Given a repo with owner "acme" and name "webapp"
+    And a PR #42 on branch "feat/auth" with checks in "FAILURE" state
+
+  # ===================================================================
+  # Data model — FailedCheck struct and PrState enrichment
+  # ===================================================================
+
+  @unit
+  Scenario: PrState includes failing check details
+    Given PR #42 has the following check runs:
+      | name                     | conclusion     |
+      | e2e-tests                | FAILURE        |
+      | unit-tests               | SUCCESS        |
+      | lint                     | SUCCESS        |
+      | check-approval-or-label  | FAILURE        |
+    When the state is built
+    Then PrState.failing_checks contains:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+    And PrState.failing_checks does NOT contain "check-approval-or-label"
+    And PrState.checks_state is "failing"
+
+  @unit
+  Scenario: Failing checks list is empty when all checks pass
+    Given PR #42 has the following check runs:
+      | name        | conclusion |
+      | e2e-tests   | SUCCESS    |
+      | unit-tests  | SUCCESS    |
+    When the state is built
+    Then PrState.failing_checks is empty
+    And PrState.checks_state is "passing"
+
+  @unit
+  Scenario: Failing checks list is empty when checks are pending
+    Given PR #42 has no completed check runs yet
+    When the state is built
+    Then PrState.failing_checks is empty
+    And PrState.checks_state is "pending"
+
+  @unit
+  Scenario: Multiple failing checks are all captured
+    Given PR #42 has the following check runs:
+      | name        | conclusion     |
+      | e2e-tests   | FAILURE        |
+      | lint         | FAILURE        |
+      | unit-tests  | SUCCESS        |
+    When the state is built
+    Then PrState.failing_checks contains:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+      | lint        | FAILURE    |
+
+  # ===================================================================
+  # Conclusion classification — exhaustive mapping
+  # ===================================================================
+  # GitHub check conclusions: SUCCESS, FAILURE, CANCELLED, TIMED_OUT,
+  # ACTION_REQUIRED, STALE, NEUTRAL, SKIPPED, STARTUP_FAILURE
+  #
+  # Classification:
+  #   Failing  = FAILURE | TIMED_OUT | ACTION_REQUIRED | STARTUP_FAILURE
+  #   Passing  = SUCCESS | NEUTRAL | SKIPPED
+  #   Ignored  = CANCELLED | STALE (transient, not actionable)
+
+  @unit
+  Scenario: TIMED_OUT conclusion is treated as failing
+    Given PR #42 has the following check runs:
+      | name       | conclusion |
+      | e2e-tests  | TIMED_OUT  |
+    When the state is built
+    Then PrState.failing_checks contains "e2e-tests" with conclusion "TIMED_OUT"
+
+  @unit
+  Scenario: ACTION_REQUIRED conclusion is treated as failing
+    Given PR #42 has the following check runs:
+      | name         | conclusion      |
+      | deploy-gate  | ACTION_REQUIRED |
+    When the state is built
+    Then PrState.failing_checks contains "deploy-gate" with conclusion "ACTION_REQUIRED"
+
+  @unit
+  Scenario: CANCELLED and STALE conclusions are not treated as failing
+    Given PR #42 has the following check runs:
+      | name        | conclusion |
+      | e2e-tests   | CANCELLED  |
+      | lint        | STALE      |
+      | unit-tests  | SUCCESS    |
+    When the state is built
+    Then PrState.failing_checks is empty
+
+  @unit
+  Scenario: NEUTRAL and SKIPPED conclusions are not treated as failing
+    Given PR #42 has the following check runs:
+      | name        | conclusion |
+      | optional    | NEUTRAL    |
+      | skipped-job | SKIPPED    |
+    When the state is built
+    Then PrState.failing_checks is empty
+
+  # ===================================================================
+  # Non-blocking check exclusion — applied at build_state, not parse
+  # ===================================================================
+  # Non-blocking checks are filtered when building PrState from CachedPr,
+  # NOT at GraphQL parse time. This preserves all data in cache so that
+  # exclusion rules can change without cache invalidation.
+
+  @unit
+  Scenario: check-approval-or-label is excluded from failing checks
+    Given PR #42 has the following check runs:
+      | name                     | conclusion |
+      | check-approval-or-label  | FAILURE    |
+      | unit-tests               | SUCCESS    |
+    When the state is built
+    Then PrState.failing_checks is empty
+
+  @unit
+  Scenario: CachedPr retains excluded checks for future configurability
+    Given PR #42 has the following check runs:
+      | name                     | conclusion |
+      | check-approval-or-label  | FAILURE    |
+      | e2e-tests                | FAILURE    |
+    When PRs are parsed from the GraphQL response
+    Then CachedPr.failing_checks contains both "check-approval-or-label" and "e2e-tests"
+    But when the state is built, PrState.failing_checks contains only "e2e-tests"
+
+  # ===================================================================
+  # GraphQL fetching — CheckRun AND StatusContext union types
+  # ===================================================================
+  # statusCheckRollup.contexts is a union of CheckRun and StatusContext.
+  # Both must be handled to avoid silently dropping legacy CI results.
+
+  @unit
+  Scenario: GraphQL query fetches CheckRun details
+    Given the GraphQL response includes statusCheckRollup.contexts with:
+      | __typename   | name       | conclusion |
+      | CheckRun     | e2e-tests  | FAILURE    |
+      | CheckRun     | lint       | SUCCESS    |
+    When PRs are parsed from the GraphQL response
+    Then CachedPr.failing_checks contains:
+      | name      | conclusion |
+      | e2e-tests | FAILURE    |
+
+  @unit
+  Scenario: GraphQL query handles StatusContext (legacy commit status)
+    Given the GraphQL response includes statusCheckRollup.contexts with:
+      | __typename    | context    | state   |
+      | StatusContext | ci/travis  | FAILURE |
+      | StatusContext | ci/circle  | SUCCESS |
+    When PRs are parsed from the GraphQL response
+    Then CachedPr.failing_checks contains:
+      | name      | conclusion |
+      | ci/travis | FAILURE    |
+
+  @unit
+  Scenario: Mixed CheckRun and StatusContext are both captured
+    Given the GraphQL response includes statusCheckRollup.contexts with:
+      | __typename    | name/context | conclusion/state |
+      | CheckRun      | e2e-tests    | FAILURE          |
+      | StatusContext | ci/travis    | FAILURE          |
+    When PRs are parsed from the GraphQL response
+    Then CachedPr.failing_checks contains both "e2e-tests" and "ci/travis"
+
+  @unit
+  Scenario: Warn when pagination truncates check results
+    Given the GraphQL response has statusCheckRollup.contexts with pageInfo.hasNextPage = true
+    When PRs are parsed from the GraphQL response
+    Then a warning is logged: "PR #42 has more than 100 checks; some may be missing"
+
+  # ===================================================================
+  # Cache layer — serialization round-trip
+  # ===================================================================
+
+  @unit
+  Scenario: Failing checks survive cache serialization round-trip
+    Given a CachedPr with failing_checks:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+    When the CachedPr is serialized to JSON and deserialized back
+    Then the deserialized failing_checks matches the original
+
+  @unit
+  Scenario: Existing cache files without failing_checks deserialize with empty vec
+    Given a cached PR JSON without a "failingChecks" field
+    When the JSON is deserialized to CachedPr
+    Then CachedPr.failing_checks is an empty vec
+
+  # ===================================================================
+  # JSON output — orchard --json (version bump to 5)
+  # ===================================================================
+  # Adding failingChecks to JsonPr is an additive schema change.
+  # Bump version from 4 to 5 per the module's forward-compat contract.
+
+  @unit
+  Scenario: orchard --json schema version is 5
+    When the state is serialized to JSON output
+    Then the top-level "version" field is 5
+
+  @unit
+  Scenario: orchard --json PR object includes failingChecks
+    Given a WorktreeState with a PR that has failing checks:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+    When the state is serialized to JSON output
+    Then the JSON PR object contains:
+      """json
+      "failingChecks": [
+        { "name": "e2e-tests", "conclusion": "FAILURE" }
+      ]
+      """
+
+  @unit
+  Scenario: orchard --json PR object has empty failingChecks when passing
+    Given a WorktreeState with a PR that has no failing checks
+    When the state is serialized to JSON output
+    Then the JSON PR object contains:
+      """json
+      "failingChecks": []
+      """
+
+  # ===================================================================
+  # TUI — failing check names in status row
+  # ===================================================================
+
+  @unit
+  Scenario: TUI status row shows failing check names
+    Given a WorktreeRow with PR failing checks:
+      | name       |
+      | e2e-tests  |
+      | lint       |
+    When pr_status_text is rendered
+    Then the text contains "failing: e2e-tests, lint"
+
+  @unit
+  Scenario: TUI status row shows single failing check name
+    Given a WorktreeRow with PR failing checks:
+      | name      |
+      | e2e-tests |
+    When pr_status_text is rendered
+    Then the text contains "failing: e2e-tests"
+
+  @unit
+  Scenario: TUI status row truncates long check lists
+    Given a WorktreeRow with 5 failing checks
+    When pr_status_text is rendered
+    Then the text shows at most 3 check names followed by "+2 more"
+
+  @unit
+  Scenario: TUI status row falls back to generic failing when checks list is empty
+    Given a WorktreeRow with checks_state "failing" but empty failing_checks
+    When pr_status_text is rendered
+    Then the text contains "failing" without specific check names
+
+  # ===================================================================
+  # Watch system — CiFailed event enrichment
+  # ===================================================================
+  # Field name: failing_checks (consistent with PrState)
+
+  @unit
+  Scenario: CiFailed event includes which checks failed
+    Given old state has PR #42 with checks_state "passing"
+    And new state has PR #42 with checks_state "failing" and failing_checks:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+    When the watch diff is computed
+    Then a CiFailed event is emitted with failing_checks:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+
+  @unit
+  Scenario: CiPassed event does not include failing checks
+    Given old state has PR #42 with checks_state "failing"
+    And new state has PR #42 with checks_state "passing" and no failing checks
+    When the watch diff is computed
+    Then a CiPassed event is emitted without failing_checks
+
+  # ===================================================================
+  # PR labels — flow through state model
+  # ===================================================================
+  # PR labels are fetched via GraphQL and stored in CachedPr, PrState, JsonPr.
+
+  @unit
+  Scenario: PrState includes PR labels
+    Given PR #42 has labels: "low-risk-change", "P0"
+    When the state is built
+    Then PrState.labels contains "low-risk-change" and "P0"
+
+  @unit
+  Scenario: PrState has empty labels when PR has none
+    Given PR #42 has no labels
+    When the state is built
+    Then PrState.labels is empty
+
+  @unit
+  Scenario: GraphQL query fetches PR labels
+    Given the GraphQL response includes labels.nodes with:
+      | name              |
+      | low-risk-change   |
+      | needs-plan        |
+    When PRs are parsed from the GraphQL response
+    Then CachedPr.labels contains "low-risk-change" and "needs-plan"
+
+  @unit
+  Scenario: CachedPr without labels field deserializes with empty vec
+    Given a cached PR JSON without a "labels" field
+    When the JSON is deserialized to CachedPr
+    Then CachedPr.labels is an empty vec
+
+  @unit
+  Scenario: orchard --json PR object includes labels
+    Given a WorktreeState with a PR that has labels: "low-risk-change"
+    When the state is serialized to JSON output
+    Then the JSON PR object contains:
+      """json
+      "labels": ["low-risk-change"]
+      """
+
+  # ===================================================================
+  # Issue labels — flow through state model
+  # ===================================================================
+  # Issue labels are already in CachedIssue. Just need to flow to IssueInfo and JSON.
+
+  @unit
+  Scenario: IssueInfo includes issue labels
+    Given issue #10 has labels: "bug", "P1"
+    When the state is built
+    Then IssueInfo.labels contains "bug" and "P1"
+
+  @unit
+  Scenario: IssueInfo has empty labels when issue has none
+    Given issue #10 has no labels
+    When the state is built
+    Then IssueInfo.labels is empty
+
+  @unit
+  Scenario: orchard --json issue object includes labels
+    Given a WorktreeState with an issue that has labels: "bug", "priority:high"
+    When the state is serialized to JSON output
+    Then the JSON issue object contains:
+      """json
+      "labels": ["bug", "priority:high"]
+      """


### PR DESCRIPTION
## Why

Closes #201

Orchard shows "CI failing" with no detail on *what* failed. Drew needs to know at a glance whether it's e2e tests, lint, or a non-blocking gate like `check-approval-or-label`. Similarly, issue and PR labels (P0, low-risk-change, needs-plan) weren't in the state model, forcing consumers to make extra API calls.

## What changed

Enriched the core state model with three new data points that flow through to all consumers:

1. **Failing check details** — `PrState` now carries a `failing_checks: Vec<FailedCheck>` with check name and conclusion for each non-passing CI check. The GraphQL query was expanded to fetch individual check runs (both `CheckRun` and legacy `StatusContext` types). Non-blocking checks like `check-approval-or-label` are filtered at `build_state` time (not parse time, preserving raw data in cache for future configurability).

2. **PR labels** — `PrState.labels: Vec<String>` fetched via GraphQL, flows through cache → state → JSON output.

3. **Issue labels** — `IssueInfo.labels: Vec<String>` already existed in cache; now flows through to the state model and JSON output.

All three surface in `orchard --json` (schema bumped to v5), the TUI status row, and watch system events.

## How it works

- **Conclusion classification**: Exhaustive mapping of GitHub check conclusions — `FAILURE | TIMED_OUT | ACTION_REQUIRED | STARTUP_FAILURE` = failing; `CANCELLED | STALE` = ignored (transient); `SUCCESS | NEUTRAL | SKIPPED` = passing.
- **GraphQL union handling**: `statusCheckRollup.contexts` is a union of `CheckRun` (name + conclusion) and `StatusContext` (context + state). Both are parsed; StatusContext state is mapped to a normalized conclusion.
- **TUI truncation**: Status row shows up to 3 check names (`"failing: e2e-tests, lint"`) with `+N more` for longer lists. Falls back to plain `"failing"` when the check list is empty.
- **Cache backward compat**: New fields use `#[serde(default, skip_serializing_if = "Vec::is_empty")]` so existing cache files deserialize cleanly.

## Test plan

- `extract_failing_checks`: 11 unit tests covering CheckRun FAILURE/SUCCESS, StatusContext FAILURE/ERROR, TIMED_OUT, CANCELLED, STALE, pagination warning, empty commits, null rollup
- `parse_prs_graphql`: Integration test verifying failing checks flow through full GraphQL parse pipeline
- `build_state`: Tests for non-blocking check filtering and pass-through
- Cache: Backward compat deserialization, round-trip, empty-not-serialized
- JSON output: Version bump to 5, `failingChecks` and `labels` fields on PR and issue objects
- TUI: `pr_status_text` with check names, truncation at 4+ checks, empty fallback
- Watch: `CiFailed` event carries `failing_checks`, diff test verifies enrichment

## Anything surprising?

- `check-approval-or-label` exclusion is currently hardcoded as `NON_BLOCKING_CHECKS`. Deliberately kept simple — the cache retains all checks so making this configurable later won't require cache invalidation.
- `contexts(last: 100)` pagination: logs a warning when `hasNextPage` is true but doesn't paginate further. Sufficient for typical repos; large matrix builds (100+ checks) may see incomplete lists.
- The TUI "detail/preview pane" mentioned in the issue already shows tmux capture content, not PR metadata. The status row enrichment is the correct delivery point for check names.

# Related issue

- #201

# Related issue

- #201

# Related issue

- #201