### PR TITLE
feat: orchard v2 polish — focus-driven sorting, ORCHARD tab, tags column, bug sweep

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,0 +1,9 @@
+---
+active: true
+iteration: 1
+max_iterations: 0
+completion_promise: null
+started_at: "2026-04-10T23:35:22Z"
+---
+
+get all of the bugs fixed and all the issues merged, and a built binary. it should all work.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,7 +2831,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,6 +2852,7 @@ dependencies = [
  "tempfile",
  "throbber-widgets-tui",
  "tokio",
+ "tracing",
  "tui-scrollview",
 ]
 

--- a/crates/orchard/Cargo.toml
+++ b/crates/orchard/Cargo.toml
@@ -35,6 +35,7 @@ throbber-widgets-tui = "0.11.0"
 tui-scrollview = "0.6.2"
 nucleo-matcher = "0.3.1"
 ctrlc = "3"
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -371,6 +371,7 @@ mod tests {
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
+            last_activity: None,
         }
     }
 
@@ -501,6 +502,7 @@ mod tests {
             host: Some("ubuntu@10.0.0.1".to_string()),
             last_output_lines: vec![],
             claude_state_raw: Some(make_state_file(state, name, timestamp)),
+            last_activity: None,
         }
     }
 
@@ -582,6 +584,7 @@ mod tests {
             host: Some("ubuntu@10.0.0.1".to_string()),
             last_output_lines: vec![],
             claude_state_raw: None,
+            last_activity: None,
         };
         let states = extract_fresh_remote_states(&[session]);
         assert!(states.is_empty());

--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -245,11 +245,19 @@ pub fn build_state_with_hosts(
 pub fn refresh_and_build(config: &GlobalConfig) -> OrchardState {
     // Refresh local sources first.
     for repo in &config.repos {
-        let _ = sources::worktrees::refresh_local(repo);
-        let _ = sources::github::refresh_issues(repo);
-        let _ = sources::github::refresh_prs(repo);
+        if let Err(e) = sources::worktrees::refresh_local(repo) {
+            tracing::warn!("refresh local worktrees failed for {}: {e}", repo.slug);
+        }
+        if let Err(e) = sources::github::refresh_issues(repo) {
+            tracing::warn!("refresh GitHub issues failed for {}: {e}", repo.slug);
+        }
+        if let Err(e) = sources::github::refresh_prs(repo) {
+            tracing::warn!("refresh GitHub PRs failed for {}: {e}", repo.slug);
+        }
     }
-    let _ = sources::tmux::refresh_local();
+    if let Err(e) = sources::tmux::refresh_local() {
+        tracing::warn!("refresh local tmux sessions failed: {e}");
+    }
 
     // Probe and refresh remote sources.
     let mut hosts: HashMap<String, HostState> = HashMap::new();
@@ -261,13 +269,30 @@ pub fn refresh_and_build(config: &GlobalConfig) -> OrchardState {
                 let reachable = sources::hosts::probe_reachability(&remote.host);
                 hosts.insert(remote.host.clone(), HostState { reachable });
                 if reachable {
-                    let _ = sources::worktrees::refresh_remote(repo, remote);
-                    let _ = sources::tmux::refresh_remote(&remote.host);
+                    if let Err(e) = sources::worktrees::refresh_remote(repo, remote) {
+                        tracing::warn!(
+                            "refresh remote worktrees failed for {} on {}: {e}",
+                            repo.slug,
+                            remote.host
+                        );
+                    }
+                    if let Err(e) = sources::tmux::refresh_remote(&remote.host) {
+                        tracing::warn!(
+                            "refresh remote tmux sessions failed for {}: {e}",
+                            remote.host
+                        );
+                    }
                 }
             } else if let Some(state) = hosts.get(&remote.host) {
                 // Already probed — refresh worktrees for this repo if reachable.
-                if state.reachable {
-                    let _ = sources::worktrees::refresh_remote(repo, remote);
+                if state.reachable
+                    && let Err(e) = sources::worktrees::refresh_remote(repo, remote)
+                {
+                    tracing::warn!(
+                        "refresh remote worktrees failed for {} on {}: {e}",
+                        repo.slug,
+                        remote.host
+                    );
                 }
             }
         }

--- a/crates/orchard/src/cache.rs
+++ b/crates/orchard/src/cache.rs
@@ -52,6 +52,12 @@ pub struct CachedPr {
     /// the GraphQL `closingIssuesReferences` nodes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub linked_issue_state: Option<String>,
+    /// Whether the PR is a draft (not ready for review).
+    ///
+    /// Uses `serde(default)` so existing cache files without this field
+    /// deserialize with `false` rather than failing.
+    #[serde(default)]
+    pub is_draft: bool,
 }
 
 /// A git worktree entry as stored in the worktrees cache file.
@@ -311,6 +317,7 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            is_draft: false,
         }
     }
 
@@ -635,5 +642,36 @@ mod tests {
         // Also verify the JSON on disk contains the field name.
         let json = std::fs::read_to_string(&path).unwrap();
         assert!(json.contains("\"last_refreshed\""));
+    }
+
+    // -- CachedPr is_draft default -------------------------------------------
+
+    #[test]
+    fn cached_pr_is_draft_defaults_to_false_for_legacy_json() {
+        // Simulates a legacy cache entry without the is_draft field.
+        let json = r#"{
+            "number": 7,
+            "branch": "feat/my-branch",
+            "linked_issue": 42,
+            "state": "open",
+            "review_decision": "approved",
+            "checks_state": "passing",
+            "has_conflicts": false,
+            "unresolved_threads": 0
+        }"#;
+        let pr: CachedPr = serde_json::from_str(json).unwrap();
+        assert!(
+            !pr.is_draft,
+            "is_draft should default to false for legacy cache entries without the field"
+        );
+    }
+
+    #[test]
+    fn cached_pr_is_draft_true_when_set() {
+        let mut pr = make_pr();
+        pr.is_draft = true;
+        let json = serde_json::to_string(&pr).unwrap();
+        let parsed: CachedPr = serde_json::from_str(&json).unwrap();
+        assert!(parsed.is_draft, "is_draft should roundtrip as true");
     }
 }

--- a/crates/orchard/src/cache.rs
+++ b/crates/orchard/src/cache.rs
@@ -52,7 +52,16 @@ pub struct CachedPr {
     /// the GraphQL `closingIssuesReferences` nodes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub linked_issue_state: Option<String>,
+    /// Individual non-passing CI checks (ALL non-passing, before exclusion filtering).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failing_checks: Vec<crate::orchard_state::FailedCheck>,
+    /// Labels applied to this PR.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
 }
+
+// Re-export FailedCheck for convenience in tests and other modules.
+pub use crate::orchard_state::FailedCheck;
 
 /// A git worktree entry as stored in the worktrees cache file.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -311,6 +320,8 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            failing_checks: vec![],
+            labels: vec![],
         }
     }
 
@@ -635,5 +646,53 @@ mod tests {
         // Also verify the JSON on disk contains the field name.
         let json = std::fs::read_to_string(&path).unwrap();
         assert!(json.contains("\"last_refreshed\""));
+    }
+
+    // -- CachedPr backward compat -------------------------------------------
+
+    #[test]
+    fn cached_pr_missing_failing_checks_defaults_to_empty() {
+        // Old cache format without failing_checks field.
+        let json = r#"{
+            "number": 7,
+            "branch": "feat/my-branch",
+            "linked_issue": 42,
+            "state": "open",
+            "review_decision": "approved",
+            "checks_state": "passing",
+            "has_conflicts": false,
+            "unresolved_threads": 0
+        }"#;
+        let parsed: CachedPr = serde_json::from_str(json).unwrap();
+        assert!(
+            parsed.failing_checks.is_empty(),
+            "failing_checks should default to empty vec when missing from JSON"
+        );
+    }
+
+    #[test]
+    fn cached_pr_failing_checks_roundtrip() {
+        let pr = CachedPr {
+            failing_checks: vec![FailedCheck {
+                name: "e2e-tests".to_string(),
+                conclusion: "FAILURE".to_string(),
+            }],
+            ..make_pr()
+        };
+        let json = serde_json::to_string(&pr).unwrap();
+        let parsed: CachedPr = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.failing_checks.len(), 1);
+        assert_eq!(parsed.failing_checks[0].name, "e2e-tests");
+        assert_eq!(parsed.failing_checks[0].conclusion, "FAILURE");
+    }
+
+    #[test]
+    fn cached_pr_empty_failing_checks_not_serialized() {
+        let pr = make_pr(); // failing_checks: vec![]
+        let json = serde_json::to_string(&pr).unwrap();
+        assert!(
+            !json.contains("failing_checks"),
+            "empty failing_checks should be omitted from JSON"
+        );
     }
 }

--- a/crates/orchard/src/cache.rs
+++ b/crates/orchard/src/cache.rs
@@ -122,6 +122,13 @@ pub struct CachedTmuxSession {
     /// Only populated for remote sessions. `None` means no state file was found
     /// on the remote host for this session at the time of the last SSH refresh.
     pub claude_state_raw: Option<ClaudeStateFile>,
+    /// Unix timestamp (seconds) of the last activity in this tmux session,
+    /// as reported by `#{session_activity}`.
+    ///
+    /// Uses `serde(default)` so old cache files without this field deserialize
+    /// to `None` rather than failing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_activity: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -354,6 +361,7 @@ mod tests {
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
+            last_activity: None,
         }
     }
 
@@ -576,6 +584,7 @@ mod tests {
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
+            last_activity: None,
         };
         let json = serde_json::to_string(&session).unwrap();
         let parsed: CachedTmuxSession = serde_json::from_str(&json).unwrap();

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -829,6 +829,7 @@ mod tests {
     }
 
     /// Helper to build a single PR node in GraphQL format with explicit `is_draft` flag.
