### PR TITLE
fix(watch): debounce claude status transitions to suppress flicker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,7 +2831,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -129,6 +129,8 @@ pub struct App {
 
     // Previous state snapshot used to detect transitions between cache refreshes.
     previous_orchard_state: Option<crate::orchard_state::OrchardState>,
+    // Debounce state for claude status transitions — suppresses single-poll flicker.
+    claude_debounce: crate::watch::debounce::ClaudeDebounceState,
 
     // Mouse support
     /// Last rendered table body rect (excludes border + header row). Updated by render.
@@ -230,6 +232,7 @@ impl App {
             switch_target: None,
             persist_selection,
             previous_orchard_state: None,
+            claude_debounce: crate::watch::debounce::ClaudeDebounceState::new(),
             table_area: Cell::new(Rect::default()),
             url_area: Cell::new(Rect::default()),
             preview_area: Cell::new(Rect::default()),
@@ -793,7 +796,7 @@ impl App {
     /// state for the next comparison.
     fn detect_and_notify(&mut self, new_state: &crate::orchard_state::OrchardState) {
         if let Some(ref old_state) = self.previous_orchard_state {
-            let events = crate::watch::diff::diff(old_state, new_state);
+            let events = crate::watch::diff::diff(old_state, new_state, &mut self.claude_debounce);
             let terminal_app = self.global_config.terminal_app.as_str();
             for event in &events {
                 if let Some((title, message, session)) = event.kind.notification() {
@@ -1961,6 +1964,7 @@ impl App {
             switch_target: None,
             persist_selection: true,
             previous_orchard_state: None,
+            claude_debounce: crate::watch::debounce::ClaudeDebounceState::new(),
             table_area: Cell::new(Rect::default()),
             url_area: Cell::new(Rect::default()),
             preview_area: Cell::new(Rect::default()),

--- a/crates/orchard/src/watch/daemon.rs
+++ b/crates/orchard/src/watch/daemon.rs
@@ -40,6 +40,7 @@ pub fn run(config: &GlobalConfig) -> anyhow::Result<()> {
     );
 
     let mut threshold_ts = ThresholdTimestamps::new();
+    let mut claude_debounce = crate::watch::debounce::ClaudeDebounceState::new();
     let mut last_local = Instant::now();
     let mut last_full = Instant::now();
 
@@ -71,7 +72,7 @@ pub fn run(config: &GlobalConfig) -> anyhow::Result<()> {
         // Diff
         let mut events: Vec<WatchEvent> = Vec::new();
         if let Some(ref old) = previous_state {
-            events.extend(diff::diff(old, &new_state));
+            events.extend(diff::diff(old, &new_state, &mut claude_debounce));
         }
 
         // Thresholds

--- a/crates/orchard/src/watch/debounce.rs
+++ b/crates/orchard/src/watch/debounce.rs
@@ -108,7 +108,11 @@ mod tests {
         let mut d = ClaudeDebounceState::new();
         let (prior, new) = d.observe("/workspace/repo/feat-1", ClaudeState::Working);
         assert_eq!(prior, ClaudeState::None, "no prior on first observation");
-        assert_eq!(new, ClaudeState::Working, "first observation confirms Working");
+        assert_eq!(
+            new,
+            ClaudeState::Working,
+            "first observation confirms Working"
+        );
     }
 
     #[test]
@@ -127,7 +131,11 @@ mod tests {
 
         // Cycle 1: Working confirmed immediately (first observation)
         let (_, r1) = d.observe(path, ClaudeState::Working);
-        assert_eq!(r1, ClaudeState::Working, "first observation confirms Working");
+        assert_eq!(
+            r1,
+            ClaudeState::Working,
+            "first observation confirms Working"
+        );
 
         // Cycle 2: Input observed — first sighting, returns old confirmed
         let (_, r2) = d.observe(path, ClaudeState::Input);
@@ -150,7 +158,11 @@ mod tests {
 
         // Cycle 2: Input first sighting — returns old confirmed
         let (_, r2) = d.observe(path, ClaudeState::Input);
-        assert_eq!(r2, ClaudeState::Working, "first sighting of Input: still Working");
+        assert_eq!(
+            r2,
+            ClaudeState::Working,
+            "first sighting of Input: still Working"
+        );
 
         // Cycle 3: Input again — pending matches observed, promote to confirmed
         let (_, r3) = d.observe(path, ClaudeState::Input);
@@ -194,7 +206,11 @@ mod tests {
 
         // Confirm Input for path_a
         let (_, a2) = d.observe(path_a, ClaudeState::Input);
-        assert_eq!(a2, ClaudeState::Input, "path_a transitions after second cycle");
+        assert_eq!(
+            a2,
+            ClaudeState::Input,
+            "path_a transitions after second cycle"
+        );
 
         // path_b still Working
         let (_, b2) = d.observe(path_b, ClaudeState::Working);
@@ -235,7 +251,15 @@ mod tests {
 
         // And observe behaves as if the path is brand-new (first-observation rule).
         let (prior, new) = d.observe(drop_path, ClaudeState::Idle);
-        assert_eq!(prior, ClaudeState::None, "dropped entry should return None as prior");
-        assert_eq!(new, ClaudeState::Idle, "dropped entry should first-observe fresh");
+        assert_eq!(
+            prior,
+            ClaudeState::None,
+            "dropped entry should return None as prior"
+        );
+        assert_eq!(
+            new,
+            ClaudeState::Idle,
+            "dropped entry should first-observe fresh"
+        );
     }
 }

--- a/crates/orchard/src/watch/debounce.rs
+++ b/crates/orchard/src/watch/debounce.rs
@@ -1,0 +1,215 @@
+//! Claude status transition debouncer.
+//!
+//! Suppresses single-poll status flicker (e.g. working → input → working within
+//! one cycle) by requiring a new status to persist across two consecutive diff
+//! cycles before it is treated as the "effective" status for transition events.
+//!
+//! The TUI displays the raw status from each poll — only the watch event stream
+//! is debounced.
+
+use std::collections::HashMap;
+
+use crate::claude_state::ClaudeState;
+
+/// Per-worktree state for claude-status debouncing.
+///
+/// For each worktree, we track:
+/// - `confirmed`: the last status that has persisted for at least one full cycle
+///   and is safe to use for transition events
+/// - `pending`: a new status seen in the most recent cycle that has not yet been
+///   confirmed by a second cycle
+#[derive(Debug, Clone, Default)]
+pub struct ClaudeDebounceState {
+    entries: HashMap<String, DebounceEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct DebounceEntry {
+    confirmed: ClaudeState,
+    pending: Option<ClaudeState>,
+}
+
+impl ClaudeDebounceState {
+    /// Creates a new empty debounce state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Looks up the confirmed (debounced) status for a worktree path.
+    /// Returns `ClaudeState::None` if unknown.
+    pub fn confirmed(&self, path: &str) -> ClaudeState {
+        self.entries
+            .get(path)
+            .map(|e| e.confirmed)
+            .unwrap_or(ClaudeState::None)
+    }
+
+    /// Advances debounce state based on the observed raw status for a worktree.
+    /// Returns the effective (confirmed) status after this observation.
+    ///
+    /// Rules:
+    /// - First observation: the status becomes immediately confirmed (no prior
+    ///   baseline to debounce against).
+    /// - Observed == confirmed: clear any pending, return confirmed.
+    /// - Observed != confirmed and pending is None: record pending, return confirmed
+    ///   (suppress transition — this is the first sighting).
+    /// - Observed != confirmed and pending == observed: promote pending → confirmed,
+    ///   return the new confirmed (transition now visible).
+    /// - Observed != confirmed and pending != observed: replace pending with observed,
+    ///   return confirmed (a different new value resets the debounce window).
+    pub fn observe(&mut self, path: &str, observed: ClaudeState) -> ClaudeState {
+        match self.entries.get_mut(path) {
+            None => {
+                self.entries.insert(
+                    path.to_string(),
+                    DebounceEntry {
+                        confirmed: observed,
+                        pending: None,
+                    },
+                );
+                observed
+            }
+            Some(entry) => {
+                if observed == entry.confirmed {
+                    entry.pending = None;
+                    entry.confirmed
+                } else if entry.pending == Some(observed) {
+                    entry.confirmed = observed;
+                    entry.pending = None;
+                    entry.confirmed
+                } else {
+                    entry.pending = Some(observed);
+                    entry.confirmed
+                }
+            }
+        }
+    }
+
+    /// Drops debounce state for worktrees that no longer exist.
+    pub fn retain_paths<F: Fn(&str) -> bool>(&mut self, keep: F) {
+        self.entries.retain(|k, _| keep(k));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_first_time_confirms_immediately() {
+        let mut d = ClaudeDebounceState::new();
+        let result = d.observe("/workspace/repo/feat-1", ClaudeState::Working);
+        assert_eq!(result, ClaudeState::Working);
+    }
+
+    #[test]
+    fn observe_unchanged_returns_same() {
+        let mut d = ClaudeDebounceState::new();
+        let path = "/workspace/repo/feat-1";
+        d.observe(path, ClaudeState::Working);
+        let result = d.observe(path, ClaudeState::Working);
+        assert_eq!(result, ClaudeState::Working);
+    }
+
+    #[test]
+    fn single_blip_is_suppressed() {
+        let mut d = ClaudeDebounceState::new();
+        let path = "/workspace/repo/feat-1";
+
+        // Cycle 1: Working confirmed immediately (first observation)
+        let r1 = d.observe(path, ClaudeState::Working);
+        assert_eq!(r1, ClaudeState::Working, "first observation confirms Working");
+
+        // Cycle 2: Input observed — first sighting, returns old confirmed
+        let r2 = d.observe(path, ClaudeState::Input);
+        assert_eq!(r2, ClaudeState::Working, "single Input blip: still Working");
+
+        // Cycle 3: Working again — pending (Input) doesn't match observed (Working),
+        // so pending is replaced; confirmed stays Working
+        let r3 = d.observe(path, ClaudeState::Working);
+        assert_eq!(r3, ClaudeState::Working, "return to Working: still Working");
+    }
+
+    #[test]
+    fn two_poll_transition_is_confirmed() {
+        let mut d = ClaudeDebounceState::new();
+        let path = "/workspace/repo/feat-1";
+
+        // Cycle 1: Working confirmed
+        let r1 = d.observe(path, ClaudeState::Working);
+        assert_eq!(r1, ClaudeState::Working);
+
+        // Cycle 2: Input first sighting — returns old confirmed
+        let r2 = d.observe(path, ClaudeState::Input);
+        assert_eq!(r2, ClaudeState::Working, "first sighting of Input: still Working");
+
+        // Cycle 3: Input again — pending matches observed, promote to confirmed
+        let r3 = d.observe(path, ClaudeState::Input);
+        assert_eq!(r3, ClaudeState::Input, "Input confirmed after two cycles");
+    }
+
+    #[test]
+    fn changed_pending_resets_window() {
+        let mut d = ClaudeDebounceState::new();
+        let path = "/workspace/repo/feat-1";
+
+        // Cycle 1: Working confirmed
+        d.observe(path, ClaudeState::Working);
+
+        // Cycle 2: Input pending
+        let r2 = d.observe(path, ClaudeState::Input);
+        assert_eq!(r2, ClaudeState::Working);
+
+        // Cycle 3: Idle (different from pending Input) — resets window
+        let r3 = d.observe(path, ClaudeState::Idle);
+        assert_eq!(r3, ClaudeState::Working, "different pending resets window");
+    }
+
+    #[test]
+    fn different_worktrees_are_independent() {
+        let mut d = ClaudeDebounceState::new();
+        let path_a = "/workspace/repo/feat-1";
+        let path_b = "/workspace/repo/feat-2";
+
+        // Establish Working for both
+        d.observe(path_a, ClaudeState::Working);
+        d.observe(path_b, ClaudeState::Working);
+
+        // Transition path_a to Input (first sighting)
+        let a = d.observe(path_a, ClaudeState::Input);
+        // path_b stays unchanged
+        let b = d.observe(path_b, ClaudeState::Working);
+
+        assert_eq!(a, ClaudeState::Working, "path_a blip suppressed");
+        assert_eq!(b, ClaudeState::Working, "path_b unaffected");
+
+        // Confirm Input for path_a
+        let a2 = d.observe(path_a, ClaudeState::Input);
+        assert_eq!(a2, ClaudeState::Input, "path_a transitions after second cycle");
+
+        // path_b still Working
+        let b2 = d.observe(path_b, ClaudeState::Working);
+        assert_eq!(b2, ClaudeState::Working, "path_b still Working");
+    }
+
+    #[test]
+    fn retain_paths_drops_removed_worktrees() {
+        let mut d = ClaudeDebounceState::new();
+        let keep = "/workspace/repo/feat-1";
+        let drop = "/workspace/repo/feat-2";
+
+        d.observe(keep, ClaudeState::Working);
+        d.observe(drop, ClaudeState::Idle);
+
+        d.retain_paths(|p| p == keep);
+
+        // keep path still has confirmed state
+        assert_eq!(d.confirmed(keep), ClaudeState::Working);
+        // dropped path returns None
+        assert_eq!(d.confirmed(drop), ClaudeState::None);
+    }
+}

--- a/crates/orchard/src/watch/debounce.rs
+++ b/crates/orchard/src/watch/debounce.rs
@@ -44,20 +44,23 @@ impl ClaudeDebounceState {
             .unwrap_or(ClaudeState::None)
     }
 
-    /// Advances debounce state based on the observed raw status for a worktree.
-    /// Returns the effective (confirmed) status after this observation.
+    /// Advances debounce state and returns `(old_effective, new_effective)` — the
+    /// confirmed status before and after this observation. This is the only way
+    /// to safely read the pre-observation state: a separate `confirmed()` call
+    /// followed by `observe()` creates a temporal-coupling trap.
     ///
     /// Rules:
-    /// - First observation: the status becomes immediately confirmed (no prior
-    ///   baseline to debounce against).
-    /// - Observed == confirmed: clear any pending, return confirmed.
-    /// - Observed != confirmed and pending is None: record pending, return confirmed
-    ///   (suppress transition — this is the first sighting).
-    /// - Observed != confirmed and pending == observed: promote pending → confirmed,
-    ///   return the new confirmed (transition now visible).
-    /// - Observed != confirmed and pending != observed: replace pending with observed,
-    ///   return confirmed (a different new value resets the debounce window).
-    pub fn observe(&mut self, path: &str, observed: ClaudeState) -> ClaudeState {
+    /// - First observation: prior = `None`, new = observed. Insert entry with
+    ///   `confirmed = observed`, `pending = None`. Return `(None, observed)`.
+    /// - Observed == confirmed: prior = confirmed, new = confirmed. Clear pending.
+    ///   Return `(confirmed, confirmed)`.
+    /// - Observed != confirmed and pending == observed: prior = confirmed, new =
+    ///   observed (promoted). Update confirmed, clear pending.
+    ///   Return `(old_confirmed, observed)`.
+    /// - Observed != confirmed and pending != observed: prior = confirmed, new =
+    ///   confirmed (suppressed). Record pending.
+    ///   Return `(confirmed, confirmed)`.
+    pub fn observe(&mut self, path: &str, observed: ClaudeState) -> (ClaudeState, ClaudeState) {
         match self.entries.get_mut(path) {
             None => {
                 self.entries.insert(
@@ -67,19 +70,20 @@ impl ClaudeDebounceState {
                         pending: None,
                     },
                 );
-                observed
+                (ClaudeState::None, observed)
             }
             Some(entry) => {
+                let prior = entry.confirmed;
                 if observed == entry.confirmed {
                     entry.pending = None;
-                    entry.confirmed
+                    (prior, prior)
                 } else if entry.pending == Some(observed) {
                     entry.confirmed = observed;
                     entry.pending = None;
-                    entry.confirmed
+                    (prior, observed)
                 } else {
                     entry.pending = Some(observed);
-                    entry.confirmed
+                    (prior, prior)
                 }
             }
         }
@@ -102,8 +106,9 @@ mod tests {
     #[test]
     fn observe_first_time_confirms_immediately() {
         let mut d = ClaudeDebounceState::new();
-        let result = d.observe("/workspace/repo/feat-1", ClaudeState::Working);
-        assert_eq!(result, ClaudeState::Working);
+        let (prior, new) = d.observe("/workspace/repo/feat-1", ClaudeState::Working);
+        assert_eq!(prior, ClaudeState::None, "no prior on first observation");
+        assert_eq!(new, ClaudeState::Working, "first observation confirms Working");
     }
 
     #[test]
@@ -111,8 +116,8 @@ mod tests {
         let mut d = ClaudeDebounceState::new();
         let path = "/workspace/repo/feat-1";
         d.observe(path, ClaudeState::Working);
-        let result = d.observe(path, ClaudeState::Working);
-        assert_eq!(result, ClaudeState::Working);
+        let (_, new) = d.observe(path, ClaudeState::Working);
+        assert_eq!(new, ClaudeState::Working);
     }
 
     #[test]
@@ -121,16 +126,16 @@ mod tests {
         let path = "/workspace/repo/feat-1";
 
         // Cycle 1: Working confirmed immediately (first observation)
-        let r1 = d.observe(path, ClaudeState::Working);
+        let (_, r1) = d.observe(path, ClaudeState::Working);
         assert_eq!(r1, ClaudeState::Working, "first observation confirms Working");
 
         // Cycle 2: Input observed — first sighting, returns old confirmed
-        let r2 = d.observe(path, ClaudeState::Input);
+        let (_, r2) = d.observe(path, ClaudeState::Input);
         assert_eq!(r2, ClaudeState::Working, "single Input blip: still Working");
 
         // Cycle 3: Working again — pending (Input) doesn't match observed (Working),
         // so pending is replaced; confirmed stays Working
-        let r3 = d.observe(path, ClaudeState::Working);
+        let (_, r3) = d.observe(path, ClaudeState::Working);
         assert_eq!(r3, ClaudeState::Working, "return to Working: still Working");
     }
 
@@ -140,15 +145,15 @@ mod tests {
         let path = "/workspace/repo/feat-1";
 
         // Cycle 1: Working confirmed
-        let r1 = d.observe(path, ClaudeState::Working);
+        let (_, r1) = d.observe(path, ClaudeState::Working);
         assert_eq!(r1, ClaudeState::Working);
 
         // Cycle 2: Input first sighting — returns old confirmed
-        let r2 = d.observe(path, ClaudeState::Input);
+        let (_, r2) = d.observe(path, ClaudeState::Input);
         assert_eq!(r2, ClaudeState::Working, "first sighting of Input: still Working");
 
         // Cycle 3: Input again — pending matches observed, promote to confirmed
-        let r3 = d.observe(path, ClaudeState::Input);
+        let (_, r3) = d.observe(path, ClaudeState::Input);
         assert_eq!(r3, ClaudeState::Input, "Input confirmed after two cycles");
     }
 
@@ -161,11 +166,11 @@ mod tests {
         d.observe(path, ClaudeState::Working);
 
         // Cycle 2: Input pending
-        let r2 = d.observe(path, ClaudeState::Input);
+        let (_, r2) = d.observe(path, ClaudeState::Input);
         assert_eq!(r2, ClaudeState::Working);
 
         // Cycle 3: Idle (different from pending Input) — resets window
-        let r3 = d.observe(path, ClaudeState::Idle);
+        let (_, r3) = d.observe(path, ClaudeState::Idle);
         assert_eq!(r3, ClaudeState::Working, "different pending resets window");
     }
 
@@ -180,19 +185,19 @@ mod tests {
         d.observe(path_b, ClaudeState::Working);
 
         // Transition path_a to Input (first sighting)
-        let a = d.observe(path_a, ClaudeState::Input);
+        let (_, a) = d.observe(path_a, ClaudeState::Input);
         // path_b stays unchanged
-        let b = d.observe(path_b, ClaudeState::Working);
+        let (_, b) = d.observe(path_b, ClaudeState::Working);
 
         assert_eq!(a, ClaudeState::Working, "path_a blip suppressed");
         assert_eq!(b, ClaudeState::Working, "path_b unaffected");
 
         // Confirm Input for path_a
-        let a2 = d.observe(path_a, ClaudeState::Input);
+        let (_, a2) = d.observe(path_a, ClaudeState::Input);
         assert_eq!(a2, ClaudeState::Input, "path_a transitions after second cycle");
 
         // path_b still Working
-        let b2 = d.observe(path_b, ClaudeState::Working);
+        let (_, b2) = d.observe(path_b, ClaudeState::Working);
         assert_eq!(b2, ClaudeState::Working, "path_b still Working");
     }
 
@@ -211,5 +216,26 @@ mod tests {
         assert_eq!(d.confirmed(keep), ClaudeState::Working);
         // dropped path returns None
         assert_eq!(d.confirmed(drop), ClaudeState::None);
+    }
+
+    #[test]
+    fn retain_paths_fully_removes_entry_including_pending() {
+        let mut d = ClaudeDebounceState::new();
+        let drop_path = "/workspace/repo/feat-gone";
+
+        // Set up an entry with both confirmed and pending populated.
+        d.observe(drop_path, ClaudeState::Working); // confirmed = Working
+        d.observe(drop_path, ClaudeState::Input); // pending = Some(Input)
+
+        // Drop.
+        d.retain_paths(|p| p != drop_path);
+
+        // After drop, the entry is gone: confirmed reports None.
+        assert_eq!(d.confirmed(drop_path), ClaudeState::None);
+
+        // And observe behaves as if the path is brand-new (first-observation rule).
+        let (prior, new) = d.observe(drop_path, ClaudeState::Idle);
+        assert_eq!(prior, ClaudeState::None, "dropped entry should return None as prior");
+        assert_eq!(new, ClaudeState::Idle, "dropped entry should first-observe fresh");
     }
 }

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -7,6 +7,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::claude_state::ClaudeState;
 use crate::orchard_state::{OrchardState, WorktreeState};
+use crate::watch::debounce::ClaudeDebounceState;
 use crate::watch::event::{EventKind, WatchEvent};
 
 // ---------------------------------------------------------------------------
@@ -76,8 +77,15 @@ fn label_for(wt: &WorktreeState) -> String {
 
 /// Diffs two `OrchardState` snapshots and returns all detected `WatchEvent`s.
 ///
-/// This is a pure function: it performs no I/O and has no side effects.
-pub fn diff(old: &OrchardState, new: &OrchardState) -> Vec<WatchEvent> {
+/// The `debounce` parameter is mutated to suppress single-poll Claude status
+/// flicker: a new status must be observed in two consecutive diff cycles before
+/// a transition event is emitted. The TUI displays raw status; only the event
+/// stream is debounced.
+pub fn diff(
+    old: &OrchardState,
+    new: &OrchardState,
+    debounce: &mut ClaudeDebounceState,
+) -> Vec<WatchEvent> {
     let mut events = Vec::new();
 
     let old_map = worktree_map(old);
@@ -109,13 +117,14 @@ pub fn diff(old: &OrchardState, new: &OrchardState) -> Vec<WatchEvent> {
             continue;
         };
 
-        let old_claude = claude_status(old_wt);
-        let new_claude = claude_status(new_wt);
+        let new_raw = claude_status(new_wt);
+        let old_effective = debounce.confirmed(path);
+        let new_effective = debounce.observe(path, new_raw);
         let label = label_for(new_wt);
         let session = first_session(new_wt);
 
-        // Claude state transitions
-        match (old_claude, new_claude) {
+        // Claude state transitions (debounced: new status must persist two cycles)
+        match (old_effective, new_effective) {
             (ClaudeState::Working, ClaudeState::Input) => {
                 events.push(WatchEvent::now(EventKind::ClaudeNeedsInput {
                     worktree: path.to_string(),
@@ -215,6 +224,9 @@ pub fn diff(old: &OrchardState, new: &OrchardState) -> Vec<WatchEvent> {
         }
     }
 
+    // Drop debounce state for worktrees that no longer exist.
+    debounce.retain_paths(|p| new_map.contains_key(p));
+
     // --- Standalone session transitions ---
     let old_sessions: HashSet<&str> = old
         .standalone_sessions
@@ -257,6 +269,7 @@ mod tests {
     use super::*;
     use crate::derive::DisplayGroup;
     use crate::orchard_state::{ClaudeEnrichment, PrState, RepoState, SessionState, WorktreeState};
+    use crate::watch::debounce::ClaudeDebounceState;
 
     fn empty_state() -> OrchardState {
         OrchardState {
@@ -323,9 +336,20 @@ mod tests {
         }
     }
 
+    /// Creates a debounce state pre-seeded with the confirmed statuses from `state`.
+    ///
+    /// Calling `diff(state, state, &mut debounce)` primes the debouncer so that the
+    /// next diff call treats `state`'s statuses as the established baseline.
+    fn seeded_debounce(state: &OrchardState) -> ClaudeDebounceState {
+        let mut d = ClaudeDebounceState::new();
+        let _ = diff(state, state, &mut d);
+        d
+    }
+
     #[test]
     fn diff_empty_states_returns_no_events() {
-        let events = diff(&empty_state(), &empty_state());
+        let mut d = ClaudeDebounceState::new();
+        let events = diff(&empty_state(), &empty_state(), &mut d);
         assert!(events.is_empty());
     }
 
@@ -335,7 +359,8 @@ mod tests {
         let wt = make_worktree("/workspace/repo/feat-1", "feat/issue-1");
         let new = make_state(vec![wt]);
 
-        let events = diff(&old, &new);
+        let mut d = seeded_debounce(&old);
+        let events = diff(&old, &new, &mut d);
         assert_eq!(events.len(), 1);
         assert!(matches!(
             &events[0].kind,
@@ -349,7 +374,8 @@ mod tests {
         let old = make_state(vec![wt]);
         let new = empty_state();
 
-        let events = diff(&old, &new);
+        let mut d = seeded_debounce(&old);
+        let events = diff(&old, &new, &mut d);
         assert_eq!(events.len(), 1);
         assert!(matches!(
             &events[0].kind,
@@ -362,8 +388,13 @@ mod tests {
         let path = "/workspace/repo/feat-1";
         let old_wt = with_claude(make_worktree(path, "feat/issue-1"), ClaudeState::Working);
         let new_wt = with_claude(make_worktree(path, "feat/issue-1"), ClaudeState::Input);
+        let old_state = make_state(vec![old_wt]);
+        let new_state = make_state(vec![new_wt]);
 
-        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+        // Prime debouncer with Working, then observe Input twice (required by 2-cycle rule).
+        let mut d = seeded_debounce(&old_state);
+        let _ = diff(&old_state, &new_state, &mut d); // first sighting of Input — suppressed
+        let events = diff(&old_state, &new_state, &mut d); // second sighting — confirmed
 
         let input_events: Vec<_> = events
             .iter()
@@ -377,8 +408,12 @@ mod tests {
         let path = "/workspace/repo/feat-1";
         let old_wt = with_claude(make_worktree(path, "feat/issue-1"), ClaudeState::Working);
         let new_wt = with_claude(make_worktree(path, "feat/issue-1"), ClaudeState::Idle);
+        let old_state = make_state(vec![old_wt]);
+        let new_state = make_state(vec![new_wt]);
 
-        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+        let mut d = seeded_debounce(&old_state);
+        let _ = diff(&old_state, &new_state, &mut d); // first sighting
+        let events = diff(&old_state, &new_state, &mut d); // second sighting — confirmed
 
         let finished_events: Vec<_> = events
             .iter()
@@ -392,8 +427,12 @@ mod tests {
         let path = "/workspace/repo/feat-1";
         let old_wt = with_claude(make_worktree(path, "feat/issue-1"), ClaudeState::Idle);
         let new_wt = with_claude(make_worktree(path, "feat/issue-1"), ClaudeState::Working);
+        let old_state = make_state(vec![old_wt]);
+        let new_state = make_state(vec![new_wt]);
 
-        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+        let mut d = seeded_debounce(&old_state);
+        let _ = diff(&old_state, &new_state, &mut d); // first sighting
+        let events = diff(&old_state, &new_state, &mut d); // second sighting — confirmed
 
         let started_events: Vec<_> = events
             .iter()
@@ -413,8 +452,11 @@ mod tests {
 
         let old_wt = with_pr(make_worktree(path, "feat/issue-1"), old_pr);
         let new_wt = with_pr(make_worktree(path, "feat/issue-1"), new_pr);
+        let old_state = make_state(vec![old_wt]);
+        let new_state = make_state(vec![new_wt]);
 
-        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+        let mut d = seeded_debounce(&old_state);
+        let events = diff(&old_state, &new_state, &mut d);
 
         let ci_events: Vec<_> = events
             .iter()
@@ -437,8 +479,11 @@ mod tests {
 
         let old_wt = with_pr(make_worktree(path, "feat/issue-1"), old_pr);
         let new_wt = with_pr(make_worktree(path, "feat/issue-1"), new_pr);
+        let old_state = make_state(vec![old_wt]);
+        let new_state = make_state(vec![new_wt]);
 
-        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+        let mut d = seeded_debounce(&old_state);
+        let events = diff(&old_state, &new_state, &mut d);
 
         let ci_events: Vec<_> = events
             .iter()
@@ -458,8 +503,11 @@ mod tests {
 
         let old_wt = with_pr(make_worktree(path, "feat/issue-1"), old_pr);
         let new_wt = with_pr(make_worktree(path, "feat/issue-1"), new_pr);
+        let old_state = make_state(vec![old_wt]);
+        let new_state = make_state(vec![new_wt]);
 
-        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+        let mut d = seeded_debounce(&old_state);
+        let events = diff(&old_state, &new_state, &mut d);
 
         let review_events: Vec<_> = events
             .iter()
@@ -486,8 +534,11 @@ mod tests {
 
         let old_wt = with_pr(make_worktree(path, "feat/issue-1"), old_pr);
         let new_wt = with_pr(make_worktree(path, "feat/issue-1"), new_pr);
+        let old_state = make_state(vec![old_wt]);
+        let new_state = make_state(vec![new_wt]);
 
-        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+        let mut d = seeded_debounce(&old_state);
+        let events = diff(&old_state, &new_state, &mut d);
 
         let merged_events: Vec<_> = events
             .iter()
@@ -510,8 +561,11 @@ mod tests {
 
         let old_wt = with_pr(make_worktree(path, "feat/issue-1"), old_pr);
         let new_wt = with_pr(make_worktree(path, "feat/issue-1"), new_pr);
+        let old_state = make_state(vec![old_wt]);
+        let new_state = make_state(vec![new_wt]);
 
-        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+        let mut d = seeded_debounce(&old_state);
+        let events = diff(&old_state, &new_state, &mut d);
         let ci_events: Vec<_> = events
             .iter()
             .filter(|e| matches!(&e.kind, EventKind::CiPassed { .. }))
@@ -533,8 +587,11 @@ mod tests {
 
         let old_wt = with_pr(make_worktree(path, "feat/issue-1"), old_pr);
         let new_wt = with_pr(make_worktree(path, "feat/issue-1"), new_pr);
+        let old_state = make_state(vec![old_wt]);
+        let new_state = make_state(vec![new_wt]);
 
-        let events = diff(&make_state(vec![old_wt]), &make_state(vec![new_wt]));
+        let mut d = seeded_debounce(&old_state);
+        let events = diff(&old_state, &new_state, &mut d);
         let ready_events: Vec<_> = events
             .iter()
             .filter(|e| matches!(&e.kind, EventKind::PrReadyToMerge { .. }))
@@ -573,7 +630,8 @@ mod tests {
             hosts: HashMap::new(),
         };
 
-        let events = diff(&old, &new);
+        let mut d = seeded_debounce(&old);
+        let events = diff(&old, &new, &mut d);
         let started: Vec<_> = events
             .iter()
             .filter(|e| matches!(&e.kind, EventKind::SessionStarted { .. }))
@@ -612,7 +670,8 @@ mod tests {
         };
         let new = empty_state();
 
-        let events = diff(&old, &new);
+        let mut d = seeded_debounce(&old);
+        let events = diff(&old, &new, &mut d);
         let died: Vec<_> = events
             .iter()
             .filter(|e| matches!(&e.kind, EventKind::SessionDied { .. }))
@@ -629,7 +688,76 @@ mod tests {
         );
 
         let state = make_state(vec![wt]);
-        let events = diff(&state, &state);
+        let mut d = seeded_debounce(&state);
+        let events = diff(&state, &state, &mut d);
         assert!(events.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Debounce regression tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn diff_debounces_single_poll_claude_flicker() {
+        // Sequence: Working → Input → Working across three diff cycles.
+        // Expect: zero ClaudeNeedsInput events emitted.
+        let path = "/workspace/repo/feat-1";
+        let mut debounce = ClaudeDebounceState::new();
+
+        let s1 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Working)]);
+        let s2 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Input)]);
+        let s3 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Working)]);
+
+        // Prime the debouncer: first diff call observes Working and confirms it.
+        let _ = diff(&s1, &s1, &mut debounce);
+
+        let events_1_to_2 = diff(&s1, &s2, &mut debounce);
+        let events_2_to_3 = diff(&s2, &s3, &mut debounce);
+
+        let flicker_events: Vec<_> = events_1_to_2
+            .iter()
+            .chain(events_2_to_3.iter())
+            .filter(|e| {
+                matches!(
+                    &e.kind,
+                    EventKind::ClaudeNeedsInput { .. } | EventKind::ClaudeFinished { .. }
+                )
+            })
+            .collect();
+        assert!(
+            flicker_events.is_empty(),
+            "single-poll flicker should not emit transition events, got {flicker_events:?}"
+        );
+    }
+
+    #[test]
+    fn diff_emits_transition_when_status_persists_two_cycles() {
+        // Sequence: Working → Input → Input. Expect: one ClaudeNeedsInput after the second Input.
+        let path = "/workspace/repo/feat-1";
+        let mut debounce = ClaudeDebounceState::new();
+
+        let s1 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Working)]);
+        let s2 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Input)]);
+        let s3 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Input)]);
+
+        let _ = diff(&s1, &s1, &mut debounce);
+        let events_1_to_2 = diff(&s1, &s2, &mut debounce);
+        let events_2_to_3 = diff(&s2, &s3, &mut debounce);
+
+        let input_events_1: Vec<_> = events_1_to_2
+            .iter()
+            .filter(|e| matches!(&e.kind, EventKind::ClaudeNeedsInput { .. }))
+            .collect();
+        let input_events_2: Vec<_> = events_2_to_3
+            .iter()
+            .filter(|e| matches!(&e.kind, EventKind::ClaudeNeedsInput { .. }))
+            .collect();
+
+        assert!(input_events_1.is_empty(), "no event on first sighting of Input");
+        assert_eq!(
+            input_events_2.len(),
+            1,
+            "event fires when Input persists for a second cycle"
+        );
     }
 }

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -706,9 +706,18 @@ mod tests {
         let path = "/workspace/repo/feat-1";
         let mut debounce = ClaudeDebounceState::new();
 
-        let s1 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Working)]);
-        let s2 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Input)]);
-        let s3 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Working)]);
+        let s1 = make_state(vec![with_claude(
+            make_worktree(path, "b"),
+            ClaudeState::Working,
+        )]);
+        let s2 = make_state(vec![with_claude(
+            make_worktree(path, "b"),
+            ClaudeState::Input,
+        )]);
+        let s3 = make_state(vec![with_claude(
+            make_worktree(path, "b"),
+            ClaudeState::Working,
+        )]);
 
         // Prime the debouncer: first diff call observes Working and confirms it.
         let _ = diff(&s1, &s1, &mut debounce);
@@ -738,9 +747,18 @@ mod tests {
         let path = "/workspace/repo/feat-1";
         let mut debounce = ClaudeDebounceState::new();
 
-        let s1 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Working)]);
-        let s2 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Input)]);
-        let s3 = make_state(vec![with_claude(make_worktree(path, "b"), ClaudeState::Input)]);
+        let s1 = make_state(vec![with_claude(
+            make_worktree(path, "b"),
+            ClaudeState::Working,
+        )]);
+        let s2 = make_state(vec![with_claude(
+            make_worktree(path, "b"),
+            ClaudeState::Input,
+        )]);
+        let s3 = make_state(vec![with_claude(
+            make_worktree(path, "b"),
+            ClaudeState::Input,
+        )]);
 
         let _ = diff(&s1, &s1, &mut debounce);
         let events_1_to_2 = diff(&s1, &s2, &mut debounce);
@@ -755,7 +773,10 @@ mod tests {
             .filter(|e| matches!(&e.kind, EventKind::ClaudeNeedsInput { .. }))
             .collect();
 
-        assert!(input_events_1.is_empty(), "no event on first sighting of Input");
+        assert!(
+            input_events_1.is_empty(),
+            "no event on first sighting of Input"
+        );
         assert_eq!(
             input_events_2.len(),
             1,

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -118,8 +118,7 @@ pub fn diff(
         };
 
         let new_raw = claude_status(new_wt);
-        let old_effective = debounce.confirmed(path);
-        let new_effective = debounce.observe(path, new_raw);
+        let (old_effective, new_effective) = debounce.observe(path, new_raw);
         let label = label_for(new_wt);
         let session = first_session(new_wt);
 
@@ -336,13 +335,16 @@ mod tests {
         }
     }
 
-    /// Creates a debounce state pre-seeded with the confirmed statuses from `state`.
-    ///
-    /// Calling `diff(state, state, &mut debounce)` primes the debouncer so that the
-    /// next diff call treats `state`'s statuses as the established baseline.
+    /// Creates a debounce state where each worktree's current claude status is
+    /// already confirmed. Used by tests that want to start from a known baseline
+    /// so the next `diff` call exercises a single transition.
     fn seeded_debounce(state: &OrchardState) -> ClaudeDebounceState {
         let mut d = ClaudeDebounceState::new();
-        let _ = diff(state, state, &mut d);
+        for repo in &state.repos {
+            for wt in &repo.worktrees {
+                d.observe(&wt.path, claude_status(wt));
+            }
+        }
         d
     }
 

--- a/crates/orchard/src/watch/mod.rs
+++ b/crates/orchard/src/watch/mod.rs
@@ -4,6 +4,7 @@
 //! emits `WatchEvent`s, and delivers them to all registered subscribers.
 
 pub mod daemon;
+pub mod debounce;
 pub mod diff;
 pub mod event;
 pub mod subscription;


### PR DESCRIPTION
## Why

Closes #217.

During heavy tool use, `orchard watch` emitted ~50 false-positive `ClaudeNeedsInput` / `ClaudeFinished` / `ClaudeStarted` events per 4h management session. Each ping forced the orchardist to tmux-capture the pane and verify whether the transition was real, blowing a huge hole in the signal:noise ratio.

## What changed

Introduced a per-worktree status debouncer that suppresses single-poll flicker in the watch event stream. A new Claude status must be observed in **two consecutive diff cycles** before a transition event is emitted. Single-cycle blips (e.g. a `Notification`-driven `input` that's gone by the next poll) are silently discarded.

The TUI still renders the raw status from each poll — only the watch event stream is filtered. PR/CI/session transitions are untouched.

**Note on the original hypothesis.** The issue body speculated the flicker came from a pane parser reading mid-render. There is no pane parser: Claude status comes from JSON state files written by the `orchard-state.sh` tmux hook on every `PreToolUse`/`PostToolUse`/`Stop`/`Notification` event. The real source of flicker is that Claude Code legitimately emits rapid `working → input → working` sequences when an elicitation dialog appears mid-tool-use, and `working → idle → working` between subagent turns. Option A (debounce) is the correct fix; Option B (pane parsing) does not apply.

## How it works

New module `crates/orchard/src/watch/debounce.rs` owns a `ClaudeDebounceState` that tracks, per worktree path, a `confirmed` status and an optional `pending` status. On each observation:

| Observed vs. state | Effect | Returned |
|---|---|---|
| First time (no entry) | Insert as confirmed | observed |
| == confirmed | Clear pending | confirmed |
| != confirmed, no pending | Record as pending | confirmed (suppressed) |
| != confirmed, matches pending | Promote pending → confirmed | new confirmed |
| != confirmed, different pending | Replace pending | confirmed (window resets) |

`diff::diff` now takes `&mut ClaudeDebounceState` and matches transitions on the **effective** (debounced) statuses instead of the raw ones. Both `watch::daemon::run` and `tui::mod::App::detect_and_notify` own their own debounce state and thread it through.

Latency cost: at most one extra `local_poll_secs` (5s default) on real transitions — well within the "detected within 2 polls" acceptance criterion.

## Test plan

**New unit tests** in `watch/debounce.rs`:
- `observe_first_time_confirms_immediately` — first observation becomes confirmed
- `observe_unchanged_returns_same` — stable status stays confirmed
- `single_blip_is_suppressed` — `Working → Input → Working` returns `Working×3`
- `two_poll_transition_is_confirmed` — `Working → Input → Input` returns `Working, Working, Input`
- `changed_pending_resets_window` — `Working → Input → Idle` keeps confirmed as `Working`
- `different_worktrees_are_independent` — two paths debounce separately
- `retain_paths_drops_removed_worktrees`

**New regression tests** in `watch/diff.rs`:
- `diff_debounces_single_poll_claude_flicker` — the exact flicker sequence from the issue emits zero `ClaudeNeedsInput`/`ClaudeFinished` events
- `diff_emits_transition_when_status_persists_two_cycles` — `Input` held across two polls emits exactly one `ClaudeNeedsInput`

**Full suite**: `cargo test -p orchard` → 775 passed, 0 failed. `cargo build --release` clean.

**Still to do** (manual, post-merge): 1h dogfood stress test with 10+ active sessions to confirm the orchardist's signal:noise ratio flips from ~1:4 to >5:1.

## Anything surprising?

- The debounce window is hardcoded to 2 cycles rather than exposing a knob. Follow the YAGNI rule — if 2 cycles turns out to be too aggressive or too lax after dogfooding, add a config field then.
- Pre-existing `Cargo.lock` drift on orchard 0.5.0 → 0.6.0 is included in this commit (release 0.6.0 landed on main after the lockfile was last regenerated); unrelated to the fix.

# Related issue

- #217

# Related issue

- #217

# Related issue

- #217