+    #[allow(clippy::too_many_arguments)]
     fn gql_pr_node_draft(
         number: u32,
         branch: &str,
@@ -1073,7 +1074,10 @@ mod tests {
         let node = gql_pr_node_draft(1, "feat/x", None, "MERGEABLE", None, vec![], 0, true);
         let json = graphql_prs(json!([node]));
         let prs = parse_prs_graphql(&json);
-        assert!(prs[0].is_draft, "isDraft field must be parsed from GraphQL response");
+        assert!(
+            prs[0].is_draft,
+            "isDraft field must be parsed from GraphQL response"
+        );
     }
 
     // -- parse_worktree_porcelain -------------------------------------------

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -301,7 +301,12 @@ pub fn parse_worktree_porcelain(output: &str) -> Vec<CachedWorktree> {
 /// Parses the combined output of `tmux list-sessions` and per-session pane
 /// information into `Vec<CachedTmuxSession>`.
 ///
-/// `sessions_output` has lines in the format `{session_name}:{session_path}`.
+/// `sessions_output` has lines in the format
+/// `{session_name}:{session_activity}:{session_path}`.
+/// The `session_activity` field is a Unix timestamp (seconds) from
+/// `#{session_activity}`. The session path may itself contain colons, so the
+/// format is split as `name:activity:rest-of-path`.
+///
 /// `panes_fn` is called with each session name and returns lines in the format
 /// `{pane_title}:{pane_current_command}`.
 /// `content_fn` is called with each session name and returns the last few lines
@@ -318,12 +323,20 @@ pub fn parse_tmux_output(
         if line.is_empty() {
             continue;
         }
-        // Format: "{session_name}:{session_path}"
-        // Session path may itself contain colons (e.g. Windows paths or
-        // absolute paths on some systems), so we split on the first colon only.
-        let Some((name, path)) = line.split_once(':') else {
+        // Format: "{session_name}:{session_activity}:{session_path}"
+        // Split on the first colon to get the name, then the second colon to
+        // separate the activity timestamp from the path. The path may itself
+        // contain colons (e.g. absolute paths), so we only split twice.
+        let Some((name, rest)) = line.split_once(':') else {
             continue;
         };
+        let (activity_str, path) = match rest.split_once(':') {
+            Some((act, p)) => (act, p),
+            // Backward-compat: old format had no activity field — treat entire
+            // rest as path and leave last_activity as None.
+            None => ("", rest),
+        };
+        let last_activity = activity_str.parse::<u64>().ok().filter(|&v| v > 0);
 
         let pane_output = panes_fn(name);
         let parsed = parse_pane_lines(&pane_output);
@@ -340,6 +353,7 @@ pub fn parse_tmux_output(
             host: host.map(|h| h.to_string()),
             last_output_lines,
             claude_state_raw: None, // populated after parsing remote Claude state
+            last_activity,
         });
     }
 
@@ -643,11 +657,15 @@ pub fn refresh_tmux_sessions(host: Option<&str>) -> anyhow::Result<()> {
     let sessions_out = match host {
         None => run_local(
             "tmux",
-            &["list-sessions", "-F", "#{session_name}:#{session_path}"],
+            &[
+                "list-sessions",
+                "-F",
+                "#{session_name}:#{session_activity}:#{session_path}",
+            ],
         ),
         Some(h) => {
             let cmd = format!(
-                "tmux list-sessions -F '#{{session_name}}:#{{session_path}}' && echo '{}' && cat '${{TMPDIR:-/tmp}}'/orchard-claude-*.json 2>/dev/null; true",
+                "tmux list-sessions -F '#{{session_name}}:#{{session_activity}}:#{{session_path}}' && echo '{}' && cat '${{TMPDIR:-/tmp}}'/orchard-claude-*.json 2>/dev/null; true",
                 CLAUDE_STATE_SENTINEL
             );
             remote::ssh_exec(h, &cmd)

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -232,6 +232,7 @@ pub fn extract_failing_checks(pr: &serde_json::Value) -> Vec<FailedCheck> {
                 _ => None,
             }
         })
+        .filter(|c| !c.name.is_empty())
         .collect()
 }
 
@@ -1439,6 +1440,43 @@ mod tests {
         let checks = extract_failing_checks(&pr);
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].conclusion, "TIMED_OUT");
+    }
+
+    #[test]
+    fn extract_failing_checks_action_required_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "deploy-gate",
+            "conclusion": "ACTION_REQUIRED"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "deploy-gate");
+        assert_eq!(checks[0].conclusion, "ACTION_REQUIRED");
+    }
+
+    #[test]
+    fn extract_failing_checks_startup_failure_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "build",
+            "conclusion": "STARTUP_FAILURE"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "build");
+        assert_eq!(checks[0].conclusion, "STARTUP_FAILURE");
+    }
+
+    #[test]
+    fn extract_failing_checks_empty_name_filtered() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "",
+            "conclusion": "FAILURE"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
     }
 
     #[test]

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -9,6 +9,7 @@ use crate::cache::{self, CachedIssue, CachedPr, CachedTmuxSession, CachedWorktre
 use crate::global_config::RepoConfig;
 use crate::logger::LOG;
 use crate::orchard_state::FailedCheck;
+use crate::paths::normalize_path;
 use crate::remote;
 
 // ---------------------------------------------------------------------------
@@ -286,7 +287,7 @@ pub fn parse_worktree_porcelain(output: &str) -> Vec<CachedWorktree> {
         }
 
         worktrees.push(CachedWorktree {
-            path,
+            path: normalize_path(&path).to_string(),
             branch,
             is_bare,
             is_locked,
@@ -330,7 +331,7 @@ pub fn parse_tmux_output(
 
         sessions.push(CachedTmuxSession {
             name: name.to_string(),
-            path: path.to_string(),
+            path: normalize_path(path).to_string(),
             pane_targets: parsed.targets,
             pane_titles: parsed.titles,
             pane_commands: parsed.commands,
@@ -492,7 +493,11 @@ pub fn refresh_issues(config: &RepoConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Fetches open GitHub PRs for `config.slug` via GraphQL and writes to the PRs cache.
+/// Fetches open and recently merged GitHub PRs for `config.slug` via GraphQL and writes to the PRs cache.
+///
+/// Fetches both OPEN and MERGED states so that merged PRs remain in the cache and
+/// can be matched to their worktree branches. On API failure the error is logged and
+/// the existing cache is left intact.
 ///
 /// Uses GraphQL to get closingIssuesReferences (linked issues) and reviewThreads,
 /// which are not available via `gh pr list --json`.
@@ -503,7 +508,7 @@ pub fn refresh_prs(config: &RepoConfig) -> anyhow::Result<()> {
     let query = format!(
         r#"query {{
   repository(owner: "{owner}", name: "{name}") {{
-    pullRequests(first: 100, states: OPEN, orderBy: {{field: CREATED_AT, direction: DESC}}) {{
+    pullRequests(first: 100, states: [OPEN, MERGED], orderBy: {{field: CREATED_AT, direction: DESC}}) {{
       nodes {{
         number
         headRefName
@@ -571,7 +576,10 @@ pub fn refresh_prs(config: &RepoConfig) -> anyhow::Result<()> {
         }
         Ok(json) => {
             let prs = parse_prs_graphql(&json);
-            cache::write_cache_if_nonempty(&path, &prs)?;
+            // Use write_cache (not write_cache_if_nonempty) so that a successful
+            // API response with zero PRs clears stale entries from a previous run.
+            // The early-return in the Err branch above protects against network failures.
+            cache::write_cache(&path, &prs)?;
             LOG.info(&format!(
                 "cache_sources: refresh_prs({}): wrote {} entries",
                 config.slug,
@@ -1179,6 +1187,79 @@ mod tests {
             prs[0].is_draft,
             "isDraft field must be parsed from GraphQL response"
         );
+    }
+
+    #[test]
+    fn parse_prs_graphql_preserves_merged_state() {
+        // Merged PRs returned by the GraphQL query (states: [OPEN, MERGED]) must
+        // round-trip with state == "merged" so derive can match them to worktrees.
+        let node = json!({
+            "number": 77,
+            "headRefName": "feat/issue-77",
+            "baseRefName": "main",
+            "state": "MERGED",
+            "isDraft": false,
+            "reviewDecision": "APPROVED",
+            "mergeable": "UNKNOWN",
+            "labels": {"nodes": []},
+            "reviewThreads": {"nodes": []},
+            "closingIssuesReferences": {"nodes": [
+                {"number": 77, "state": "CLOSED", "stateReason": "COMPLETED"}
+            ]},
+            "commits": {"nodes": [{"commit": {"statusCheckRollup": null}}]}
+        });
+        let json = graphql_prs(json!([node]));
+        let prs = parse_prs_graphql(&json);
+
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 77);
+        assert_eq!(prs[0].state, "merged");
+        assert_eq!(prs[0].branch, "feat/issue-77");
+        assert_eq!(prs[0].linked_issue, Some(77));
+        assert_eq!(
+            prs[0].linked_issue_state.as_deref(),
+            Some("completed"),
+            "linked issue state should be 'completed' for COMPLETED stateReason"
+        );
+    }
+
+    #[test]
+    fn parse_prs_graphql_open_and_merged_both_included() {
+        // When the response contains both OPEN and MERGED PRs (as returned by
+        // states: [OPEN, MERGED]), both must be preserved in the parsed output.
+        let open_node = json!({
+            "number": 10,
+            "headRefName": "feat/open-pr",
+            "baseRefName": "main",
+            "state": "OPEN",
+            "isDraft": false,
+            "reviewDecision": null,
+            "mergeable": "MERGEABLE",
+            "labels": {"nodes": []},
+            "reviewThreads": {"nodes": []},
+            "closingIssuesReferences": {"nodes": []},
+            "commits": {"nodes": [{"commit": {"statusCheckRollup": null}}]}
+        });
+        let merged_node = json!({
+            "number": 11,
+            "headRefName": "feat/merged-pr",
+            "baseRefName": "main",
+            "state": "MERGED",
+            "isDraft": false,
+            "reviewDecision": "APPROVED",
+            "mergeable": "UNKNOWN",
+            "labels": {"nodes": []},
+            "reviewThreads": {"nodes": []},
+            "closingIssuesReferences": {"nodes": []},
+            "commits": {"nodes": [{"commit": {"statusCheckRollup": null}}]}
+        });
+        let json = graphql_prs(json!([open_node, merged_node]));
+        let prs = parse_prs_graphql(&json);
+
+        assert_eq!(prs.len(), 2);
+        let states: Vec<&str> = prs.iter().map(|p| p.state.as_str()).collect();
+        assert!(states.contains(&"open"), "expected an open PR");
+        assert!(states.contains(&"merged"), "expected a merged PR");
     }
 
     // -- parse_worktree_porcelain -------------------------------------------

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -6,6 +6,7 @@
 use std::process::Command;
 
 use crate::cache::{self, CachedIssue, CachedPr, CachedTmuxSession, CachedWorktree};
+use crate::orchard_state::FailedCheck;
 use crate::global_config::RepoConfig;
 use crate::logger::LOG;
 use crate::remote;
@@ -126,6 +127,17 @@ pub fn parse_prs_graphql(json: &str) -> Vec<CachedPr> {
                 Some(normalised.to_string())
             });
 
+            let failing_checks = extract_failing_checks(v);
+
+            let labels: Vec<String> = v["labels"]["nodes"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|n| n["name"].as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
             Some(CachedPr {
                 number,
                 branch,
@@ -136,6 +148,8 @@ pub fn parse_prs_graphql(json: &str) -> Vec<CachedPr> {
                 has_conflicts,
                 unresolved_threads,
                 linked_issue_state,
+                failing_checks,
+                labels,
             })
         })
         .collect()
@@ -154,6 +168,71 @@ fn derive_checks_state_graphql(pr: &serde_json::Value) -> Option<String> {
         "PENDING" => Some("pending".to_string()),
         _ => None,
     }
+}
+
+/// Extracts individual failing CI check details from the GraphQL PR response.
+///
+/// Navigates to `commits.nodes[last].commit.statusCheckRollup.contexts.nodes`
+/// and collects all non-passing, actionable checks. Logs a warning when the
+/// contexts list is paginated (more than 100 checks — extremely rare).
+///
+/// Filters applied:
+/// - **Included** conclusions: `FAILURE`, `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`
+/// - **Excluded** (transient / not actionable): `CANCELLED`, `STALE`, `SUCCESS`, `NEUTRAL`, `SKIPPED`
+/// - `StatusContext` states `FAILURE` and `ERROR` are mapped to conclusion `FAILURE`.
+pub fn extract_failing_checks(pr: &serde_json::Value) -> Vec<FailedCheck> {
+    let rollup = match pr["commits"]["nodes"]
+        .as_array()
+        .and_then(|nodes| nodes.last())
+    {
+        Some(node) => &node["commit"]["statusCheckRollup"],
+        None => return Vec::new(),
+    };
+
+    let contexts = match rollup["contexts"]["nodes"].as_array() {
+        Some(c) => c,
+        None => return Vec::new(),
+    };
+
+    // Warn if there are more than 100 checks (pagination not supported).
+    if rollup["contexts"]["pageInfo"]["hasNextPage"]
+        .as_bool()
+        .unwrap_or(false)
+    {
+        LOG.warn("cache_sources: PR has more than 100 CI checks; some may be missing from failing_checks");
+    }
+
+    contexts
+        .iter()
+        .filter_map(|node| {
+            match node["__typename"].as_str()? {
+                "CheckRun" => {
+                    let name = node["name"].as_str().unwrap_or("").to_string();
+                    let conclusion = node["conclusion"].as_str().unwrap_or("").to_string();
+                    // Include only actionable failures.
+                    match conclusion.as_str() {
+                        "FAILURE" | "TIMED_OUT" | "ACTION_REQUIRED" | "STARTUP_FAILURE" => {
+                            Some(FailedCheck { name, conclusion })
+                        }
+                        _ => None,
+                    }
+                }
+                "StatusContext" => {
+                    let name = node["context"].as_str().unwrap_or("").to_string();
+                    let state = node["state"].as_str().unwrap_or("");
+                    // Map FAILURE/ERROR states to conclusion FAILURE; skip everything else.
+                    match state {
+                        "FAILURE" | "ERROR" => Some(FailedCheck {
+                            name,
+                            conclusion: "FAILURE".to_string(),
+                        }),
+                        _ => None,
+                    }
+                }
+                _ => None,
+            }
+        })
+        .collect()
 }
 
 /// Parses the output of `git worktree list --porcelain` into `Vec<CachedWorktree>`.
@@ -428,6 +507,11 @@ pub fn refresh_prs(config: &RepoConfig) -> anyhow::Result<()> {
         state
         reviewDecision
         mergeable
+        labels(first: 20) {{
+          nodes {{
+            name
+          }}
+        }}
         reviewThreads(first: 100) {{
           nodes {{
             isResolved
@@ -445,6 +529,22 @@ pub fn refresh_prs(config: &RepoConfig) -> anyhow::Result<()> {
             commit {{
               statusCheckRollup {{
                 state
+                contexts(last: 100) {{
+                  pageInfo {{
+                    hasNextPage
+                  }}
+                  nodes {{
+                    __typename
+                    ... on CheckRun {{
+                      name
+                      conclusion
+                    }}
+                    ... on StatusContext {{
+                      context
+                      state
+                    }}
+                  }}
+                }}
               }}
             }}
           }}
@@ -1257,5 +1357,198 @@ mod tests {
         assert_eq!(parsed.window_active, vec!["1"]);
         assert_eq!(parsed.titles, vec!["Claude"]);
         assert_eq!(parsed.commands, vec![" my-project:node"]);
+    }
+
+    // -- extract_failing_checks -----------------------------------------------
+
+    /// Builds a minimal PR value with a statusCheckRollup contexts array.
+    fn pr_with_check_nodes(nodes: serde_json::Value) -> serde_json::Value {
+        json!({
+            "commits": {
+                "nodes": [{
+                    "commit": {
+                        "statusCheckRollup": {
+                            "state": "FAILURE",
+                            "contexts": {
+                                "pageInfo": {"hasNextPage": false},
+                                "nodes": nodes
+                            }
+                        }
+                    }
+                }]
+            }
+        })
+    }
+
+    #[test]
+    fn extract_failing_checks_checkrun_failure_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "e2e-tests",
+            "conclusion": "FAILURE"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "e2e-tests");
+        assert_eq!(checks[0].conclusion, "FAILURE");
+    }
+
+    #[test]
+    fn extract_failing_checks_checkrun_success_excluded() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "unit-tests",
+            "conclusion": "SUCCESS"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn extract_failing_checks_status_context_failure_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "StatusContext",
+            "context": "ci/travis",
+            "state": "FAILURE"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name, "ci/travis");
+        assert_eq!(checks[0].conclusion, "FAILURE");
+    }
+
+    #[test]
+    fn extract_failing_checks_status_context_error_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "StatusContext",
+            "context": "ci/circle",
+            "state": "ERROR"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].conclusion, "FAILURE");
+    }
+
+    #[test]
+    fn extract_failing_checks_timed_out_included() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "integration-tests",
+            "conclusion": "TIMED_OUT"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].conclusion, "TIMED_OUT");
+    }
+
+    #[test]
+    fn extract_failing_checks_cancelled_excluded() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "deploy",
+            "conclusion": "CANCELLED"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn extract_failing_checks_stale_excluded() {
+        let pr = pr_with_check_nodes(json!([{
+            "__typename": "CheckRun",
+            "name": "stale-job",
+            "conclusion": "STALE"
+        }]));
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn extract_failing_checks_pagination_warning_does_not_panic() {
+        // When hasNextPage is true, a warning is logged but no panic occurs.
+        let pr = json!({
+            "commits": {
+                "nodes": [{
+                    "commit": {
+                        "statusCheckRollup": {
+                            "state": "FAILURE",
+                            "contexts": {
+                                "pageInfo": {"hasNextPage": true},
+                                "nodes": [{
+                                    "__typename": "CheckRun",
+                                    "name": "test",
+                                    "conclusion": "FAILURE"
+                                }]
+                            }
+                        }
+                    }
+                }]
+            }
+        });
+        // Must not panic; result should still include the visible checks.
+        let checks = extract_failing_checks(&pr);
+        assert_eq!(checks.len(), 1);
+    }
+
+    #[test]
+    fn extract_failing_checks_empty_when_no_commits() {
+        let pr = json!({"commits": {"nodes": []}});
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn extract_failing_checks_empty_when_rollup_null() {
+        let pr = json!({
+            "commits": {
+                "nodes": [{"commit": {"statusCheckRollup": null}}]
+            }
+        });
+        let checks = extract_failing_checks(&pr);
+        assert!(checks.is_empty());
+    }
+
+    #[test]
+    fn parse_prs_graphql_includes_failing_checks() {
+        // Integration: parse_prs_graphql should populate failing_checks from check nodes.
+        let pr_node = json!({
+            "number": 42,
+            "headRefName": "feat/fix",
+            "baseRefName": "main",
+            "state": "OPEN",
+            "reviewDecision": null,
+            "mergeable": "MERGEABLE",
+            "reviewThreads": {"nodes": []},
+            "closingIssuesReferences": {"nodes": []},
+            "commits": {
+                "nodes": [{
+                    "commit": {
+                        "statusCheckRollup": {
+                            "state": "FAILURE",
+                            "contexts": {
+                                "pageInfo": {"hasNextPage": false},
+                                "nodes": [
+                                    {
+                                        "__typename": "CheckRun",
+                                        "name": "unit-tests",
+                                        "conclusion": "FAILURE"
+                                    },
+                                    {
+                                        "__typename": "CheckRun",
+                                        "name": "lint",
+                                        "conclusion": "SUCCESS"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }]
+            }
+        });
+        let json = graphql_prs(json!([pr_node]));
+        let prs = parse_prs_graphql(&json);
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].failing_checks.len(), 1);
+        assert_eq!(prs[0].failing_checks[0].name, "unit-tests");
     }
 }

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -705,14 +705,22 @@ pub fn refresh_tmux_sessions(host: Option<&str>) -> anyhow::Result<()> {
                     "tmux",
                     &["list-panes", "-s", "-t", session_name, "-F", pane_fmt],
                 )
-                .unwrap_or_default(),
+                .unwrap_or_else(|e| {
+                    tracing::warn!("tmux pane list failed for session {session_name}: {e}");
+                    String::new()
+                }),
                 Some(h) => {
                     let cmd = format!(
                         "tmux list-panes -s -t {} -F '{}'",
                         remote::shell_escape(session_name),
                         pane_fmt
                     );
-                    remote::ssh_exec(h, &cmd).unwrap_or_default()
+                    remote::ssh_exec(h, &cmd).unwrap_or_else(|e| {
+                        tracing::warn!(
+                            "tmux pane list failed for session {session_name} on {h}: {e}"
+                        );
+                        String::new()
+                    })
                 }
             }
         },
@@ -722,13 +730,21 @@ pub fn refresh_tmux_sessions(host: Option<&str>) -> anyhow::Result<()> {
                     "tmux",
                     &["capture-pane", "-p", "-t", session_name, "-S", "-5"],
                 )
-                .unwrap_or_default(),
+                .unwrap_or_else(|e| {
+                    tracing::warn!("tmux capture-pane failed for session {session_name}: {e}");
+                    String::new()
+                }),
                 Some(h) => {
                     let cmd = format!(
                         "tmux capture-pane -p -t {} -S -5",
                         remote::shell_escape(session_name)
                     );
-                    remote::ssh_exec(h, &cmd).unwrap_or_default()
+                    remote::ssh_exec(h, &cmd).unwrap_or_else(|e| {
+                        tracing::warn!(
+                            "tmux capture-pane failed for session {session_name} on {h}: {e}"
+                        );
+                        String::new()
+                    })
                 }
             };
             raw.lines().map(|l| l.to_string()).collect()

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -6,9 +6,9 @@
 use std::process::Command;
 
 use crate::cache::{self, CachedIssue, CachedPr, CachedTmuxSession, CachedWorktree};
-use crate::orchard_state::FailedCheck;
 use crate::global_config::RepoConfig;
 use crate::logger::LOG;
+use crate::orchard_state::FailedCheck;
 use crate::remote;
 
 // ---------------------------------------------------------------------------

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -95,6 +95,8 @@ pub fn parse_prs_graphql(json: &str) -> Vec<CachedPr> {
 
             let checks_state = derive_checks_state_graphql(v);
 
+            let is_draft = v["isDraft"].as_bool().unwrap_or(false);
+
             let has_conflicts = v["mergeable"].as_str().unwrap_or("") == "CONFLICTING";
 
             let unresolved_threads = v["reviewThreads"]["nodes"]
@@ -136,6 +138,7 @@ pub fn parse_prs_graphql(json: &str) -> Vec<CachedPr> {
                 has_conflicts,
                 unresolved_threads,
                 linked_issue_state,
+                is_draft,
             })
         })
         .collect()
@@ -426,6 +429,7 @@ pub fn refresh_prs(config: &RepoConfig) -> anyhow::Result<()> {
         headRefName
         baseRefName
         state
+        isDraft
         reviewDecision
         mergeable
         reviewThreads(first: 100) {{
@@ -812,6 +816,29 @@ mod tests {
         linked_issues: Vec<u32>,
         unresolved_threads: u32,
     ) -> serde_json::Value {
+        gql_pr_node_draft(
+            number,
+            branch,
+            review_decision,
+            mergeable,
+            check_state,
+            linked_issues,
+            unresolved_threads,
+            false,
+        )
+    }
+
+    /// Helper to build a single PR node in GraphQL format with explicit `is_draft` flag.
+    fn gql_pr_node_draft(
+        number: u32,
+        branch: &str,
+        review_decision: Option<&str>,
+        mergeable: &str,
+        check_state: Option<&str>,
+        linked_issues: Vec<u32>,
+        unresolved_threads: u32,
+        is_draft: bool,
+    ) -> serde_json::Value {
         let threads: Vec<serde_json::Value> = (0..unresolved_threads)
             .map(|_| json!({"isResolved": false}))
             .collect();
@@ -827,6 +854,7 @@ mod tests {
             "number": number,
             "headRefName": branch,
             "state": "OPEN",
+            "isDraft": is_draft,
             "reviewDecision": review_decision,
             "mergeable": mergeable,
             "reviewThreads": {"nodes": threads},
@@ -1002,6 +1030,50 @@ mod tests {
     #[test]
     fn parse_prs_graphql_invalid_json_returns_empty() {
         assert!(parse_prs_graphql("{bad}").is_empty());
+    }
+
+    #[test]
+    fn parse_prs_graphql_is_draft_true() {
+        let json = graphql_prs(json!([gql_pr_node_draft(
+            20,
+            "feat/draft-pr",
+            None,
+            "MERGEABLE",
+            None,
+            vec![],
+            0,
+            true
+        )]));
+
+        let prs = parse_prs_graphql(&json);
+        assert!(prs[0].is_draft, "expected is_draft to be true");
+    }
+
+    #[test]
+    fn parse_prs_graphql_is_draft_false_by_default() {
+        let json = graphql_prs(json!([gql_pr_node(
+            21,
+            "feat/ready-pr",
+            None,
+            "MERGEABLE",
+            None,
+            vec![],
+            0
+        )]));
+
+        let prs = parse_prs_graphql(&json);
+        assert!(!prs[0].is_draft, "expected is_draft to be false");
+    }
+
+    #[test]
+    fn graphql_query_includes_is_draft_field() {
+        // The GraphQL query is built inside refresh_prs. We verify the isDraft field
+        // is present in our test node builder and parsed correctly, which mirrors
+        // that the query includes the field.
+        let node = gql_pr_node_draft(1, "feat/x", None, "MERGEABLE", None, vec![], 0, true);
+        let json = graphql_prs(json!([node]));
+        let prs = parse_prs_graphql(&json);
+        assert!(prs[0].is_draft, "isDraft field must be parsed from GraphQL response");
     }
 
     // -- parse_worktree_porcelain -------------------------------------------

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -68,6 +68,8 @@ pub struct PrInfo {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Whether the PR is a draft (not ready for review).
+    pub is_draft: bool,
 }
 
 /// One row in the derived worktree view. Corresponds to one non-bare worktree,
@@ -227,6 +229,7 @@ fn pr_info_from(pr: &CachedPr) -> PrInfo {
         checks_state: pr.checks_state.clone(),
         has_conflicts: pr.has_conflicts,
         unresolved_threads: pr.unresolved_threads,
+        is_draft: pr.is_draft,
     }
 }
 
@@ -501,6 +504,7 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            is_draft: false,
         }
     }
 
@@ -515,6 +519,7 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            is_draft: false,
         }
     }
 

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -154,9 +154,7 @@ pub fn derive_worktree_rows(
         let linked_issue = issue_number.and_then(|num| issues.iter().find(|i| i.number == num));
         let issue_title = linked_issue.map(|i| i.title.clone());
         let issue_state = linked_issue.map(|i| i.state.clone());
-        let issue_labels = linked_issue
-            .map(|i| i.labels.clone())
-            .unwrap_or_default();
+        let issue_labels = linked_issue.map(|i| i.labels.clone()).unwrap_or_default();
 
         let is_main_worktree =
             is_first_non_bare || session_infos.iter().any(|s| s.tmux.name.ends_with("_main"));

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -33,22 +33,18 @@ const HOOK_STATE_STALENESS_SECS: u64 = 300;
 // ---------------------------------------------------------------------------
 
 /// Rendering order for worktree rows. Variants are ordered so that `Ord` gives
-/// the correct sort order (RepoMain first, Other last).
+/// the correct sort order (RepoMain first, Done last).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DisplayGroup {
     /// Always first — the repo's main worktree.
     RepoMain,
-    /// User-flagged as priority work.
-    Prioritized,
-    /// Requires human action (blocked, conflicts, review requested).
-    NeedsAttention,
-    /// A Claude session is actively working in this worktree.
-    ClaudeWorking,
-    /// PR is approved and checks pass — ready to merge.
-    ReadyToMerge,
-    /// Worktrees without PRs or other misc work.
-    Other,
+    /// Has any running tmux session (Claude working, input needed, etc.).
+    Active,
+    /// Everything else that's still open/in-progress.
+    Normal,
+    /// Issue is closed AND PR is merged/closed, or issue closed with no PR.
+    Done,
 }
 
 /// Lightweight PR summary attached to a worktree row.
@@ -163,8 +159,6 @@ pub fn derive_worktree_rows(
 
         let display_group = if is_main_worktree {
             DisplayGroup::RepoMain
-        } else if crate::priority::is_prioritized(&wt.path) {
-            DisplayGroup::Prioritized
         } else {
             derive_display_group(pr_info.as_ref(), &session_infos, issue_state.as_deref())
         };
@@ -211,14 +205,25 @@ pub fn derive_all_repos(
         .collect();
 
     rows.sort_by(|a, b| {
-        a.display_group
-            .cmp(&b.display_group)
-            .then_with(|| match (a.issue_number, b.issue_number) {
-                (Some(a_num), Some(b_num)) => a_num.cmp(&b_num),
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => a.branch.cmp(&b.branch),
-            })
+        // Primary: group order (RepoMain < Active < Normal < Done)
+        let group_ord = a.display_group.cmp(&b.display_group);
+        if group_ord != std::cmp::Ordering::Equal {
+            return group_ord;
+        }
+        // Secondary: focus score — "what needs human attention most?"
+        let a_focus = focus_score(a);
+        let b_focus = focus_score(b);
+        let focus_ord = a_focus.cmp(&b_focus);
+        if focus_ord != std::cmp::Ordering::Equal {
+            return focus_ord;
+        }
+        // Tertiary: issue number ascending
+        match (a.issue_number, b.issue_number) {
+            (Some(a_num), Some(b_num)) => a_num.cmp(&b_num),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => a.branch.cmp(&b.branch),
+        }
     });
 
     rows
@@ -378,8 +383,7 @@ pub fn is_state_stale(timestamp: &str, max_age_secs: u64) -> bool {
     }
 }
 
-/// Derives the display group for a worktree row. Priority order:
-/// NeedsAttention > ClaudeWorking > ReadyToMerge > Other.
+/// Derives the display group for a worktree row.
 ///
 /// Never returns `RepoMain` — that is set separately based on `is_main_worktree`.
 fn derive_display_group(
@@ -387,76 +391,129 @@ fn derive_display_group(
     sessions: &[EnrichedSession],
     issue_state: Option<&str>,
 ) -> DisplayGroup {
+    // Done: closed issue with merged/closed PR, or closed issue with no PR.
+    let issue_closed = issue_state.is_some_and(|s| s == "closed" || s == "completed");
+    let pr_done = pr.is_some_and(|p| {
+        p.state.as_deref() == Some("merged")
+            || p.state.as_deref() == Some("closed")
+            || p.state.as_deref() == Some("MERGED")
+            || p.state.as_deref() == Some("CLOSED")
+    });
+    if issue_closed && (pr_done || pr.is_none()) {
+        return DisplayGroup::Done;
+    }
+
+    // Active: any running tmux session with a Claude process.
+    if sessions.iter().any(|s| s.claude.is_some()) {
+        return DisplayGroup::Active;
+    }
+
+    // Everything else is Normal.
+    DisplayGroup::Normal
+}
+
+/// Returns a focus score for sorting within a display group. Lower = needs
+/// human attention more urgently.
+///
+/// The score answers: "what needs a human to do something right now?"
+/// - Tier 0-9: Blocked on human action (Claude waiting, changes requested, conflicts)
+/// - Tier 10-19: Needs attention soon (CI failing, unresolved threads, ready to merge)
+/// - Tier 20-29: In progress, no action needed (Claude working, waiting on review)
+/// - Tier 30+: No urgency signals
+///
+/// Within a tier, priority labels (P0/P1) serve as tiebreakers.
+fn focus_score(row: &WorktreeRow) -> u32 {
     use crate::claude_state::ClaudeState;
 
-    // Claude waiting for input = needs your attention (highest priority, before PR state).
-    if sessions.iter().any(|s| {
+    // Check Claude session states
+    let has_input_needed = row.sessions.iter().any(|s| {
         s.claude
             .as_ref()
             .is_some_and(|c| c.status == ClaudeState::Input)
-    }) {
-        return DisplayGroup::NeedsAttention;
-    }
+    });
+    let has_claude_working = row.sessions.iter().any(|s| {
+        s.claude
+            .as_ref()
+            .is_some_and(|c| c.status == ClaudeState::Working)
+    });
 
-    // Closed/completed issue with no PR = stale worktree, needs cleanup.
-    if pr.is_none()
-        && let Some(state) = issue_state
-        && (state == "closed" || state == "completed")
-    {
-        return DisplayGroup::NeedsAttention;
-    }
+    // Check PR states
+    let changes_requested = row
+        .pr
+        .as_ref()
+        .is_some_and(|p| p.review_decision.as_deref() == Some("CHANGES_REQUESTED"));
+    let has_conflicts = row.pr.as_ref().is_some_and(|p| p.has_conflicts);
+    let ci_failing = row
+        .pr
+        .as_ref()
+        .is_some_and(|p| p.checks_state.as_deref() == Some("FAILURE"));
+    let has_unresolved = row.pr.as_ref().is_some_and(|p| p.unresolved_threads > 0);
+    let ready_to_merge = row.pr.as_ref().is_some_and(|p| {
+        p.review_decision.as_deref() == Some("APPROVED")
+            && !p.has_conflicts
+            && p.checks_state.as_deref() == Some("SUCCESS")
+    });
+    let pr_waiting_review = row.pr.as_ref().is_some_and(|p| {
+        p.review_decision.as_deref() == Some("REVIEW_REQUIRED")
+            || p.review_decision.is_none()
+    });
+    let has_pr = row.pr.is_some();
 
-    if let Some(pr) = pr {
-        // Merged/closed PR = stale worktree.
-        if pr.state.as_deref() == Some("merged") || pr.state.as_deref() == Some("closed") {
-            return DisplayGroup::NeedsAttention;
-        }
-
-        if is_needs_attention(pr) {
-            return DisplayGroup::NeedsAttention;
-        }
-
-        if sessions.iter().any(|s| {
-            s.claude
-                .as_ref()
-                .is_some_and(|c| c.status == ClaudeState::Working)
-        }) {
-            return DisplayGroup::ClaudeWorking;
-        }
-
-        if is_ready_to_merge(pr) {
-            return DisplayGroup::ReadyToMerge;
-        }
+    // Compute base score by urgency tier
+    let base = if has_input_needed {
+        0 // Claude is blocked on you — act now
+    } else if changes_requested {
+        1 // Reviewer is waiting on you
+    } else if has_conflicts {
+        2 // Blocking progress, needs resolution
+    } else if ci_failing {
+        10 // Something broke, needs investigation
+    } else if has_unresolved {
+        11 // Active conversation, needs response
+    } else if ready_to_merge {
+        12 // Quick win — one click to merge
+    } else if has_claude_working {
+        20 // In progress, no action needed
+    } else if pr_waiting_review {
+        21 // Waiting on others, nothing to do
+    } else if has_pr {
+        22 // PR exists but unclear state
     } else {
-        // No PR — check if Claude is actively working in sessions.
-        if sessions.iter().any(|s| {
-            s.claude
-                .as_ref()
-                .is_some_and(|c| c.status == ClaudeState::Working)
-        }) {
-            return DisplayGroup::ClaudeWorking;
-        }
-    }
+        30 // No PR, no sessions — lowest urgency
+    };
 
-    DisplayGroup::Other
+    // Tiebreaker: priority labels shift within the tier (max shift of 4)
+    let label_bonus = label_priority_weight(
+        &row.issue_labels,
+        row.pr.as_ref().map(|p| &p.labels),
+    );
+    // label_bonus is 0-3 for P0-P3, 100 for no label. Clamp to 0-4 range.
+    let tiebreak = if label_bonus <= 3 { label_bonus } else { 4 };
+
+    base * 10 + tiebreak
+}
+
+/// Returns a priority weight from labels. Lower = higher priority.
+/// Used as a tiebreaker within focus score tiers.
+fn label_priority_weight(issue_labels: &[String], pr_labels: Option<&Vec<String>>) -> u32 {
+    let all_labels = issue_labels.iter().chain(pr_labels.into_iter().flatten());
+    let mut best = 100u32;
+    for label in all_labels {
+        let lower = label.to_lowercase();
+        let weight = match lower.as_str() {
+            "p0" | "critical" | "urgent" => 0,
+            "p1" | "high" => 1,
+            "p2" | "medium" => 2,
+            "p3" | "low" => 3,
+            _ => continue,
+        };
+        best = best.min(weight);
+    }
+    best
 }
 
 fn is_default_branch(branch: &str) -> bool {
     matches!(branch, "main" | "master" | "develop" | "dev")
-}
-
-fn is_needs_attention(pr: &PrInfo) -> bool {
-    pr.review_decision.as_deref() == Some("changes_requested")
-        || pr.has_conflicts
-        || pr.checks_state.as_deref() == Some("failing")
-        || pr.unresolved_threads > 0
-}
-
-fn is_ready_to_merge(pr: &PrInfo) -> bool {
-    pr.review_decision.as_deref() == Some("approved")
-        && pr.checks_state.as_deref() == Some("passing")
-        && !pr.has_conflicts
-        && pr.unresolved_threads == 0
 }
 
 // ---------------------------------------------------------------------------
@@ -808,7 +865,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn display_group_needs_attention_changes_requested() {
+    fn display_group_normal_changes_requested_no_session() {
+        // Without an active session, changes_requested PR → Normal
         let prs = vec![CachedPr {
             review_decision: Some("changes_requested".to_string()),
             ..pr_for_branch(55, "feat/branch")
@@ -819,11 +877,11 @@ mod tests {
         let all_wts = vec![worktree("/workspace/repo", "main"), worktrees[0].clone()];
         let rows = derive_worktree_rows(&[], &prs, &all_wts, &[], "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::NeedsAttention);
+        assert_eq!(rows[1].display_group, DisplayGroup::Normal);
     }
 
     #[test]
-    fn display_group_needs_attention_conflicts() {
+    fn display_group_normal_conflicts_no_session() {
         let prs = vec![CachedPr {
             has_conflicts: true,
             ..pr_for_branch(55, "feat/branch")
@@ -834,11 +892,11 @@ mod tests {
         ];
         let rows = derive_worktree_rows(&[], &prs, &all_wts, &[], "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::NeedsAttention);
+        assert_eq!(rows[1].display_group, DisplayGroup::Normal);
     }
 
     #[test]
-    fn display_group_needs_attention_failing_ci() {
+    fn display_group_normal_failing_ci_no_session() {
         let prs = vec![CachedPr {
             checks_state: Some("failing".to_string()),
             ..pr_for_branch(55, "feat/branch")
@@ -849,11 +907,11 @@ mod tests {
         ];
         let rows = derive_worktree_rows(&[], &prs, &all_wts, &[], "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::NeedsAttention);
+        assert_eq!(rows[1].display_group, DisplayGroup::Normal);
     }
 
     #[test]
-    fn display_group_needs_attention_unresolved_threads() {
+    fn display_group_normal_unresolved_threads_no_session() {
         let prs = vec![CachedPr {
             unresolved_threads: 2,
             ..pr_for_branch(55, "feat/branch")
@@ -864,11 +922,11 @@ mod tests {
         ];
         let rows = derive_worktree_rows(&[], &prs, &all_wts, &[], "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::NeedsAttention);
+        assert_eq!(rows[1].display_group, DisplayGroup::Normal);
     }
 
     #[test]
-    fn display_group_claude_working_with_pr() {
+    fn display_group_active_claude_working_with_pr() {
         let prs = vec![pr_for_branch(55, "feat/branch")];
         let all_wts = vec![
             worktree("/workspace/repo", "main"),
@@ -881,11 +939,11 @@ mod tests {
 
         let rows = derive_worktree_rows(&[], &prs, &all_wts, &sessions, "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::ClaudeWorking);
+        assert_eq!(rows[1].display_group, DisplayGroup::Active);
     }
 
     #[test]
-    fn display_group_claude_working_without_pr() {
+    fn display_group_active_claude_working_without_pr() {
         let all_wts = vec![
             worktree("/workspace/repo", "main"),
             worktree("/workspace/repo-47", "feat/branch"),
@@ -897,11 +955,12 @@ mod tests {
 
         let rows = derive_worktree_rows(&[], &[], &all_wts, &sessions, "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::ClaudeWorking);
+        assert_eq!(rows[1].display_group, DisplayGroup::Active);
     }
 
     #[test]
-    fn display_group_ready_to_merge() {
+    fn display_group_normal_ready_to_merge_no_session() {
+        // Ready-to-merge with no active session → Normal
         let prs = vec![approved_passing_pr_for_branch(55, "feat/branch")];
         let all_wts = vec![
             worktree("/workspace/repo", "main"),
@@ -909,26 +968,63 @@ mod tests {
         ];
         let rows = derive_worktree_rows(&[], &prs, &all_wts, &[], "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::ReadyToMerge);
+        assert_eq!(rows[1].display_group, DisplayGroup::Normal);
     }
 
     #[test]
-    fn display_group_other_no_pr() {
+    fn display_group_normal_no_pr() {
         let all_wts = vec![
             worktree("/workspace/repo", "main"),
             worktree("/workspace/repo-feat", "feat/branch"),
         ];
         let rows = derive_worktree_rows(&[], &[], &all_wts, &[], "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::Other);
+        assert_eq!(rows[1].display_group, DisplayGroup::Normal);
+    }
+
+    #[test]
+    fn display_group_done_closed_issue_no_pr() {
+        let issues = vec![CachedIssue {
+            number: 47,
+            title: "done issue".to_string(),
+            state: "closed".to_string(),
+            labels: vec![],
+        }];
+        let all_wts = vec![
+            worktree("/workspace/repo", "main"),
+            worktree("/workspace/repo-47", "feat/issue-47"),
+        ];
+        let rows = derive_worktree_rows(&issues, &[], &all_wts, &[], "owner/repo", &[]);
+
+        assert_eq!(rows[1].display_group, DisplayGroup::Done);
+    }
+
+    #[test]
+    fn display_group_done_closed_issue_with_merged_pr() {
+        let issues = vec![CachedIssue {
+            number: 47,
+            title: "done issue".to_string(),
+            state: "closed".to_string(),
+            labels: vec![],
+        }];
+        let prs = vec![CachedPr {
+            state: "merged".to_string(),
+            ..pr_for_branch(55, "feat/issue-47")
+        }];
+        let all_wts = vec![
+            worktree("/workspace/repo", "main"),
+            worktree("/workspace/repo-47", "feat/issue-47"),
+        ];
+        let rows = derive_worktree_rows(&issues, &prs, &all_wts, &[], "owner/repo", &[]);
+
+        assert_eq!(rows[1].display_group, DisplayGroup::Done);
     }
 
     #[test]
     fn display_group_ordering() {
-        assert!(DisplayGroup::RepoMain < DisplayGroup::NeedsAttention);
-        assert!(DisplayGroup::NeedsAttention < DisplayGroup::ClaudeWorking);
-        assert!(DisplayGroup::ClaudeWorking < DisplayGroup::ReadyToMerge);
-        assert!(DisplayGroup::ReadyToMerge < DisplayGroup::Other);
+        assert!(DisplayGroup::RepoMain < DisplayGroup::Active);
+        assert!(DisplayGroup::Active < DisplayGroup::Normal);
+        assert!(DisplayGroup::Normal < DisplayGroup::Done);
     }
 
     #[test]
@@ -1013,7 +1109,7 @@ mod tests {
     }
 
     #[test]
-    fn display_group_needs_attention_when_claude_needs_input() {
+    fn display_group_active_when_claude_needs_input() {
         let all_wts = vec![
             worktree("/workspace/repo", "main"),
             worktree("/workspace/repo-47", "feat/branch"),
@@ -1026,11 +1122,11 @@ mod tests {
 
         let rows = derive_worktree_rows(&[], &[], &all_wts, &sessions, "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::NeedsAttention);
+        assert_eq!(rows[1].display_group, DisplayGroup::Active);
     }
 
     #[test]
-    fn claude_needs_input_takes_priority_over_claude_working() {
+    fn active_when_claude_needs_input_with_pr() {
         let prs = vec![pr_for_branch(55, "feat/branch")];
         let all_wts = vec![
             worktree("/workspace/repo", "main"),
@@ -1044,11 +1140,12 @@ mod tests {
 
         let rows = derive_worktree_rows(&[], &prs, &all_wts, &sessions, "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::NeedsAttention);
+        assert_eq!(rows[1].display_group, DisplayGroup::Active);
     }
 
     #[test]
-    fn needs_attention_takes_priority_over_claude_working() {
+    fn active_when_claude_session_present_despite_pr_issues() {
+        // Session presence trumps PR state — any active Claude session = Active
         let prs = vec![CachedPr {
             review_decision: Some("changes_requested".to_string()),
             ..pr_for_branch(55, "feat/branch")
@@ -1061,7 +1158,7 @@ mod tests {
 
         let rows = derive_worktree_rows(&[], &prs, &all_wts, &sessions, "owner/repo", &[]);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::NeedsAttention);
+        assert_eq!(rows[1].display_group, DisplayGroup::Active);
     }
 
     // -----------------------------------------------------------------------
@@ -1085,7 +1182,8 @@ mod tests {
 
         assert_eq!(rows[0].display_group, DisplayGroup::RepoMain);
         assert!(rows[0].is_main_worktree);
-        assert_eq!(rows[1].display_group, DisplayGroup::ReadyToMerge);
+        // Ready-to-merge with no session → Normal
+        assert_eq!(rows[1].display_group, DisplayGroup::Normal);
     }
 
     #[test]
@@ -1116,29 +1214,31 @@ mod tests {
 
         let rows = derive_all_repos(&repo_caches, &[]);
 
-        // RepoMain first (sorted by issue number / branch)
+        // RepoMain rows come first
         let shepherd_rows: Vec<&WorktreeRow> = rows
             .iter()
             .filter(|r| r.display_group == DisplayGroup::RepoMain)
             .collect();
         assert_eq!(shepherd_rows.len(), 2);
 
-        // ReadyToMerge before Other
+        // All non-main rows are Normal (no sessions, no closed issues)
         let non_shepherd: Vec<&WorktreeRow> = rows
             .iter()
             .filter(|r| r.display_group != DisplayGroup::RepoMain)
             .collect();
-        assert_eq!(non_shepherd[0].display_group, DisplayGroup::ReadyToMerge);
-        assert_eq!(non_shepherd[0].issue_number, Some(100));
-
-        // Other rows sorted by issue number
-        let other_rows: Vec<&WorktreeRow> = rows
+        assert!(non_shepherd
             .iter()
-            .filter(|r| r.display_group == DisplayGroup::Other)
+            .all(|r| r.display_group == DisplayGroup::Normal));
+
+        // Normal rows sorted by issue number
+        let normal_rows: Vec<&WorktreeRow> = rows
+            .iter()
+            .filter(|r| r.display_group == DisplayGroup::Normal)
             .collect();
-        assert_eq!(other_rows.len(), 2);
-        assert_eq!(other_rows[0].issue_number, Some(300));
-        assert_eq!(other_rows[1].issue_number, Some(500));
+        assert_eq!(normal_rows.len(), 3);
+        assert_eq!(normal_rows[0].issue_number, Some(100));
+        assert_eq!(normal_rows[1].issue_number, Some(300));
+        assert_eq!(normal_rows[2].issue_number, Some(500));
     }
 
     #[test]
@@ -1157,13 +1257,82 @@ mod tests {
 
         let rows = derive_all_repos(&repo_caches, &[]);
 
-        let other_rows: Vec<&WorktreeRow> = rows
+        let normal_rows: Vec<&WorktreeRow> = rows
             .iter()
-            .filter(|r| r.display_group == DisplayGroup::Other)
+            .filter(|r| r.display_group == DisplayGroup::Normal)
             .collect();
-        assert_eq!(other_rows.len(), 2);
-        assert_eq!(other_rows[0].branch, "a-feature");
-        assert_eq!(other_rows[1].branch, "z-feature");
+        assert_eq!(normal_rows.len(), 2);
+        assert_eq!(normal_rows[0].branch, "a-feature");
+        assert_eq!(normal_rows[1].branch, "z-feature");
+    }
+
+    #[test]
+    fn label_priority_weight_p0_is_lowest() {
+        assert_eq!(label_priority_weight(&["p0".to_string()], None), 0);
+    }
+
+    #[test]
+    fn label_priority_weight_p1_is_1() {
+        assert_eq!(label_priority_weight(&["p1".to_string()], None), 1);
+    }
+
+    #[test]
+    fn label_priority_weight_no_label_is_100() {
+        assert_eq!(label_priority_weight(&["bugfix".to_string()], None), 100);
+    }
+
+    #[test]
+    fn label_priority_weight_pr_labels_checked() {
+        assert_eq!(
+            label_priority_weight(&[], Some(&vec!["critical".to_string()])),
+            0
+        );
+    }
+
+    #[test]
+    fn label_priority_weight_best_wins() {
+        assert_eq!(
+            label_priority_weight(&["p3".to_string(), "p1".to_string()], None),
+            1
+        );
+    }
+
+    #[test]
+    fn derive_all_repos_sorts_by_label_weight_within_group() {
+        let repo_caches = vec![(
+            "owner/repo".to_string(),
+            vec![
+                CachedIssue {
+                    number: 1,
+                    title: "low priority".to_string(),
+                    state: "open".to_string(),
+                    labels: vec!["p3".to_string()],
+                },
+                CachedIssue {
+                    number: 2,
+                    title: "critical".to_string(),
+                    state: "open".to_string(),
+                    labels: vec!["p0".to_string()],
+                },
+            ],
+            vec![],
+            vec![
+                worktree("/workspace/repo", "main"),
+                worktree("/workspace/repo-1", "feat/issue-1"),
+                worktree("/workspace/repo-2", "feat/issue-2"),
+            ],
+            vec![],
+        )];
+
+        let rows = derive_all_repos(&repo_caches, &[]);
+
+        let normal_rows: Vec<&WorktreeRow> = rows
+            .iter()
+            .filter(|r| r.display_group == DisplayGroup::Normal)
+            .collect();
+        // p0 (issue 2) should sort before p3 (issue 1) despite higher issue number
+        assert_eq!(normal_rows[0].issue_number, Some(2));
+        assert_eq!(normal_rows[1].issue_number, Some(1));
     }
 
     // -----------------------------------------------------------------------
@@ -1275,7 +1444,7 @@ mod tests {
     }
 
     #[test]
-    fn hook_state_display_group_input_becomes_needs_attention() {
+    fn hook_state_display_group_input_becomes_active() {
         let all_wts = vec![
             worktree("/workspace/repo", "main"),
             worktree("/workspace/repo-47", "feat/branch"),
@@ -1285,11 +1454,11 @@ mod tests {
 
         let rows = derive_worktree_rows(&[], &[], &all_wts, &sessions, "owner/repo", &states);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::NeedsAttention);
+        assert_eq!(rows[1].display_group, DisplayGroup::Active);
     }
 
     #[test]
-    fn hook_state_display_group_working_becomes_claude_working() {
+    fn hook_state_display_group_working_becomes_active() {
         let all_wts = vec![
             worktree("/workspace/repo", "main"),
             worktree("/workspace/repo-47", "feat/branch"),
@@ -1299,7 +1468,7 @@ mod tests {
 
         let rows = derive_worktree_rows(&[], &[], &all_wts, &sessions, "owner/repo", &states);
 
-        assert_eq!(rows[1].display_group, DisplayGroup::ClaudeWorking);
+        assert_eq!(rows[1].display_group, DisplayGroup::Active);
     }
 
     #[test]

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -697,6 +697,68 @@ mod tests {
     }
 
     #[test]
+    fn session_does_not_match_worktree_with_longer_path_sharing_prefix() {
+        // Regression guard for bug #191: session at "/workspace/langwatch" must
+        // NOT match the worktree at "/workspace/langwatch-sdk". The paths must
+        // be equal, not merely prefix-sharing.
+        let worktrees = vec![
+            worktree("/workspace/langwatch-sdk", "main"),
+            worktree("/workspace/langwatch-sdk-feat", "feat/branch"),
+        ];
+        let sessions = vec![session("langwatch", "/workspace/langwatch", vec!["bash"])];
+
+        let rows = derive_worktree_rows(&[], &[], &worktrees, &sessions, "owner/repo", &[]);
+
+        assert_eq!(rows.len(), 2);
+        // Neither worktree should have the session attached — path is different.
+        assert!(
+            rows[0].sessions.is_empty(),
+            "langwatch-sdk must not receive the langwatch session"
+        );
+        assert!(
+            rows[1].sessions.is_empty(),
+            "langwatch-sdk-feat must not receive the langwatch session"
+        );
+    }
+
+    #[test]
+    fn session_does_not_match_worktree_when_path_is_substring() {
+        // "main" session must NOT match "/workspace/domain-main-service" worktree.
+        let worktrees = vec![worktree("/workspace/domain-main-service", "feat/branch")];
+        let sessions = vec![session("main", "/workspace/main", vec!["bash"])];
+
+        let rows = derive_worktree_rows(&[], &[], &worktrees, &sessions, "owner/repo", &[]);
+
+        assert_eq!(rows.len(), 1);
+        assert!(
+            rows[0].sessions.is_empty(),
+            "domain-main-service must not receive the main session"
+        );
+    }
+
+    #[test]
+    fn session_with_trailing_slash_joins_correct_worktree() {
+        // Tmux on some versions appends a trailing slash to #{session_path}.
+        // After normalization, it should still match exactly.
+        let worktrees = vec![worktree("/workspace/webapp-47", "feat/branch")];
+        // Trailing slash is stripped by normalize_path when building CachedTmuxSession,
+        // so the stored path is "/workspace/webapp-47" — we pass the normalized form here.
+        let normalized_sessions = vec![session("webapp_47", "/workspace/webapp-47", vec!["bash"])];
+
+        let rows = derive_worktree_rows(
+            &[],
+            &[],
+            &worktrees,
+            &normalized_sessions,
+            "owner/repo",
+            &[],
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].sessions.len(), 1);
+    }
+
+    #[test]
     fn multiple_sessions_at_same_path_all_join() {
         let worktrees = vec![worktree("/workspace/webapp-47", "feat/task-centric")];
         let sessions = vec![

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -483,8 +483,7 @@ fn focus_score(row: &WorktreeRow) -> u32 {
             && p.checks_state.as_deref() == Some("SUCCESS")
     });
     let pr_waiting_review = row.pr.as_ref().is_some_and(|p| {
-        p.review_decision.as_deref() == Some("REVIEW_REQUIRED")
-            || p.review_decision.is_none()
+        p.review_decision.as_deref() == Some("REVIEW_REQUIRED") || p.review_decision.is_none()
     });
     let has_pr = row.pr.is_some();
 
@@ -512,10 +511,7 @@ fn focus_score(row: &WorktreeRow) -> u32 {
     };
 
     // Tiebreaker: priority labels shift within the tier (max shift of 4)
-    let label_bonus = label_priority_weight(
-        &row.issue_labels,
-        row.pr.as_ref().map(|p| &p.labels),
-    );
+    let label_bonus = label_priority_weight(&row.issue_labels, row.pr.as_ref().map(|p| &p.labels));
     // label_bonus is 0-3 for P0-P3, 100 for no label. Clamp to 0-4 range.
     let tiebreak = if label_bonus <= 3 { label_bonus } else { 4 };
 
@@ -1379,9 +1375,11 @@ mod tests {
             .iter()
             .filter(|r| r.display_group != DisplayGroup::RepoMain)
             .collect();
-        assert!(non_shepherd
-            .iter()
-            .all(|r| r.display_group == DisplayGroup::Normal));
+        assert!(
+            non_shepherd
+                .iter()
+                .all(|r| r.display_group == DisplayGroup::Normal)
+        );
 
         // Normal rows sorted by issue number
         let normal_rows: Vec<&WorktreeRow> = rows

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -5,6 +5,7 @@
 //! here — all input comes from the cache layer, making this fully testable.
 use crate::cache::{CachedIssue, CachedPr, CachedTmuxSession, CachedWorktree};
 use crate::github;
+use crate::paths::paths_match;
 use crate::session::{
     ClaudeSessionInfo, EnrichedSession, Host, PaneInfo, SessionStatus, TmuxSessionInfo, WindowInfo,
     build_windows_and_panes,
@@ -140,7 +141,7 @@ pub fn derive_worktree_rows(
 
         let session_infos: Vec<EnrichedSession> = sessions
             .iter()
-            .filter(|s| s.path == wt.path)
+            .filter(|s| paths_match(&s.path, &wt.path))
             .map(|s| enrich_session(s, claude_states))
             .collect();
 
@@ -1018,6 +1019,67 @@ mod tests {
         let rows = derive_worktree_rows(&issues, &prs, &all_wts, &[], "owner/repo", &[]);
 
         assert_eq!(rows[1].display_group, DisplayGroup::Done);
+    }
+
+    #[test]
+    fn merged_pr_in_cache_links_to_worktree_branch() {
+        // Regression: merged PRs must be matched to their worktree by branch name
+        // so that `orchard --json` shows the PR on the worktree row. This requires
+        // the PR cache to contain merged PRs (fixed in refresh_prs: states: [OPEN, MERGED]).
+        let prs = vec![CachedPr {
+            state: "merged".to_string(),
+            ..pr_for_branch(99, "feat/issue-99")
+        }];
+        let worktrees = vec![
+            worktree("/workspace/repo", "main"),
+            worktree("/workspace/repo-99", "feat/issue-99"),
+        ];
+
+        let rows = derive_worktree_rows(&[], &prs, &worktrees, &[], "owner/repo", &[]);
+
+        let feat_row = rows
+            .iter()
+            .find(|r| r.branch == "feat/issue-99")
+            .expect("worktree row for feat/issue-99 must exist");
+        let pr = feat_row
+            .pr
+            .as_ref()
+            .expect("merged PR must be linked to the worktree");
+        assert_eq!(pr.number, 99);
+        assert_eq!(pr.state.as_deref(), Some("merged"));
+    }
+
+    #[test]
+    fn merged_pr_with_closed_issue_is_done() {
+        // When a merged PR is in the cache (bug #95 fixed), and its linked issue
+        // is closed, the worktree row must derive DisplayGroup::Done (bug #152).
+        let issues = vec![CachedIssue {
+            number: 99,
+            title: "completed feature".to_string(),
+            state: "closed".to_string(),
+            labels: vec![],
+        }];
+        let prs = vec![CachedPr {
+            linked_issue: Some(99),
+            state: "merged".to_string(),
+            ..pr_for_branch(55, "feat/issue-99")
+        }];
+        let worktrees = vec![
+            worktree("/workspace/repo", "main"),
+            worktree("/workspace/repo-99", "feat/issue-99"),
+        ];
+
+        let rows = derive_worktree_rows(&issues, &prs, &worktrees, &[], "owner/repo", &[]);
+
+        let feat_row = rows
+            .iter()
+            .find(|r| r.branch == "feat/issue-99")
+            .expect("worktree row for feat/issue-99 must exist");
+        assert_eq!(
+            feat_row.display_group,
+            DisplayGroup::Done,
+            "merged PR + closed issue must derive DisplayGroup::Done"
+        );
     }
 
     #[test]

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -68,6 +68,10 @@ pub struct PrInfo {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Individual non-passing CI checks, before non-blocking exclusion filtering.
+    pub failing_checks: Vec<crate::orchard_state::FailedCheck>,
+    /// Labels applied to this PR.
+    pub labels: Vec<String>,
 }
 
 /// One row in the derived worktree view. Corresponds to one non-bare worktree,
@@ -89,6 +93,8 @@ pub struct WorktreeRow {
     /// State of the linked issue ("open", "closed", "completed"), if any.
     /// Used to detect stale worktrees whose issue has been resolved without a PR.
     pub issue_state: Option<String>,
+    /// Labels applied to the linked issue, if any.
+    pub issue_labels: Vec<String>,
     /// Linked pull request, if one exists for this branch.
     pub pr: Option<PrInfo>,
     /// Active tmux sessions associated with this worktree path.
@@ -148,6 +154,9 @@ pub fn derive_worktree_rows(
         let linked_issue = issue_number.and_then(|num| issues.iter().find(|i| i.number == num));
         let issue_title = linked_issue.map(|i| i.title.clone());
         let issue_state = linked_issue.map(|i| i.state.clone());
+        let issue_labels = linked_issue
+            .map(|i| i.labels.clone())
+            .unwrap_or_default();
 
         let is_main_worktree =
             is_first_non_bare || session_infos.iter().any(|s| s.tmux.name.ends_with("_main"));
@@ -168,6 +177,7 @@ pub fn derive_worktree_rows(
             issue_number,
             issue_title,
             issue_state,
+            issue_labels,
             pr: pr_info,
             sessions: session_infos,
             display_group,
@@ -227,6 +237,8 @@ fn pr_info_from(pr: &CachedPr) -> PrInfo {
         checks_state: pr.checks_state.clone(),
         has_conflicts: pr.has_conflicts,
         unresolved_threads: pr.unresolved_threads,
+        failing_checks: pr.failing_checks.clone(),
+        labels: pr.labels.clone(),
     }
 }
 
@@ -501,6 +513,8 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            failing_checks: vec![],
+            labels: vec![],
         }
     }
 
@@ -515,6 +529,8 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            failing_checks: vec![],
+            labels: vec![],
         }
     }
 

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -102,6 +102,13 @@ pub struct WorktreeRow {
     pub display_group: DisplayGroup,
     /// True when this is the repo's main worktree.
     pub is_main_worktree: bool,
+    /// Unix timestamp (seconds) of the most recent tmux activity across all
+    /// sessions attached to this worktree. `None` when no sessions are
+    /// attached or none reported activity.
+    ///
+    /// Used as a sort tiebreaker within a display group: rows with more recent
+    /// activity sort before those with older or no activity.
+    pub last_activity: Option<u64>,
 }
 
 // ---------------------------------------------------------------------------
@@ -139,9 +146,18 @@ pub fn derive_worktree_rows(
         };
         let pr_info = pr.map(pr_info_from);
 
-        let session_infos: Vec<EnrichedSession> = sessions
+        let matched_sessions: Vec<&CachedTmuxSession> = sessions
             .iter()
             .filter(|s| paths_match(&s.path, &wt.path))
+            .collect();
+
+        let last_activity = matched_sessions
+            .iter()
+            .filter_map(|s| s.last_activity)
+            .max();
+
+        let session_infos: Vec<EnrichedSession> = matched_sessions
+            .iter()
             .map(|s| enrich_session(s, claude_states))
             .collect();
 
@@ -177,6 +193,7 @@ pub fn derive_worktree_rows(
             sessions: session_infos,
             display_group,
             is_main_worktree,
+            last_activity,
         });
 
         is_first_non_bare = false;
@@ -218,7 +235,18 @@ pub fn derive_all_repos(
         if focus_ord != std::cmp::Ordering::Equal {
             return focus_ord;
         }
-        // Tertiary: issue number ascending
+        // Tertiary: last tmux activity — more recent activity sorts first.
+        // Rows with no activity sort after rows with activity.
+        let activity_ord = match (a.last_activity, b.last_activity) {
+            (Some(a_ts), Some(b_ts)) => b_ts.cmp(&a_ts), // reverse: higher timestamp first
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => std::cmp::Ordering::Equal,
+        };
+        if activity_ord != std::cmp::Ordering::Equal {
+            return activity_ord;
+        }
+        // Quaternary: issue number ascending
         match (a.issue_number, b.issue_number) {
             (Some(a_num), Some(b_num)) => a_num.cmp(&b_num),
             (Some(_), None) => std::cmp::Ordering::Less,
@@ -628,6 +656,7 @@ mod tests {
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
+            last_activity: None,
         }
     }
 
@@ -1747,6 +1776,7 @@ mod tests {
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
+            last_activity: None,
         }
     }
 
@@ -1783,6 +1813,7 @@ mod tests {
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
+            last_activity: None,
         };
         let enriched = enrich_session_from_scraping_for_test(&sess);
         assert!(enriched.panes.is_empty());

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -668,12 +668,10 @@ mod tests {
     fn json_pr_includes_failing_checks_field() {
         use crate::orchard_state::FailedCheck;
         let pr = PrState {
-            failing_checks: vec![
-                FailedCheck {
-                    name: "e2e-tests".to_string(),
-                    conclusion: "FAILURE".to_string(),
-                },
-            ],
+            failing_checks: vec![FailedCheck {
+                name: "e2e-tests".to_string(),
+                conclusion: "FAILURE".to_string(),
+            }],
             ..make_pr_state()
         };
         let jp = JsonPr::from(&pr);

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -200,11 +200,9 @@ pub struct JsonHostState {
 fn display_group_str(g: DisplayGroup) -> &'static str {
     match g {
         DisplayGroup::RepoMain => "repo_main",
-        DisplayGroup::Prioritized => "prioritized",
-        DisplayGroup::NeedsAttention => "needs_attention",
-        DisplayGroup::ClaudeWorking => "claude_working",
-        DisplayGroup::ReadyToMerge => "ready_to_merge",
-        DisplayGroup::Other => "other",
+        DisplayGroup::Active => "active",
+        DisplayGroup::Normal => "normal",
+        DisplayGroup::Done => "done",
     }
 }
 
@@ -439,31 +437,24 @@ mod tests {
     }
 
     #[test]
-    fn display_group_needs_attention_serializes_to_snake_case() {
-        let wt = make_worktree(DisplayGroup::NeedsAttention);
+    fn display_group_active_serializes_to_snake_case() {
+        let wt = make_worktree(DisplayGroup::Active);
         let jw = JsonWorktree::from(&wt);
-        assert_eq!(jw.display_group, "needs_attention");
+        assert_eq!(jw.display_group, "active");
     }
 
     #[test]
-    fn display_group_claude_working_serializes_to_snake_case() {
-        let wt = make_worktree(DisplayGroup::ClaudeWorking);
+    fn display_group_normal_serializes_to_snake_case() {
+        let wt = make_worktree(DisplayGroup::Normal);
         let jw = JsonWorktree::from(&wt);
-        assert_eq!(jw.display_group, "claude_working");
+        assert_eq!(jw.display_group, "normal");
     }
 
     #[test]
-    fn display_group_ready_to_merge_serializes_to_snake_case() {
-        let wt = make_worktree(DisplayGroup::ReadyToMerge);
+    fn display_group_done_serializes_to_snake_case() {
+        let wt = make_worktree(DisplayGroup::Done);
         let jw = JsonWorktree::from(&wt);
-        assert_eq!(jw.display_group, "ready_to_merge");
-    }
-
-    #[test]
-    fn display_group_other_serializes_to_snake_case() {
-        let wt = make_worktree(DisplayGroup::Other);
-        let jw = JsonWorktree::from(&wt);
-        assert_eq!(jw.display_group, "other");
+        assert_eq!(jw.display_group, "done");
     }
 
     #[test]

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -11,7 +11,8 @@ use serde::Serialize;
 use crate::claude_state::ClaudeState;
 use crate::derive::DisplayGroup;
 use crate::orchard_state::{
-    IssueInfo, OrchardState, PrState, RepoState, SessionState, WindowState, WorktreeState,
+    FailedCheck, IssueInfo, OrchardState, PrState, RepoState, SessionState, WindowState,
+    WorktreeState,
 };
 use crate::session::StandaloneSessionRow;
 
@@ -73,7 +74,7 @@ pub struct JsonWorktree {
 
 /// Issue information in JSON output.
 ///
-/// Subset of GitHub issue data: number, title, and state (open/closed).
+/// Subset of GitHub issue data: number, title, state (open/closed), and labels.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonIssue {
@@ -83,11 +84,13 @@ pub struct JsonIssue {
     pub title: String,
     /// Issue state: "open", "closed", or "completed".
     pub state: String,
+    /// Labels applied to this issue.
+    pub labels: Vec<String>,
 }
 
 /// Pull request information in JSON output.
 ///
-/// Includes PR metadata: number, branch, state, review decision, CI checks, conflicts, and unresolved review threads.
+/// Includes PR metadata: number, branch, state, review decision, CI checks, conflicts, unresolved review threads, and failing check details.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonPr {
@@ -105,6 +108,10 @@ pub struct JsonPr {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Individual failing CI checks (name + conclusion).
+    pub failing_checks: Vec<FailedCheck>,
+    /// Labels applied to this PR.
+    pub labels: Vec<String>,
 }
 
 /// Session information in JSON output using the EnrichedSession shape.
@@ -218,6 +225,7 @@ impl From<&IssueInfo> for JsonIssue {
             number: i.number,
             title: i.title.clone(),
             state: i.state.clone(),
+            labels: i.labels.clone(),
         }
     }
 }
@@ -233,6 +241,8 @@ impl From<&PrState> for JsonPr {
             checks_state: pr.checks_state.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            failing_checks: pr.failing_checks.clone(),
+            labels: pr.labels.clone(),
         }
     }
 }
@@ -356,7 +366,7 @@ impl From<&StandaloneSessionRow> for JsonSession {
 }
 
 impl From<&OrchardState> for JsonOutput {
-    /// Converts the unified `OrchardState` to JSON output, setting version to 4.
+    /// Converts the unified `OrchardState` to JSON output, setting version to 5.
     fn from(state: &OrchardState) -> Self {
         let hosts = state
             .hosts
@@ -372,7 +382,7 @@ impl From<&OrchardState> for JsonOutput {
             .collect();
 
         Self {
-            version: 4,
+            version: 5,
             tmux_sessions: state.standalone_sessions.iter().map(Into::into).collect(),
             repos: state.repos.iter().map(Into::into).collect(),
             hosts,
@@ -405,9 +415,9 @@ mod tests {
     }
 
     #[test]
-    fn from_orchard_state_produces_version_4() {
+    fn from_orchard_state_produces_version_5() {
         let output = JsonOutput::from(&empty_state());
-        assert_eq!(output.version, 4);
+        assert_eq!(output.version, 5);
     }
 
     #[test]
@@ -573,9 +583,9 @@ mod tests {
     }
 
     #[test]
-    fn json_version_is_4() {
+    fn json_version_is_5() {
         let output = JsonOutput::from(&empty_state());
-        assert_eq!(output.version, 4);
+        assert_eq!(output.version, 5);
     }
 
     #[test]
@@ -636,5 +646,102 @@ mod tests {
         };
         let js = JsonSession::from(&session);
         assert_eq!(js.windows.len(), 1);
+    }
+
+    // -- JsonPr failing_checks and labels tests -------------------------------
+
+    fn make_pr_state() -> PrState {
+        PrState {
+            number: 99,
+            branch: "feat/test".to_string(),
+            state: Some("OPEN".to_string()),
+            review_decision: None,
+            checks_state: Some("failing".to_string()),
+            has_conflicts: false,
+            unresolved_threads: 0,
+            failing_checks: vec![],
+            labels: vec![],
+        }
+    }
+
+    #[test]
+    fn json_pr_includes_failing_checks_field() {
+        use crate::orchard_state::FailedCheck;
+        let pr = PrState {
+            failing_checks: vec![
+                FailedCheck {
+                    name: "e2e-tests".to_string(),
+                    conclusion: "FAILURE".to_string(),
+                },
+            ],
+            ..make_pr_state()
+        };
+        let jp = JsonPr::from(&pr);
+        assert_eq!(jp.failing_checks.len(), 1);
+        assert_eq!(jp.failing_checks[0].name, "e2e-tests");
+        assert_eq!(jp.failing_checks[0].conclusion, "FAILURE");
+    }
+
+    #[test]
+    fn json_pr_failing_checks_empty_by_default() {
+        let pr = make_pr_state();
+        let jp = JsonPr::from(&pr);
+        assert!(jp.failing_checks.is_empty());
+    }
+
+    #[test]
+    fn json_pr_failing_checks_serializes_to_camelcase() {
+        use crate::orchard_state::FailedCheck;
+        let pr = PrState {
+            failing_checks: vec![FailedCheck {
+                name: "unit-tests".to_string(),
+                conclusion: "TIMED_OUT".to_string(),
+            }],
+            ..make_pr_state()
+        };
+        let value = serde_json::to_value(JsonPr::from(&pr)).unwrap();
+        assert!(
+            value.get("failingChecks").is_some(),
+            "expected camelCase 'failingChecks'"
+        );
+        let checks = &value["failingChecks"];
+        assert_eq!(checks[0]["name"], "unit-tests");
+        assert_eq!(checks[0]["conclusion"], "TIMED_OUT");
+    }
+
+    #[test]
+    fn json_pr_includes_labels_field() {
+        let pr = PrState {
+            labels: vec!["bug".to_string(), "priority:high".to_string()],
+            ..make_pr_state()
+        };
+        let jp = JsonPr::from(&pr);
+        assert_eq!(jp.labels, vec!["bug", "priority:high"]);
+    }
+
+    // -- JsonIssue labels test ------------------------------------------------
+
+    #[test]
+    fn json_issue_includes_labels_field() {
+        let issue = IssueInfo {
+            number: 1,
+            title: "Test issue".to_string(),
+            state: "open".to_string(),
+            labels: vec!["enhancement".to_string()],
+        };
+        let ji = JsonIssue::from(&issue);
+        assert_eq!(ji.labels, vec!["enhancement"]);
+    }
+
+    #[test]
+    fn json_issue_labels_empty_by_default() {
+        let issue = IssueInfo {
+            number: 2,
+            title: "Another issue".to_string(),
+            state: "open".to_string(),
+            labels: vec![],
+        };
+        let ji = JsonIssue::from(&issue);
+        assert!(ji.labels.is_empty());
     }
 }

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -87,7 +87,7 @@ pub struct JsonIssue {
 
 /// Pull request information in JSON output.
 ///
-/// Includes PR metadata: number, branch, state, review decision, CI checks, conflicts, and unresolved review threads.
+/// Includes PR metadata: number, branch, state, review decision, CI checks, conflicts, unresolved review threads, and draft status.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonPr {
@@ -105,6 +105,8 @@ pub struct JsonPr {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Whether the PR is a draft (not ready for review).
+    pub is_draft: bool,
 }
 
 /// Session information in JSON output using the EnrichedSession shape.
@@ -233,6 +235,7 @@ impl From<&PrState> for JsonPr {
             checks_state: pr.checks_state.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            is_draft: pr.is_draft,
         }
     }
 }

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -248,13 +248,18 @@ fn handle_json() {
 /// Runs the TUI. If inside tmux and run directly (not via popup wrapper),
 /// re-launches itself as a tmux popup using the wrapper script so that
 /// session switching works correctly after the popup closes.
+///
+/// Set `ORCHARD_NO_POPUP=1` to skip the popup re-launch and run the TUI
+/// directly in the current pane. Useful when tmux popups are broken or
+/// rendering incorrectly in your terminal.
 fn handle_tui(command: &str) {
     let inside_tmux = env::var("TMUX").is_ok();
     let is_tty = std::io::stdout().is_terminal();
+    let no_popup = env::var("ORCHARD_NO_POPUP").is_ok();
 
     // If inside tmux and stdout is a TTY, we were run directly (not via popup).
-    // Re-launch as a popup through the wrapper script.
-    if inside_tmux && is_tty {
+    // Re-launch as a popup through the wrapper script (unless ORCHARD_NO_POPUP is set).
+    if inside_tmux && is_tty && !no_popup {
         let wrapper = dirs::home_dir()
             .map(|h| h.join(".local/bin/orchard-popup"))
             .unwrap_or_else(|| std::path::PathBuf::from("orchard-popup"));

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -467,7 +467,10 @@ mod tests {
             is_draft: true,
         };
         let pr_state = PrState::from(&pr_info);
-        assert!(pr_state.is_draft, "is_draft must propagate from PrInfo to PrState");
+        assert!(
+            pr_state.is_draft,
+            "is_draft must propagate from PrInfo to PrState"
+        );
     }
 
     // -- From<&EnrichedSession> for SessionState tests ----------------------

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -6,6 +6,8 @@
 
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::claude_state::ClaudeState;
 use crate::derive::DisplayGroup;
 use crate::session::{EnrichedSession, Host, StandaloneSessionRow};
@@ -110,6 +112,17 @@ pub struct IssueInfo {
     pub title: String,
     /// Issue state: "open", "closed", or "completed".
     pub state: String,
+    /// Labels applied to this issue.
+    pub labels: Vec<String>,
+}
+
+/// A single non-passing CI check.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FailedCheck {
+    /// Check name (e.g. "e2e-tests", "ci/travis").
+    pub name: String,
+    /// GitHub conclusion string (e.g. "FAILURE", "TIMED_OUT").
+    pub conclusion: String,
 }
 
 /// Lightweight PR summary attached to a worktree.
@@ -129,6 +142,10 @@ pub struct PrState {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Individual failing CI checks (filtered: excludes non-blocking checks).
+    pub failing_checks: Vec<FailedCheck>,
+    /// Labels applied to this PR.
+    pub labels: Vec<String>,
 }
 
 /// Lightweight tmux session summary attached to a worktree.
@@ -206,8 +223,17 @@ pub struct HostState {
 // From conversions from derive types
 // ---------------------------------------------------------------------------
 
+/// CI checks that are informational-only and should not surface as actionable failures.
+const NON_BLOCKING_CHECKS: &[&str] = &["check-approval-or-label"];
+
 impl From<&crate::derive::PrInfo> for PrState {
     fn from(pr: &crate::derive::PrInfo) -> Self {
+        let failing_checks = pr
+            .failing_checks
+            .iter()
+            .filter(|c| !NON_BLOCKING_CHECKS.contains(&c.name.as_str()))
+            .cloned()
+            .collect();
         Self {
             number: pr.number,
             branch: pr.branch.clone(),
@@ -216,6 +242,8 @@ impl From<&crate::derive::PrInfo> for PrState {
             checks_state: pr.checks_state.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            failing_checks,
+            labels: pr.labels.clone(),
         }
     }
 }
@@ -270,6 +298,7 @@ impl From<&crate::derive::WorktreeRow> for WorktreeState {
                 .issue_state
                 .clone()
                 .unwrap_or_else(|| "open".to_string()),
+            labels: row.issue_labels.clone(),
         });
 
         Self {
@@ -306,6 +335,7 @@ mod tests {
             issue_number,
             issue_title: issue_number.map(|n| format!("Issue {}", n)),
             issue_state: issue_state.map(|s| s.to_string()),
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group,
@@ -429,6 +459,8 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            failing_checks: vec![],
+            labels: vec![],
         };
         let pr_state = PrState::from(&pr_info);
         assert_eq!(pr_state.state, Some("open".to_string()));
@@ -444,9 +476,60 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            failing_checks: vec![],
+            labels: vec![],
         };
         let pr_state = PrState::from(&pr_info);
         assert!(pr_state.state.is_none());
+    }
+
+    #[test]
+    fn from_pr_info_filters_non_blocking_check() {
+        let pr_info = PrInfo {
+            number: 1,
+            branch: "feat/branch".to_string(),
+            state: None,
+            review_decision: None,
+            checks_state: Some("failing".to_string()),
+            has_conflicts: false,
+            unresolved_threads: 0,
+            failing_checks: vec![
+                FailedCheck {
+                    name: "check-approval-or-label".to_string(),
+                    conclusion: "FAILURE".to_string(),
+                },
+                FailedCheck {
+                    name: "e2e-tests".to_string(),
+                    conclusion: "FAILURE".to_string(),
+                },
+            ],
+            labels: vec![],
+        };
+        let pr_state = PrState::from(&pr_info);
+        assert_eq!(pr_state.failing_checks.len(), 1);
+        assert_eq!(pr_state.failing_checks[0].name, "e2e-tests");
+    }
+
+    #[test]
+    fn from_pr_info_passes_through_failing_checks() {
+        let pr_info = PrInfo {
+            number: 1,
+            branch: "feat/branch".to_string(),
+            state: None,
+            review_decision: None,
+            checks_state: Some("failing".to_string()),
+            has_conflicts: false,
+            unresolved_threads: 0,
+            failing_checks: vec![FailedCheck {
+                name: "unit-tests".to_string(),
+                conclusion: "TIMED_OUT".to_string(),
+            }],
+            labels: vec![],
+        };
+        let pr_state = PrState::from(&pr_info);
+        assert_eq!(pr_state.failing_checks.len(), 1);
+        assert_eq!(pr_state.failing_checks[0].name, "unit-tests");
+        assert_eq!(pr_state.failing_checks[0].conclusion, "TIMED_OUT");
     }
 
     // -- From<&EnrichedSession> for SessionState tests ----------------------

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -343,6 +343,7 @@ mod tests {
             sessions: vec![],
             display_group,
             is_main_worktree: false,
+            last_activity: None,
         }
     }
 

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -129,6 +129,8 @@ pub struct PrState {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Whether the PR is a draft (not ready for review).
+    pub is_draft: bool,
 }
 
 /// Lightweight tmux session summary attached to a worktree.
@@ -216,6 +218,7 @@ impl From<&crate::derive::PrInfo> for PrState {
             checks_state: pr.checks_state.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            is_draft: pr.is_draft,
         }
     }
 }
@@ -429,6 +432,7 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            is_draft: false,
         };
         let pr_state = PrState::from(&pr_info);
         assert_eq!(pr_state.state, Some("open".to_string()));
@@ -444,9 +448,26 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            is_draft: false,
         };
         let pr_state = PrState::from(&pr_info);
         assert!(pr_state.state.is_none());
+    }
+
+    #[test]
+    fn from_pr_info_propagates_is_draft_true() {
+        let pr_info = PrInfo {
+            number: 42,
+            branch: "feat/draft".to_string(),
+            state: Some("open".to_string()),
+            review_decision: None,
+            checks_state: None,
+            has_conflicts: false,
+            unresolved_threads: 0,
+            is_draft: true,
+        };
+        let pr_state = PrState::from(&pr_info);
+        assert!(pr_state.is_draft, "is_draft must propagate from PrInfo to PrState");
     }
 
     // -- From<&EnrichedSession> for SessionState tests ----------------------

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -374,31 +374,31 @@ mod tests {
                 "feat/issue-5",
                 Some(5),
                 None,
-                DisplayGroup::Other,
+                DisplayGroup::Normal,
             ),
             make_row(
                 "owner/repo",
                 "feat/issue-2",
                 Some(2),
                 None,
-                DisplayGroup::NeedsAttention,
+                DisplayGroup::Active,
             ),
             make_row(
                 "owner/repo",
                 "feat/issue-1",
                 Some(1),
                 None,
-                DisplayGroup::NeedsAttention,
+                DisplayGroup::Active,
             ),
         ];
         let state = make_state_with_rows(rows);
         let all = state.all_worktrees();
         assert_eq!(all.len(), 3);
-        // NeedsAttention sorts before Other
-        assert_eq!(all[0].display_group, DisplayGroup::NeedsAttention);
-        assert_eq!(all[1].display_group, DisplayGroup::NeedsAttention);
-        assert_eq!(all[2].display_group, DisplayGroup::Other);
-        // Within NeedsAttention, issue 1 sorts before issue 2
+        // Active sorts before Normal
+        assert_eq!(all[0].display_group, DisplayGroup::Active);
+        assert_eq!(all[1].display_group, DisplayGroup::Active);
+        assert_eq!(all[2].display_group, DisplayGroup::Normal);
+        // Within Active, issue 1 sorts before issue 2
         assert_eq!(all[0].issue.as_ref().unwrap().number, 1);
         assert_eq!(all[1].issue.as_ref().unwrap().number, 2);
     }
@@ -420,7 +420,7 @@ mod tests {
             "feat/issue-10",
             Some(10),
             Some("open"),
-            DisplayGroup::Other,
+            DisplayGroup::Normal,
         );
         let ws = WorktreeState::from(&row);
         assert_eq!(ws.issue.unwrap().state, "open");
@@ -433,7 +433,7 @@ mod tests {
             "feat/issue-10",
             Some(10),
             Some("closed"),
-            DisplayGroup::Other,
+            DisplayGroup::Normal,
         );
         let ws = WorktreeState::from(&row);
         assert_eq!(ws.issue.unwrap().state, "closed");
@@ -446,7 +446,7 @@ mod tests {
             "feat/issue-10",
             Some(10),
             None,
-            DisplayGroup::Other,
+            DisplayGroup::Normal,
         );
         let ws = WorktreeState::from(&row);
         assert_eq!(ws.issue.unwrap().state, "open");

--- a/crates/orchard/src/paths.rs
+++ b/crates/orchard/src/paths.rs
@@ -7,6 +7,7 @@
 //! `normalize_path` strips trailing slashes for consistent path comparisons.
 //! `paths_match` performs exact path comparison with symlink resolution as a
 //! fallback, preventing both false positives and missed matches.
+
 /// Normalizes a filesystem path for comparison by stripping trailing slashes.
 ///
 /// Tmux reports `#{session_path}` with a trailing slash in some versions;

--- a/crates/orchard/src/paths.rs
+++ b/crates/orchard/src/paths.rs
@@ -4,6 +4,74 @@
 //! with `~`; `truncate_left` caps display width by eliding from the left with
 //! a `…` character. `sanitize_branch_slug` and `derive_local_worktree_path`
 //! produce filesystem-safe paths for worktree directories.
+//! `normalize_path` strips trailing slashes for consistent path comparisons.
+//! `paths_match` performs exact path comparison with symlink resolution as a
+//! fallback, preventing both false positives and missed matches.
+/// Normalizes a filesystem path for comparison by stripping trailing slashes.
+///
+/// Tmux reports `#{session_path}` with a trailing slash in some versions;
+/// `git worktree list --porcelain` never does. Normalizing both sides before
+/// comparison prevents false mismatches.
+///
+/// The root path `"/"` is returned unchanged.
+///
+/// # Examples
+///
+/// ```
+/// use orchard::paths::normalize_path;
+/// assert_eq!(normalize_path("/home/user/repo/"), "/home/user/repo");
+/// assert_eq!(normalize_path("/home/user/repo"), "/home/user/repo");
+/// assert_eq!(normalize_path("/"), "/");
+/// ```
+pub fn normalize_path(path: &str) -> &str {
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        // The input was all slashes (e.g. "/") — preserve the root.
+        "/"
+    } else {
+        trimmed
+    }
+}
+
+/// Compares two filesystem paths for equality, handling symlinks and trailing
+/// slashes correctly.
+///
+/// The fast path is normalized string equality (both sides have trailing
+/// slashes stripped). If that fails — which can happen on macOS where `/var`
+/// and `/tmp` are symlinks to `/private/var` and `/private/tmp`, or where git
+/// resolves symlinks differently from tmux — both paths are canonicalized via
+/// the filesystem and compared again.
+///
+/// Returns `true` if both paths refer to the same filesystem location.
+///
+/// # Examples
+///
+/// ```
+/// use orchard::paths::paths_match;
+/// assert!(paths_match("/home/user/repo", "/home/user/repo"));
+/// assert!(paths_match("/home/user/repo/", "/home/user/repo"));
+/// assert!(!paths_match("/home/user/repo", "/home/user/repo-sdk"));
+/// assert!(!paths_match("/home/user/langwatch", "/home/user/langwatch-sdk"));
+/// ```
+pub fn paths_match(a: &str, b: &str) -> bool {
+    // Fast path: normalized string equality.
+    let a_norm = normalize_path(a);
+    let b_norm = normalize_path(b);
+    if a_norm == b_norm {
+        return true;
+    }
+
+    // Slow path: canonicalize to resolve symlinks (e.g. macOS /private/var vs /var).
+    let a_canon = std::fs::canonicalize(a);
+    let b_canon = std::fs::canonicalize(b);
+    match (a_canon, b_canon) {
+        (Ok(ac), Ok(bc)) => ac == bc,
+        // If either path doesn't exist on disk, fall back to the already-false
+        // normalized comparison — no match.
+        _ => false,
+    }
+}
+
 /// Replaces the user's home directory prefix in `path` with `~`.
 /// Returns the path unchanged if it does not start with `$HOME`.
 pub fn tildify(path: &str) -> String {
@@ -175,6 +243,33 @@ mod tests {
         assert_eq!(sanitize_branch_slug("main"), "main");
     }
 
+    // --- normalize_path ---
+
+    #[test]
+    fn normalize_path_strips_trailing_slash() {
+        assert_eq!(normalize_path("/home/user/repo/"), "/home/user/repo");
+    }
+
+    #[test]
+    fn normalize_path_no_trailing_slash_unchanged() {
+        assert_eq!(normalize_path("/home/user/repo"), "/home/user/repo");
+    }
+
+    #[test]
+    fn normalize_path_root_preserved() {
+        assert_eq!(normalize_path("/"), "/");
+    }
+
+    #[test]
+    fn normalize_path_multiple_trailing_slashes() {
+        assert_eq!(normalize_path("/home/user/repo///"), "/home/user/repo");
+    }
+
+    #[test]
+    fn normalize_path_empty_string_returns_root() {
+        assert_eq!(normalize_path(""), "/");
+    }
+
     // --- derive_local_worktree_path ---
 
     #[test]
@@ -195,5 +290,73 @@ mod tests {
             "got: {}",
             result
         );
+    }
+
+    // --- paths_match ---
+
+    #[test]
+    fn paths_match_identical_paths() {
+        assert!(paths_match("/home/user/repo", "/home/user/repo"));
+    }
+
+    #[test]
+    fn paths_match_trailing_slash_on_one_side() {
+        assert!(paths_match("/home/user/repo/", "/home/user/repo"));
+    }
+
+    #[test]
+    fn paths_match_trailing_slash_on_both_sides() {
+        assert!(paths_match("/home/user/repo/", "/home/user/repo/"));
+    }
+
+    #[test]
+    fn paths_match_rejects_prefix_collision() {
+        // "langwatch" must NOT match "langwatch-sdk" — substring is not a match.
+        assert!(!paths_match(
+            "/home/user/langwatch",
+            "/home/user/langwatch-sdk"
+        ));
+    }
+
+    #[test]
+    fn paths_match_rejects_suffix_collision() {
+        // "main" must NOT match "domain-main-service".
+        assert!(!paths_match(
+            "/home/user/main",
+            "/home/user/domain-main-service"
+        ));
+    }
+
+    #[test]
+    fn paths_match_rejects_completely_different_paths() {
+        assert!(!paths_match("/home/user/repo-a", "/home/user/repo-b"));
+    }
+
+    #[test]
+    fn paths_match_real_dirs_via_canonicalize() {
+        // Use two real directories that definitely exist to exercise the
+        // canonicalize code path. /tmp and /var are always present on Unix.
+        let a = std::env::temp_dir();
+        let a_str = a.to_string_lossy();
+        assert!(paths_match(&a_str, &a_str));
+    }
+
+    #[test]
+    fn paths_match_nonexistent_paths_with_same_normalized_form_still_match() {
+        // Two paths that are equal after normalization but don't exist on disk —
+        // the fast path catches this before canonicalize is attempted.
+        assert!(paths_match(
+            "/nonexistent/path/repo",
+            "/nonexistent/path/repo"
+        ));
+    }
+
+    #[test]
+    fn paths_match_nonexistent_paths_differ() {
+        // Two different non-existent paths must not match.
+        assert!(!paths_match(
+            "/nonexistent/path/repo",
+            "/nonexistent/path/other"
+        ));
     }
 }

--- a/crates/orchard/src/remote.rs
+++ b/crates/orchard/src/remote.rs
@@ -10,6 +10,7 @@ use std::process::Command;
 use anyhow::anyhow;
 
 use crate::logger::LOG;
+use crate::paths::normalize_path;
 use crate::types::{RemoteConfig, TmuxSession, Worktree};
 
 /// Shell-escape a string for safe use in SSH command strings.
@@ -121,7 +122,7 @@ fn parse_tmux_output(out: &str) -> Vec<TmuxSession> {
         }
         sessions.push(TmuxSession {
             name: parts[0].to_string(),
-            path: parts[1].to_string(),
+            path: normalize_path(parts[1]).to_string(),
             attached: parts[2] == "1",
             pane_title: None,
         });

--- a/crates/orchard/src/shell.rs
+++ b/crates/orchard/src/shell.rs
@@ -318,10 +318,7 @@ fn configure_tmux_binding_step(home: &Path, _tmux_version: &str) -> Result<Strin
     let tmux_conf = detect_tmux_conf(home);
 
     let existing = std::fs::read_to_string(&tmux_conf).unwrap_or_else(|e| {
-        tracing::warn!(
-            "could not read tmux config at {}: {e}",
-            tmux_conf.display()
-        );
+        tracing::warn!("could not read tmux config at {}: {e}", tmux_conf.display());
         String::new()
     });
 
@@ -370,9 +367,7 @@ fn configure_tmux_binding_step(home: &Path, _tmux_version: &str) -> Result<Strin
     if add_status {
         eprintln!("  Added status bar segment");
     } else {
-        eprintln!(
-            "  To configure the tmux status bar later, add this to your tmux.conf:"
-        );
+        eprintln!("  To configure the tmux status bar later, add this to your tmux.conf:");
         eprintln!("    {status_line}");
     }
 
@@ -1213,14 +1208,20 @@ mod tests {
     fn tmux_status_line_contains_set_status_right() {
         let state_dir = std::path::Path::new("/home/user/.local/state/orchard");
         let line = get_tmux_status_line(state_dir);
-        assert!(line.contains("set -g status-right"), "must be a status-right directive");
+        assert!(
+            line.contains("set -g status-right"),
+            "must be a status-right directive"
+        );
     }
 
     #[test]
     fn tmux_status_line_references_status_txt() {
         let state_dir = std::path::Path::new("/home/user/.local/state/orchard");
         let line = get_tmux_status_line(state_dir);
-        assert!(line.contains("status.txt"), "must reference the status.txt file");
+        assert!(
+            line.contains("status.txt"),
+            "must reference the status.txt file"
+        );
     }
 
     #[test]

--- a/crates/orchard/src/shell.rs
+++ b/crates/orchard/src/shell.rs
@@ -299,6 +299,18 @@ fn install_wrapper(home: &Path) -> Result<(), String> {
     Ok(())
 }
 
+/// Returns the recommended `tmux set -g status-right` line for orchard.
+///
+/// The `state_dir` parameter should be the path to `~/.local/state/orchard`.
+/// The returned string is suitable for pasting directly into `tmux.conf` or
+/// running via `tmux source-file`.
+pub fn get_tmux_status_line(state_dir: &Path) -> String {
+    format!(
+        "set -g status-right \"#(cat {}/status.txt) | %H:%M\"",
+        state_dir.display()
+    )
+}
+
 /// Steps 4 & 5: Prompt for key, inject tmux binding (and optionally status bar) into tmux.conf.
 /// Returns the key chosen by the user.
 fn configure_tmux_binding_step(home: &Path, _tmux_version: &str) -> Result<String, String> {
@@ -318,13 +330,10 @@ fn configure_tmux_binding_step(home: &Path, _tmux_version: &str) -> Result<Strin
 
     // Step 5: Optionally add status bar segment.
     eprintln!("{BOLD}{CYAN}[5/{TOTAL_STEPS}] Status bar{RESET}");
-    let add_status = prompt_yn("  Add orchard status to tmux status bar? [Y/n]", true);
-
     let state_dir = home.join(".local/state/orchard");
-    let status_line = format!(
-        "set -g status-right \"#(cat {}/status.txt) | %H:%M\"",
-        state_dir.display()
-    );
+    let status_line = get_tmux_status_line(&state_dir);
+
+    let add_status = prompt_yn("  Add orchard status to tmux status bar? [Y/n]", true);
 
     // Warn about conflict between the main popup key and chat key.
     // Then prompt the user for the chat key (default O).
@@ -354,6 +363,11 @@ fn configure_tmux_binding_step(home: &Path, _tmux_version: &str) -> Result<Strin
     eprintln!("  Added keybinding to {}", tmux_conf.display());
     if add_status {
         eprintln!("  Added status bar segment");
+    } else {
+        eprintln!(
+            "  To configure the tmux status bar later, add this to your tmux.conf:"
+        );
+        eprintln!("    {status_line}");
     }
 
     Ok(key)
@@ -1174,5 +1188,61 @@ mod tests {
     fn chat_wrapper_script_embeds_absolute_path() {
         let script = get_chat_wrapper_script("/custom/path/orchard");
         assert!(script.contains("\"/custom/path/orchard\""));
+    }
+
+    // -----------------------------------------------------------------------
+    // get_tmux_status_line
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tmux_status_line_contains_set_status_right() {
+        let state_dir = std::path::Path::new("/home/user/.local/state/orchard");
+        let line = get_tmux_status_line(state_dir);
+        assert!(line.contains("set -g status-right"), "must be a status-right directive");
+    }
+
+    #[test]
+    fn tmux_status_line_references_status_txt() {
+        let state_dir = std::path::Path::new("/home/user/.local/state/orchard");
+        let line = get_tmux_status_line(state_dir);
+        assert!(line.contains("status.txt"), "must reference the status.txt file");
+    }
+
+    #[test]
+    fn tmux_status_line_embeds_state_dir_path() {
+        let state_dir = std::path::Path::new("/home/user/.local/state/orchard");
+        let line = get_tmux_status_line(state_dir);
+        assert!(
+            line.contains("/home/user/.local/state/orchard"),
+            "must embed the provided state directory path"
+        );
+    }
+
+    #[test]
+    fn block_without_status_does_not_contain_status_right() {
+        // When the user declines the status bar, the injected block must not
+        // set status-right and thereby clobber the user's existing config.
+        let binding = get_tmux_binding("o");
+        let chat_binding = get_chat_tmux_binding("O");
+        let block_content = format!("{binding}\n{chat_binding}");
+        let result = inject_config_block("", &block_content);
+        assert!(
+            !result.contains("status-right"),
+            "block without status must not contain status-right"
+        );
+    }
+
+    #[test]
+    fn block_with_status_contains_status_right() {
+        let state_dir = std::path::Path::new("/home/user/.local/state/orchard");
+        let binding = get_tmux_binding("o");
+        let chat_binding = get_chat_tmux_binding("O");
+        let status_line = get_tmux_status_line(state_dir);
+        let block_content = format!("{binding}\n{chat_binding}\n{status_line}");
+        let result = inject_config_block("", &block_content);
+        assert!(
+            result.contains("status-right"),
+            "block with status must contain status-right"
+        );
     }
 }

--- a/crates/orchard/src/shell.rs
+++ b/crates/orchard/src/shell.rs
@@ -317,7 +317,13 @@ fn configure_tmux_binding_step(home: &Path, _tmux_version: &str) -> Result<Strin
     eprintln!("{BOLD}{CYAN}[4/{TOTAL_STEPS}] Configuring tmux keybinding{RESET}");
     let tmux_conf = detect_tmux_conf(home);
 
-    let existing = std::fs::read_to_string(&tmux_conf).unwrap_or_default();
+    let existing = std::fs::read_to_string(&tmux_conf).unwrap_or_else(|e| {
+        tracing::warn!(
+            "could not read tmux config at {}: {e}",
+            tmux_conf.display()
+        );
+        String::new()
+    });
 
     // Warn about existing bind-key o conflict (only if it's not our binding).
     if (existing.contains("bind-key o") || existing.contains("bind o "))
@@ -390,9 +396,12 @@ fn reload_tmux_config_step(home: &Path) {
     if std::env::var("TMUX").is_ok() {
         // Remove the old session-closed hook that would unbind 'o' when
         // the legacy orchard session dies.
-        let _ = std::process::Command::new("tmux")
+        if let Err(e) = std::process::Command::new("tmux")
             .args(["set-hook", "-gu", "session-closed[99]"])
-            .status();
+            .status()
+        {
+            tracing::warn!("tmux cleanup command failed: {e}");
+        }
 
         // Kill any legacy *_orchard sessions so they don't interfere.
         if let Ok(output) = std::process::Command::new("tmux")
@@ -403,9 +412,12 @@ fn reload_tmux_config_step(home: &Path) {
             for session in sessions.lines() {
                 if session.ends_with("_orchard") {
                     eprintln!("  Killing legacy session: {session}");
-                    let _ = std::process::Command::new("tmux")
+                    if let Err(e) = std::process::Command::new("tmux")
                         .args(["kill-session", "-t", session])
-                        .status();
+                        .status()
+                    {
+                        tracing::warn!("tmux cleanup command failed: {e}");
+                    }
                 }
             }
         }
@@ -413,9 +425,12 @@ fn reload_tmux_config_step(home: &Path) {
         // Unbind the old 'o' key first — runtime bindings from the old
         // orchard binary take precedence over config-file bindings, so
         // source-file alone won't override them.
-        let _ = std::process::Command::new("tmux")
+        if let Err(e) = std::process::Command::new("tmux")
             .args(["unbind-key", "o"])
-            .status();
+            .status()
+        {
+            tracing::warn!("tmux cleanup command failed: {e}");
+        }
 
         // Reload the tmux config to activate the new popup binding.
         let result = std::process::Command::new("tmux")

--- a/crates/orchard/src/tmux.rs
+++ b/crates/orchard/src/tmux.rs
@@ -8,6 +8,7 @@ use std::process::Command;
 use anyhow::{Context, Result};
 
 use crate::logger::LOG;
+use crate::paths::normalize_path;
 use crate::types::{SwitchToSessionOptions, TmuxSession};
 
 /// Lists all active tmux sessions. Returns an empty vec when tmux is not running.
@@ -38,7 +39,7 @@ pub fn list_tmux_sessions() -> Vec<TmuxSession> {
         }
         sessions.push(TmuxSession {
             name: parts[0].to_string(),
-            path: parts[1].to_string(),
+            path: normalize_path(parts[1]).to_string(),
             attached: parts[2] == "1",
             pane_title: None,
         });

--- a/crates/orchard/src/tui/dialogs.rs
+++ b/crates/orchard/src/tui/dialogs.rs
@@ -485,6 +485,7 @@ mod tests {
                 sessions: vec![],
                 display_group: crate::derive::DisplayGroup::Normal,
                 is_main_worktree: false,
+                last_activity: None,
             },
             phase: Phase::InProgress,
             error: None,

--- a/crates/orchard/src/tui/dialogs.rs
+++ b/crates/orchard/src/tui/dialogs.rs
@@ -480,6 +480,7 @@ mod tests {
                 issue_number: None,
                 issue_title: None,
                 issue_state: None,
+                issue_labels: vec![],
                 pr: None,
                 sessions: vec![],
                 display_group: crate::derive::DisplayGroup::Other,

--- a/crates/orchard/src/tui/dialogs.rs
+++ b/crates/orchard/src/tui/dialogs.rs
@@ -483,7 +483,7 @@ mod tests {
                 issue_labels: vec![],
                 pr: None,
                 sessions: vec![],
-                display_group: crate::derive::DisplayGroup::Other,
+                display_group: crate::derive::DisplayGroup::Normal,
                 is_main_worktree: false,
             },
             phase: Phase::InProgress,

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -412,6 +412,7 @@ mod tests {
             sessions: vec![],
             display_group: DisplayGroup::Normal,
             is_main_worktree: false,
+            last_activity: None,
         }
     }
 

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -405,6 +405,7 @@ mod tests {
             issue_number: Some(42),
             issue_title: Some("Fix Azure integration bug".to_string()),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: DisplayGroup::NeedsAttention,
@@ -484,6 +485,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..base_row()
         };
@@ -539,6 +542,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..base_row()
         };

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -121,7 +121,11 @@ fn pr_status_haystack(row: &WorktreeRow) -> String {
         return format!("{}\u{25cb} unresolved ({})", prefix, pr.unresolved_threads);
     }
     if pr.checks_state.as_deref() == Some("failing") {
-        return format!("{}\u{2716} failing", prefix);
+        let names: Vec<&str> = pr.failing_checks.iter().map(|c| c.name.as_str()).collect();
+        if names.is_empty() {
+            return format!("{}\u{2716} failing", prefix);
+        }
+        return format!("{}\u{2716} failing {}", prefix, names.join(" "));
     }
     if pr.checks_state.as_deref() == Some("pending") {
         return format!("{}\u{25d0} pending CI", prefix);
@@ -509,6 +513,8 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..base_row()
         };

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -484,6 +484,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..base_row()
         };
@@ -506,6 +507,7 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..base_row()
         };
@@ -539,6 +541,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..base_row()
         };

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -153,11 +153,9 @@ fn session_status_haystack(row: &WorktreeRow) -> String {
 fn display_group_label(group: DisplayGroup) -> String {
     match group {
         DisplayGroup::RepoMain => "repo main".to_string(),
-        DisplayGroup::Prioritized => "prioritized".to_string(),
-        DisplayGroup::NeedsAttention => "needs attention".to_string(),
-        DisplayGroup::ClaudeWorking => "claude working".to_string(),
-        DisplayGroup::ReadyToMerge => "ready to merge".to_string(),
-        DisplayGroup::Other => "other".to_string(),
+        DisplayGroup::Active => "active".to_string(),
+        DisplayGroup::Normal => "work in progress".to_string(),
+        DisplayGroup::Done => "done".to_string(),
     }
 }
 
@@ -412,7 +410,7 @@ mod tests {
             issue_labels: vec![],
             pr: None,
             sessions: vec![],
-            display_group: DisplayGroup::NeedsAttention,
+            display_group: DisplayGroup::Normal,
             is_main_worktree: false,
         }
     }
@@ -580,10 +578,10 @@ mod tests {
 
     #[test]
     fn haystack_includes_display_group_label() {
-        let row = base_row(); // NeedsAttention
+        let row = base_row(); // Normal
         let haystack = row_haystack(&row);
         assert!(
-            haystack.text.contains("needs attention"),
+            haystack.text.contains("work in progress"),
             "display group label missing from haystack: {}",
             haystack.text
         );

--- a/crates/orchard/src/tui/last_selection.rs
+++ b/crates/orchard/src/tui/last_selection.rs
@@ -291,6 +291,7 @@ mod tests {
             sessions: vec![],
             display_group: DisplayGroup::Normal,
             is_main_worktree: false,
+            last_activity: None,
         }
     }
 

--- a/crates/orchard/src/tui/last_selection.rs
+++ b/crates/orchard/src/tui/last_selection.rs
@@ -287,7 +287,7 @@ mod tests {
             issue_labels: vec![],
             pr: None,
             sessions: vec![],
-            display_group: DisplayGroup::Other,
+            display_group: DisplayGroup::Normal,
             is_main_worktree: false,
         }
     }

--- a/crates/orchard/src/tui/last_selection.rs
+++ b/crates/orchard/src/tui/last_selection.rs
@@ -154,9 +154,11 @@ pub(crate) fn resolve_cursor(
 
 /// Resolves a `LastSelection` to an `active_repo_index`.
 ///
+/// Tab layout: 0 = ALL, 1 = ORCHARD, 2..N+1 = repos[0..N-1].
+///
 /// Resolution rules:
 /// - `active_repo_slug` is `None`: return 0 ("all repos").
-/// - Slug found at position `i` in `repos`: return `i + 1` (1-based, index 0 = all repos).
+/// - Slug found at position `i` in `repos`: return `i + 2` (repos start at index 2).
 /// - Slug not found (repo removed): return 0 ("all repos").
 pub(crate) fn resolve_active_repo_index(
     sel: &LastSelection,
@@ -167,7 +169,7 @@ pub(crate) fn resolve_active_repo_index(
         Some(slug) => repos
             .iter()
             .position(|r| &r.slug == slug)
-            .map(|i| i + 1)
+            .map(|i| i + 2)
             .unwrap_or(0),
     }
 }
@@ -425,8 +427,8 @@ mod tests {
             make_repo_config("acme/alpha"),
             make_repo_config("acme/beta"),
         ];
-        // "acme/beta" is at index 1 in repos, so active_repo_index = 2 (1-based).
-        assert_eq!(resolve_active_repo_index(&sel, &repos), 2);
+        // "acme/beta" is at repos[1], so active_repo_index = 3 (ALL=0, ORCHARD=1, repos start at 2).
+        assert_eq!(resolve_active_repo_index(&sel, &repos), 3);
     }
 
     #[test]

--- a/crates/orchard/src/tui/last_selection.rs
+++ b/crates/orchard/src/tui/last_selection.rs
@@ -284,6 +284,7 @@ mod tests {
             issue_number: Some(issue_number),
             issue_title: Some(format!("Test task {issue_number}")),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: DisplayGroup::Other,

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1033,19 +1033,17 @@ impl App {
 
         let show_branch = self.show_branch_column;
 
-        // TAGS column is visible when any worktree row has a draft PR.
-        let has_tags = tasks
-            .iter()
-            .any(|vt| vt.row.pr.as_ref().is_some_and(|pr| pr.is_draft));
+        // TAGS column is always visible — shows GitHub labels and draft status.
+        let has_tags = true;
 
         // Compute available width for the TITLE column.
         // Column order: BAR (1) + # (3) + CLAUDE (10) + ISSUE (6) + TITLE (flex)
-        //               + [BRANCH (20)] + [HOST (12)] + [TAGS (7)] + STATUS (22)
+        //               + [BRANCH (20)] + [HOST (12)] + TAGS (18) + STATUS (22)
         // Each column has 1 spacing. Plus borders (2).
         let fixed = 1 + 1 + 3 + 1 + 10 + 1 + 6 + 1 + 1 + 22 + 2;
         let branch_extra = if show_branch { 20 + 1 } else { 0 };
         let host_extra = if has_remote { 12 + 1 } else { 0 };
-        let tags_extra = if has_tags { 7 + 1 } else { 0 };
+        let tags_extra = if has_tags { 18 + 1 } else { 0 };
         let title_width =
             (area.width as usize).saturating_sub(fixed + branch_extra + host_extra + tags_extra);
 
@@ -1064,7 +1062,7 @@ impl App {
             widths.push(Constraint::Length(12)); // HOST
         }
         if has_tags {
-            widths.push(Constraint::Length(7)); // TAGS
+            widths.push(Constraint::Length(18)); // TAGS
         }
         widths.push(Constraint::Length(22)); // STATUS (last)
 
@@ -1685,10 +1683,36 @@ impl App {
             }
 
             if has_tags {
-                let tags_cell = if vt.row.pr.as_ref().is_some_and(|pr| pr.is_draft) {
-                    Cell::from(" draft").style(Style::default().fg(theme.dimmed))
-                } else {
-                    Cell::from("")
+                let tags_cell = {
+                    // Collect all unique labels from issue + PR, plus draft badge.
+                    let mut tags: Vec<&str> = Vec::new();
+                    if vt.row.pr.as_ref().is_some_and(|pr| pr.is_draft) {
+                        tags.push("draft");
+                    }
+                    for label in &vt.row.issue_labels {
+                        if !tags.contains(&label.as_str()) {
+                            tags.push(label.as_str());
+                        }
+                    }
+                    if let Some(pr) = &vt.row.pr {
+                        for label in &pr.labels {
+                            if !tags.contains(&label.as_str()) {
+                                tags.push(label.as_str());
+                            }
+                        }
+                    }
+                    if tags.is_empty() {
+                        Cell::from("")
+                    } else {
+                        let text = tags.join(", ");
+                        // Truncate to fit column width
+                        let display = if text.len() > 18 {
+                            format!("{}…", &text[..17])
+                        } else {
+                            text
+                        };
+                        Cell::from(display).style(Style::default().fg(theme.dimmed))
+                    }
                 };
                 cells.push(tags_cell);
             }
@@ -3713,7 +3737,7 @@ mod tests {
     }
 
     #[test]
-    fn tags_column_appears_in_header_when_any_row_has_draft_pr() {
+    fn tags_column_always_in_header() {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
@@ -3725,13 +3749,13 @@ mod tests {
         let header = find_header_line(terminal.backend().buffer()).unwrap();
         assert!(
             header.contains("TAGS"),
-            "TAGS header must appear when a draft PR exists; header: {:?}",
+            "TAGS header must always be present; header: {:?}",
             header
         );
     }
 
     #[test]
-    fn tags_column_hidden_when_no_rows_have_draft_prs() {
+    fn tags_column_always_visible_even_without_drafts() {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
@@ -3745,8 +3769,8 @@ mod tests {
 
         let header = find_header_line(terminal.backend().buffer()).unwrap();
         assert!(
-            !header.contains("TAGS"),
-            "TAGS header must be absent when no draft PRs exist; header: {:?}",
+            header.contains("TAGS"),
+            "TAGS header must always be visible; header: {:?}",
             header
         );
     }
@@ -3808,7 +3832,7 @@ mod tests {
     }
 
     #[test]
-    fn tags_column_not_present_with_all_non_draft_prs() {
+    fn tags_column_visible_with_all_non_draft_prs() {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
@@ -3820,8 +3844,8 @@ mod tests {
 
         let header = find_header_line(terminal.backend().buffer()).unwrap();
         assert!(
-            !header.contains("TAGS"),
-            "TAGS must not appear when all PRs are non-draft; header: {:?}",
+            header.contains("TAGS"),
+            "TAGS must always be visible; header: {:?}",
             header
         );
         assert!(

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -2361,6 +2361,7 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_task_row(1, DisplayGroup::ReadyToMerge)
         };
@@ -2460,6 +2461,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2482,6 +2484,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: true,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2504,6 +2507,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 3,
+                is_draft: false,
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2527,6 +2531,7 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2678,6 +2683,7 @@ mod tests {
                 checks_state: Some("pending".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_task_row(1, DisplayGroup::Other)
         };
@@ -2787,6 +2793,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_task_row(1, DisplayGroup::ReadyToMerge)
         };

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -2341,6 +2341,7 @@ mod tests {
             sessions: vec![],
             display_group: group,
             is_main_worktree: false,
+            last_activity: None,
         }
     }
 

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -283,7 +283,11 @@ fn pr_status_text(row: &WorktreeRow, theme: &Theme) -> (String, Style) {
                 .take(3)
                 .map(|c| c.name.as_str())
                 .collect();
-            format!(": {} +{} more", shown.join(", "), pr.failing_checks.len() - 3)
+            format!(
+                ": {} +{} more",
+                shown.join(", "),
+                pr.failing_checks.len() - 3
+            )
         };
         return (
             format!("{}\u{2716} failing{}", prefix, detail),
@@ -2600,10 +2604,22 @@ mod tests {
     fn pr_status_failing_ci_truncates_at_four_checks() {
         use crate::orchard_state::FailedCheck;
         let failing_checks = vec![
-            FailedCheck { name: "check-a".to_string(), conclusion: "FAILURE".to_string() },
-            FailedCheck { name: "check-b".to_string(), conclusion: "FAILURE".to_string() },
-            FailedCheck { name: "check-c".to_string(), conclusion: "FAILURE".to_string() },
-            FailedCheck { name: "check-d".to_string(), conclusion: "FAILURE".to_string() },
+            FailedCheck {
+                name: "check-a".to_string(),
+                conclusion: "FAILURE".to_string(),
+            },
+            FailedCheck {
+                name: "check-b".to_string(),
+                conclusion: "FAILURE".to_string(),
+            },
+            FailedCheck {
+                name: "check-c".to_string(),
+                conclusion: "FAILURE".to_string(),
+            },
+            FailedCheck {
+                name: "check-d".to_string(),
+                conclusion: "FAILURE".to_string(),
+            },
         ];
         let row = WorktreeRow {
             pr: Some(PrInfo {

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -979,6 +979,7 @@ impl App {
 struct SubRowContext<'a> {
     show_branch: bool,
     has_remote: bool,
+    has_tags: bool,
     theme: &'a Theme,
     bar_color: Color,
     prefix: &'a str,
@@ -1009,14 +1010,21 @@ impl App {
 
         let show_branch = self.show_branch_column;
 
+        // TAGS column is visible when any worktree row has a draft PR.
+        let has_tags = tasks
+            .iter()
+            .any(|vt| vt.row.pr.as_ref().is_some_and(|pr| pr.is_draft));
+
         // Compute available width for the TITLE column.
         // Column order: BAR (1) + # (3) + CLAUDE (10) + ISSUE (6) + TITLE (flex)
-        //               + [BRANCH (20)] + [HOST (12)] + STATUS (22)
+        //               + [BRANCH (20)] + [HOST (12)] + [TAGS (7)] + STATUS (22)
         // Each column has 1 spacing. Plus borders (2).
         let fixed = 1 + 1 + 3 + 1 + 10 + 1 + 6 + 1 + 1 + 22 + 2;
         let branch_extra = if show_branch { 20 + 1 } else { 0 };
         let host_extra = if has_remote { 12 + 1 } else { 0 };
-        let title_width = (area.width as usize).saturating_sub(fixed + branch_extra + host_extra);
+        let tags_extra = if has_tags { 7 + 1 } else { 0 };
+        let title_width =
+            (area.width as usize).saturating_sub(fixed + branch_extra + host_extra + tags_extra);
 
         // Column widths — CLAUDE after #, STATUS at end.
         let mut widths: Vec<Constraint> = vec![
@@ -1032,6 +1040,9 @@ impl App {
         if has_remote {
             widths.push(Constraint::Length(12)); // HOST
         }
+        if has_tags {
+            widths.push(Constraint::Length(7)); // TAGS
+        }
         widths.push(Constraint::Length(22)); // STATUS (last)
 
         // Build rows for the table, including standalone sessions and section header rows.
@@ -1041,6 +1052,7 @@ impl App {
             &tasks,
             show_branch,
             has_remote,
+            has_tags,
             title_width,
             num_columns,
         );
@@ -1122,6 +1134,9 @@ impl App {
         }
         if has_remote {
             header_cells.push(Cell::from("HOST"));
+        }
+        if has_tags {
+            header_cells.push(Cell::from("TAGS"));
         }
         header_cells.push(Cell::from("STATUS"));
         let header_row = Row::new(header_cells).style(header_style);
@@ -1340,7 +1355,7 @@ impl App {
 
     /// Builds table rows: standalone sessions first, then worktree task rows with group headers.
     ///
-    /// Column order: BAR, #, CLAUDE, ISSUE, TITLE, [BRANCH], [HOST], STATUS.
+    /// Column order: BAR, #, CLAUDE, ISSUE, TITLE, [BRANCH], [HOST], [TAGS], STATUS.
     /// Unified sequential numbering across standalone + worktree rows.
     /// Expanded rows get pane sub-rows inserted after the parent.
     fn build_task_table_rows_with_standalone(
@@ -1348,6 +1363,7 @@ impl App {
         tasks: &[VisibleTask],
         show_branch: bool,
         has_remote: bool,
+        has_tags: bool,
         title_width: usize,
         num_columns: usize,
     ) -> (Vec<Row<'static>>, Vec<u16>, Option<usize>) {
@@ -1408,6 +1424,9 @@ impl App {
             if has_remote {
                 cells.push(Cell::from("")); // always local
             }
+            if has_tags {
+                cells.push(Cell::from("")); // no tags for standalone sessions
+            }
             cells.push(Cell::from(status_text).style(status_style));
 
             rows.push(Row::new(cells).style(row_style));
@@ -1418,6 +1437,7 @@ impl App {
                 let sub_ctx = SubRowContext {
                     show_branch,
                     has_remote,
+                    has_tags,
                     theme,
                     bar_color: Color::DarkGray,
                     prefix: "",
@@ -1641,6 +1661,15 @@ impl App {
                 cells.push(host_cell);
             }
 
+            if has_tags {
+                let tags_cell = if vt.row.pr.as_ref().is_some_and(|pr| pr.is_draft) {
+                    Cell::from(" draft").style(Style::default().fg(theme.dimmed))
+                } else {
+                    Cell::from("")
+                };
+                cells.push(tags_cell);
+            }
+
             cells.push(status_cell);
 
             rows.push(Row::new(cells).style(row_style));
@@ -1651,6 +1680,7 @@ impl App {
                 let sub_ctx = SubRowContext {
                     show_branch,
                     has_remote,
+                    has_tags,
                     theme,
                     bar_color,
                     prefix: "",
@@ -1752,6 +1782,9 @@ impl App {
             if ctx.has_remote {
                 cells.push(Cell::from("")); // HOST: empty
             }
+            if ctx.has_tags {
+                cells.push(Cell::from("")); // TAGS: empty
+            }
             cells.push(Cell::from("")); // STATUS: empty
 
             rows.push(Row::new(cells).style(row_style));
@@ -1836,6 +1869,9 @@ impl App {
             }
             if ctx.has_remote {
                 cells.push(Cell::from(""));
+            }
+            if ctx.has_tags {
+                cells.push(Cell::from("")); // TAGS: empty
             }
             cells.push(Cell::from("")); // STATUS: empty
 
@@ -3497,6 +3533,207 @@ mod tests {
         assert!(
             table_chunk_height >= TABLE_MIN_HEIGHT,
             "table chunk height {table_chunk_height} should be >= {TABLE_MIN_HEIGHT}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // TAGS column tests
+    // -----------------------------------------------------------------------
+
+    fn make_draft_pr_row(issue: u32) -> WorktreeRow {
+        WorktreeRow {
+            pr: Some(PrInfo {
+                number: issue,
+                branch: format!("feat/issue-{}", issue),
+                state: None,
+                review_decision: None,
+                checks_state: None,
+                has_conflicts: false,
+                unresolved_threads: 0,
+                is_draft: true,
+            }),
+            ..make_task_row(issue, DisplayGroup::Other)
+        }
+    }
+
+    fn make_non_draft_pr_row(issue: u32) -> WorktreeRow {
+        WorktreeRow {
+            pr: Some(PrInfo {
+                number: issue,
+                branch: format!("feat/issue-{}", issue),
+                state: None,
+                review_decision: None,
+                checks_state: None,
+                has_conflicts: false,
+                unresolved_threads: 0,
+                is_draft: false,
+            }),
+            ..make_task_row(issue, DisplayGroup::Other)
+        }
+    }
+
+    /// Collects all rendered text from the terminal buffer.
+    fn buffer_text(buffer: &ratatui::buffer::Buffer) -> String {
+        let mut text = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                text.push_str(buffer[(x, y)].symbol());
+            }
+        }
+        text
+    }
+
+    /// Finds the header line (the one containing "TITLE" and "STATUS").
+    fn find_header_line(buffer: &ratatui::buffer::Buffer) -> Option<String> {
+        for y in 0..buffer.area.height {
+            let mut line = String::new();
+            for x in 0..buffer.area.width {
+                line.push_str(buffer[(x, y)].symbol());
+            }
+            if line.contains("TITLE") && line.contains("STATUS") {
+                return Some(line);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn tags_column_appears_in_header_when_any_row_has_draft_pr() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let app = App::new_test(vec![make_draft_pr_row(1)]);
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.render_task_list(f)).unwrap();
+
+        let header = find_header_line(terminal.backend().buffer()).unwrap();
+        assert!(
+            header.contains("TAGS"),
+            "TAGS header must appear when a draft PR exists; header: {:?}",
+            header
+        );
+    }
+
+    #[test]
+    fn tags_column_hidden_when_no_rows_have_draft_prs() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let app = App::new_test(vec![
+            make_non_draft_pr_row(1),
+            make_task_row(2, DisplayGroup::Other),
+        ]);
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.render_task_list(f)).unwrap();
+
+        let header = find_header_line(terminal.backend().buffer()).unwrap();
+        assert!(
+            !header.contains("TAGS"),
+            "TAGS header must be absent when no draft PRs exist; header: {:?}",
+            header
+        );
+    }
+
+    #[test]
+    fn draft_badge_appears_for_draft_pr_row() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let app = App::new_test(vec![make_draft_pr_row(1)]);
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.render_task_list(f)).unwrap();
+
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(
+            text.contains("draft"),
+            "rendered output must contain 'draft' badge for a draft PR row"
+        );
+    }
+
+    #[test]
+    fn tags_cell_empty_for_non_draft_pr_when_tags_column_visible() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        // One draft row makes TAGS column visible; second row is non-draft.
+        let app = App::new_test(vec![make_draft_pr_row(1), make_non_draft_pr_row(2)]);
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.render_task_list(f)).unwrap();
+
+        let header = find_header_line(terminal.backend().buffer()).unwrap();
+        assert!(
+            header.contains("TAGS"),
+            "TAGS column must be visible when at least one draft PR exists"
+        );
+        // The column exists but non-draft row contributes no extra "draft" text beyond row 1.
+        // We simply confirm the render doesn't panic and TAGS column is present.
+    }
+
+    #[test]
+    fn tags_cell_empty_for_row_without_pr() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        // One draft row forces TAGS visible; second row has no PR.
+        let app = App::new_test(vec![
+            make_draft_pr_row(1),
+            make_task_row(2, DisplayGroup::Other),
+        ]);
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.render_task_list(f)).unwrap();
+
+        // Render must succeed without panic — column exists with empty cell for no-PR row.
+        let header = find_header_line(terminal.backend().buffer()).unwrap();
+        assert!(header.contains("TAGS"), "TAGS must be present");
+    }
+
+    #[test]
+    fn tags_column_not_present_with_all_non_draft_prs() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let rows: Vec<WorktreeRow> = (1..=3).map(make_non_draft_pr_row).collect();
+        let app = App::new_test(rows);
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.render_task_list(f)).unwrap();
+
+        let header = find_header_line(terminal.backend().buffer()).unwrap();
+        assert!(
+            !header.contains("TAGS"),
+            "TAGS must not appear when all PRs are non-draft; header: {:?}",
+            header
+        );
+        assert!(
+            header.contains("STATUS"),
+            "STATUS must remain last column; header: {:?}",
+            header
+        );
+    }
+
+    #[test]
+    fn tags_column_appears_after_title_before_status() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let app = App::new_test(vec![make_draft_pr_row(1)]);
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| app.render_task_list(f)).unwrap();
+
+        let header = find_header_line(terminal.backend().buffer()).unwrap();
+        let tags_pos = header.find("TAGS").unwrap();
+        let status_pos = header.find("STATUS").unwrap();
+        assert!(
+            tags_pos < status_pos,
+            "TAGS ({}) must appear before STATUS ({})",
+            tags_pos,
+            status_pos
         );
     }
 }

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -265,8 +265,28 @@ fn pr_status_text(row: &WorktreeRow, theme: &Theme) -> (String, Style) {
         );
     }
     if pr.checks_state.as_deref() == Some("failing") {
+        let detail = if pr.failing_checks.is_empty() {
+            String::new()
+        } else if pr.failing_checks.len() <= 3 {
+            format!(
+                ": {}",
+                pr.failing_checks
+                    .iter()
+                    .map(|c| c.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        } else {
+            let shown: Vec<&str> = pr
+                .failing_checks
+                .iter()
+                .take(3)
+                .map(|c| c.name.as_str())
+                .collect();
+            format!(": {} +{} more", shown.join(", "), pr.failing_checks.len() - 3)
+        };
         return (
-            format!("{}\u{2716} failing", prefix),
+            format!("{}\u{2716} failing{}", prefix, detail),
             Style::default().fg(theme.error),
         );
     }
@@ -2242,6 +2262,7 @@ mod tests {
             issue_number: Some(issue_number),
             issue_title: Some(format!("Test task {}", issue_number)),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: group,
@@ -2361,6 +2382,8 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::ReadyToMerge)
         };
@@ -2460,6 +2483,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2482,6 +2507,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: true,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2504,6 +2531,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 3,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2518,6 +2547,7 @@ mod tests {
 
     #[test]
     fn pr_status_failing_ci() {
+        use crate::orchard_state::FailedCheck;
         let row = WorktreeRow {
             pr: Some(PrInfo {
                 number: 1,
@@ -2527,11 +2557,80 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![FailedCheck {
+                    name: "e2e-tests".to_string(),
+                    conclusion: "FAILURE".to_string(),
+                }],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert!(text.contains("failing"), "expected 'failing' in: {}", text);
+        assert!(
+            text.contains("e2e-tests"),
+            "expected check name 'e2e-tests' in: {}",
+            text
+        );
+    }
+
+    #[test]
+    fn pr_status_failing_ci_no_checks_shows_no_detail() {
+        let row = WorktreeRow {
+            pr: Some(PrInfo {
+                number: 1,
+                branch: "feat/branch".to_string(),
+                state: None,
+                review_decision: None,
+                checks_state: Some("failing".to_string()),
+                has_conflicts: false,
+                unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
+            }),
+            ..make_task_row(1, DisplayGroup::NeedsAttention)
+        };
+        let (text, _) = pr_status_text(&row, &Theme::default());
+        assert!(text.contains("failing"), "expected 'failing' in: {}", text);
+        // No colon-separated detail when failing_checks is empty.
+        assert!(!text.contains(':'), "unexpected colon in: {}", text);
+    }
+
+    #[test]
+    fn pr_status_failing_ci_truncates_at_four_checks() {
+        use crate::orchard_state::FailedCheck;
+        let failing_checks = vec![
+            FailedCheck { name: "check-a".to_string(), conclusion: "FAILURE".to_string() },
+            FailedCheck { name: "check-b".to_string(), conclusion: "FAILURE".to_string() },
+            FailedCheck { name: "check-c".to_string(), conclusion: "FAILURE".to_string() },
+            FailedCheck { name: "check-d".to_string(), conclusion: "FAILURE".to_string() },
+        ];
+        let row = WorktreeRow {
+            pr: Some(PrInfo {
+                number: 2,
+                branch: "feat/branch".to_string(),
+                state: None,
+                review_decision: None,
+                checks_state: Some("failing".to_string()),
+                has_conflicts: false,
+                unresolved_threads: 0,
+                failing_checks,
+                labels: vec![],
+            }),
+            ..make_task_row(2, DisplayGroup::NeedsAttention)
+        };
+        let (text, _) = pr_status_text(&row, &Theme::default());
+        assert!(text.contains("failing"), "expected 'failing' in: {}", text);
+        assert!(
+            text.contains("+1 more"),
+            "expected '+1 more' truncation in: {}",
+            text
+        );
+        assert!(
+            text.contains("check-a"),
+            "expected first check name in: {}",
+            text
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -2678,6 +2777,8 @@ mod tests {
                 checks_state: Some("pending".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::Other)
         };
@@ -2787,6 +2888,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::ReadyToMerge)
         };

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -418,7 +418,7 @@ impl App {
     /// Returns `true` when the TUI should exit (to switch to a session).
     pub(crate) fn handle_enter_action(&mut self) -> bool {
         use super::SubCursor;
-        let standalone_count = self.standalone_sessions.len();
+        let standalone_count = self.effective_standalone_count();
 
         // Resolve pane target from SubCursor for Enter action.
         let resolve_pane_target_from_sub_cursor =
@@ -663,7 +663,7 @@ impl App {
         self.pane_content.clear();
 
         // Handle standalone sessions first.
-        let standalone_count = self.standalone_sessions.len();
+        let standalone_count = self.effective_standalone_count();
         if cursor_is_standalone(self.cursor, standalone_count)
             && let Some(ss) = self.standalone_sessions.get(self.cursor)
             && matches!(
@@ -1020,8 +1020,12 @@ impl App {
 
         let hdr_height = header_height(area.height);
 
-        let tasks =
-            visible_tasks_filtered(&self.task_rows, &self.filter_text, self.active_repo_slug());
+        // On the ORCHARD tab only standalone sessions are shown; suppress all worktree rows.
+        let tasks = if self.is_orchard_tab() {
+            vec![]
+        } else {
+            visible_tasks_filtered(&self.task_rows, &self.filter_text, self.active_repo_slug())
+        };
 
         // Only show HOST column when at least one task has a remote session or remote worktree.
         let has_remote = self.task_rows.iter().any(|r| {
@@ -1068,7 +1072,7 @@ impl App {
 
         // Build rows for the table, including standalone sessions and section header rows.
         let num_columns = widths.len();
-        let standalone_count = self.standalone_sessions.len();
+        let standalone_count = self.effective_standalone_count();
         let (rows, row_heights, selected_visual_idx) = self.build_task_table_rows_with_standalone(
             &tasks,
             show_branch,
@@ -1162,9 +1166,13 @@ impl App {
         header_cells.push(Cell::from("STATUS"));
         let header_row = Row::new(header_cells).style(header_style);
 
-        let table_title = match self.active_repo_slug() {
-            Some(slug) => format!(" TASKS \u{2014} {} ", slug),
-            None => " TASKS ".to_string(),
+        let table_title = if self.is_orchard_tab() {
+            " ORCHARD \u{2014} orchestrator sessions ".to_string()
+        } else {
+            match self.active_repo_slug() {
+                Some(slug) => format!(" TASKS \u{2014} {} ", slug),
+                None => " TASKS ".to_string(),
+            }
         };
         let block = Block::default()
             .title(table_title)
@@ -1273,11 +1281,18 @@ impl App {
             active: bool,
         }
 
-        let mut tabs = vec![TabInfo {
-            label: "ALL".to_string(),
-            color: theme.accent,
-            active: self.active_repo_index == 0,
-        }];
+        let mut tabs = vec![
+            TabInfo {
+                label: "ALL".to_string(),
+                color: theme.accent,
+                active: self.active_repo_index == 0,
+            },
+            TabInfo {
+                label: "ORCHARD".to_string(),
+                color: theme.dimmed,
+                active: self.active_repo_index == 1,
+            },
+        ];
 
         for (i, repo) in self.global_config.repos.iter().enumerate() {
             let name = repo
@@ -1289,7 +1304,7 @@ impl App {
             tabs.push(TabInfo {
                 label: name,
                 color: repo_color(i),
-                active: self.active_repo_index == i + 1,
+                active: self.active_repo_index == i + 2,
             });
         }
 
@@ -1379,6 +1394,10 @@ impl App {
     /// Column order: BAR, #, CLAUDE, ISSUE, TITLE, [BRANCH], [HOST], [TAGS], STATUS.
     /// Unified sequential numbering across standalone + worktree rows.
     /// Expanded rows get pane sub-rows inserted after the parent.
+    ///
+    /// Standalone sessions are rendered only on ALL (0) and ORCHARD (1) tabs, derived
+    /// from `self.effective_standalone_count()`. On repo tabs the count is 0 and
+    /// the loop body never executes.
     fn build_task_table_rows_with_standalone(
         &self,
         tasks: &[VisibleTask],
@@ -1392,13 +1411,14 @@ impl App {
         let mut rows: Vec<Row<'static>> = Vec::new();
         let mut row_heights: Vec<u16> = Vec::new();
         let mut selected_visual_idx: Option<usize> = None;
-        let standalone_count = self.standalone_sessions.len();
+        // On repo tabs (index >= 2) this is 0, so the standalone loop body never runs.
+        let standalone_count = self.effective_standalone_count();
 
         // Unified numbering counter (1-based, spans standalone + worktree).
         let mut unified_num = 1usize;
 
-        // Render standalone session rows first.
-        for (idx, ss) in self.standalone_sessions.iter().enumerate() {
+        // Render standalone session rows first (empty slice on repo tabs).
+        for (idx, ss) in self.standalone_sessions.iter().enumerate().take(standalone_count) {
             let selected = idx == self.cursor && matches!(self.sub_cursor, super::SubCursor::None);
             if selected {
                 selected_visual_idx = Some(rows.len());
@@ -2130,7 +2150,7 @@ impl App {
 
         // PR link hint — dim when standalone or selected task has no PR.
         let has_pr = !is_standalone && !self.task_rows.is_empty() && {
-            let standalone_count = self.standalone_sessions.len();
+            let standalone_count = self.effective_standalone_count();
             let worktree_cursor = self.cursor.saturating_sub(standalone_count);
             let visible =
                 visible_tasks_filtered(&self.task_rows, &self.filter_text, self.active_repo_slug());
@@ -3174,7 +3194,7 @@ mod tests {
         use ratatui::backend::TestBackend;
 
         let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
-        // Simulate a repo selected.
+        // Simulate the ORCHARD tab selected (index 1).
         app.active_repo_index = 1;
         let backend = TestBackend::new(200, 40);
         let mut terminal = Terminal::new(backend).unwrap();
@@ -3347,9 +3367,10 @@ mod tests {
             path: "/workspace/alpha".to_string(),
             remotes: vec![],
         }];
+        // ORCHARD tab (index 1) is active; ALL tab must still render.
         let app = make_repo_app(repos, 1);
         let buf = render_tabs_to_buffer(&app);
-        // Inactive ALL: label on row 1 should have dimmed fg.
+        // Inactive ALL: label on row 1 should still appear.
         let all_cell = (0..buf.area.width)
             .map(|x| &buf[(x, 1)])
             .find(|c| c.symbol() == "A");
@@ -3385,17 +3406,17 @@ mod tests {
             path: "/workspace/beta".to_string(),
             remotes: vec![],
         }];
-        let app = make_repo_app(repos, 1);
+        // Repos start at index 2 (ALL=0, ORCHARD=1, repos start at 2).
+        let app = make_repo_app(repos, 2);
         let buf = render_tabs_to_buffer(&app);
-        // Active repo badge starts after ALL badge (width 7) + 1 gap = x=8.
-        // The border corner at row 0 should have repo_color(0) fg.
+        // The border corner ╭ of the active repo tab should have repo_color(0) fg.
         let expected_color = repo_color(0);
-        // Inactive ALL has no border, so the only ╭ is the active repo's.
+        // Only the active tab renders a border, so find any ╭ that has the repo color.
         let corner = (0..buf.area.width)
             .map(|x| &buf[(x, 0)])
-            .find(|c| c.symbol() == "╭");
+            .find(|c| c.symbol() == "╭" && c.style().fg == Some(expected_color));
         assert!(
-            corner.is_some_and(|c| c.style().fg == Some(expected_color)),
+            corner.is_some(),
             "active repo tab border must use repo_color"
         );
     }
@@ -3415,7 +3436,9 @@ mod tests {
                 remotes: vec![],
             },
         ];
-        let app = make_repo_app(repos, 2);
+        // Index 3 = repos[1] = "owner/beta" active; "owner/alpha" (ALPHA) is inactive.
+        // Tab layout: ALL=0, ORCHARD=1, owner/alpha=2, owner/beta=3.
+        let app = make_repo_app(repos, 3);
         let buf = render_tabs_to_buffer(&app);
         let text = buffer_to_string(&buf);
         assert!(

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1418,7 +1418,12 @@ impl App {
         let mut unified_num = 1usize;
 
         // Render standalone session rows first (empty slice on repo tabs).
-        for (idx, ss) in self.standalone_sessions.iter().enumerate().take(standalone_count) {
+        for (idx, ss) in self
+            .standalone_sessions
+            .iter()
+            .enumerate()
+            .take(standalone_count)
+        {
             let selected = idx == self.cursor && matches!(self.sub_cursor, super::SubCursor::None);
             if selected {
                 selected_visual_idx = Some(rows.len());

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -77,14 +77,13 @@ pub(crate) fn cursor_is_standalone(cursor: usize, standalone_count: usize) -> bo
 }
 
 impl DisplayGroup {
-    fn label(self) -> &'static str {
+    /// Returns the human-readable section header label for this group.
+    pub fn label(self) -> &'static str {
         match self {
             Self::RepoMain => "repo main",
-            Self::Prioritized => "prioritized",
-            Self::NeedsAttention => "needs attention",
-            Self::ClaudeWorking => "claude working",
-            Self::ReadyToMerge => "ready to merge",
-            Self::Other => "other",
+            Self::Active => "active",
+            Self::Normal => "work in progress",
+            Self::Done => "done",
         }
     }
 }
@@ -2123,15 +2122,6 @@ impl App {
         }
         spans.push(sep.clone());
 
-        // Dim 'p' (priority) for standalone sessions.
-        if is_standalone {
-            spans.push(Span::styled("p priority", dim));
-        } else {
-            spans.push(Span::styled("p", key_style));
-            spans.push(Span::raw(" priority"));
-        }
-        spans.push(sep.clone());
-
         spans.push(Span::styled("B", key_style));
         spans.push(Span::raw(" branch"));
         spans.push(sep.clone());
@@ -2346,9 +2336,9 @@ mod tests {
     #[test]
     fn visible_tasks_returns_all_rows_including_other() {
         let rows = vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::ClaudeWorking),
-            make_task_row(3, DisplayGroup::Other),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
+            make_task_row(3, DisplayGroup::Normal),
         ];
         // All rows are always visible — no backlog collapsing.
         let visible = visible_tasks(&rows, "");
@@ -2358,7 +2348,7 @@ mod tests {
     #[test]
     fn other_group_always_shown() {
         let rows: Vec<WorktreeRow> = (1u32..=5)
-            .map(|i| make_task_row(i, DisplayGroup::Other))
+            .map(|i| make_task_row(i, DisplayGroup::Normal))
             .collect();
         let visible = visible_tasks(&rows, "");
         assert_eq!(visible.len(), 5, "Other rows are always visible");
@@ -2367,28 +2357,28 @@ mod tests {
     #[test]
     fn sequential_numbering_across_groups() {
         let rows = vec![
-            make_task_row(10, DisplayGroup::NeedsAttention),
-            make_task_row(20, DisplayGroup::ClaudeWorking),
-            make_task_row(30, DisplayGroup::Other),
+            make_task_row(10, DisplayGroup::Active),
+            make_task_row(20, DisplayGroup::Active),
+            make_task_row(30, DisplayGroup::Normal),
         ];
         let visible = visible_tasks(&rows, "");
         assert_eq!(visible.len(), 3);
         // Unified numbering now happens at render time, not in visible_tasks.
         // Verify all three rows pass through with correct groups.
-        assert_eq!(visible[0].group, DisplayGroup::NeedsAttention);
-        assert_eq!(visible[1].group, DisplayGroup::ClaudeWorking);
-        assert_eq!(visible[2].group, DisplayGroup::Other);
+        assert_eq!(visible[0].group, DisplayGroup::Active);
+        assert_eq!(visible[1].group, DisplayGroup::Active);
+        assert_eq!(visible[2].group, DisplayGroup::Normal);
     }
 
     #[test]
     fn search_filters_by_text() {
         let row_match = WorktreeRow {
             branch: "feat/my-feature".to_string(),
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let row_no_match = WorktreeRow {
             branch: "feat/other-thing".to_string(),
-            ..make_task_row(2, DisplayGroup::ClaudeWorking)
+            ..make_task_row(2, DisplayGroup::Active)
         };
         let rows = vec![row_match, row_no_match];
         let visible = visible_tasks(&rows, "my-feature");
@@ -2403,7 +2393,7 @@ mod tests {
             branch: "main".to_string(),
             ..make_task_row(1, DisplayGroup::RepoMain)
         };
-        let other = make_task_row(2, DisplayGroup::NeedsAttention);
+        let other = make_task_row(2, DisplayGroup::Active);
         let rows = vec![shepherd, other];
         // Shepherd bypasses search filter.
         let visible = visible_tasks(&rows, "nomatch");
@@ -2426,7 +2416,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(1, DisplayGroup::ReadyToMerge)
+            ..make_task_row(1, DisplayGroup::Normal)
         };
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert!(
@@ -2443,7 +2433,7 @@ mod tests {
 
     #[test]
     fn pr_status_no_pr() {
-        let row = make_task_row(1, DisplayGroup::Other);
+        let row = make_task_row(1, DisplayGroup::Normal);
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert_eq!(text, "no PR");
     }
@@ -2466,7 +2456,7 @@ mod tests {
                 windows: vec![],
                 panes: vec![],
             }],
-            ..make_task_row(1, DisplayGroup::ClaudeWorking)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = claude_status_text(&row, &Theme::default());
         assert!(text.contains("active"), "expected 'active' in: {}", text);
@@ -2476,7 +2466,7 @@ mod tests {
     fn claude_status_idle() {
         let row = WorktreeRow {
             sessions: vec![make_session("sess")],
-            ..make_task_row(1, DisplayGroup::ClaudeWorking)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = claude_status_text(&row, &Theme::default());
         assert!(text.contains("idle"), "expected 'idle' in: {}", text);
@@ -2500,7 +2490,7 @@ mod tests {
                 windows: vec![],
                 panes: vec![],
             }],
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = claude_status_text(&row, &Theme::default());
         assert!(text.contains("input"), "expected 'input' in: {}", text);
@@ -2508,7 +2498,7 @@ mod tests {
 
     #[test]
     fn claude_status_none_when_no_session() {
-        let row = make_task_row(1, DisplayGroup::Other);
+        let row = make_task_row(1, DisplayGroup::Normal);
         let (text, _) = claude_status_text(&row, &Theme::default());
         assert!(text.contains("none"), "expected 'none' in: {}", text);
     }
@@ -2528,7 +2518,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert!(
@@ -2553,7 +2543,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert!(
@@ -2578,7 +2568,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert!(
@@ -2608,7 +2598,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert!(text.contains("failing"), "expected 'failing' in: {}", text);
@@ -2634,7 +2624,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert!(text.contains("failing"), "expected 'failing' in: {}", text);
@@ -2676,7 +2666,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(2, DisplayGroup::NeedsAttention)
+            ..make_task_row(2, DisplayGroup::Active)
         };
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert!(text.contains("failing"), "expected 'failing' in: {}", text);
@@ -2761,7 +2751,7 @@ mod tests {
                 crate::claude_state::ClaudeState::Working,
                 Some(73.0),
             )],
-            ..make_task_row(1, DisplayGroup::ClaudeWorking)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = claude_status_text(&row, &Theme::default());
         assert!(text.contains("active"), "expected 'active' in: {}", text);
@@ -2775,7 +2765,7 @@ mod tests {
                 crate::claude_state::ClaudeState::Idle,
                 None,
             )],
-            ..make_task_row(1, DisplayGroup::Other)
+            ..make_task_row(1, DisplayGroup::Normal)
         };
         let (text, _) = claude_status_text(&row, &Theme::default());
         assert!(text.contains("idle"), "expected 'idle' in: {}", text);
@@ -2788,7 +2778,7 @@ mod tests {
                 crate::claude_state::ClaudeState::Input,
                 None,
             )],
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = claude_status_text(&row, &Theme::default());
         assert!(text.contains("input"), "expected 'input' in: {}", text);
@@ -2801,7 +2791,7 @@ mod tests {
                 crate::claude_state::ClaudeState::Input,
                 Some(95.0),
             )],
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = claude_status_text(&row, &Theme::default());
         assert!(text.contains("input"), "expected 'input' in: {}", text);
@@ -2815,7 +2805,7 @@ mod tests {
                 crate::claude_state::ClaudeState::Working,
                 None,
             )],
-            ..make_task_row(1, DisplayGroup::ClaudeWorking)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = claude_status_text(&row, &Theme::default());
         assert!(
@@ -2840,7 +2830,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(1, DisplayGroup::Other)
+            ..make_task_row(1, DisplayGroup::Normal)
         };
         let (text, _) = pr_status_text(&row, &Theme::default());
         assert!(text.contains("pending"), "expected 'pending' in: {}", text);
@@ -2881,7 +2871,7 @@ mod tests {
                     panes: vec![],
                 },
             ],
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let (text, _) = claude_status_text(&row, &Theme::default());
         // Input takes priority over working; count suffix should show " 2"
@@ -2895,7 +2885,7 @@ mod tests {
 
     #[test]
     fn search_is_case_insensitive() {
-        let rows = vec![make_task_row(1, DisplayGroup::NeedsAttention)];
+        let rows = vec![make_task_row(1, DisplayGroup::Active)];
         // Search with uppercase should match lowercase branch "feat/issue-1"
         let visible = visible_tasks(&rows, "FEAT/ISSUE");
         assert_eq!(visible.len(), 1);
@@ -2903,10 +2893,10 @@ mod tests {
 
     #[test]
     fn search_with_multiple_rows() {
-        let mut row_match = make_task_row(1, DisplayGroup::NeedsAttention);
+        let mut row_match = make_task_row(1, DisplayGroup::Active);
         row_match.branch = "feat/target-branch".to_string();
 
-        let mut row_no_match = make_task_row(2, DisplayGroup::NeedsAttention);
+        let mut row_no_match = make_task_row(2, DisplayGroup::Active);
         row_no_match.branch = "feat/other-branch".to_string();
 
         let rows = vec![row_match, row_no_match];
@@ -2925,11 +2915,11 @@ mod tests {
     fn search_matches_issue_title() {
         let row_azure = WorktreeRow {
             issue_title: Some("Fix Azure integration bug".to_string()),
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let row_other = WorktreeRow {
             issue_title: Some("Unrelated task name".to_string()),
-            ..make_task_row(2, DisplayGroup::Other)
+            ..make_task_row(2, DisplayGroup::Normal)
         };
         let rows = vec![row_azure, row_other];
         let visible = visible_tasks(&rows, "Azure");
@@ -2952,9 +2942,9 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(1, DisplayGroup::ReadyToMerge)
+            ..make_task_row(1, DisplayGroup::Normal)
         };
-        let row_no_pr = make_task_row(2, DisplayGroup::Other);
+        let row_no_pr = make_task_row(2, DisplayGroup::Normal);
         let rows = vec![row_approved, row_no_pr];
         // "approved" is in the haystack for row_approved via pr_status_haystack.
         let visible = visible_tasks(&rows, "approved");
@@ -2973,13 +2963,13 @@ mod tests {
         let row_strong = WorktreeRow {
             issue_title: Some("Azure storage fix".to_string()),
             branch: "feat/issue-1".to_string(),
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         // Row 2: branch contains letters a-z-u-r-e but not as the word "azure".
         let row_weak = WorktreeRow {
             issue_title: Some("Fix remote auth".to_string()),
             branch: "feat/issue-2".to_string(),
-            ..make_task_row(2, DisplayGroup::Other)
+            ..make_task_row(2, DisplayGroup::Normal)
         };
         let rows = vec![row_weak, row_strong]; // weak first in input
         let visible = visible_tasks(&rows, "azure");
@@ -3007,7 +2997,7 @@ mod tests {
             issue_title: None,
             ..make_task_row(0, DisplayGroup::RepoMain)
         };
-        let other = make_task_row(1, DisplayGroup::NeedsAttention);
+        let other = make_task_row(1, DisplayGroup::Active);
         let rows = vec![main, other];
         // "nomatch" won't match either row normally, but main always passes.
         let visible = visible_tasks(&rows, "nomatch");
@@ -3026,9 +3016,9 @@ mod tests {
     #[test]
     fn empty_filter_preserves_original_order() {
         let rows = vec![
-            make_task_row(10, DisplayGroup::NeedsAttention),
-            make_task_row(20, DisplayGroup::ClaudeWorking),
-            make_task_row(30, DisplayGroup::Other),
+            make_task_row(10, DisplayGroup::Active),
+            make_task_row(20, DisplayGroup::Active),
+            make_task_row(30, DisplayGroup::Normal),
         ];
         let visible = visible_tasks(&rows, "");
         assert_eq!(visible.len(), 3);
@@ -3045,7 +3035,7 @@ mod tests {
     fn match_indices_present_when_filter_active() {
         let row = WorktreeRow {
             issue_title: Some("Fix Azure bug".to_string()),
-            ..make_task_row(1, DisplayGroup::NeedsAttention)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let rows = vec![row];
         let visible = visible_tasks(&rows, "azure");
@@ -3058,7 +3048,7 @@ mod tests {
 
     #[test]
     fn match_indices_empty_when_filter_empty() {
-        let rows = vec![make_task_row(1, DisplayGroup::Other)];
+        let rows = vec![make_task_row(1, DisplayGroup::Normal)];
         let visible = visible_tasks(&rows, "");
         assert_eq!(visible.len(), 1);
         assert!(
@@ -3127,7 +3117,7 @@ mod tests {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let backend = TestBackend::new(200, 40);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
@@ -3159,7 +3149,7 @@ mod tests {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         // Simulate a repo selected.
         app.active_repo_index = 1;
         let backend = TestBackend::new(200, 40);
@@ -3193,7 +3183,7 @@ mod tests {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let backend = TestBackend::new(200, 40);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
@@ -3420,7 +3410,7 @@ mod tests {
         use ratatui::backend::TestBackend;
 
         let theme = Theme::default();
-        let row = group_header_row(DisplayGroup::Other, 5, &theme);
+        let row = group_header_row(DisplayGroup::Normal, 5, &theme);
         let backend = TestBackend::new(80, 5);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
@@ -3486,7 +3476,7 @@ mod tests {
 
         let row = WorktreeRow {
             sessions: vec![make_session("sess")],
-            ..make_task_row(42, DisplayGroup::Other)
+            ..make_task_row(42, DisplayGroup::Normal)
         };
         let app = App::new_test(vec![row]);
         let backend = TestBackend::new(160, 40);
@@ -3541,7 +3531,7 @@ mod tests {
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
 
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let backend = TestBackend::new(200, 40);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
@@ -3573,7 +3563,7 @@ mod tests {
         use ratatui::backend::TestBackend;
 
         // Row exists but pane_content is empty — placeholder should render.
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let backend = TestBackend::new(120, 50);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| app.render_task_list(f)).unwrap();
@@ -3597,7 +3587,7 @@ mod tests {
         use ratatui::backend::TestBackend;
 
         // Placeholder should not be scroll-interactive — preview_area must be zero.
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let backend = TestBackend::new(120, 50);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal.draw(|f| app.render_task_list(f)).unwrap();
@@ -3616,7 +3606,7 @@ mod tests {
     fn make_task_row_with_session_for_preview(issue: u32) -> WorktreeRow {
         WorktreeRow {
             sessions: vec![make_session(&format!("sess-{}", issue))],
-            ..make_task_row(issue, DisplayGroup::Other)
+            ..make_task_row(issue, DisplayGroup::Normal)
         }
     }
 
@@ -3675,7 +3665,7 @@ mod tests {
                 labels: vec![],
                 is_draft: true,
             }),
-            ..make_task_row(issue, DisplayGroup::Other)
+            ..make_task_row(issue, DisplayGroup::Normal)
         }
     }
 
@@ -3693,7 +3683,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(issue, DisplayGroup::Other)
+            ..make_task_row(issue, DisplayGroup::Normal)
         }
     }
 
@@ -3747,7 +3737,7 @@ mod tests {
 
         let app = App::new_test(vec![
             make_non_draft_pr_row(1),
-            make_task_row(2, DisplayGroup::Other),
+            make_task_row(2, DisplayGroup::Normal),
         ]);
         let backend = TestBackend::new(160, 40);
         let mut terminal = Terminal::new(backend).unwrap();
@@ -3806,7 +3796,7 @@ mod tests {
         // One draft row forces TAGS visible; second row has no PR.
         let app = App::new_test(vec![
             make_draft_pr_row(1),
-            make_task_row(2, DisplayGroup::Other),
+            make_task_row(2, DisplayGroup::Normal),
         ]);
         let backend = TestBackend::new(160, 40);
         let mut terminal = Terminal::new(backend).unwrap();

--- a/crates/orchard/src/tui/message.rs
+++ b/crates/orchard/src/tui/message.rs
@@ -36,8 +36,6 @@ pub enum Message {
     ToggleBranchColumn,
     /// Open the delete-worktree confirmation dialog.
     Delete,
-    /// Toggle the priority flag for the selected worktree.
-    TogglePriority,
     /// Open the new-session name-entry dialog.
     NewSession,
     /// Open the stale-worktree cleanup dialog.

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -2168,6 +2168,7 @@ mod tests {
             sessions: vec![],
             display_group: group,
             is_main_worktree: false,
+            last_activity: None,
         }
     }
 
@@ -2703,6 +2704,7 @@ mod tests {
             sessions: vec![],
             display_group: group,
             is_main_worktree: false,
+            last_activity: None,
         }
     }
 
@@ -3122,6 +3124,7 @@ mod tests {
             host: None,
             last_output_lines: vec![],
             claude_state_raw: None,
+            last_activity: None,
         }
     }
 
@@ -3886,6 +3889,7 @@ mod tests {
             }],
             display_group: DisplayGroup::Normal,
             is_main_worktree: false,
+            last_activity: None,
         }
     }
 

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -99,7 +99,7 @@ pub struct App {
     /// Standalone tmux sessions from global config, enriched with live state.
     standalone_sessions: Vec<StandaloneSessionRow>,
     global_config: global_config::GlobalConfig,
-    /// Index into `global_config.repos`: 0 = all repos, 1+ = specific repo.
+    /// Active tab index: 0 = ALL, 1 = ORCHARD, 2..N+1 = repos[0..N-1].
     active_repo_index: usize,
     show_branch_column: bool,
     /// Text accumulated by bare keystrokes — filters the visible task list in real time.
@@ -245,16 +245,37 @@ impl App {
     // Active repo filtering
     // -------------------------------------------------------------------
 
-    /// Returns the active repo slug when a specific repo is selected (index > 0).
+    /// Returns the active repo slug when a specific repo tab is selected.
     ///
-    /// Index 0 means "all repos" (returns `None`). Index N returns
-    /// `global_config.repos[N-1].slug`.
+    /// Index 0 = "ALL" (returns `None`).
+    /// Index 1 = "ORCHARD" (returns `None`).
+    /// Index 2..N+1 = repos[0..N-1] (returns the slug).
     pub(crate) fn active_repo_slug(&self) -> Option<&str> {
-        if self.active_repo_index == 0 {
-            return None;
+        if self.active_repo_index <= 1 {
+            return None; // ALL or ORCHARD — no repo filter
         }
-        let idx = self.active_repo_index.saturating_sub(1);
+        let idx = self.active_repo_index.saturating_sub(2);
         self.global_config.repos.get(idx).map(|r| r.slug.as_str())
+    }
+
+    /// Returns `true` when the ORCHARD tab (index 1) is active.
+    ///
+    /// The ORCHARD tab shows only standalone sessions; worktree rows are hidden.
+    pub(crate) fn is_orchard_tab(&self) -> bool {
+        self.active_repo_index == 1
+    }
+
+    /// Returns the effective standalone session count for cursor arithmetic.
+    ///
+    /// On repo tabs (index >= 2) standalone sessions are not rendered, so they
+    /// do not occupy cursor positions and the effective count is 0.
+    /// On ALL (0) and ORCHARD (1) tabs the full count is returned.
+    pub(crate) fn effective_standalone_count(&self) -> usize {
+        if self.active_repo_index >= 2 {
+            0
+        } else {
+            self.standalone_sessions.len()
+        }
     }
 
     // -------------------------------------------------------------------
@@ -266,7 +287,7 @@ impl App {
     /// For standalone sessions (idx < standalone_count), the key is the session name.
     /// For worktree rows, the key is the worktree path.
     fn expansion_key_at(&self, idx: usize) -> Option<String> {
-        let standalone_count = self.standalone_sessions.len();
+        let standalone_count = self.effective_standalone_count();
         if idx < standalone_count {
             self.standalone_sessions
                 .get(idx)
@@ -287,7 +308,7 @@ impl App {
     /// For standalone sessions: pane count from the session's panes vec.
     /// For worktree rows: pane count from the first session (if any).
     fn pane_count_at(&self, idx: usize) -> usize {
-        let standalone_count = self.standalone_sessions.len();
+        let standalone_count = self.effective_standalone_count();
         if idx < standalone_count {
             self.standalone_sessions
                 .get(idx)
@@ -449,7 +470,7 @@ impl App {
     /// For worktree rows, returns windows from the first session (if any).
     /// Returns an owned Vec because the worktree path requires a temporary lookup.
     fn windows_at(&self, idx: usize) -> Vec<WindowInfo> {
-        let standalone_count = self.standalone_sessions.len();
+        let standalone_count = self.effective_standalone_count();
         if idx < standalone_count {
             self.standalone_sessions
                 .get(idx)
@@ -493,7 +514,7 @@ impl App {
 
     /// Returns the session name for the row at cursor position `idx`.
     fn session_name_at(&self, idx: usize) -> Option<String> {
-        let standalone_count = self.standalone_sessions.len();
+        let standalone_count = self.effective_standalone_count();
         if idx < standalone_count {
             self.standalone_sessions
                 .get(idx)
@@ -697,7 +718,7 @@ impl App {
                     // Accept pane content when session matches the current row (standalone or worktree).
                     // Use the filtered visible list so repo-tab filtering doesn't cause a mismatch
                     // between the fetched session and the acceptance check (Bug #99).
-                    let standalone_count = self.standalone_sessions.len();
+                    let standalone_count = self.effective_standalone_count();
                     let matches = if self.cursor < standalone_count {
                         self.standalone_sessions
                             .get(self.cursor)
@@ -838,7 +859,7 @@ impl App {
 
         match &self.view {
             ViewState::List => {
-                let standalone_count = self.standalone_sessions.len();
+                let standalone_count = self.effective_standalone_count();
                 let worktree_visible_count = list::visible_tasks_filtered(
                     &self.task_rows,
                     &self.filter_text,
@@ -1065,7 +1086,7 @@ impl App {
             }
         }
 
-        let standalone_count = self.standalone_sessions.len();
+        let standalone_count = self.effective_standalone_count();
 
         // For worktree rows, account for group header rows and sub-rows.
         let tasks = list::visible_tasks_filtered(
@@ -1232,7 +1253,7 @@ impl App {
                         }
                     }
                     _ => {
-                        let standalone_count = self.standalone_sessions.len();
+                        let standalone_count = self.effective_standalone_count();
                         let worktree_visible_count = list::visible_tasks_filtered(
                             &self.task_rows,
                             &self.filter_text,
@@ -1390,7 +1411,7 @@ impl App {
                 ok()
             }
             Message::OpenPR => {
-                let standalone_count = self.standalone_sessions.len();
+                let standalone_count = self.effective_standalone_count();
                 if self.guard_requires_worktree(standalone_count) {
                     return ok();
                 }
@@ -1409,7 +1430,7 @@ impl App {
                 ok()
             }
             Message::OpenIssue => {
-                let standalone_count = self.standalone_sessions.len();
+                let standalone_count = self.effective_standalone_count();
                 if self.guard_requires_worktree(standalone_count) {
                     return ok();
                 }
@@ -1432,7 +1453,7 @@ impl App {
                 ok()
             }
             Message::Delete => {
-                let standalone_count = self.standalone_sessions.len();
+                let standalone_count = self.effective_standalone_count();
                 if self.guard_requires_worktree(standalone_count) {
                     return ok();
                 }
@@ -1472,7 +1493,8 @@ impl App {
             }
             Message::NextRepo => {
                 let repo_count = self.global_config.repos.len();
-                self.active_repo_index = (self.active_repo_index + 1).min(repo_count);
+                // Total tabs: ALL (0) + ORCHARD (1) + repos (2..repo_count+1).
+                self.active_repo_index = (self.active_repo_index + 1).min(repo_count + 1);
                 self.cursor = 0;
                 self.sub_cursor = SubCursor::None;
                 self.pane_content.clear();
@@ -4443,7 +4465,7 @@ mod tests {
                 remotes: vec![],
             },
         ];
-        app.active_repo_index = 2; // repos[1] = "acme/repo-b"
+        app.active_repo_index = 3; // repos[1] = "acme/repo-b" (ALL=0, ORCHARD=1, repos start at 2)
         app.cursor = 0; // visible[0] under repo-b filter = row_b
 
         // Simulate the background thread delivering pane content for the repo-b session.
@@ -4501,7 +4523,7 @@ mod tests {
                 remotes: vec![],
             },
         ];
-        app.active_repo_index = 2; // repo-b tab
+        app.active_repo_index = 3; // repo-b tab (ALL=0, ORCHARD=1, repo-a=2, repo-b=3)
         app.cursor = 0; // visible[0] under repo-b filter = row_b (no session)
 
         // Stale content for repo-a's session arrives — must be rejected.
@@ -4698,7 +4720,7 @@ mod tests {
                 remotes: vec![],
             },
         ];
-        app.active_repo_index = 2; // index 2 = repos[1] = "acme/beta"
+        app.active_repo_index = 3; // index 3 = repos[1] = "acme/beta" (ALL=0, ORCHARD=1, repos start at 2)
         app.cursor = 0;
         let sel = current_selection(&app).unwrap();
         assert_eq!(sel.active_repo_slug, Some("acme/beta".to_string()));

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -2278,6 +2278,7 @@ mod tests {
                     checks_state: None,
                     has_conflicts: false,
                     unresolved_threads: 0,
+                    is_draft: false,
                 }),
                 ..make_task_row(1, DisplayGroup::Other)
             },
@@ -2308,6 +2309,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_task_row(1, DisplayGroup::Other)
         }];
@@ -2337,6 +2339,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_task_row(1, DisplayGroup::Other)
         }];
@@ -2575,6 +2578,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_task_row(42, DisplayGroup::ReadyToMerge)
         };
@@ -2740,6 +2744,7 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_worktree_row("feat/needs-attn", DisplayGroup::NeedsAttention)
         };
@@ -2770,6 +2775,7 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_worktree_row("feat/approved", DisplayGroup::ReadyToMerge)
         };
@@ -2845,6 +2851,7 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_worktree_row("feat/branch", DisplayGroup::NeedsAttention)
         };
@@ -3302,6 +3309,7 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 2,
+                is_draft: false,
             }),
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
@@ -3329,6 +3337,7 @@ mod tests {
                 checks_state: Some("pending".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
@@ -3360,6 +3369,7 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                is_draft: false,
             }),
             ..make_task_row_with_title(54, "Add Theme struct", DisplayGroup::ReadyToMerge)
         };

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -695,6 +695,8 @@ impl App {
                 }
                 AppMsg::PaneContent(session_name, content) => {
                     // Accept pane content when session matches the current row (standalone or worktree).
+                    // Use the filtered visible list so repo-tab filtering doesn't cause a mismatch
+                    // between the fetched session and the acceptance check (Bug #99).
                     let standalone_count = self.standalone_sessions.len();
                     let matches = if self.cursor < standalone_count {
                         self.standalone_sessions
@@ -702,8 +704,13 @@ impl App {
                             .is_some_and(|ss| ss.session.tmux.name == session_name)
                     } else {
                         let wt_cursor = self.cursor - standalone_count;
-                        self.task_rows.get(wt_cursor).is_some_and(|row| {
-                            row.sessions.iter().any(|s| s.tmux.name == session_name)
+                        let visible = list::visible_tasks_filtered(
+                            &self.task_rows,
+                            &self.filter_text,
+                            self.active_repo_slug(),
+                        );
+                        visible.get(wt_cursor).is_some_and(|vt| {
+                            vt.row.sessions.iter().any(|s| s.tmux.name == session_name)
                         })
                     };
                     if matches {
@@ -1459,6 +1466,8 @@ impl App {
                 self.active_repo_index = self.active_repo_index.saturating_sub(1);
                 self.cursor = 0;
                 self.sub_cursor = SubCursor::None;
+                self.pane_content.clear();
+                self.fetch_task_pane_content();
                 ok()
             }
             Message::NextRepo => {
@@ -1466,6 +1475,8 @@ impl App {
                 self.active_repo_index = (self.active_repo_index + 1).min(repo_count);
                 self.cursor = 0;
                 self.sub_cursor = SubCursor::None;
+                self.pane_content.clear();
+                self.fetch_task_pane_content();
                 ok()
             }
             Message::ExpandRow => {
@@ -1980,6 +1991,10 @@ pub fn run(command: &str) -> anyhow::Result<Option<String>> {
     terminal.clear()?;
 
     let mut app = App::new(command);
+
+    // Expand all rows immediately using cached disk data, so the first frame
+    // renders with hierarchy visible instead of waiting for background refresh.
+    app.prune_expansion_state();
 
     // Guard: standalone session names must not collide with worktree-derived names.
     check_standalone_collisions(&app.standalone_sessions, &app.task_rows)?;
@@ -4325,6 +4340,205 @@ mod tests {
         assert_eq!(app.input_phase, InputPhase::Idle);
         let o_key = KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(o_key), Some(Message::OpenPR));
+    }
+
+    // -----------------------------------------------------------------------
+    // Bug #111: 'o' key must resolve to parent worktree row when on a sub-row
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn open_pr_resolves_parent_when_on_pane_sub_row() {
+        // Cursor stays at the parent row even when sub_cursor points at a pane.
+        // OpenPR must look up the parent row (where PR info lives), not the sub-row.
+        let row = WorktreeRow {
+            pr: Some(DPrInfo {
+                number: 42,
+                branch: "feat/issue-42".to_string(),
+                state: Some("open".to_string()),
+                review_decision: None,
+                checks_state: None,
+                has_conflicts: false,
+                unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
+                is_draft: false,
+            }),
+            ..make_task_row_with_panes(42, 3)
+        };
+        let mut app = App::new_test(vec![row]);
+        app.expanded.insert("/workspace/repo-42".to_string());
+        // Navigate into a pane sub-row.
+        app.sub_cursor = SubCursor::Pane { window: 0, pane: 1 };
+        // OpenPR must not fail — cursor still points at the parent row.
+        // We verify by checking that the message dispatches to OpenPR (key mapping)
+        // and that calling update(OpenPR) completes without panic or warning.
+        let o_key = KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE);
+        assert_eq!(
+            app.handle_event(o_key),
+            Some(Message::OpenPR),
+            "'o' key on a pane sub-row must dispatch OpenPR"
+        );
+        // update must not set a warning (which guard_requires_worktree would do if
+        // it mistakenly treated the sub-row as a standalone row).
+        app.update(Message::OpenPR);
+        assert!(
+            app.warning.is_none(),
+            "OpenPR on a pane sub-row must not trigger the 'requires worktree' warning"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Bug #99: preview pane must accept pane content under an active repo filter
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pane_content_accepted_when_repo_filter_active() {
+        // Two rows from different repos. Cursor is on repo-b's row (filtered visible[0])
+        // while task_rows[0] is a repo-a row. The PaneContent handler must use the
+        // filtered list, not task_rows, so the session name matches correctly.
+        let row_a = WorktreeRow {
+            repo_slug: "acme/repo-a".to_string(),
+            worktree_path: "/workspace/repo-a-feat".to_string(),
+            branch: "feat/issue-1".to_string(),
+            sessions: vec![EnrichedSession {
+                tmux: TmuxSessionInfo {
+                    name: "sess-repo-a".to_string(),
+                    host: Host::Local,
+                    status: SessionStatus::Running { attached: false },
+                },
+                claude: None,
+                windows: vec![],
+                panes: vec![],
+            }],
+            ..make_task_row(1, DisplayGroup::Normal)
+        };
+        let row_b = WorktreeRow {
+            repo_slug: "acme/repo-b".to_string(),
+            worktree_path: "/workspace/repo-b-feat".to_string(),
+            branch: "feat/issue-2".to_string(),
+            sessions: vec![EnrichedSession {
+                tmux: TmuxSessionInfo {
+                    name: "sess-repo-b".to_string(),
+                    host: Host::Local,
+                    status: SessionStatus::Running { attached: false },
+                },
+                claude: None,
+                windows: vec![],
+                panes: vec![],
+            }],
+            ..make_task_row(2, DisplayGroup::Normal)
+        };
+
+        let mut app = App::new_test(vec![row_a, row_b]);
+        // Configure two repos so active_repo_index 2 = repos[1] = "acme/repo-b".
+        app.global_config.repos = vec![
+            global_config::RepoConfig {
+                slug: "acme/repo-a".to_string(),
+                path: "/workspace/repo-a".to_string(),
+                remotes: vec![],
+            },
+            global_config::RepoConfig {
+                slug: "acme/repo-b".to_string(),
+                path: "/workspace/repo-b".to_string(),
+                remotes: vec![],
+            },
+        ];
+        app.active_repo_index = 2; // repos[1] = "acme/repo-b"
+        app.cursor = 0; // visible[0] under repo-b filter = row_b
+
+        // Simulate the background thread delivering pane content for the repo-b session.
+        app.tx
+            .send(AppMsg::PaneContent(
+                "sess-repo-b".to_string(),
+                "repo-b pane output".to_string(),
+            ))
+            .unwrap();
+        app.check_updates();
+
+        assert_eq!(
+            app.pane_content, "repo-b pane output",
+            "pane content for the repo-b session must be accepted when repo-b filter is active"
+        );
+    }
+
+    #[test]
+    fn pane_content_rejected_for_stale_session_under_repo_filter() {
+        // Pane content for repo-a's session must be rejected when the filter shows only repo-b.
+        let row_a = WorktreeRow {
+            repo_slug: "acme/repo-a".to_string(),
+            worktree_path: "/workspace/repo-a-feat".to_string(),
+            branch: "feat/issue-1".to_string(),
+            sessions: vec![EnrichedSession {
+                tmux: TmuxSessionInfo {
+                    name: "sess-repo-a".to_string(),
+                    host: Host::Local,
+                    status: SessionStatus::Running { attached: false },
+                },
+                claude: None,
+                windows: vec![],
+                panes: vec![],
+            }],
+            ..make_task_row(1, DisplayGroup::Normal)
+        };
+        let row_b = WorktreeRow {
+            repo_slug: "acme/repo-b".to_string(),
+            worktree_path: "/workspace/repo-b-feat".to_string(),
+            branch: "feat/issue-2".to_string(),
+            sessions: vec![],
+            ..make_task_row(2, DisplayGroup::Normal)
+        };
+
+        let mut app = App::new_test(vec![row_a, row_b]);
+        app.global_config.repos = vec![
+            global_config::RepoConfig {
+                slug: "acme/repo-a".to_string(),
+                path: "/workspace/repo-a".to_string(),
+                remotes: vec![],
+            },
+            global_config::RepoConfig {
+                slug: "acme/repo-b".to_string(),
+                path: "/workspace/repo-b".to_string(),
+                remotes: vec![],
+            },
+        ];
+        app.active_repo_index = 2; // repo-b tab
+        app.cursor = 0; // visible[0] under repo-b filter = row_b (no session)
+
+        // Stale content for repo-a's session arrives — must be rejected.
+        app.tx
+            .send(AppMsg::PaneContent(
+                "sess-repo-a".to_string(),
+                "stale repo-a output".to_string(),
+            ))
+            .unwrap();
+        app.check_updates();
+
+        assert!(
+            app.pane_content.is_empty(),
+            "stale pane content for a filtered-out repo must be rejected"
+        );
+    }
+
+    #[test]
+    fn switching_repo_tab_clears_pane_content() {
+        // Switching repo tabs must clear stale pane content from the previous tab.
+        let row = WorktreeRow {
+            repo_slug: "acme/repo-a".to_string(),
+            ..make_task_row(1, DisplayGroup::Normal)
+        };
+        let mut app = App::new_test(vec![row]);
+        app.pane_content = "old content".to_string();
+        app.global_config.repos = vec![global_config::RepoConfig {
+            slug: "acme/repo-a".to_string(),
+            path: "/workspace/repo-a".to_string(),
+            remotes: vec![],
+        }];
+
+        app.update(Message::NextRepo);
+        assert!(
+            app.pane_content.is_empty(),
+            "switching repo tabs must clear stale pane content"
+        );
     }
 
     #[test]

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -2784,7 +2784,9 @@ mod tests {
         let mut app = App::new_test(vec![active_row, normal_row]);
         let output = render_to_string(&mut app, 120, 40);
 
-        let pos_active = output.find("active").expect("expected 'active' section header");
+        let pos_active = output
+            .find("active")
+            .expect("expected 'active' section header");
         let pos_wip = output
             .find("work in progress")
             .expect("expected 'work in progress' section header");
@@ -3342,11 +3344,7 @@ mod tests {
                 windows: vec![],
                 panes: vec![],
             }],
-            ..make_task_row_with_title(
-                47,
-                "Shepherd persistent session",
-                DisplayGroup::Active,
-            )
+            ..make_task_row_with_title(47, "Shepherd persistent session", DisplayGroup::Active)
         };
         let ready = WorktreeRow {
             pr: Some(DPrInfo {

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -2150,6 +2150,7 @@ mod tests {
             issue_number: Some(issue_number),
             issue_title: Some(format!("Test task {}", issue_number)),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: group,
@@ -2278,6 +2279,8 @@ mod tests {
                     checks_state: None,
                     has_conflicts: false,
                     unresolved_threads: 0,
+                    failing_checks: vec![],
+                    labels: vec![],
                 }),
                 ..make_task_row(1, DisplayGroup::Other)
             },
@@ -2308,6 +2311,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::Other)
         }];
@@ -2337,6 +2342,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::Other)
         }];
@@ -2575,6 +2582,8 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row(42, DisplayGroup::ReadyToMerge)
         };
@@ -2672,6 +2681,7 @@ mod tests {
             issue_number: None,
             issue_title: None,
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: group,
@@ -2740,6 +2750,8 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_worktree_row("feat/needs-attn", DisplayGroup::NeedsAttention)
         };
@@ -2770,6 +2782,8 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_worktree_row("feat/approved", DisplayGroup::ReadyToMerge)
         };
@@ -2845,6 +2859,8 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_worktree_row("feat/branch", DisplayGroup::NeedsAttention)
         };
@@ -3302,6 +3318,8 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 2,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
@@ -3329,6 +3347,8 @@ mod tests {
                 checks_state: Some("pending".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
@@ -3360,6 +3380,8 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                failing_checks: vec![],
+                labels: vec![],
             }),
             ..make_task_row_with_title(54, "Add Theme struct", DisplayGroup::ReadyToMerge)
         };
@@ -3875,6 +3897,7 @@ mod tests {
             issue_number: None,
             issue_title: None,
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -848,7 +848,6 @@ impl App {
                             KeyCode::Char('i') => Some(Message::OpenIssue),
                             KeyCode::Char('B') => Some(Message::ToggleBranchColumn),
                             KeyCode::Char('d') => Some(Message::Delete),
-                            KeyCode::Char('p') => Some(Message::TogglePriority),
                             KeyCode::Char('n') => Some(Message::NewSession),
                             KeyCode::Char('w') => Some(Message::NewWorktree),
                             KeyCode::Char('c') => Some(Message::Cleanup),
@@ -1442,29 +1441,6 @@ impl App {
                         phase: Phase::Confirm,
                         error: None,
                     }));
-                }
-                ok()
-            }
-            Message::TogglePriority => {
-                let standalone_count = self.standalone_sessions.len();
-                if self.guard_requires_worktree(standalone_count) {
-                    return ok();
-                }
-                let worktree_cursor = self.cursor - standalone_count;
-                let visible = list::visible_tasks_filtered(
-                    &self.task_rows,
-                    &self.filter_text,
-                    self.active_repo_slug(),
-                );
-                if let Some(vt) = visible.get(worktree_cursor) {
-                    let path = vt.row.worktree_path.clone();
-                    drop(visible);
-                    crate::priority::toggle_priority(&path);
-                    self.task_rows = crate::build_state::build_task_rows(&self.global_config);
-                    let total = standalone_count + self.task_rows.len();
-                    if total > 0 && self.cursor >= total {
-                        self.cursor = total - 1;
-                    }
                 }
                 ok()
             }
@@ -2283,9 +2259,9 @@ mod tests {
                     labels: vec![],
                     is_draft: false,
                 }),
-                ..make_task_row(1, DisplayGroup::Other)
+                ..make_task_row(1, DisplayGroup::Normal)
             },
-            make_task_row(2, DisplayGroup::Other),
+            make_task_row(2, DisplayGroup::Normal),
         ];
         let stale = filter_stale(&rows);
         assert_eq!(stale.len(), 1);
@@ -2295,7 +2271,7 @@ mod tests {
     fn filter_stale_closed_issue() {
         let rows = vec![WorktreeRow {
             issue_state: Some("closed".to_string()),
-            ..make_task_row(1, DisplayGroup::Other)
+            ..make_task_row(1, DisplayGroup::Normal)
         }];
         let stale = filter_stale(&rows);
         assert_eq!(stale.len(), 1);
@@ -2316,7 +2292,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(1, DisplayGroup::Other)
+            ..make_task_row(1, DisplayGroup::Normal)
         }];
         let stale = filter_stale(&rows);
         assert_eq!(stale.len(), 1);
@@ -2326,7 +2302,7 @@ mod tests {
     fn filter_stale_completed_issue() {
         let rows = vec![WorktreeRow {
             issue_state: Some("completed".to_string()),
-            ..make_task_row(1, DisplayGroup::Other)
+            ..make_task_row(1, DisplayGroup::Normal)
         }];
         let stale = filter_stale(&rows);
         assert_eq!(stale.len(), 1);
@@ -2348,7 +2324,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(1, DisplayGroup::Other)
+            ..make_task_row(1, DisplayGroup::Normal)
         }];
         let stale = filter_stale(&rows);
         assert!(stale.is_empty());
@@ -2479,14 +2455,14 @@ mod tests {
         let rows = vec![make_task_row_with_title(
             42,
             "Fix login bug",
-            DisplayGroup::Other,
+            DisplayGroup::Normal,
         )];
         let mut app = App::new_test(rows);
         let output = render_to_string(&mut app, 120, 40);
         assert!(output.contains("Fix login bug"), "expected title in output");
         assert!(output.contains("#42"), "expected issue number in output");
         assert!(
-            output.contains("other"),
+            output.contains("work in progress"),
             "expected section header in output"
         );
     }
@@ -2551,8 +2527,8 @@ mod tests {
     #[test]
     fn j_advances_cursor_in_task_view() {
         let rows = vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::ClaudeWorking),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
         ];
         let mut app = App::new_test(rows);
         assert_eq!(app.cursor, 0);
@@ -2564,8 +2540,8 @@ mod tests {
     #[test]
     fn k_moves_cursor_up_in_task_view() {
         let rows = vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::ClaudeWorking),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
         ];
         let mut app = App::new_test(rows);
         app.cursor = 1;
@@ -2589,7 +2565,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row(42, DisplayGroup::ReadyToMerge)
+            ..make_task_row(42, DisplayGroup::Normal)
         };
         let mut app = App::new_test(vec![row]);
         let output = render_to_string(&mut app, 120, 40);
@@ -2611,7 +2587,7 @@ mod tests {
                 windows: vec![],
                 panes: vec![],
             }],
-            ..make_task_row(1, DisplayGroup::ClaudeWorking)
+            ..make_task_row(1, DisplayGroup::Active)
         };
         let mut app = App::new_test(vec![row]);
         app.host_reachable.insert("gpu1".to_string(), false);
@@ -2664,7 +2640,7 @@ mod tests {
     fn enter_on_worktree_without_session_creates_session() {
         // In the worktree-first model, every row has a worktree, so Enter
         // creates a session rather than showing a dialog.
-        let rows = vec![make_task_row(42, DisplayGroup::NeedsAttention)];
+        let rows = vec![make_task_row(42, DisplayGroup::Active)];
         let mut app = App::new_test(rows);
         let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
         send_key(&mut app, key);
@@ -2704,20 +2680,20 @@ mod tests {
             display_group: DisplayGroup::RepoMain,
             ..make_worktree_row("main", DisplayGroup::RepoMain)
         };
-        let other = make_worktree_row("feat/something", DisplayGroup::Other);
-        let mut app = App::new_test(vec![main_wt, other]);
+        let normal_wt = make_worktree_row("feat/something", DisplayGroup::Normal);
+        let mut app = App::new_test(vec![main_wt, normal_wt]);
         let output = render_to_string(&mut app, 120, 40);
 
-        // "repo main" section header must appear before "other"
+        // "repo main" section header must appear before "work in progress"
         let repo_main_pos = output
             .find("repo main")
             .expect("expected 'repo main' section header");
-        let other_pos = output
-            .find("other")
-            .expect("expected 'other' section header");
+        let wip_pos = output
+            .find("work in progress")
+            .expect("expected 'work in progress' section header");
         assert!(
-            repo_main_pos < other_pos,
-            "repo main section must appear before other section"
+            repo_main_pos < wip_pos,
+            "repo main section must appear before work in progress section"
         );
 
         // The main worktree row must be visible (shows repo name in TITLE column).
@@ -2728,8 +2704,8 @@ mod tests {
     }
 
     #[test]
-    fn worktree_without_pr_renders_in_other_section() {
-        let row = make_worktree_row("experimental", DisplayGroup::Other);
+    fn worktree_without_pr_renders_in_normal_section() {
+        let row = make_worktree_row("experimental", DisplayGroup::Normal);
         let mut app = App::new_test(vec![row]);
         let output = render_to_string(&mut app, 120, 40);
 
@@ -2738,29 +2714,14 @@ mod tests {
             "expected branch name in output"
         );
         assert!(
-            output.contains("other"),
-            "expected 'other' section header in output"
+            output.contains("work in progress"),
+            "expected 'work in progress' section header in output"
         );
     }
 
     #[test]
     fn display_groups_render_in_correct_order() {
-        let needs_attention = WorktreeRow {
-            pr: Some(DPrInfo {
-                number: 10,
-                branch: "feat/needs-attn".to_string(),
-                state: None,
-                review_decision: None,
-                checks_state: Some("failing".to_string()),
-                has_conflicts: false,
-                unresolved_threads: 0,
-                failing_checks: vec![],
-                labels: vec![],
-                is_draft: false,
-            }),
-            ..make_worktree_row("feat/needs-attn", DisplayGroup::NeedsAttention)
-        };
-        let claude_working = WorktreeRow {
+        let active_row = WorktreeRow {
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
                     host: Host::Local,
@@ -2776,53 +2737,27 @@ mod tests {
                 windows: vec![],
                 panes: vec![],
             }],
-            ..make_worktree_row("feat/claude-active", DisplayGroup::ClaudeWorking)
+            ..make_worktree_row("feat/claude-active", DisplayGroup::Active)
         };
-        let ready_to_merge = WorktreeRow {
-            pr: Some(DPrInfo {
-                number: 20,
-                branch: "feat/approved".to_string(),
-                state: None,
-                review_decision: Some("approved".to_string()),
-                checks_state: Some("passing".to_string()),
-                has_conflicts: false,
-                unresolved_threads: 0,
-                failing_checks: vec![],
-                labels: vec![],
-                is_draft: false,
-            }),
-            ..make_worktree_row("feat/approved", DisplayGroup::ReadyToMerge)
-        };
-        let other = make_worktree_row("feat/plain", DisplayGroup::Other);
+        let normal_row = make_worktree_row("feat/plain", DisplayGroup::Normal);
 
-        // Pre-sort to match expected display order (as derive::derive_all_repos would produce)
-        let mut app = App::new_test(vec![needs_attention, claude_working, ready_to_merge, other]);
+        // Active group renders before Normal group.
+        let mut app = App::new_test(vec![active_row, normal_row]);
         let output = render_to_string(&mut app, 120, 40);
 
-        let pos_na = output
-            .find("needs attention")
-            .expect("expected 'needs attention'");
-        let pos_cw = output
-            .find("claude working")
-            .expect("expected 'claude working'");
-        let pos_rtm = output
-            .find("ready to merge")
-            .expect("expected 'ready to merge'");
-        let pos_other = output.find("other").expect("expected 'other'");
+        let pos_active = output.find("active").expect("expected 'active' section header");
+        let pos_wip = output
+            .find("work in progress")
+            .expect("expected 'work in progress' section header");
 
         assert!(
-            pos_na < pos_cw,
-            "needs attention must come before claude working"
+            pos_active < pos_wip,
+            "active must come before work in progress"
         );
-        assert!(
-            pos_cw < pos_rtm,
-            "claude working must come before ready to merge"
-        );
-        assert!(pos_rtm < pos_other, "ready to merge must come before other");
     }
 
     #[test]
-    fn claude_needs_input_indicator_renders_and_row_in_needs_attention() {
+    fn claude_needs_input_indicator_renders_and_row_in_active() {
         let row = WorktreeRow {
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
@@ -2839,7 +2774,7 @@ mod tests {
                 windows: vec![],
                 panes: vec![],
             }],
-            ..make_worktree_row("feat/waiting", DisplayGroup::NeedsAttention)
+            ..make_worktree_row("feat/waiting", DisplayGroup::Active)
         };
         let mut app = App::new_test(vec![row]);
         let output = render_to_string(&mut app, 120, 40);
@@ -2849,8 +2784,8 @@ mod tests {
             "expected 'input' claude status indicator"
         );
         assert!(
-            output.contains("needs attention"),
-            "expected NeedsAttention section header"
+            output.contains("active"),
+            "expected 'active' section header"
         );
     }
 
@@ -2869,7 +2804,7 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_worktree_row("feat/branch", DisplayGroup::NeedsAttention)
+            ..make_worktree_row("feat/branch", DisplayGroup::Active)
         };
         let mut app = App::new_test(vec![row]);
         let output = render_to_string(&mut app, 120, 40);
@@ -2885,7 +2820,7 @@ mod tests {
     fn remote_host_indicator_renders_for_remote_worktree() {
         let row = WorktreeRow {
             worktree_host: Some("gpu1".to_string()),
-            ..make_worktree_row("feat/remote", DisplayGroup::Other)
+            ..make_worktree_row("feat/remote", DisplayGroup::Normal)
         };
         let mut app = App::new_test(vec![row]);
         app.host_reachable.insert("gpu1".to_string(), true);
@@ -2912,7 +2847,7 @@ mod tests {
                 windows: vec![],
                 panes: vec![],
             }],
-            ..make_worktree_row("feat/remote", DisplayGroup::Other)
+            ..make_worktree_row("feat/remote", DisplayGroup::Normal)
         };
         let mut app = App::new_test(vec![row]);
         app.host_reachable.insert("gpu1".to_string(), false);
@@ -2930,7 +2865,7 @@ mod tests {
         let row = WorktreeRow {
             issue_number: Some(2478),
             issue_title: Some("Support workflow agents".to_string()),
-            ..make_worktree_row("webapp-2478", DisplayGroup::Other)
+            ..make_worktree_row("webapp-2478", DisplayGroup::Normal)
         };
         let mut app = App::new_test(vec![row]);
         let output = render_to_string(&mut app, 120, 40);
@@ -2966,9 +2901,9 @@ mod tests {
     #[test]
     fn j_moves_cursor_down_in_worktree_first_view() {
         let rows = vec![
-            make_worktree_row("feat/one", DisplayGroup::NeedsAttention),
-            make_worktree_row("feat/two", DisplayGroup::ClaudeWorking),
-            make_worktree_row("feat/three", DisplayGroup::ReadyToMerge),
+            make_worktree_row("feat/one", DisplayGroup::Active),
+            make_worktree_row("feat/two", DisplayGroup::Active),
+            make_worktree_row("feat/three", DisplayGroup::Normal),
         ];
         let mut app = App::new_test(rows);
         assert_eq!(app.cursor, 0);
@@ -2981,9 +2916,9 @@ mod tests {
     #[test]
     fn k_moves_cursor_up_in_worktree_first_view() {
         let rows = vec![
-            make_worktree_row("feat/one", DisplayGroup::NeedsAttention),
-            make_worktree_row("feat/two", DisplayGroup::ClaudeWorking),
-            make_worktree_row("feat/three", DisplayGroup::ReadyToMerge),
+            make_worktree_row("feat/one", DisplayGroup::Active),
+            make_worktree_row("feat/two", DisplayGroup::Active),
+            make_worktree_row("feat/three", DisplayGroup::Normal),
         ];
         let mut app = App::new_test(rows);
         app.cursor = 1;
@@ -2996,9 +2931,9 @@ mod tests {
     #[test]
     fn q_returns_true_in_worktree_first_view() {
         let rows = vec![
-            make_worktree_row("feat/one", DisplayGroup::NeedsAttention),
-            make_worktree_row("feat/two", DisplayGroup::ClaudeWorking),
-            make_worktree_row("feat/three", DisplayGroup::ReadyToMerge),
+            make_worktree_row("feat/one", DisplayGroup::Active),
+            make_worktree_row("feat/two", DisplayGroup::Active),
+            make_worktree_row("feat/three", DisplayGroup::Normal),
         ];
         let mut app = App::new_test(rows);
         let q = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE);
@@ -3066,9 +3001,9 @@ mod tests {
     fn handle_event_digit_in_searching_goes_to_filter() {
         // Digits are printable chars — in Searching phase they feed the filter.
         let rows = vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::ClaudeWorking),
-            make_task_row(3, DisplayGroup::Other),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
+            make_task_row(3, DisplayGroup::Normal),
         ];
         let mut app = App::new_test(rows);
         app.input_phase = InputPhase::Searching;
@@ -3080,9 +3015,9 @@ mod tests {
     fn handle_event_digit_in_idle_returns_cursor_to() {
         // Digits dispatch CursorTo directly in Idle phase.
         let rows = vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::ClaudeWorking),
-            make_task_row(3, DisplayGroup::Other),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
+            make_task_row(3, DisplayGroup::Normal),
         ];
         let app = App::new_test(rows);
         let key = KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE);
@@ -3093,7 +3028,7 @@ mod tests {
     fn handle_event_delete_confirm_y() {
         let mut app = App::new_test(vec![]);
         app.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
-            target: make_task_row(1, DisplayGroup::Other),
+            target: make_task_row(1, DisplayGroup::Normal),
             phase: Phase::Confirm,
             error: None,
         }));
@@ -3117,18 +3052,11 @@ mod tests {
     }
 
     #[test]
-    fn handle_event_p_maps_to_toggle_priority() {
-        // 'p' dispatches TogglePriority directly in Idle phase.
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+    fn handle_event_p_is_unbound() {
+        // 'p' is no longer bound — TogglePriority has been removed.
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let key = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE);
-        assert_eq!(app.handle_event(key), Some(Message::TogglePriority));
-    }
-
-    #[test]
-    fn toggle_priority_update_does_not_quit() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
-        let result = app.update(Message::TogglePriority);
-        assert!(!result.quit);
+        assert_eq!(app.handle_event(key), None);
     }
 
     // -----------------------------------------------------------------------
@@ -3344,7 +3272,7 @@ mod tests {
                 windows: vec![],
                 panes: vec![],
             }],
-            ..make_task_row_with_title(53, "TEA pattern refactor", DisplayGroup::NeedsAttention)
+            ..make_task_row_with_title(53, "TEA pattern refactor", DisplayGroup::Active)
         };
         let working = WorktreeRow {
             pr: Some(DPrInfo {
@@ -3377,7 +3305,7 @@ mod tests {
             ..make_task_row_with_title(
                 47,
                 "Shepherd persistent session",
-                DisplayGroup::ClaudeWorking,
+                DisplayGroup::Active,
             )
         };
         let ready = WorktreeRow {
@@ -3393,9 +3321,9 @@ mod tests {
                 labels: vec![],
                 is_draft: false,
             }),
-            ..make_task_row_with_title(54, "Add Theme struct", DisplayGroup::ReadyToMerge)
+            ..make_task_row_with_title(54, "Add Theme struct", DisplayGroup::Normal)
         };
-        let other = make_task_row_with_title(16, "Orchard heal command", DisplayGroup::Other);
+        let other = make_task_row_with_title(16, "Orchard heal command", DisplayGroup::Normal);
 
         let mut app = App::new_test(vec![shepherd, needs_attn, working, ready, other]);
         let ansi = render_to_ansi(&mut app, 120, 30);
@@ -3451,21 +3379,21 @@ mod tests {
 
     #[test]
     fn mouse_scroll_down_in_table_returns_cursor_down() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         let event = make_mouse_event(MouseEventKind::ScrollDown, 10, 7);
         assert_eq!(app.handle_mouse_event(event), Some(Message::CursorDown));
     }
 
     #[test]
     fn mouse_scroll_up_in_table_returns_cursor_up() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         let event = make_mouse_event(MouseEventKind::ScrollUp, 10, 7);
         assert_eq!(app.handle_mouse_event(event), Some(Message::CursorUp));
     }
 
     #[test]
     fn mouse_scroll_outside_table_returns_none() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         // y=2 is above the table body (starts at y=5).
         let event = make_mouse_event(MouseEventKind::ScrollDown, 10, 2);
         assert_eq!(app.handle_mouse_event(event), None);
@@ -3474,9 +3402,9 @@ mod tests {
     #[test]
     fn mouse_click_selects_row() {
         let mut app = app_with_table_area(vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::NeedsAttention),
-            make_task_row(3, DisplayGroup::NeedsAttention),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
+            make_task_row(3, DisplayGroup::Active),
         ]);
         // All in same group, so group header at visual row 0, data rows at 1, 2, 3.
         // Click on visual row 2 (y=5+2=7) -> task index 1 -> cursor 1.
@@ -3486,7 +3414,7 @@ mod tests {
 
     #[test]
     fn mouse_click_on_group_header_returns_none() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         // Group header is at visual row 0 (y=5).
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 5);
         assert_eq!(app.handle_mouse_event(event), None);
@@ -3494,7 +3422,7 @@ mod tests {
 
     #[test]
     fn mouse_click_below_last_row_returns_none() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         // One group header + one data row = 2 visual rows. Click at visual row 5 is out of range.
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 10);
         assert_eq!(app.handle_mouse_event(event), None);
@@ -3502,7 +3430,7 @@ mod tests {
 
     #[test]
     fn mouse_click_outside_table_x_returns_none() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         // x=90 is outside the table (width=80).
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 90, 7);
         assert_eq!(app.handle_mouse_event(event), None);
@@ -3511,8 +3439,8 @@ mod tests {
     #[test]
     fn mouse_double_click_returns_activate_row() {
         let mut app = app_with_table_area(vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::NeedsAttention),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
         ]);
         // First click: visual row 1 (y=6) -> cursor 0.
         let event1 = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 6);
@@ -3531,9 +3459,9 @@ mod tests {
     #[test]
     fn mouse_clicks_on_different_rows_not_double_click() {
         let mut app = app_with_table_area(vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::NeedsAttention),
-            make_task_row(3, DisplayGroup::NeedsAttention),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
+            make_task_row(3, DisplayGroup::Active),
         ]);
         // Click on row 0 (visual row 1, y=6).
         let event1 = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 6);
@@ -3548,8 +3476,8 @@ mod tests {
     fn mouse_events_work_during_filtering() {
         // Mouse events are processed in List view regardless of filter state.
         let mut app = app_with_table_area(vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::NeedsAttention),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
         ]);
         app.filter_text = "some-filter".to_string();
         let event = make_mouse_event(MouseEventKind::ScrollDown, 10, 7);
@@ -3558,7 +3486,7 @@ mod tests {
 
     #[test]
     fn mouse_events_ignored_in_help_view() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         app.view = ViewState::Help;
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 7);
         assert_eq!(app.handle_mouse_event(event), None);
@@ -3568,7 +3496,7 @@ mod tests {
     fn mouse_events_ignored_in_confirm_delete_view() {
         let mut app = app_with_table_area(vec![]);
         app.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
-            target: make_task_row(1, DisplayGroup::Other),
+            target: make_task_row(1, DisplayGroup::Normal),
             phase: Phase::Confirm,
             error: None,
         }));
@@ -3584,7 +3512,7 @@ mod tests {
 
     #[test]
     fn last_click_stored_after_single_click() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 6);
         app.handle_mouse_event(event);
         assert!(app.last_click.is_some());
@@ -3594,7 +3522,7 @@ mod tests {
 
     #[test]
     fn last_click_reset_after_double_click() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 6);
         app.handle_mouse_event(event);
         assert!(app.last_click.is_some());
@@ -3620,7 +3548,7 @@ mod tests {
 
     #[test]
     fn visual_row_to_cursor_standalone_sessions() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Active)]);
         // Add a standalone session.
         app.standalone_sessions
             .push(crate::session::StandaloneSessionRow {
@@ -3644,7 +3572,7 @@ mod tests {
 
         // Visual row 0 = standalone session -> cursor 0.
         assert_eq!(app.visual_row_to_cursor(0), Some(0));
-        // Visual row 1 = group header for NeedsAttention -> None.
+        // Visual row 1 = group header for Active -> None.
         assert_eq!(app.visual_row_to_cursor(1), None);
         // Visual row 2 = first task row -> cursor 1 (standalone_count=1 + task_idx=0).
         assert_eq!(app.visual_row_to_cursor(2), Some(1));
@@ -3653,15 +3581,15 @@ mod tests {
     #[test]
     fn visual_row_to_cursor_multiple_groups() {
         let app = App::new_test(vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::NeedsAttention),
-            make_task_row(3, DisplayGroup::Other),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
+            make_task_row(3, DisplayGroup::Normal),
         ]);
         // No standalone sessions. Layout:
-        // Row 0: NeedsAttention group header -> None
+        // Row 0: Active group header -> None
         // Row 1: task 0 -> cursor 0
         // Row 2: task 1 -> cursor 1
-        // Row 3: Other group header -> None
+        // Row 3: Normal group header -> None
         // Row 4: task 2 -> cursor 2
         assert_eq!(app.visual_row_to_cursor(0), None);
         assert_eq!(app.visual_row_to_cursor(1), Some(0));
@@ -3706,8 +3634,8 @@ mod tests {
     #[test]
     fn mouse_double_click_expired_returns_cursor_to() {
         let mut app = app_with_table_area(vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::NeedsAttention),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Active),
         ]);
         // First click on row 0.
         let event1 = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 6);
@@ -3723,7 +3651,7 @@ mod tests {
 
     #[test]
     fn mouse_right_click_on_table_returns_none() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Right), 10, 6);
         assert_eq!(app.handle_mouse_event(event), None);
     }
@@ -3733,7 +3661,7 @@ mod tests {
 
     #[test]
     fn handle_event_page_up_returns_preview_scroll() {
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Active)]);
         let key = KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::PreviewPageUp));
@@ -3741,7 +3669,7 @@ mod tests {
 
     #[test]
     fn handle_event_page_down_returns_preview_scroll() {
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Active)]);
         let key = KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::PreviewPageDown));
@@ -3749,7 +3677,7 @@ mod tests {
 
     #[test]
     fn preview_page_down_advances_scroll_state() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Active)]);
         let initial = app.preview_scroll_state.get();
         app.update(Message::PreviewPageDown);
         let after = app.preview_scroll_state.get();
@@ -3762,7 +3690,7 @@ mod tests {
 
     #[test]
     fn preview_page_up_decrements_scroll_state() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Active)]);
         // First scroll down, then back up.
         app.update(Message::PreviewPageDown);
         app.update(Message::PreviewPageDown);
@@ -3793,7 +3721,7 @@ mod tests {
 
     #[test]
     fn mouse_scroll_down_in_preview_returns_preview_scroll_down() {
-        let mut app = app_with_preview_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_preview_area(vec![make_task_row(1, DisplayGroup::Active)]);
         let event = make_mouse_event(MouseEventKind::ScrollDown, 10, 22);
         assert_eq!(
             app.handle_mouse_event(event),
@@ -3803,7 +3731,7 @@ mod tests {
 
     #[test]
     fn mouse_scroll_up_in_preview_returns_preview_scroll_up() {
-        let mut app = app_with_preview_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_preview_area(vec![make_task_row(1, DisplayGroup::Active)]);
         let event = make_mouse_event(MouseEventKind::ScrollUp, 10, 22);
         assert_eq!(
             app.handle_mouse_event(event),
@@ -3813,7 +3741,7 @@ mod tests {
 
     #[test]
     fn mouse_scroll_in_preview_with_zero_rect_returns_none() {
-        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = app_with_table_area(vec![make_task_row(1, DisplayGroup::Active)]);
         // preview_area defaults to Rect::default() (width=0), so no hit.
         let event = make_mouse_event(MouseEventKind::ScrollDown, 10, 22);
         assert_eq!(app.handle_mouse_event(event), None);
@@ -3821,7 +3749,7 @@ mod tests {
 
     #[test]
     fn preview_scroll_down_advances_state_by_three_lines() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Active)]);
         let initial = app.preview_scroll_state.get();
         app.update(Message::PreviewScrollDown);
         let after = app.preview_scroll_state.get();
@@ -3834,7 +3762,7 @@ mod tests {
 
     #[test]
     fn preview_scroll_up_decreases_state_by_three_lines() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Active)]);
         // Scroll down first so we have room to scroll up.
         app.update(Message::PreviewScrollDown);
         app.update(Message::PreviewScrollDown);
@@ -3850,7 +3778,7 @@ mod tests {
 
     #[test]
     fn ascii_art_renders_in_tall_terminal() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Active)]);
         app.repo_name = "orchard".to_string();
         let output = render_to_string(&mut app, 120, 40);
         // The ASCII art logo should always appear in tall terminals.
@@ -3862,7 +3790,7 @@ mod tests {
 
     #[test]
     fn compact_header_on_short_terminal() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::NeedsAttention)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Active)]);
         app.repo_name = "orchard".to_string();
         // Short terminal: 20 rows, well below FULL_HEADER_MIN_HEIGHT.
         let output = render_to_string(&mut app, 120, 20);
@@ -3919,7 +3847,7 @@ mod tests {
                 windows: vec![],
                 panes: vec![],
             }],
-            display_group: DisplayGroup::Other,
+            display_group: DisplayGroup::Normal,
             is_main_worktree: false,
         }
     }
@@ -3967,7 +3895,7 @@ mod tests {
     #[test]
     fn h_key_maps_to_collapse_behind_leader() {
         // 'h' dispatches CollapseRow directly in Idle phase.
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let key = KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::CollapseRow));
@@ -3975,7 +3903,7 @@ mod tests {
 
     #[test]
     fn left_arrow_maps_to_collapse() {
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let key = KeyEvent::new(KeyCode::Left, KeyModifiers::NONE);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::CollapseRow));
@@ -3983,7 +3911,7 @@ mod tests {
 
     #[test]
     fn right_arrow_maps_to_expand() {
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let key = KeyEvent::new(KeyCode::Right, KeyModifiers::NONE);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::ExpandRow));
@@ -3992,7 +3920,7 @@ mod tests {
     #[test]
     fn l_key_maps_to_expand_behind_leader() {
         // 'l' dispatches ExpandRow directly in Idle phase.
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let key = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::ExpandRow));
@@ -4000,7 +3928,7 @@ mod tests {
 
     #[test]
     fn tab_maps_to_next_repo() {
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let key = KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::NextRepo));
@@ -4008,7 +3936,7 @@ mod tests {
 
     #[test]
     fn backtab_maps_to_prev_repo() {
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let key = KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::PrevRepo));
@@ -4017,7 +3945,7 @@ mod tests {
     #[test]
     fn e_key_maps_to_toggle_expand_all_behind_leader() {
         // 'E' dispatches ToggleExpandAll directly in Idle phase.
-        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         let key = KeyEvent::new(KeyCode::Char('E'), KeyModifiers::SHIFT);
         let msg = app.handle_event(key);
         assert_eq!(msg, Some(Message::ToggleExpandAll));
@@ -4054,7 +3982,7 @@ mod tests {
                 windows,
                 panes,
             }],
-            ..make_task_row(issue, DisplayGroup::Other)
+            ..make_task_row(issue, DisplayGroup::Normal)
         }
     }
 
@@ -4095,7 +4023,7 @@ mod tests {
                 windows,
                 panes: all_panes,
             }],
-            ..make_task_row(issue, DisplayGroup::Other)
+            ..make_task_row(issue, DisplayGroup::Normal)
         }
     }
 
@@ -4354,8 +4282,8 @@ mod tests {
     #[test]
     fn filter_char_appends_and_resets_cursor() {
         let rows = vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::Other),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Normal),
         ];
         let mut app = App::new_test(rows);
         app.cursor = 1;
@@ -4369,7 +4297,7 @@ mod tests {
 
     #[test]
     fn filter_backspace_removes_last_char() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         app.filter_text = "abc".to_string();
         app.update(Message::FilterBackspace);
         assert_eq!(app.filter_text, "ab");
@@ -4409,7 +4337,7 @@ mod tests {
 
     #[test]
     fn enter_clears_filter() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         app.filter_text = "feat".to_string();
         app.update(Message::Enter);
         assert_eq!(app.filter_text, "", "Enter should clear the filter");
@@ -4442,8 +4370,8 @@ mod tests {
     fn arrow_keys_work_without_leader_in_idle() {
         // Up/Down arrow keys dispatch directly in Idle phase.
         let rows = vec![
-            make_task_row(1, DisplayGroup::NeedsAttention),
-            make_task_row(2, DisplayGroup::Other),
+            make_task_row(1, DisplayGroup::Active),
+            make_task_row(2, DisplayGroup::Normal),
         ];
         let mut app = App::new_test(rows);
         app.cursor = 1;
@@ -4457,7 +4385,7 @@ mod tests {
     #[test]
     fn printable_chars_go_to_filter_in_searching_not_actions() {
         // In Searching phase, 'o' becomes FilterChar('o'), not OpenPR.
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         app.input_phase = InputPhase::Searching;
         let key = KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(key), Some(Message::FilterChar('o')));
@@ -4472,7 +4400,7 @@ mod tests {
 
     #[test]
     fn searching_phase_persists_through_action_messages() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         app.input_phase = InputPhase::Searching;
         app.update(Message::CursorDown);
         assert_eq!(app.input_phase, InputPhase::Searching);
@@ -4510,8 +4438,8 @@ mod tests {
     #[test]
     fn current_selection_for_worktree_row() {
         let mut app = App::new_test(vec![
-            make_task_row(1, DisplayGroup::Other),
-            make_task_row(2, DisplayGroup::Other),
+            make_task_row(1, DisplayGroup::Normal),
+            make_task_row(2, DisplayGroup::Normal),
         ]);
         app.cursor = 1;
         let sel = current_selection(&app).unwrap();
@@ -4521,7 +4449,7 @@ mod tests {
 
     #[test]
     fn current_selection_for_standalone_row() {
-        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Other)]);
+        let mut app = App::new_test(vec![make_task_row(1, DisplayGroup::Normal)]);
         app.standalone_sessions = vec![make_standalone_session("my-standalone")];
         app.cursor = 0;
         let sel = current_selection(&app).unwrap();
@@ -4539,9 +4467,9 @@ mod tests {
     #[test]
     fn current_selection_includes_active_repo_slug() {
         let mut app = App::new_test(vec![
-            make_task_row(1, DisplayGroup::Other),
-            make_task_row(2, DisplayGroup::Other),
-            make_task_row(3, DisplayGroup::Other),
+            make_task_row(1, DisplayGroup::Normal),
+            make_task_row(2, DisplayGroup::Normal),
+            make_task_row(3, DisplayGroup::Normal),
         ]);
         // Populate two repos in global_config so index 2 maps to "acme/beta".
         app.global_config.repos = vec![

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -1437,11 +1437,11 @@ impl App {
                     self.active_repo_slug(),
                 );
                 if let Some(vt) = visible.get(worktree_cursor) {
-                    self.view = ViewState::ConfirmDelete(state::DeleteState {
+                    self.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
                         target: vt.row.clone(),
                         phase: Phase::Confirm,
                         error: None,
-                    });
+                    }));
                 }
                 ok()
             }
@@ -3085,11 +3085,11 @@ mod tests {
     #[test]
     fn handle_event_delete_confirm_y() {
         let mut app = App::new_test(vec![]);
-        app.view = ViewState::ConfirmDelete(state::DeleteState {
+        app.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
             target: make_task_row(1, DisplayGroup::Other),
             phase: Phase::Confirm,
             error: None,
-        });
+        }));
         let key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(key), Some(Message::ConfirmYes));
     }
@@ -3557,11 +3557,11 @@ mod tests {
     #[test]
     fn mouse_events_ignored_in_confirm_delete_view() {
         let mut app = app_with_table_area(vec![]);
-        app.view = ViewState::ConfirmDelete(state::DeleteState {
+        app.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
             target: make_task_row(1, DisplayGroup::Other),
             phase: Phase::Confirm,
             error: None,
-        });
+        }));
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 7);
         assert_eq!(app.handle_mouse_event(event), None);
     }

--- a/crates/orchard/src/tui/state.rs
+++ b/crates/orchard/src/tui/state.rs
@@ -17,7 +17,7 @@ pub enum ViewState {
     /// The main worktree task list.
     List,
     /// A confirmation dialog for deleting a worktree.
-    ConfirmDelete(DeleteState),
+    ConfirmDelete(Box<DeleteState>),
     /// A multi-select dialog for cleaning up stale worktrees.
     Cleanup(CleanupState),
     /// A text-entry dialog for creating a new tmux session.

--- a/crates/orchard/src/tui/theme.rs
+++ b/crates/orchard/src/tui/theme.rs
@@ -152,11 +152,9 @@ impl Default for Theme {
 pub fn display_group_color(group: DisplayGroup, theme: &Theme) -> Color {
     match group {
         DisplayGroup::RepoMain => theme.orchardist,
-        DisplayGroup::Prioritized => theme.prioritized,
-        DisplayGroup::NeedsAttention => theme.error,
-        DisplayGroup::ClaudeWorking => theme.claude_active,
-        DisplayGroup::ReadyToMerge => theme.accent,
-        DisplayGroup::Other => theme.dimmed,
+        DisplayGroup::Active => theme.claude_active,
+        DisplayGroup::Normal => theme.dimmed,
+        DisplayGroup::Done => theme.dimmed,
     }
 }
 
@@ -288,46 +286,28 @@ mod tests {
     }
 
     #[test]
-    fn display_group_needs_attention_returns_theme_error() {
+    fn display_group_active_returns_theme_claude_active() {
         let theme = Theme::default();
         assert_eq!(
-            display_group_color(DisplayGroup::NeedsAttention, &theme),
-            theme.error
-        );
-    }
-
-    #[test]
-    fn display_group_claude_working_returns_theme_claude_active() {
-        let theme = Theme::default();
-        assert_eq!(
-            display_group_color(DisplayGroup::ClaudeWorking, &theme),
+            display_group_color(DisplayGroup::Active, &theme),
             theme.claude_active
         );
     }
 
     #[test]
-    fn display_group_ready_to_merge_returns_theme_accent() {
+    fn display_group_normal_returns_theme_dimmed() {
         let theme = Theme::default();
         assert_eq!(
-            display_group_color(DisplayGroup::ReadyToMerge, &theme),
-            theme.accent
+            display_group_color(DisplayGroup::Normal, &theme),
+            theme.dimmed
         );
     }
 
     #[test]
-    fn display_group_prioritized_returns_theme_prioritized() {
+    fn display_group_done_returns_theme_dimmed() {
         let theme = Theme::default();
         assert_eq!(
-            display_group_color(DisplayGroup::Prioritized, &theme),
-            theme.prioritized
-        );
-    }
-
-    #[test]
-    fn display_group_other_returns_theme_dimmed() {
-        let theme = Theme::default();
-        assert_eq!(
-            display_group_color(DisplayGroup::Other, &theme),
+            display_group_color(DisplayGroup::Done, &theme),
             theme.dimmed
         );
     }

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -320,6 +320,7 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            is_draft: false,
         }
     }
 

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -276,7 +276,7 @@ mod tests {
             issue: None,
             pr: None,
             sessions: vec![],
-            display_group: DisplayGroup::Other,
+            display_group: DisplayGroup::Normal,
             is_main_worktree: false,
         }
     }

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -154,6 +154,7 @@ pub fn diff(old: &OrchardState, new: &OrchardState) -> Vec<WatchEvent> {
                         worktree: path.to_string(),
                         pr_number,
                         label: label.clone(),
+                        failing_checks: new_pr.failing_checks.clone(),
                     }));
                 }
 
@@ -320,6 +321,8 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            failing_checks: vec![],
+            labels: vec![],
         }
     }
 
@@ -421,6 +424,38 @@ mod tests {
             .filter(|e| matches!(&e.kind, EventKind::CiFailed { .. }))
             .collect();
         assert_eq!(ci_events.len(), 1);
+    }
+
+    #[test]
+    fn diff_ci_failed_event_carries_failing_checks() {
+        use crate::orchard_state::FailedCheck;
+        let path = "/workspace/repo/feat-1";
+        let old_pr = make_pr(10);
+        let new_pr = PrState {
+            checks_state: Some("failing".to_string()),
+            failing_checks: vec![FailedCheck {
+                name: "e2e-tests".to_string(),
+                conclusion: "FAILURE".to_string(),
+            }],
+            ..make_pr(10)
+        };
+
+        let old_wt = with_pr(make_worktree(path, "feat/issue-1"), old_pr);
+        let new_wt = with_pr(make_worktree(path, "feat/issue-1"), new_pr);
+
+        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+
+        let ci_event = events
+            .iter()
+            .find(|e| matches!(&e.kind, EventKind::CiFailed { .. }))
+            .expect("expected a CiFailed event");
+
+        if let EventKind::CiFailed { failing_checks, .. } = &ci_event.kind {
+            assert_eq!(failing_checks.len(), 1);
+            assert_eq!(failing_checks[0].name, "e2e-tests");
+        } else {
+            panic!("unexpected event kind");
+        }
     }
 
     #[test]

--- a/crates/orchard/src/watch/event.rs
+++ b/crates/orchard/src/watch/event.rs
@@ -64,6 +64,8 @@ pub enum EventKind {
         pr_number: u32,
         /// Human-readable label (issue title or branch name).
         label: String,
+        /// Individual failing CI checks (name + conclusion).
+        failing_checks: Vec<crate::orchard_state::FailedCheck>,
     },
     /// CI checks transitioned to passing for a PR.
     CiPassed {
@@ -232,6 +234,7 @@ mod tests {
                 worktree: "/wt/c".to_string(),
                 pr_number: 42,
                 label: "Branch".to_string(),
+                failing_checks: vec![],
             },
             EventKind::Heartbeat {
                 worktree_count: 5,
@@ -272,5 +275,44 @@ mod tests {
             session_count: 1,
         };
         assert!(kind.notification().is_none());
+    }
+
+    #[test]
+    fn ci_failed_event_includes_failing_checks_in_roundtrip() {
+        use crate::orchard_state::FailedCheck;
+        let kind = EventKind::CiFailed {
+            worktree: "/wt/x".to_string(),
+            pr_number: 10,
+            label: "Fix CI".to_string(),
+            failing_checks: vec![FailedCheck {
+                name: "e2e-tests".to_string(),
+                conclusion: "FAILURE".to_string(),
+            }],
+        };
+        let event = WatchEvent::now(kind);
+        let json = serde_json::to_string(&event).unwrap();
+        let decoded: WatchEvent = serde_json::from_str(&json).unwrap();
+        let json2 = serde_json::to_string(&decoded).unwrap();
+        assert_eq!(json, json2, "CiFailed with failing_checks must round-trip");
+        assert!(
+            json.contains("e2e-tests"),
+            "failing_checks must appear in serialized output"
+        );
+    }
+
+    #[test]
+    fn ci_failed_notification_returns_pr_label() {
+        let kind = EventKind::CiFailed {
+            worktree: "/wt/x".to_string(),
+            pr_number: 42,
+            label: "My Feature".to_string(),
+            failing_checks: vec![],
+        };
+        let notif = kind.notification();
+        assert!(notif.is_some());
+        let (title, msg, _) = notif.unwrap();
+        assert_eq!(title, "CI Failed");
+        assert!(msg.contains("42"));
+        assert!(msg.contains("My Feature"));
     }
 }

--- a/crates/orchard/src/watch/threshold.rs
+++ b/crates/orchard/src/watch/threshold.rs
@@ -140,7 +140,7 @@ mod tests {
             issue: None,
             pr: None,
             sessions: vec![session],
-            display_group: DisplayGroup::Other,
+            display_group: DisplayGroup::Normal,
             is_main_worktree: false,
         };
         OrchardState {

--- a/crates/orchard/tests/common/mod.rs
+++ b/crates/orchard/tests/common/mod.rs
@@ -141,6 +141,8 @@ pub fn make_pr(number: u32, branch: &str) -> CachedPr {
         has_conflicts: false,
         unresolved_threads: 0,
         linked_issue_state: None,
+        failing_checks: vec![],
+        labels: vec![],
     }
 }
 

--- a/crates/orchard/tests/common/mod.rs
+++ b/crates/orchard/tests/common/mod.rs
@@ -186,6 +186,7 @@ pub fn make_session(name: &str, path: &str, pane_commands: Vec<&str>) -> CachedT
         host: None,
         last_output_lines: vec![],
         claude_state_raw: None,
+        last_activity: None,
     }
 }
 

--- a/crates/orchard/tests/common/mod.rs
+++ b/crates/orchard/tests/common/mod.rs
@@ -141,6 +141,7 @@ pub fn make_pr(number: u32, branch: &str) -> CachedPr {
         has_conflicts: false,
         unresolved_threads: 0,
         linked_issue_state: None,
+        is_draft: false,
     }
 }
 

--- a/crates/orchard/tests/derive_integration.rs
+++ b/crates/orchard/tests/derive_integration.rs
@@ -64,13 +64,13 @@ fn repo_with_no_cache_shows_empty() {
 }
 
 // ---------------------------------------------------------------------------
-// Display group: NeedsAttention when PR has changes_requested
+// Display group: Normal when PR has changes_requested (no running session)
 // ---------------------------------------------------------------------------
 
 /// A non-shepherd worktree whose PR has `review_decision = "changes_requested"`
-/// must derive `NeedsAttention`.
+/// and no running session must derive `Normal`.
 #[test]
-fn display_group_needs_attention_changes_requested() {
+fn display_group_normal_for_changes_requested_no_session() {
     let worktrees = vec![
         make_worktree("/workspace/repo", "main"),
         make_worktree("/workspace/repo-feat", "feat/branch"),
@@ -80,17 +80,17 @@ fn display_group_needs_attention_changes_requested() {
     let rows = derive_worktree_rows(&[], &prs, &worktrees, &[], "owner/repo", &[]);
 
     assert_eq!(rows.len(), 2);
-    assert_eq!(rows[1].display_group, DisplayGroup::NeedsAttention);
+    assert_eq!(rows[1].display_group, DisplayGroup::Normal);
 }
 
 // ---------------------------------------------------------------------------
-// Display group: ClaudeWorking when session has "claude" in pane_commands
+// Display group: Active when session has "claude" in pane_commands
 // ---------------------------------------------------------------------------
 
 /// A worktree with a tmux session running `claude` as a pane command must
-/// derive `ClaudeWorking`.
+/// derive `Active`.
 #[test]
-fn display_group_claude_working_when_agent_active() {
+fn display_group_active_when_agent_active() {
     let worktrees = vec![
         make_worktree("/workspace/repo", "main"),
         make_worktree("/workspace/repo-feat", "feat/branch"),
@@ -99,17 +99,17 @@ fn display_group_claude_working_when_agent_active() {
 
     let rows = derive_worktree_rows(&[], &[], &worktrees, &sessions, "owner/repo", &[]);
 
-    assert_eq!(rows[1].display_group, DisplayGroup::ClaudeWorking);
+    assert_eq!(rows[1].display_group, DisplayGroup::Active);
 }
 
 // ---------------------------------------------------------------------------
-// Display group: ReadyToMerge when PR is approved + passing + no conflicts
+// Display group: Normal when PR is approved + passing + no conflicts (no session)
 // ---------------------------------------------------------------------------
 
-/// A worktree whose PR is approved, passing CI, and has no conflicts must
-/// derive `ReadyToMerge`.
+/// A worktree whose PR is approved, passing CI, and has no conflicts but no
+/// running session must derive `Normal`.
 #[test]
-fn display_group_ready_to_merge() {
+fn display_group_normal_for_approved_pr_no_session() {
     let worktrees = vec![
         make_worktree("/workspace/repo", "main"),
         make_worktree("/workspace/repo-feat", "feat/branch"),
@@ -118,17 +118,17 @@ fn display_group_ready_to_merge() {
 
     let rows = derive_worktree_rows(&[], &prs, &worktrees, &[], "owner/repo", &[]);
 
-    assert_eq!(rows[1].display_group, DisplayGroup::ReadyToMerge);
+    assert_eq!(rows[1].display_group, DisplayGroup::Normal);
 }
 
 // ---------------------------------------------------------------------------
-// Display group: Other when there is no PR
+// Display group: Normal when there is no PR
 // ---------------------------------------------------------------------------
 
 /// A non-shepherd worktree with no matching PR and no tmux session must
-/// derive `Other`.
+/// derive `Normal`.
 #[test]
-fn display_group_other_for_no_pr() {
+fn display_group_normal_for_no_pr() {
     let worktrees = vec![
         make_worktree("/workspace/repo", "main"),
         make_worktree("/workspace/repo-feat", "feat/branch"),
@@ -136,7 +136,7 @@ fn display_group_other_for_no_pr() {
 
     let rows = derive_worktree_rows(&[], &[], &worktrees, &[], "owner/repo", &[]);
 
-    assert_eq!(rows[1].display_group, DisplayGroup::Other);
+    assert_eq!(rows[1].display_group, DisplayGroup::Normal);
 }
 
 // ---------------------------------------------------------------------------
@@ -144,13 +144,12 @@ fn display_group_other_for_no_pr() {
 // ---------------------------------------------------------------------------
 
 /// The `Ord` derivation on `DisplayGroup` must produce the documented order:
-/// Shepherd < NeedsAttention < ClaudeWorking < ReadyToMerge < Other.
+/// RepoMain < Active < Normal < Done.
 #[test]
 fn display_groups_ordered_for_rendering() {
-    assert!(DisplayGroup::RepoMain < DisplayGroup::NeedsAttention);
-    assert!(DisplayGroup::NeedsAttention < DisplayGroup::ClaudeWorking);
-    assert!(DisplayGroup::ClaudeWorking < DisplayGroup::ReadyToMerge);
-    assert!(DisplayGroup::ReadyToMerge < DisplayGroup::Other);
+    assert!(DisplayGroup::RepoMain < DisplayGroup::Active);
+    assert!(DisplayGroup::Active < DisplayGroup::Normal);
+    assert!(DisplayGroup::Normal < DisplayGroup::Done);
 }
 
 // ---------------------------------------------------------------------------
@@ -270,5 +269,5 @@ fn cache_file_roundtrip_feeds_into_derive_pipeline() {
 
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0].display_group, DisplayGroup::RepoMain);
-    assert_eq!(rows[1].display_group, DisplayGroup::ReadyToMerge);
+    assert_eq!(rows[1].display_group, DisplayGroup::Normal);
 }

--- a/specs/features/ci-failure-details.feature
+++ b/specs/features/ci-failure-details.feature
@@ -1,0 +1,346 @@
+Feature: CI failure details and labels in core state model
+  As a developer using orchard
+  I want to see which CI checks failed and what labels are on issues/PRs
+  So that I can decide whether to investigate, ignore, or prioritize at a glance
+
+  Background:
+    Given a repo with owner "acme" and name "webapp"
+    And a PR #42 on branch "feat/auth" with checks in "FAILURE" state
+
+  # ===================================================================
+  # Data model — FailedCheck struct and PrState enrichment
+  # ===================================================================
+
+  @unit
+  Scenario: PrState includes failing check details
+    Given PR #42 has the following check runs:
+      | name                     | conclusion     |
+      | e2e-tests                | FAILURE        |
+      | unit-tests               | SUCCESS        |
+      | lint                     | SUCCESS        |
+      | check-approval-or-label  | FAILURE        |
+    When the state is built
+    Then PrState.failing_checks contains:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+    And PrState.failing_checks does NOT contain "check-approval-or-label"
+    And PrState.checks_state is "failing"
+
+  @unit
+  Scenario: Failing checks list is empty when all checks pass
+    Given PR #42 has the following check runs:
+      | name        | conclusion |
+      | e2e-tests   | SUCCESS    |
+      | unit-tests  | SUCCESS    |
+    When the state is built
+    Then PrState.failing_checks is empty
+    And PrState.checks_state is "passing"
+
+  @unit
+  Scenario: Failing checks list is empty when checks are pending
+    Given PR #42 has no completed check runs yet
+    When the state is built
+    Then PrState.failing_checks is empty
+    And PrState.checks_state is "pending"
+
+  @unit
+  Scenario: Multiple failing checks are all captured
+    Given PR #42 has the following check runs:
+      | name        | conclusion     |
+      | e2e-tests   | FAILURE        |
+      | lint         | FAILURE        |
+      | unit-tests  | SUCCESS        |
+    When the state is built
+    Then PrState.failing_checks contains:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+      | lint        | FAILURE    |
+
+  # ===================================================================
+  # Conclusion classification — exhaustive mapping
+  # ===================================================================
+  # GitHub check conclusions: SUCCESS, FAILURE, CANCELLED, TIMED_OUT,
+  # ACTION_REQUIRED, STALE, NEUTRAL, SKIPPED, STARTUP_FAILURE
+  #
+  # Classification:
+  #   Failing  = FAILURE | TIMED_OUT | ACTION_REQUIRED | STARTUP_FAILURE
+  #   Passing  = SUCCESS | NEUTRAL | SKIPPED
+  #   Ignored  = CANCELLED | STALE (transient, not actionable)
+
+  @unit
+  Scenario: TIMED_OUT conclusion is treated as failing
+    Given PR #42 has the following check runs:
+      | name       | conclusion |
+      | e2e-tests  | TIMED_OUT  |
+    When the state is built
+    Then PrState.failing_checks contains "e2e-tests" with conclusion "TIMED_OUT"
+
+  @unit
+  Scenario: ACTION_REQUIRED conclusion is treated as failing
+    Given PR #42 has the following check runs:
+      | name         | conclusion      |
+      | deploy-gate  | ACTION_REQUIRED |
+    When the state is built
+    Then PrState.failing_checks contains "deploy-gate" with conclusion "ACTION_REQUIRED"
+
+  @unit
+  Scenario: CANCELLED and STALE conclusions are not treated as failing
+    Given PR #42 has the following check runs:
+      | name        | conclusion |
+      | e2e-tests   | CANCELLED  |
+      | lint        | STALE      |
+      | unit-tests  | SUCCESS    |
+    When the state is built
+    Then PrState.failing_checks is empty
+
+  @unit
+  Scenario: NEUTRAL and SKIPPED conclusions are not treated as failing
+    Given PR #42 has the following check runs:
+      | name        | conclusion |
+      | optional    | NEUTRAL    |
+      | skipped-job | SKIPPED    |
+    When the state is built
+    Then PrState.failing_checks is empty
+
+  # ===================================================================
+  # Non-blocking check exclusion — applied at build_state, not parse
+  # ===================================================================
+  # Non-blocking checks are filtered when building PrState from CachedPr,
+  # NOT at GraphQL parse time. This preserves all data in cache so that
+  # exclusion rules can change without cache invalidation.
+
+  @unit
+  Scenario: check-approval-or-label is excluded from failing checks
+    Given PR #42 has the following check runs:
+      | name                     | conclusion |
+      | check-approval-or-label  | FAILURE    |
+      | unit-tests               | SUCCESS    |
+    When the state is built
+    Then PrState.failing_checks is empty
+
+  @unit
+  Scenario: CachedPr retains excluded checks for future configurability
+    Given PR #42 has the following check runs:
+      | name                     | conclusion |
+      | check-approval-or-label  | FAILURE    |
+      | e2e-tests                | FAILURE    |
+    When PRs are parsed from the GraphQL response
+    Then CachedPr.failing_checks contains both "check-approval-or-label" and "e2e-tests"
+    But when the state is built, PrState.failing_checks contains only "e2e-tests"
+
+  # ===================================================================
+  # GraphQL fetching — CheckRun AND StatusContext union types
+  # ===================================================================
+  # statusCheckRollup.contexts is a union of CheckRun and StatusContext.
+  # Both must be handled to avoid silently dropping legacy CI results.
+
+  @unit
+  Scenario: GraphQL query fetches CheckRun details
+    Given the GraphQL response includes statusCheckRollup.contexts with:
+      | __typename   | name       | conclusion |
+      | CheckRun     | e2e-tests  | FAILURE    |
+      | CheckRun     | lint       | SUCCESS    |
+    When PRs are parsed from the GraphQL response
+    Then CachedPr.failing_checks contains:
+      | name      | conclusion |
+      | e2e-tests | FAILURE    |
+
+  @unit
+  Scenario: GraphQL query handles StatusContext (legacy commit status)
+    Given the GraphQL response includes statusCheckRollup.contexts with:
+      | __typename    | context    | state   |
+      | StatusContext | ci/travis  | FAILURE |
+      | StatusContext | ci/circle  | SUCCESS |
+    When PRs are parsed from the GraphQL response
+    Then CachedPr.failing_checks contains:
+      | name      | conclusion |
+      | ci/travis | FAILURE    |
+
+  @unit
+  Scenario: Mixed CheckRun and StatusContext are both captured
+    Given the GraphQL response includes statusCheckRollup.contexts with:
+      | __typename    | name/context | conclusion/state |
+      | CheckRun      | e2e-tests    | FAILURE          |
+      | StatusContext | ci/travis    | FAILURE          |
+    When PRs are parsed from the GraphQL response
+    Then CachedPr.failing_checks contains both "e2e-tests" and "ci/travis"
+
+  @unit
+  Scenario: Warn when pagination truncates check results
+    Given the GraphQL response has statusCheckRollup.contexts with pageInfo.hasNextPage = true
+    When PRs are parsed from the GraphQL response
+    Then a warning is logged: "PR #42 has more than 100 checks; some may be missing"
+
+  # ===================================================================
+  # Cache layer — serialization round-trip
+  # ===================================================================
+
+  @unit
+  Scenario: Failing checks survive cache serialization round-trip
+    Given a CachedPr with failing_checks:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+    When the CachedPr is serialized to JSON and deserialized back
+    Then the deserialized failing_checks matches the original
+
+  @unit
+  Scenario: Existing cache files without failing_checks deserialize with empty vec
+    Given a cached PR JSON without a "failingChecks" field
+    When the JSON is deserialized to CachedPr
+    Then CachedPr.failing_checks is an empty vec
+
+  # ===================================================================
+  # JSON output — orchard --json (version bump to 5)
+  # ===================================================================
+  # Adding failingChecks to JsonPr is an additive schema change.
+  # Bump version from 4 to 5 per the module's forward-compat contract.
+
+  @unit
+  Scenario: orchard --json schema version is 5
+    When the state is serialized to JSON output
+    Then the top-level "version" field is 5
+
+  @unit
+  Scenario: orchard --json PR object includes failingChecks
+    Given a WorktreeState with a PR that has failing checks:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+    When the state is serialized to JSON output
+    Then the JSON PR object contains:
+      """json
+      "failingChecks": [
+        { "name": "e2e-tests", "conclusion": "FAILURE" }
+      ]
+      """
+
+  @unit
+  Scenario: orchard --json PR object has empty failingChecks when passing
+    Given a WorktreeState with a PR that has no failing checks
+    When the state is serialized to JSON output
+    Then the JSON PR object contains:
+      """json
+      "failingChecks": []
+      """
+
+  # ===================================================================
+  # TUI — failing check names in status row
+  # ===================================================================
+
+  @unit
+  Scenario: TUI status row shows failing check names
+    Given a WorktreeRow with PR failing checks:
+      | name       |
+      | e2e-tests  |
+      | lint       |
+    When pr_status_text is rendered
+    Then the text contains "failing: e2e-tests, lint"
+
+  @unit
+  Scenario: TUI status row shows single failing check name
+    Given a WorktreeRow with PR failing checks:
+      | name      |
+      | e2e-tests |
+    When pr_status_text is rendered
+    Then the text contains "failing: e2e-tests"
+
+  @unit
+  Scenario: TUI status row truncates long check lists
+    Given a WorktreeRow with 5 failing checks
+    When pr_status_text is rendered
+    Then the text shows at most 3 check names followed by "+2 more"
+
+  @unit
+  Scenario: TUI status row falls back to generic failing when checks list is empty
+    Given a WorktreeRow with checks_state "failing" but empty failing_checks
+    When pr_status_text is rendered
+    Then the text contains "failing" without specific check names
+
+  # ===================================================================
+  # Watch system — CiFailed event enrichment
+  # ===================================================================
+  # Field name: failing_checks (consistent with PrState)
+
+  @unit
+  Scenario: CiFailed event includes which checks failed
+    Given old state has PR #42 with checks_state "passing"
+    And new state has PR #42 with checks_state "failing" and failing_checks:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+    When the watch diff is computed
+    Then a CiFailed event is emitted with failing_checks:
+      | name       | conclusion |
+      | e2e-tests  | FAILURE    |
+
+  @unit
+  Scenario: CiPassed event does not include failing checks
+    Given old state has PR #42 with checks_state "failing"
+    And new state has PR #42 with checks_state "passing" and no failing checks
+    When the watch diff is computed
+    Then a CiPassed event is emitted without failing_checks
+
+  # ===================================================================
+  # PR labels — flow through state model
+  # ===================================================================
+  # PR labels are fetched via GraphQL and stored in CachedPr, PrState, JsonPr.
+
+  @unit
+  Scenario: PrState includes PR labels
+    Given PR #42 has labels: "low-risk-change", "P0"
+    When the state is built
+    Then PrState.labels contains "low-risk-change" and "P0"
+
+  @unit
+  Scenario: PrState has empty labels when PR has none
+    Given PR #42 has no labels
+    When the state is built
+    Then PrState.labels is empty
+
+  @unit
+  Scenario: GraphQL query fetches PR labels
+    Given the GraphQL response includes labels.nodes with:
+      | name              |
+      | low-risk-change   |
+      | needs-plan        |
+    When PRs are parsed from the GraphQL response
+    Then CachedPr.labels contains "low-risk-change" and "needs-plan"
+
+  @unit
+  Scenario: CachedPr without labels field deserializes with empty vec
+    Given a cached PR JSON without a "labels" field
+    When the JSON is deserialized to CachedPr
+    Then CachedPr.labels is an empty vec
+
+  @unit
+  Scenario: orchard --json PR object includes labels
+    Given a WorktreeState with a PR that has labels: "low-risk-change"
+    When the state is serialized to JSON output
+    Then the JSON PR object contains:
+      """json
+      "labels": ["low-risk-change"]
+      """
+
+  # ===================================================================
+  # Issue labels — flow through state model
+  # ===================================================================
+  # Issue labels are already in CachedIssue. Just need to flow to IssueInfo and JSON.
+
+  @unit
+  Scenario: IssueInfo includes issue labels
+    Given issue #10 has labels: "bug", "P1"
+    When the state is built
+    Then IssueInfo.labels contains "bug" and "P1"
+
+  @unit
+  Scenario: IssueInfo has empty labels when issue has none
+    Given issue #10 has no labels
+    When the state is built
+    Then IssueInfo.labels is empty
+
+  @unit
+  Scenario: orchard --json issue object includes labels
+    Given a WorktreeState with an issue that has labels: "bug", "priority:high"
+    When the state is serialized to JSON output
+    Then the JSON issue object contains:
+      """json
+      "labels": ["bug", "priority:high"]
+      """

--- a/specs/features/tags-column-draft-badge.feature
+++ b/specs/features/tags-column-draft-badge.feature
@@ -1,0 +1,161 @@
+Feature: Tags column with draft badge
+  As an orchard user managing multiple PRs
+  I want to see contextual tags like "draft" on worktree rows
+  So I can quickly identify PR status without leaving the TUI
+
+  # Current state:
+  #   - `CachedPr` has `state`, `review_decision`, `checks_state`, `has_conflicts`, `unresolved_threads`
+  #   - `isDraft` is NOT in the GraphQL query or any PR struct
+  #   - `orchard --json` PR objects have no draft indicator
+  #   - TUI columns: BAR | # | CLAUDE | ISSUE | TITLE | [BRANCH] | [HOST] | STATUS
+  #   - No tags/badges column exists
+  #
+  # What changes:
+  #   1. Add `isDraft` to the GitHub GraphQL PR query (field already available in API)
+  #   2. Add `is_draft: bool` to CachedPr, PrInfo, PrState, and JsonPr structs
+  #   3. Thread `is_draft` through parse → cache → derive → state → JSON conversion chain
+  #   4. Add TAGS column to TUI between [HOST]/[BRANCH] and STATUS
+  #   5. Render "draft" badge in TAGS column when pr.is_draft == true
+  #   6. TAGS column is conditionally sized — zero-width when no rows have tags
+  #
+  # Files affected:
+  #   - `src/cache.rs` — add `is_draft: bool` to `CachedPr`
+  #   - `src/cache_sources.rs` — add `isDraft` to GraphQL query, extract in `parse_prs_graphql`
+  #   - `src/derive.rs` — add `is_draft: bool` to `PrInfo`, propagate in `pr_info_from`
+  #   - `src/orchard_state.rs` — add `is_draft: bool` to `PrState`, propagate in `From<&PrInfo>`
+  #   - `src/json_output.rs` — add `is_draft: bool` to `JsonPr`, propagate in `From<&PrState>`
+  #   - `src/tui/list.rs` — TAGS column width/constraint, header cell, row cell rendering
+  #
+  # Non-goals:
+  #   - No new API calls — `isDraft` piggybacks on the existing GraphQL PR query
+  #   - No theme/color customization for tags (use existing styles; future work)
+  #   - Future tag candidates (conflicts, stale, behind) are out of scope
+
+  Background:
+    Given the TUI is running with at least one repo configured
+    And there are worktree rows with PRs
+
+  # ===================================================================
+  # 1. Data layer: isDraft in GraphQL and PR structs
+  # ===================================================================
+
+  @unit
+  Scenario: GraphQL query includes isDraft field
+    When the PR GraphQL query is built
+    Then the query includes "isDraft" in the PR node fields
+
+  @unit
+  Scenario: CachedPr stores is_draft from GraphQL response
+    Given a GraphQL PR node with isDraft: true
+    When the node is parsed into a CachedPr
+    Then CachedPr.is_draft is true
+
+  @unit
+  Scenario: CachedPr defaults is_draft to false for legacy cache entries
+    Given a cached PR JSON without an is_draft field
+    When the JSON is deserialized into a CachedPr
+    Then CachedPr.is_draft is false
+
+  @unit
+  Scenario: is_draft propagates through the conversion chain
+    Given a CachedPr with is_draft: true
+    When it is converted to PrInfo via pr_info_from
+    And PrInfo is converted to PrState
+    And PrState is converted to JsonPr
+    Then PrInfo.is_draft is true
+    And PrState.is_draft is true
+    And JsonPr.is_draft is true
+
+  # ===================================================================
+  # 2. JSON output: isDraft in orchard --json
+  # ===================================================================
+
+  @unit
+  Scenario: orchard --json includes is_draft in PR object
+    Given a worktree with a draft PR
+    When orchard --json output is generated
+    Then the pr object contains "is_draft": true
+
+  @unit
+  Scenario: orchard --json shows is_draft false for non-draft PRs
+    Given a worktree with a non-draft PR
+    When orchard --json output is generated
+    Then the pr object contains "is_draft": false
+
+  # ===================================================================
+  # 3. TUI: Tags column rendering
+  # ===================================================================
+
+  @unit
+  Scenario: TAGS column appears in header when any row has tags
+    Given at least one worktree row has a draft PR
+    When the task list header renders
+    Then the column order includes TAGS between the last optional column and STATUS
+
+  @unit
+  Scenario: TAGS column is hidden when no rows have tags
+    Given no worktree rows have draft PRs
+    When the task list header renders
+    Then the TAGS column is not present
+    And STATUS remains the last column
+
+  @unit
+  Scenario: Draft badge appears for draft PRs
+    Given a worktree row with a draft PR (is_draft: true)
+    When the row renders
+    Then the TAGS cell contains "draft"
+
+  @unit
+  Scenario: TAGS cell is empty for non-draft PRs
+    Given a worktree row with a non-draft PR (is_draft: false)
+    When the row renders
+    Then the TAGS cell is empty
+
+  @unit
+  Scenario: TAGS cell is empty for rows without PRs
+    Given a worktree row with no PR
+    When the row renders
+    Then the TAGS cell is empty
+
+  @unit
+  Scenario: Standalone session rows have empty TAGS cell
+    Given a standalone tmux session row
+    And the TAGS column is visible
+    When the row renders
+    Then the TAGS cell is empty
+
+  @unit
+  Scenario: TAGS column width is fixed at 7 characters
+    Given the TAGS column is visible
+    When column widths are calculated
+    Then the TAGS column constraint is Length(7) to fit " draft " with padding
+    And the TITLE column absorbs the remaining flexible space
+
+  @unit
+  Scenario: TAGS column visible with BRANCH and HOST both hidden
+    Given a single-host setup (no remote hosts)
+    And show_branch is false
+    And at least one worktree row has a draft PR
+    When the task list renders
+    Then the column order is BAR, #, CLAUDE, ISSUE, TITLE, TAGS, STATUS
+    And the fixed arithmetic accounts for tags_extra but not branch_extra or host_extra
+
+  @unit
+  Scenario: TAGS column appears dynamically when draft PR arrives on refresh
+    Given no worktree rows have draft PRs
+    And the TAGS column is not visible
+    When state refreshes and a PR becomes draft
+    Then the TAGS column becomes visible on the next render
+
+  @unit
+  Scenario: TAGS column disappears when last draft PR is un-drafted
+    Given one worktree row has a draft PR
+    And the TAGS column is visible
+    When state refreshes and the PR is marked ready for review
+    Then the TAGS column is no longer visible
+
+  @unit
+  Scenario: Tag presence is computed during state derivation not render
+    When build_task_table_rows computes worktree rows
+    Then a has_tags boolean is derived from the row set
+    And the render function uses the precomputed has_tags flag


### PR DESCRIPTION
## Summary

Major TUI iteration to make orchard tight for daily use. Replaces priority groups with focus-driven sorting, adds always-visible TAGS column, dedicated ORCHARD tab, and fixes a sweep of bugs.

## What's in this PR

Includes the work from #201, #202, #203, #204 plus 11 new commits.

### Features
- **Focus-driven sorting** (#211): Replace prioritized/needs-attention/other groups with 4 clean tiers (RepoMain, Active, Normal, Done). Within tiers, sort by 'what needs human action?' — Claude waiting for input bubbles to top, monitoring tasks sit in middle, done items sink.
- **Always-visible TAGS column** (#202): Shows all GitHub labels from issues and PRs, with draft as a tag. Was previously hidden when no draft PRs existed.
- **Dedicated ORCHARD tab** (#210): Orchestrator/shepherd sessions get their own tab. Project tabs no longer cluttered with orchard's own sessions.
- **Sort by tmux activity** (#156): Within focus tiers, recently active worktrees bubble up, stale ones sink.
- **CI failure details in --json** (#201): Failed checks and labels now in core state model and JSON output.

### Bug fixes
- **Immediate row expansion** (#209): No more delay before rows expand on startup
- **Preview pane on repo tabs** (#99): Was indexing into unfiltered list under repo filter
- **'o' key for opening PRs** (#111): Confirmed working with regression tests
- **Stale PR cache** (#95) + **merged PR linking** (#152): Both already fixed; verified
- **Session-to-worktree matching** (#191): Now uses paths_match() with symlink resolution, no substring collisions
- **Silent error swallowing** (#155): Refresh pipeline now logs errors via tracing::warn
- **orchard init clobbering tmux config** (#112): Now prints recommended status line, doesn't auto-apply

## Closes
Closes #95, #99, #111, #112, #152, #155, #156, #191, #201, #202, #209, #210, #211

## Test plan
- [x] cargo test (843 passing)
- [x] cargo clippy (clean)
- [x] cargo build --release (success)
- [ ] Manual TUI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #2

# Related issue

- #2

# Related issue

- #2