### PR TITLE
feat(json): first-class phase field on PRs and issues (#219)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,7 +2831,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -667,7 +667,10 @@ mod tests {
             make_worktree_for_labels("/workspace/repo", "main"),
             make_worktree_for_labels("/workspace/repo-47", branch),
         ];
-        let issues = vec![make_issue_with_labels(47, vec!["in-progress", "enhancement"])];
+        let issues = vec![make_issue_with_labels(
+            47,
+            vec!["in-progress", "enhancement"],
+        )];
 
         let rows = derive_worktree_rows(&issues, &[], &worktrees, &[], "owner/repo", &[]);
         let row = rows.iter().find(|r| r.branch == branch).unwrap();

--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -592,4 +592,109 @@ mod tests {
         // This test documents the constant value.
         assert_eq!(REMOTE_HOOK_STATE_STALENESS_SECS, 30);
     }
+
+    // -----------------------------------------------------------------------
+    // Label threading: PR labels reach PrState; issue labels reach IssueInfo
+    //
+    // These tests use `derive_worktree_rows` (the pure functional core) instead
+    // of `build_state` (which reads from real cache files on disk). The
+    // build_state→derive pipeline is a direct pass-through — these tests
+    // verify the same field threading without requiring I/O.
+    // -----------------------------------------------------------------------
+
+    use crate::cache::{CachedIssue, CachedPr, CachedWorktree};
+    use crate::derive::derive_worktree_rows;
+    use crate::orchard_state::WorktreeState;
+
+    fn make_worktree_for_labels(path: &str, branch: &str) -> CachedWorktree {
+        CachedWorktree {
+            path: path.to_string(),
+            branch: branch.to_string(),
+            is_bare: false,
+            is_locked: false,
+            host: None,
+        }
+    }
+
+    fn make_pr_with_labels(number: u32, branch: &str, labels: Vec<&str>) -> CachedPr {
+        CachedPr {
+            number,
+            branch: branch.to_string(),
+            linked_issue: None,
+            state: "open".to_string(),
+            review_decision: None,
+            checks_state: None,
+            has_conflicts: false,
+            unresolved_threads: 0,
+            linked_issue_state: None,
+            labels: labels.into_iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn make_issue_with_labels(number: u32, labels: Vec<&str>) -> CachedIssue {
+        CachedIssue {
+            number,
+            title: format!("Issue #{number}"),
+            state: "open".to_string(),
+            labels: labels.into_iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn build_state_threads_pr_labels_into_pr_state() {
+        let branch = "issue55/my-feature";
+        let worktrees = vec![
+            make_worktree_for_labels("/workspace/repo", "main"),
+            make_worktree_for_labels("/workspace/repo-55", branch),
+        ];
+        let prs = vec![make_pr_with_labels(55, branch, vec!["planned"])];
+
+        let rows = derive_worktree_rows(&[], &prs, &worktrees, &[], "owner/repo", &[]);
+        let row = rows.iter().find(|r| r.branch == branch).unwrap();
+        let pr = row.pr.as_ref().expect("PR should be present");
+        assert_eq!(pr.labels, vec!["planned"]);
+
+        // Verify it reaches PrState too
+        let state = WorktreeState::from(row);
+        let pr_state = state.pr.as_ref().unwrap();
+        assert_eq!(pr_state.labels, vec!["planned"]);
+    }
+
+    #[test]
+    fn build_state_threads_issue_labels_into_issue_info() {
+        let branch = "issue47/my-feature";
+        let worktrees = vec![
+            make_worktree_for_labels("/workspace/repo", "main"),
+            make_worktree_for_labels("/workspace/repo-47", branch),
+        ];
+        let issues = vec![make_issue_with_labels(47, vec!["in-progress", "enhancement"])];
+
+        let rows = derive_worktree_rows(&issues, &[], &worktrees, &[], "owner/repo", &[]);
+        let row = rows.iter().find(|r| r.branch == branch).unwrap();
+        assert_eq!(row.issue_labels, vec!["in-progress", "enhancement"]);
+
+        // Verify it reaches IssueInfo too
+        let state = WorktreeState::from(row);
+        let issue = state.issue.as_ref().unwrap();
+        assert_eq!(issue.labels, vec!["in-progress", "enhancement"]);
+    }
+
+    #[test]
+    fn build_state_emits_empty_labels_when_pr_has_no_labels() {
+        let branch = "issue99/my-feature";
+        let worktrees = vec![
+            make_worktree_for_labels("/workspace/repo", "main"),
+            make_worktree_for_labels("/workspace/repo-99", branch),
+        ];
+        let prs = vec![make_pr_with_labels(99, branch, vec![])];
+
+        let rows = derive_worktree_rows(&[], &prs, &worktrees, &[], "owner/repo", &[]);
+        let row = rows.iter().find(|r| r.branch == branch).unwrap();
+        let pr = row.pr.as_ref().expect("PR should be present");
+        assert!(pr.labels.is_empty());
+
+        let state = WorktreeState::from(row);
+        let pr_state = state.pr.as_ref().unwrap();
+        assert_eq!(pr_state.labels, Vec::<String>::new());
+    }
 }

--- a/crates/orchard/src/cache.rs
+++ b/crates/orchard/src/cache.rs
@@ -52,6 +52,12 @@ pub struct CachedPr {
     /// the GraphQL `closingIssuesReferences` nodes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub linked_issue_state: Option<String>,
+    /// Labels applied to the PR.
+    ///
+    /// Uses `serde(default)` so pre-upgrade cache files without this key still
+    /// deserialize successfully (producing an empty vec).
+    #[serde(default)]
+    pub labels: Vec<String>,
 }
 
 /// A git worktree entry as stored in the worktrees cache file.
@@ -311,6 +317,7 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            labels: vec![],
         }
     }
 
@@ -635,5 +642,56 @@ mod tests {
         // Also verify the JSON on disk contains the field name.
         let json = std::fs::read_to_string(&path).unwrap();
         assert!(json.contains("\"last_refreshed\""));
+    }
+
+    // -- CachedPr labels migration -------------------------------------------
+
+    #[test]
+    fn cached_pr_without_labels_key_deserializes_to_empty_vec() {
+        let json = r#"{
+            "number": 55,
+            "branch": "issue/example",
+            "linked_issue": null,
+            "state": "open",
+            "review_decision": null,
+            "checks_state": null,
+            "has_conflicts": false,
+            "unresolved_threads": 0
+        }"#;
+        let pr: CachedPr = serde_json::from_str(json).expect("deserialization should succeed");
+        assert!(
+            pr.labels.is_empty(),
+            "labels should default to empty vec when key is absent"
+        );
+    }
+
+    #[test]
+    fn cached_pr_with_labels_key_round_trips() {
+        let json = r#"{
+            "number": 55,
+            "branch": "issue/example",
+            "linked_issue": null,
+            "state": "open",
+            "review_decision": null,
+            "checks_state": null,
+            "has_conflicts": false,
+            "unresolved_threads": 0,
+            "labels": ["in-progress", "bug"]
+        }"#;
+        let pr: CachedPr = serde_json::from_str(json).expect("deserialization should succeed");
+        assert_eq!(pr.labels, vec!["in-progress", "bug"]);
+    }
+
+    #[test]
+    fn cached_issue_with_labels_key_deserializes_correctly() {
+        let json = r#"{
+            "number": 42,
+            "title": "Test issue",
+            "state": "open",
+            "labels": ["enhancement"]
+        }"#;
+        let issue: CachedIssue =
+            serde_json::from_str(json).expect("deserialization should succeed");
+        assert_eq!(issue.labels, vec!["enhancement"]);
     }
 }

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -126,6 +126,15 @@ pub fn parse_prs_graphql(json: &str) -> Vec<CachedPr> {
                 Some(normalised.to_string())
             });
 
+            let labels = v["labels"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|l| l["name"].as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+
             Some(CachedPr {
                 number,
                 branch,
@@ -136,6 +145,7 @@ pub fn parse_prs_graphql(json: &str) -> Vec<CachedPr> {
                 has_conflicts,
                 unresolved_threads,
                 linked_issue_state,
+                labels,
             })
         })
         .collect()
@@ -428,6 +438,11 @@ pub fn refresh_prs(config: &RepoConfig) -> anyhow::Result<()> {
         state
         reviewDecision
         mergeable
+        labels(first: 100) {{
+          nodes {{
+            name
+          }}
+        }}
         reviewThreads(first: 100) {{
           nodes {{
             isResolved

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -126,7 +126,9 @@ pub fn parse_prs_graphql(json: &str) -> Vec<CachedPr> {
                 Some(normalised.to_string())
             });
 
-            let labels = v["labels"]
+            // GraphQL shape is `labels: { nodes: [{ name: "..." }, ...] }` —
+            // unlike `parse_issues_json` above which reads a flat REST array.
+            let labels = v["labels"]["nodes"]
                 .as_array()
                 .map(|arr| {
                     arr.iter()
@@ -438,6 +440,9 @@ pub fn refresh_prs(config: &RepoConfig) -> anyhow::Result<()> {
         state
         reviewDecision
         mergeable
+        # 100 is deliberately high: GitHub rarely surfaces more than ~20 labels
+        # on a single PR, and truncation would silently drop a phase label,
+        # flipping the computed `phase` projection from its real value to null.
         labels(first: 100) {{
           nodes {{
             name
@@ -1017,6 +1022,67 @@ mod tests {
     #[test]
     fn parse_prs_graphql_invalid_json_returns_empty() {
         assert!(parse_prs_graphql("{bad}").is_empty());
+    }
+
+    // -- parse_prs_graphql labels extraction --------------------------------
+
+    /// Builds a PR node with an explicit `labels` array of name strings.
+    fn gql_pr_node_with_labels(number: u32, label_names: &[&str]) -> serde_json::Value {
+        let mut node = gql_pr_node(number, "test/branch", None, "MERGEABLE", None, vec![], 0);
+        let label_nodes: Vec<serde_json::Value> =
+            label_names.iter().map(|n| json!({"name": n})).collect();
+        node["labels"] = json!({ "nodes": label_nodes });
+        node
+    }
+
+    #[test]
+    fn parse_prs_graphql_extracts_labels_when_present() {
+        let json = graphql_prs(json!([gql_pr_node_with_labels(
+            55,
+            &["in-progress", "bug"],
+        )]));
+        let prs = parse_prs_graphql(&json);
+        assert_eq!(prs[0].labels, vec!["in-progress", "bug"]);
+    }
+
+    #[test]
+    fn parse_prs_graphql_labels_empty_when_nodes_missing() {
+        // Existing `gql_pr_node` helper emits no `labels` key at all.
+        let json = graphql_prs(json!([gql_pr_node(
+            55,
+            "test/branch",
+            None,
+            "MERGEABLE",
+            None,
+            vec![],
+            0,
+        )]));
+        let prs = parse_prs_graphql(&json);
+        assert!(prs[0].labels.is_empty());
+    }
+
+    #[test]
+    fn parse_prs_graphql_labels_empty_when_nodes_array_is_empty() {
+        let json = graphql_prs(json!([gql_pr_node_with_labels(55, &[])]));
+        let prs = parse_prs_graphql(&json);
+        assert!(prs[0].labels.is_empty());
+    }
+
+    #[test]
+    fn parse_prs_graphql_skips_label_nodes_without_name() {
+        // Defensive: if a node in the labels array is missing a `name` field,
+        // skip it rather than panicking or emitting a placeholder.
+        let mut node = gql_pr_node(55, "test/branch", None, "MERGEABLE", None, vec![], 0);
+        node["labels"] = json!({
+            "nodes": [
+                {"name": "keep-me"},
+                {"other": "no-name-here"},
+                {"name": "also-keep"},
+            ]
+        });
+        let json = graphql_prs(json!([node]));
+        let prs = parse_prs_graphql(&json);
+        assert_eq!(prs[0].labels, vec!["keep-me", "also-keep"]);
     }
 
     // -- parse_worktree_porcelain -------------------------------------------

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -197,9 +197,7 @@ pub fn derive_worktree_rows(
         let linked_issue = issue_number.and_then(|num| issues.iter().find(|i| i.number == num));
         let issue_title = linked_issue.map(|i| i.title.clone());
         let issue_state = linked_issue.map(|i| i.state.clone());
-        let issue_labels = linked_issue
-            .map(|i| i.labels.clone())
-            .unwrap_or_default();
+        let issue_labels = linked_issue.map(|i| i.labels.clone()).unwrap_or_default();
 
         let is_main_worktree =
             is_first_non_bare || session_infos.iter().any(|s| s.tmux.name.ends_with("_main"));

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -28,23 +28,14 @@ type RepoCacheEntry = (
 /// Maximum age (in seconds) before a Claude hook state file is considered stale.
 const HOOK_STATE_STALENESS_SECS: u64 = 300;
 
-/// Phase labels applied by the `/gh-tag` skill. Source of truth:
-/// `~/.claude/skills/gh-tag/tag.sh`. Keep in sync manually.
-pub const PHASE_LABELS: &[&str] = &[
-    "investigating",
-    "needs-plan",
-    "needs-repro",
-    "planned",
-    "in-progress",
-    "in-ai-review",
-    "pr-ready",
-    "blocked",
-];
-
-/// Priority order for resolving multiple phase labels on the same issue/PR.
-/// Highest priority first. `blocked` wins over everything else — we never want
-/// a blocked PR to silently vanish from filters.
-const PHASE_PRIORITY: &[&str] = &[
+/// Workflow phase labels applied by the `/gh-tag` skill, in priority order.
+///
+/// Highest-priority first: `blocked` wins over everything so a blocked PR never
+/// silently vanishes from filters when multiple phase labels coexist.
+///
+/// Source of truth for the label set: `~/.claude/skills/gh-tag/tag.sh`.
+/// Keep in sync manually when new phase labels are added to that skill.
+pub const PHASE_PRIORITY: &[&str] = &[
     "blocked",
     "in-ai-review",
     "pr-ready",

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -28,6 +28,59 @@ type RepoCacheEntry = (
 /// Maximum age (in seconds) before a Claude hook state file is considered stale.
 const HOOK_STATE_STALENESS_SECS: u64 = 300;
 
+/// Phase labels applied by the `/gh-tag` skill. Source of truth:
+/// `~/.claude/skills/gh-tag/tag.sh`. Keep in sync manually.
+pub const PHASE_LABELS: &[&str] = &[
+    "investigating",
+    "needs-plan",
+    "needs-repro",
+    "planned",
+    "in-progress",
+    "in-ai-review",
+    "pr-ready",
+    "blocked",
+];
+
+/// Priority order for resolving multiple phase labels on the same issue/PR.
+/// Highest priority first. `blocked` wins over everything else — we never want
+/// a blocked PR to silently vanish from filters.
+const PHASE_PRIORITY: &[&str] = &[
+    "blocked",
+    "in-ai-review",
+    "pr-ready",
+    "in-progress",
+    "needs-repro",
+    "needs-plan",
+    "investigating",
+    "planned",
+];
+
+/// Derives the workflow phase from a slice of label strings.
+///
+/// Iterates `PHASE_PRIORITY` in order and returns the first label whose name
+/// appears anywhere in the input slice. Returns `None` if no phase label is
+/// present. Matching is case-sensitive and exact.
+///
+/// # Examples
+///
+/// ```
+/// use orchard::derive::phase_from_labels;
+///
+/// assert_eq!(phase_from_labels(&[]), None);
+/// assert_eq!(phase_from_labels(&["bug".to_string()]), None);
+/// assert_eq!(phase_from_labels(&["in-progress".to_string()]), Some("in-progress"));
+/// assert_eq!(
+///     phase_from_labels(&["in-progress".to_string(), "blocked".to_string()]),
+///     Some("blocked"),
+/// );
+/// ```
+pub fn phase_from_labels(labels: &[String]) -> Option<&'static str> {
+    PHASE_PRIORITY
+        .iter()
+        .find(|&&priority_label| labels.iter().any(|l| l == priority_label))
+        .copied()
+}
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -68,6 +121,8 @@ pub struct PrInfo {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Labels applied to the PR.
+    pub labels: Vec<String>,
 }
 
 /// One row in the derived worktree view. Corresponds to one non-bare worktree,
@@ -89,6 +144,9 @@ pub struct WorktreeRow {
     /// State of the linked issue ("open", "closed", "completed"), if any.
     /// Used to detect stale worktrees whose issue has been resolved without a PR.
     pub issue_state: Option<String>,
+    /// Labels on the linked issue, if any. Empty when no issue is linked or
+    /// the issue has no labels.
+    pub issue_labels: Vec<String>,
     /// Linked pull request, if one exists for this branch.
     pub pr: Option<PrInfo>,
     /// Active tmux sessions associated with this worktree path.
@@ -148,6 +206,9 @@ pub fn derive_worktree_rows(
         let linked_issue = issue_number.and_then(|num| issues.iter().find(|i| i.number == num));
         let issue_title = linked_issue.map(|i| i.title.clone());
         let issue_state = linked_issue.map(|i| i.state.clone());
+        let issue_labels = linked_issue
+            .map(|i| i.labels.clone())
+            .unwrap_or_default();
 
         let is_main_worktree =
             is_first_non_bare || session_infos.iter().any(|s| s.tmux.name.ends_with("_main"));
@@ -168,6 +229,7 @@ pub fn derive_worktree_rows(
             issue_number,
             issue_title,
             issue_state,
+            issue_labels,
             pr: pr_info,
             sessions: session_infos,
             display_group,
@@ -227,6 +289,7 @@ fn pr_info_from(pr: &CachedPr) -> PrInfo {
         checks_state: pr.checks_state.clone(),
         has_conflicts: pr.has_conflicts,
         unresolved_threads: pr.unresolved_threads,
+        labels: pr.labels.clone(),
     }
 }
 
@@ -497,6 +560,7 @@ mod tests {
             linked_issue: None,
             state: "open".to_string(),
             review_decision: None,
+            labels: vec![],
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
@@ -515,6 +579,7 @@ mod tests {
             has_conflicts: false,
             unresolved_threads: 0,
             linked_issue_state: None,
+            labels: vec![],
         }
     }
 
@@ -1487,5 +1552,148 @@ mod tests {
         let enriched = enrich_session_from_scraping_for_test(&sess);
         assert_eq!(enriched.panes.len(), 1);
         assert!(enriched.panes[0].has_claude);
+    }
+
+    // -----------------------------------------------------------------------
+    // phase_from_labels tests
+    // -----------------------------------------------------------------------
+
+    fn ls(labels: &[&str]) -> Vec<String> {
+        labels.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn phase_from_labels_empty_returns_none() {
+        assert_eq!(phase_from_labels(&[]), None);
+    }
+
+    #[test]
+    fn phase_from_labels_no_phase_labels_returns_none() {
+        assert_eq!(
+            phase_from_labels(&ls(&["bug", "enhancement", "good-first-issue"])),
+            None
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_single_phase_label_returns_it() {
+        assert_eq!(
+            phase_from_labels(&ls(&["in-progress"])),
+            Some("in-progress")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_mixed_with_unrelated_returns_phase() {
+        assert_eq!(
+            phase_from_labels(&ls(&["bug", "planned", "priority-high"])),
+            Some("planned")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_priority_resolves_two_labels() {
+        // in-progress (rank 4) beats planned (rank 8)
+        assert_eq!(
+            phase_from_labels(&ls(&["planned", "in-progress"])),
+            Some("in-progress")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_blocked_wins_over_in_progress() {
+        assert_eq!(
+            phase_from_labels(&ls(&["in-progress", "blocked"])),
+            Some("blocked")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_blocked_wins_over_in_ai_review() {
+        assert_eq!(
+            phase_from_labels(&ls(&["in-ai-review", "blocked"])),
+            Some("blocked")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_priority_resolves_three_labels() {
+        assert_eq!(
+            phase_from_labels(&ls(&["investigating", "needs-plan", "blocked"])),
+            Some("blocked")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_in_ai_review_wins_over_pr_ready() {
+        assert_eq!(
+            phase_from_labels(&ls(&["pr-ready", "in-ai-review"])),
+            Some("in-ai-review")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_recognizes_investigating() {
+        assert_eq!(
+            phase_from_labels(&ls(&["investigating"])),
+            Some("investigating")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_recognizes_needs_plan() {
+        assert_eq!(phase_from_labels(&ls(&["needs-plan"])), Some("needs-plan"));
+    }
+
+    #[test]
+    fn phase_from_labels_recognizes_needs_repro() {
+        assert_eq!(
+            phase_from_labels(&ls(&["needs-repro"])),
+            Some("needs-repro")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_recognizes_planned() {
+        assert_eq!(phase_from_labels(&ls(&["planned"])), Some("planned"));
+    }
+
+    #[test]
+    fn phase_from_labels_recognizes_in_progress() {
+        assert_eq!(
+            phase_from_labels(&ls(&["in-progress"])),
+            Some("in-progress")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_recognizes_in_ai_review() {
+        assert_eq!(
+            phase_from_labels(&ls(&["in-ai-review"])),
+            Some("in-ai-review")
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_recognizes_pr_ready() {
+        assert_eq!(phase_from_labels(&ls(&["pr-ready"])), Some("pr-ready"));
+    }
+
+    #[test]
+    fn phase_from_labels_recognizes_blocked() {
+        assert_eq!(phase_from_labels(&ls(&["blocked"])), Some("blocked"));
+    }
+
+    #[test]
+    fn phase_from_labels_ignores_unknown_labels() {
+        assert_eq!(
+            phase_from_labels(&ls(&["wontfix", "duplicate", "question"])),
+            None
+        );
+    }
+
+    #[test]
+    fn phase_from_labels_case_sensitive_no_match_for_uppercase() {
+        assert_eq!(phase_from_labels(&ls(&["In-Progress"])), None);
     }
 }

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -749,9 +749,21 @@ mod tests {
         assert_eq!(v["phase"], "in-ai-review");
         assert_eq!(v["number"], 220);
         assert_eq!(v["branch"], "issue219/phase-field");
-        assert!(v.get("reviewDecision").is_some(), "reviewDecision key must be present");
-        assert!(v.get("checksState").is_some(), "checksState key must be present");
-        assert!(v.get("hasConflicts").is_some(), "hasConflicts key must be present");
-        assert!(v.get("unresolvedThreads").is_some(), "unresolvedThreads key must be present");
+        assert!(
+            v.get("reviewDecision").is_some(),
+            "reviewDecision key must be present"
+        );
+        assert!(
+            v.get("checksState").is_some(),
+            "checksState key must be present"
+        );
+        assert!(
+            v.get("hasConflicts").is_some(),
+            "hasConflicts key must be present"
+        );
+        assert!(
+            v.get("unresolvedThreads").is_some(),
+            "unresolvedThreads key must be present"
+        );
     }
 }

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use serde::Serialize;
 
 use crate::claude_state::ClaudeState;
-use crate::derive::DisplayGroup;
+use crate::derive::{DisplayGroup, phase_from_labels};
 use crate::orchard_state::{
     IssueInfo, OrchardState, PrState, RepoState, SessionState, WindowState, WorktreeState,
 };
@@ -73,7 +73,7 @@ pub struct JsonWorktree {
 
 /// Issue information in JSON output.
 ///
-/// Subset of GitHub issue data: number, title, and state (open/closed).
+/// Subset of GitHub issue data: number, title, state, and computed workflow phase.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonIssue {
@@ -83,11 +83,15 @@ pub struct JsonIssue {
     pub title: String,
     /// Issue state: "open", "closed", or "completed".
     pub state: String,
+    /// Workflow phase derived from labels (e.g. `"in-progress"`, `"blocked"`).
+    /// Always present: `null` when no phase label is set.
+    pub phase: Option<&'static str>,
 }
 
 /// Pull request information in JSON output.
 ///
-/// Includes PR metadata: number, branch, state, review decision, CI checks, conflicts, and unresolved review threads.
+/// Includes PR metadata: number, branch, state, review decision, CI checks, conflicts,
+/// unresolved review threads, and computed workflow phase.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonPr {
@@ -105,6 +109,9 @@ pub struct JsonPr {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Workflow phase derived from labels (e.g. `"pr-ready"`, `"blocked"`).
+    /// Always present: `null` when no phase label is set.
+    pub phase: Option<&'static str>,
 }
 
 /// Session information in JSON output using the EnrichedSession shape.
@@ -218,6 +225,7 @@ impl From<&IssueInfo> for JsonIssue {
             number: i.number,
             title: i.title.clone(),
             state: i.state.clone(),
+            phase: phase_from_labels(&i.labels),
         }
     }
 }
@@ -233,6 +241,7 @@ impl From<&PrState> for JsonPr {
             checks_state: pr.checks_state.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            phase: phase_from_labels(&pr.labels),
         }
     }
 }
@@ -636,5 +645,113 @@ mod tests {
         };
         let js = JsonSession::from(&session);
         assert_eq!(js.windows.len(), 1);
+    }
+
+    // -- phase field tests ---------------------------------------------------
+
+    fn make_issue_info(number: u32, title: &str, state: &str, labels: Vec<&str>) -> IssueInfo {
+        IssueInfo {
+            number,
+            title: title.to_string(),
+            state: state.to_string(),
+            labels: labels.into_iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn make_pr_state(number: u32, branch: &str, labels: Vec<&str>) -> PrState {
+        PrState {
+            number,
+            branch: branch.to_string(),
+            state: Some("open".to_string()),
+            review_decision: None,
+            checks_state: None,
+            has_conflicts: false,
+            unresolved_threads: 0,
+            labels: labels.into_iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn json_issue_phase_null_when_no_phase_label() {
+        let issue = make_issue_info(1, "fix bug", "open", vec!["bug"]);
+        let ji = JsonIssue::from(&issue);
+        assert!(ji.phase.is_none());
+        let v = serde_json::to_value(&ji).unwrap();
+        assert_eq!(v["phase"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn json_issue_phase_serializes_matched_label() {
+        let issue = make_issue_info(2, "work item", "open", vec!["in-progress", "bug"]);
+        let ji = JsonIssue::from(&issue);
+        assert_eq!(ji.phase, Some("in-progress"));
+        let v = serde_json::to_value(&ji).unwrap();
+        assert_eq!(v["phase"], "in-progress");
+    }
+
+    #[test]
+    fn json_pr_phase_null_when_no_phase_label() {
+        let pr = make_pr_state(10, "feat/branch", vec!["enhancement"]);
+        let jp = JsonPr::from(&pr);
+        assert!(jp.phase.is_none());
+        let v = serde_json::to_value(&jp).unwrap();
+        assert_eq!(v["phase"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn json_pr_phase_serializes_matched_label() {
+        let pr = make_pr_state(10, "feat/branch", vec!["pr-ready"]);
+        let jp = JsonPr::from(&pr);
+        assert_eq!(jp.phase, Some("pr-ready"));
+        let v = serde_json::to_value(&jp).unwrap();
+        assert_eq!(v["phase"], "pr-ready");
+    }
+
+    #[test]
+    fn json_pr_phase_resolves_multi_label_by_priority() {
+        let pr = make_pr_state(10, "feat/branch", vec!["in-progress", "blocked"]);
+        let jp = JsonPr::from(&pr);
+        assert_eq!(jp.phase, Some("blocked"));
+        let v = serde_json::to_value(&jp).unwrap();
+        assert_eq!(v["phase"], "blocked");
+    }
+
+    #[test]
+    fn json_issue_phase_key_always_present_when_null() {
+        let issue = make_issue_info(3, "empty labels", "open", vec![]);
+        let v = serde_json::to_value(JsonIssue::from(&issue)).unwrap();
+        assert!(v.get("phase").is_some(), "phase key must always be present");
+        assert_eq!(v["phase"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn json_pr_phase_key_always_present_when_null() {
+        let pr = make_pr_state(11, "feat/empty", vec![]);
+        let v = serde_json::to_value(JsonPr::from(&pr)).unwrap();
+        assert!(v.get("phase").is_some(), "phase key must always be present");
+        assert_eq!(v["phase"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn json_issue_preserves_existing_fields_when_phase_added() {
+        let issue = make_issue_info(219, "phase field", "open", vec!["planned"]);
+        let v = serde_json::to_value(JsonIssue::from(&issue)).unwrap();
+        assert_eq!(v["phase"], "planned");
+        assert_eq!(v["number"], 219);
+        assert_eq!(v["title"], "phase field");
+        assert_eq!(v["state"], "open");
+    }
+
+    #[test]
+    fn json_pr_preserves_existing_fields_when_phase_added() {
+        let pr = make_pr_state(220, "issue219/phase-field", vec!["in-ai-review"]);
+        let v = serde_json::to_value(JsonPr::from(&pr)).unwrap();
+        assert_eq!(v["phase"], "in-ai-review");
+        assert_eq!(v["number"], 220);
+        assert_eq!(v["branch"], "issue219/phase-field");
+        assert!(v.get("reviewDecision").is_some(), "reviewDecision key must be present");
+        assert!(v.get("checksState").is_some(), "checksState key must be present");
+        assert!(v.get("hasConflicts").is_some(), "hasConflicts key must be present");
+        assert!(v.get("unresolvedThreads").is_some(), "unresolvedThreads key must be present");
     }
 }

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -110,6 +110,8 @@ pub struct IssueInfo {
     pub title: String,
     /// Issue state: "open", "closed", or "completed".
     pub state: String,
+    /// Labels applied to the issue.
+    pub labels: Vec<String>,
 }
 
 /// Lightweight PR summary attached to a worktree.
@@ -129,6 +131,8 @@ pub struct PrState {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Labels applied to the PR.
+    pub labels: Vec<String>,
 }
 
 /// Lightweight tmux session summary attached to a worktree.
@@ -216,6 +220,7 @@ impl From<&crate::derive::PrInfo> for PrState {
             checks_state: pr.checks_state.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            labels: pr.labels.clone(),
         }
     }
 }
@@ -270,6 +275,7 @@ impl From<&crate::derive::WorktreeRow> for WorktreeState {
                 .issue_state
                 .clone()
                 .unwrap_or_else(|| "open".to_string()),
+            labels: row.issue_labels.clone(),
         });
 
         Self {
@@ -306,6 +312,7 @@ mod tests {
             issue_number,
             issue_title: issue_number.map(|n| format!("Issue {}", n)),
             issue_state: issue_state.map(|s| s.to_string()),
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group,
@@ -429,6 +436,7 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            labels: vec![],
         };
         let pr_state = PrState::from(&pr_info);
         assert_eq!(pr_state.state, Some("open".to_string()));
@@ -444,6 +452,7 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            labels: vec![],
         };
         let pr_state = PrState::from(&pr_info);
         assert!(pr_state.state.is_none());

--- a/crates/orchard/src/tui/dialogs.rs
+++ b/crates/orchard/src/tui/dialogs.rs
@@ -480,6 +480,7 @@ mod tests {
                 issue_number: None,
                 issue_title: None,
                 issue_state: None,
+                issue_labels: vec![],
                 pr: None,
                 sessions: vec![],
                 display_group: crate::derive::DisplayGroup::Other,

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -405,6 +405,7 @@ mod tests {
             issue_number: Some(42),
             issue_title: Some("Fix Azure integration bug".to_string()),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: DisplayGroup::NeedsAttention,
@@ -484,6 +485,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..base_row()
         };
@@ -506,6 +508,7 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..base_row()
         };
@@ -539,6 +542,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..base_row()
         };

--- a/crates/orchard/src/tui/last_selection.rs
+++ b/crates/orchard/src/tui/last_selection.rs
@@ -284,6 +284,7 @@ mod tests {
             issue_number: Some(issue_number),
             issue_title: Some(format!("Test task {issue_number}")),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: DisplayGroup::Other,

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -2242,6 +2242,7 @@ mod tests {
             issue_number: Some(issue_number),
             issue_title: Some(format!("Test task {}", issue_number)),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: group,
@@ -2361,6 +2362,7 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::ReadyToMerge)
         };
@@ -2460,6 +2462,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2482,6 +2485,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: true,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2504,6 +2508,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 3,
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2527,6 +2532,7 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
@@ -2678,6 +2684,7 @@ mod tests {
                 checks_state: Some("pending".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::Other)
         };
@@ -2787,6 +2794,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::ReadyToMerge)
         };

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -1437,11 +1437,11 @@ impl App {
                     self.active_repo_slug(),
                 );
                 if let Some(vt) = visible.get(worktree_cursor) {
-                    self.view = ViewState::ConfirmDelete(state::DeleteState {
+                    self.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
                         target: vt.row.clone(),
                         phase: Phase::Confirm,
                         error: None,
-                    });
+                    }));
                 }
                 ok()
             }
@@ -3078,11 +3078,11 @@ mod tests {
     #[test]
     fn handle_event_delete_confirm_y() {
         let mut app = App::new_test(vec![]);
-        app.view = ViewState::ConfirmDelete(state::DeleteState {
+        app.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
             target: make_task_row(1, DisplayGroup::Other),
             phase: Phase::Confirm,
             error: None,
-        });
+        }));
         let key = KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE);
         assert_eq!(app.handle_event(key), Some(Message::ConfirmYes));
     }
@@ -3547,11 +3547,11 @@ mod tests {
     #[test]
     fn mouse_events_ignored_in_confirm_delete_view() {
         let mut app = app_with_table_area(vec![]);
-        app.view = ViewState::ConfirmDelete(state::DeleteState {
+        app.view = ViewState::ConfirmDelete(Box::new(state::DeleteState {
             target: make_task_row(1, DisplayGroup::Other),
             phase: Phase::Confirm,
             error: None,
-        });
+        }));
         let event = make_mouse_event(MouseEventKind::Down(MouseButton::Left), 10, 7);
         assert_eq!(app.handle_mouse_event(event), None);
     }

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -2150,6 +2150,7 @@ mod tests {
             issue_number: Some(issue_number),
             issue_title: Some(format!("Test task {}", issue_number)),
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: group,
@@ -2278,6 +2279,7 @@ mod tests {
                     checks_state: None,
                     has_conflicts: false,
                     unresolved_threads: 0,
+                    labels: vec![],
                 }),
                 ..make_task_row(1, DisplayGroup::Other)
             },
@@ -2308,6 +2310,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::Other)
         }];
@@ -2337,6 +2340,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_task_row(1, DisplayGroup::Other)
         }];
@@ -2575,6 +2579,7 @@ mod tests {
                 checks_state: None,
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_task_row(42, DisplayGroup::ReadyToMerge)
         };
@@ -2672,6 +2677,7 @@ mod tests {
             issue_number: None,
             issue_title: None,
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![],
             display_group: group,
@@ -2740,6 +2746,7 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_worktree_row("feat/needs-attn", DisplayGroup::NeedsAttention)
         };
@@ -2770,6 +2777,7 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_worktree_row("feat/approved", DisplayGroup::ReadyToMerge)
         };
@@ -2845,6 +2853,7 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_worktree_row("feat/branch", DisplayGroup::NeedsAttention)
         };
@@ -3302,6 +3311,7 @@ mod tests {
                 checks_state: Some("failing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 2,
+                labels: vec![],
             }),
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
@@ -3329,6 +3339,7 @@ mod tests {
                 checks_state: Some("pending".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {
@@ -3360,6 +3371,7 @@ mod tests {
                 checks_state: Some("passing".to_string()),
                 has_conflicts: false,
                 unresolved_threads: 0,
+                labels: vec![],
             }),
             ..make_task_row_with_title(54, "Add Theme struct", DisplayGroup::ReadyToMerge)
         };
@@ -3875,6 +3887,7 @@ mod tests {
             issue_number: None,
             issue_title: None,
             issue_state: None,
+            issue_labels: vec![],
             pr: None,
             sessions: vec![EnrichedSession {
                 tmux: TmuxSessionInfo {

--- a/crates/orchard/src/tui/state.rs
+++ b/crates/orchard/src/tui/state.rs
@@ -17,7 +17,7 @@ pub enum ViewState {
     /// The main worktree task list.
     List,
     /// A confirmation dialog for deleting a worktree.
-    ConfirmDelete(DeleteState),
+    ConfirmDelete(Box<DeleteState>),
     /// A multi-select dialog for cleaning up stale worktrees.
     Cleanup(CleanupState),
     /// A text-entry dialog for creating a new tmux session.

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -320,6 +320,7 @@ mod tests {
             checks_state: None,
             has_conflicts: false,
             unresolved_threads: 0,
+            labels: vec![],
         }
     }
 

--- a/crates/orchard/tests/common/mod.rs
+++ b/crates/orchard/tests/common/mod.rs
@@ -141,6 +141,7 @@ pub fn make_pr(number: u32, branch: &str) -> CachedPr {
         has_conflicts: false,
         unresolved_threads: 0,
         linked_issue_state: None,
+        labels: vec![],
     }
 }
 

--- a/crates/orchard/tests/phase_field_integration.rs
+++ b/crates/orchard/tests/phase_field_integration.rs
@@ -25,7 +25,7 @@
 mod common;
 
 use assert_cmd::Command;
-use common::{TestCacheDir, make_issue, make_pr, make_worktree};
+use common::{TestCacheDir, make_issue, make_pr};
 use orchard::cache::CachedPr;
 use serde_json::Value;
 
@@ -131,7 +131,15 @@ impl PhaseFixture {
             .unwrap();
 
         if !output.status.success() {
-            // Acceptable in CI environments without `gh` CLI.
+            // Acceptable in CI environments without `gh` CLI. Log the skip so
+            // it surfaces in test output — a silent skip would let a regression
+            // hide as a pass.
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            eprintln!(
+                "SKIP phase_field_integration: orchard --json exited with {:?}. stderr: {}",
+                output.status.code(),
+                stderr.trim()
+            );
             return None;
         }
 

--- a/crates/orchard/tests/phase_field_integration.rs
+++ b/crates/orchard/tests/phase_field_integration.rs
@@ -1,0 +1,419 @@
+//! Integration tests for the `phase` field in `orchard --json` output.
+//!
+//! Each test writes a minimal fixture cache (issues, PRs, worktrees) into a
+//! temp HOME directory, runs `orchard --json`, parses the JSON, and asserts
+//! the `phase` field on the relevant `issue` or `pr` object.
+//!
+//! These tests correspond to the `@integration` scenarios in
+//! `specs/features/phase-field-in-json.feature`.
+//!
+//! # Design note
+//!
+//! `orchard --json` calls `refresh_and_build`, which refreshes worktrees via
+//! `git worktree list` (overwriting any pre-written worktrees cache) but will
+//! not overwrite issues/PRs caches because `gh` is unavailable in the test
+//! environment. The worktree cache therefore reflects the real git repo state.
+//!
+//! Each test:
+//!   1. Creates a temp git repo and makes a commit so `git worktree list` works.
+//!   2. Checks out the target branch (so the worktree is on that branch).
+//!   3. Pre-writes issues/PRs caches with the matching branch and phase labels.
+//!   4. Runs `orchard --json` and asserts `phase` on the found worktree.
+//!
+//! If the binary exits non-zero (e.g. because `gh` is not available at all),
+//! the test skips rather than fails — consistent with `binary_integration.rs`.
+mod common;
+
+use assert_cmd::Command;
+use common::{TestCacheDir, make_issue, make_pr, make_worktree};
+use orchard::cache::CachedPr;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Fixture owner/repo slug used across all tests.
+// ---------------------------------------------------------------------------
+
+const OWNER: &str = "acme";
+const REPO: &str = "webapp";
+const SLUG: &str = "acme/webapp";
+
+// ---------------------------------------------------------------------------
+// Fixture harness
+// ---------------------------------------------------------------------------
+
+/// A self-contained fixture environment: temp HOME + cache dir + git repo.
+struct PhaseFixture {
+    home: tempfile::TempDir,
+    cache: TestCacheDir,
+    repo: common::TestRepo,
+}
+
+impl PhaseFixture {
+    /// Creates a fresh fixture. The git repo is initialised but stays on
+    /// whatever default branch `git init` sets (usually "main" or "master").
+    ///
+    /// Call `checkout_branch` to switch the repo to the target branch, then
+    /// write caches, call `apply_cache`, and finally `run`.
+    fn new() -> Self {
+        let home = tempfile::TempDir::new().expect("create temp HOME");
+        let cache = TestCacheDir::new();
+        let repo = common::TestRepo::new();
+
+        // Make a first commit so `git worktree list --porcelain` works.
+        std::fs::write(repo.path().join("README.md"), "test").expect("write README");
+        std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(repo.path())
+            .output()
+            .expect("git add");
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(repo.path())
+            .output()
+            .expect("git commit");
+
+        // Write a global config pointing to our test repo.
+        let config_dir = home.path().join(".config").join("orchard");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        let config_json = format!(
+            r#"{{"repos":[{{"slug":"{SLUG}","path":"{}"}}]}}"#,
+            repo.path().display()
+        );
+        std::fs::write(config_dir.join("config.json"), &config_json)
+            .expect("write config.json");
+
+        // Create the cache dir under HOME.
+        let home_cache = home.path().join(".cache").join("orchard");
+        std::fs::create_dir_all(&home_cache).expect("create cache dir");
+
+        Self { home, cache, repo }
+    }
+
+    /// Checks out (creates) a branch in the test git repo.
+    fn checkout_branch(&self, branch: &str) {
+        std::process::Command::new("git")
+            .args(["checkout", "-b", branch])
+            .current_dir(self.repo.path())
+            .output()
+            .expect("git checkout -b");
+    }
+
+    /// Returns the current branch name of the test git repo.
+    fn current_branch(&self) -> String {
+        let out = std::process::Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .current_dir(self.repo.path())
+            .output()
+            .expect("git rev-parse");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// Copies all cache files from the TestCacheDir into `$HOME/.cache/orchard/`.
+    fn apply_cache(&self) {
+        let home_cache = self.home.path().join(".cache").join("orchard");
+        for entry in std::fs::read_dir(self.cache.path()).expect("read cache dir") {
+            let entry = entry.expect("dir entry");
+            let dest = home_cache.join(entry.file_name());
+            std::fs::copy(entry.path(), &dest).expect("copy cache file");
+        }
+    }
+
+    /// Runs `orchard --json` with HOME pointing to the fixture and returns the
+    /// parsed JSON, or `None` if the binary fails (e.g. `gh` unavailable).
+    fn run(&self) -> Option<Value> {
+        let output = Command::cargo_bin("orchard")
+            .unwrap()
+            .arg("--json")
+            .current_dir(self.repo.path())
+            .env("HOME", self.home.path())
+            .env_remove("TMUX")
+            .output()
+            .unwrap();
+
+        if !output.status.success() {
+            // Acceptable in CI environments without `gh` CLI.
+            return None;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Some(serde_json::from_str(&stdout).expect("stdout should be valid JSON"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: find a worktree entry in the JSON output by branch name
+// ---------------------------------------------------------------------------
+
+/// Searches all repos' worktrees for one matching the predicate.
+fn find_worktree<'a, F>(output: &'a Value, predicate: F) -> Option<&'a Value>
+where
+    F: Fn(&Value) -> bool,
+{
+    output["repos"].as_array()?.iter().find_map(|repo| {
+        repo["worktrees"]
+            .as_array()?
+            .iter()
+            .find(|wt| predicate(wt))
+    })
+}
+
+fn find_worktree_by_branch<'a>(output: &'a Value, branch: &str) -> Option<&'a Value> {
+    find_worktree(output, |wt| wt["branch"].as_str() == Some(branch))
+}
+
+// ---------------------------------------------------------------------------
+// Integration scenario: issue with a single phase label
+// ---------------------------------------------------------------------------
+
+/// orchard --json exposes phase on an issue with a single phase label.
+///
+/// Feature `@integration` scenario:
+///   Given a fixture cache with issue #47 having labels `["in-progress"]`
+///   Then the worktree for that branch has `issue.phase` == `"in-progress"`
+#[test]
+fn json_exposes_phase_on_issue_with_single_phase_label() {
+    let fixture = PhaseFixture::new();
+
+    // The worktree will be on this branch after checkout.
+    fixture.checkout_branch("feat/issue-47");
+    let branch = fixture.current_branch();
+
+    let issue = orchard::cache::CachedIssue {
+        labels: vec!["in-progress".to_string()],
+        ..make_issue(47, "Implement phase field")
+    };
+    let pr = CachedPr {
+        linked_issue: Some(47),
+        ..make_pr(55, &branch)
+    };
+
+    fixture.cache.write_issues(OWNER, REPO, &[issue]);
+    fixture.cache.write_prs(OWNER, REPO, &[pr]);
+    fixture.apply_cache();
+
+    let Some(output) = fixture.run() else {
+        return; // gh not available
+    };
+
+    let wt = find_worktree_by_branch(&output, &branch)
+        .expect("worktree for target branch should be in output");
+
+    assert_eq!(
+        wt["issue"]["phase"],
+        Value::String("in-progress".to_string()),
+        "issue.phase should be 'in-progress'"
+    );
+    // issue.state and issue.title must still be present.
+    assert!(!wt["issue"]["state"].is_null(), "issue.state must be present");
+    assert!(!wt["issue"]["title"].is_null(), "issue.title must be present");
+}
+
+// ---------------------------------------------------------------------------
+// Integration scenario: PR with a single phase label
+// ---------------------------------------------------------------------------
+
+/// orchard --json exposes phase on a PR with a single phase label.
+///
+/// Feature `@integration` scenario:
+///   Given a fixture cache with PR #55 having labels `["pr-ready"]`
+///   Then the worktree for that branch has `pr.phase` == `"pr-ready"`
+#[test]
+fn json_exposes_phase_on_pr_with_single_phase_label() {
+    let fixture = PhaseFixture::new();
+
+    fixture.checkout_branch("feat/pr-ready");
+    let branch = fixture.current_branch();
+
+    let pr = CachedPr {
+        labels: vec!["pr-ready".to_string()],
+        ..make_pr(55, &branch)
+    };
+
+    fixture.cache.write_issues(OWNER, REPO, &[]);
+    fixture.cache.write_prs(OWNER, REPO, &[pr]);
+    fixture.apply_cache();
+
+    let Some(output) = fixture.run() else {
+        return;
+    };
+
+    let wt = find_worktree_by_branch(&output, &branch)
+        .expect("worktree for target branch should be in output");
+
+    assert_eq!(
+        wt["pr"]["phase"],
+        Value::String("pr-ready".to_string()),
+        "pr.phase should be 'pr-ready'"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integration scenario: issue with no phase labels → phase null
+// ---------------------------------------------------------------------------
+
+/// orchard --json emits phase null when an issue has no phase labels.
+///
+/// Feature `@integration` scenario:
+///   Given a fixture cache with issue #10 having labels `["bug"]`
+///   Then `issue.phase` is `null`
+#[test]
+fn json_emits_null_phase_for_issue_with_no_phase_labels() {
+    let fixture = PhaseFixture::new();
+
+    fixture.checkout_branch("feat/issue-10");
+    let branch = fixture.current_branch();
+
+    let issue = orchard::cache::CachedIssue {
+        labels: vec!["bug".to_string()],
+        ..make_issue(10, "Bug report")
+    };
+    let pr = CachedPr {
+        linked_issue: Some(10),
+        ..make_pr(20, &branch)
+    };
+
+    fixture.cache.write_issues(OWNER, REPO, &[issue]);
+    fixture.cache.write_prs(OWNER, REPO, &[pr]);
+    fixture.apply_cache();
+
+    let Some(output) = fixture.run() else {
+        return;
+    };
+
+    let wt = find_worktree_by_branch(&output, &branch)
+        .expect("worktree for target branch should be in output");
+
+    assert!(
+        wt["issue"]["phase"].is_null(),
+        "issue.phase should be null when no phase labels are present, got: {}",
+        wt["issue"]["phase"]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integration scenario: multi-phase PR resolved by priority
+// ---------------------------------------------------------------------------
+
+/// orchard --json resolves a multi-phase PR by priority.
+///
+/// Feature `@integration` scenario:
+///   Given a fixture cache with PR #60 having labels `["in-progress", "blocked"]`
+///   Then `pr.phase` is `"blocked"`
+#[test]
+fn json_resolves_multi_phase_pr_by_priority() {
+    let fixture = PhaseFixture::new();
+
+    fixture.checkout_branch("feat/multi-phase");
+    let branch = fixture.current_branch();
+
+    let pr = CachedPr {
+        labels: vec!["in-progress".to_string(), "blocked".to_string()],
+        ..make_pr(60, &branch)
+    };
+
+    fixture.cache.write_issues(OWNER, REPO, &[]);
+    fixture.cache.write_prs(OWNER, REPO, &[pr]);
+    fixture.apply_cache();
+
+    let Some(output) = fixture.run() else {
+        return;
+    };
+
+    let wt = find_worktree_by_branch(&output, &branch)
+        .expect("worktree for target branch should be in output");
+
+    assert_eq!(
+        wt["pr"]["phase"],
+        Value::String("blocked".to_string()),
+        "pr.phase should be 'blocked' (highest priority)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integration scenario: PR with no linked issue
+// ---------------------------------------------------------------------------
+
+/// orchard --json exposes phase on a PR with no linked issue.
+///
+/// Feature `@integration` scenario:
+///   Given a fixture cache with PR #70 having `linked_issue: null` and labels `["in-ai-review"]`
+///   Then `pr.phase` is `"in-ai-review"`
+#[test]
+fn json_exposes_phase_on_pr_with_no_linked_issue() {
+    let fixture = PhaseFixture::new();
+
+    fixture.checkout_branch("feat/no-issue");
+    let branch = fixture.current_branch();
+
+    let pr = CachedPr {
+        linked_issue: None,
+        labels: vec!["in-ai-review".to_string()],
+        ..make_pr(70, &branch)
+    };
+
+    fixture.cache.write_issues(OWNER, REPO, &[]);
+    fixture.cache.write_prs(OWNER, REPO, &[pr]);
+    fixture.apply_cache();
+
+    let Some(output) = fixture.run() else {
+        return;
+    };
+
+    let wt = find_worktree_by_branch(&output, &branch)
+        .expect("worktree for target branch should be in output");
+
+    assert_eq!(
+        wt["pr"]["phase"],
+        Value::String("in-ai-review".to_string()),
+        "pr.phase should be 'in-ai-review'"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integration scenario: issue and PR on the same worktree can differ
+// ---------------------------------------------------------------------------
+
+/// orchard --json allows issue and PR on the same worktree to have different phases.
+///
+/// Feature `@integration` scenario:
+///   Given issue #47 has labels `["planned"]` and PR #55 has labels `["in-ai-review"]`
+///   Then `issue.phase` is `"planned"` and `pr.phase` is `"in-ai-review"`
+#[test]
+fn json_issue_and_pr_on_same_worktree_can_have_different_phases() {
+    let fixture = PhaseFixture::new();
+
+    fixture.checkout_branch("feat/different-phases");
+    let branch = fixture.current_branch();
+
+    let issue = orchard::cache::CachedIssue {
+        labels: vec!["planned".to_string()],
+        ..make_issue(47, "Plan the work")
+    };
+    let pr = CachedPr {
+        linked_issue: Some(47),
+        labels: vec!["in-ai-review".to_string()],
+        ..make_pr(55, &branch)
+    };
+
+    fixture.cache.write_issues(OWNER, REPO, &[issue]);
+    fixture.cache.write_prs(OWNER, REPO, &[pr]);
+    fixture.apply_cache();
+
+    let Some(output) = fixture.run() else {
+        return;
+    };
+
+    let wt = find_worktree_by_branch(&output, &branch)
+        .expect("worktree for target branch should be in output");
+
+    assert_eq!(
+        wt["issue"]["phase"],
+        Value::String("planned".to_string()),
+        "issue.phase should be 'planned'"
+    );
+    assert_eq!(
+        wt["pr"]["phase"],
+        Value::String("in-ai-review".to_string()),
+        "pr.phase should be 'in-ai-review'"
+    );
+}

--- a/crates/orchard/tests/phase_field_integration.rs
+++ b/crates/orchard/tests/phase_field_integration.rs
@@ -79,8 +79,7 @@ impl PhaseFixture {
             r#"{{"repos":[{{"slug":"{SLUG}","path":"{}"}}]}}"#,
             repo.path().display()
         );
-        std::fs::write(config_dir.join("config.json"), &config_json)
-            .expect("write config.json");
+        std::fs::write(config_dir.join("config.json"), &config_json).expect("write config.json");
 
         // Create the cache dir under HOME.
         let home_cache = home.path().join(".cache").join("orchard");
@@ -153,7 +152,7 @@ impl PhaseFixture {
 // ---------------------------------------------------------------------------
 
 /// Searches all repos' worktrees for one matching the predicate.
-fn find_worktree<'a, F>(output: &'a Value, predicate: F) -> Option<&'a Value>
+fn find_worktree<F>(output: &Value, predicate: F) -> Option<&Value>
 where
     F: Fn(&Value) -> bool,
 {
@@ -212,8 +211,14 @@ fn json_exposes_phase_on_issue_with_single_phase_label() {
         "issue.phase should be 'in-progress'"
     );
     // issue.state and issue.title must still be present.
-    assert!(!wt["issue"]["state"].is_null(), "issue.state must be present");
-    assert!(!wt["issue"]["title"].is_null(), "issue.title must be present");
+    assert!(
+        !wt["issue"]["state"].is_null(),
+        "issue.state must be present"
+    );
+    assert!(
+        !wt["issue"]["title"].is_null(),
+        "issue.title must be present"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/specs/features/phase-field-in-json.feature
+++ b/specs/features/phase-field-in-json.feature
@@ -14,7 +14,7 @@ Feature: Phase field on PRs and issues in orchard --json
       | in-ai-review  |
       | pr-ready      |
       | blocked       |
-    And these labels are mirrored in a hardcoded `PHASE_LABELS` constant in `crates/orchard/src/derive.rs`
+    And these labels are mirrored in a hardcoded `PHASE_PRIORITY` constant in `crates/orchard/src/derive.rs` that also encodes the priority order
     And `phase` is computed from the `labels` array by a pure function `phase_from_labels`
     And when multiple phase labels are present, resolution follows a priority order:
       | rank | label         |

--- a/specs/features/phase-field-in-json.feature
+++ b/specs/features/phase-field-in-json.feature
@@ -1,0 +1,275 @@
+Feature: Phase field on PRs and issues in orchard --json
+  As a script consuming `orchard --json`
+  I want a first-class `phase` field on each issue and PR
+  So that I can filter, sort, and route work by workflow phase without re-parsing label lists
+
+  Background:
+    Given the `/gh-tag` skill defines 8 mutually-exclusive phase labels:
+      | label         |
+      | investigating |
+      | needs-plan    |
+      | needs-repro   |
+      | planned       |
+      | in-progress   |
+      | in-ai-review  |
+      | pr-ready      |
+      | blocked       |
+    And these labels are mirrored in a hardcoded `PHASE_LABELS` constant in `crates/orchard/src/derive.rs`
+    And `phase` is computed from the `labels` array by a pure function `phase_from_labels`
+    And when multiple phase labels are present, resolution follows a priority order:
+      | rank | label         |
+      | 1    | blocked       |
+      | 2    | in-ai-review  |
+      | 3    | pr-ready      |
+      | 4    | in-progress   |
+      | 5    | needs-repro   |
+      | 6    | needs-plan    |
+      | 7    | investigating |
+      | 8    | planned       |
+
+  # ===================================================================
+  # Parser — pure function `phase_from_labels(&[String]) -> Option<&'static str>`
+  # ===================================================================
+
+  @unit
+  Scenario: phase_from_labels returns None for an empty label list
+    When `phase_from_labels(&[])` is called
+    Then it returns `None`
+
+  @unit
+  Scenario: phase_from_labels returns None when no phase labels are present
+    When `phase_from_labels(&["bug", "enhancement", "good-first-issue"])` is called
+    Then it returns `None`
+
+  @unit
+  Scenario: phase_from_labels returns the matching phase when one phase label is present
+    When `phase_from_labels(&["in-progress"])` is called
+    Then it returns `Some("in-progress")`
+
+  @unit
+  Scenario: phase_from_labels returns the phase when mixed with unrelated labels
+    When `phase_from_labels(&["bug", "planned", "priority-high"])` is called
+    Then it returns `Some("planned")`
+
+  @unit
+  Scenario: phase_from_labels returns the higher-priority phase for two phase labels
+    When `phase_from_labels(&["planned", "in-progress"])` is called
+    Then it returns `Some("in-progress")`
+
+  @unit
+  Scenario: phase_from_labels returns blocked over in-progress
+    When `phase_from_labels(&["in-progress", "blocked"])` is called
+    Then it returns `Some("blocked")`
+
+  @unit
+  Scenario: phase_from_labels returns blocked over in-ai-review
+    When `phase_from_labels(&["in-ai-review", "blocked"])` is called
+    Then it returns `Some("blocked")`
+
+  @unit
+  Scenario: phase_from_labels resolves three simultaneous phase labels by priority
+    When `phase_from_labels(&["investigating", "needs-plan", "blocked"])` is called
+    Then it returns `Some("blocked")`
+
+  @unit
+  Scenario: phase_from_labels returns in-ai-review over pr-ready
+    When `phase_from_labels(&["pr-ready", "in-ai-review"])` is called
+    Then it returns `Some("in-ai-review")`
+
+  @unit
+  Scenario Outline: phase_from_labels recognizes every known phase label in isolation
+    When `phase_from_labels(&[<label>])` is called
+    Then it returns `Some(<label>)`
+
+    Examples:
+      | label            |
+      | "investigating"  |
+      | "needs-plan"     |
+      | "needs-repro"    |
+      | "planned"        |
+      | "in-progress"    |
+      | "in-ai-review"   |
+      | "pr-ready"       |
+      | "blocked"        |
+
+  @unit
+  Scenario: phase_from_labels ignores unknown labels
+    When `phase_from_labels(&["wontfix", "duplicate", "question"])` is called
+    Then it returns `None`
+
+  @unit
+  Scenario: phase_from_labels requires exact lowercase match
+    When `phase_from_labels(&["In-Progress"])` is called
+    Then it returns `None`
+
+  # ===================================================================
+  # CachedPr migration — labels field with serde default
+  # ===================================================================
+
+  @unit
+  Scenario: Deserializing a pre-upgrade CachedPr without labels key yields empty vec
+    Given a JSON string representing a CachedPr without a `labels` key:
+      """
+      {
+        "number": 55,
+        "branch": "issue/example",
+        "linked_issue": null,
+        "state": "open",
+        "review_decision": null,
+        "checks_state": null,
+        "has_conflicts": false,
+        "unresolved_threads": 0
+      }
+      """
+    When the string is deserialized with `serde_json::from_str::<CachedPr>`
+    Then deserialization succeeds
+    And the resulting `labels` field is an empty vector
+
+  @unit
+  Scenario: Deserializing a CachedPr with labels key preserves the labels
+    Given a JSON string representing a CachedPr with `labels: ["in-progress", "bug"]`
+    When the string is deserialized with `serde_json::from_str::<CachedPr>`
+    Then deserialization succeeds
+    And the resulting `labels` field equals `["in-progress", "bug"]`
+
+  @unit
+  Scenario: CachedIssue labels field remains required (no migration regression)
+    Given a JSON string representing a CachedIssue with `labels: ["enhancement"]`
+    When the string is deserialized with `serde_json::from_str::<CachedIssue>`
+    Then deserialization succeeds
+    And the resulting `labels` field equals `["enhancement"]`
+
+  # ===================================================================
+  # build_state — labels reach the state layer from caches
+  # ===================================================================
+
+  @unit
+  Scenario: build_state threads PR labels from cache into PrState
+    Given an in-memory PRs cache with PR #55 having labels `["planned"]`
+    And matching worktree and issues caches
+    When `build_state` is invoked
+    Then the resulting `PrState` for PR #55 has `labels` equal to `["planned"]`
+
+  @unit
+  Scenario: build_state threads issue labels from cache into IssueInfo
+    Given an in-memory issues cache with issue #47 having labels `["in-progress", "enhancement"]`
+    And matching worktree and PRs caches
+    When `build_state` is invoked
+    Then the resulting `IssueInfo` for issue #47 has `labels` equal to `["in-progress", "enhancement"]`
+
+  @unit
+  Scenario: build_state emits empty labels vec when a PR has no labels
+    Given an in-memory PRs cache with PR #99 having no labels
+    When `build_state` is invoked
+    Then the resulting `PrState` for PR #99 has `labels` equal to `vec![]`
+
+  # ===================================================================
+  # JsonIssue / JsonPr — serialized shape
+  # ===================================================================
+
+  @unit
+  Scenario: JsonIssue serializes phase as null when no phase label is set
+    Given an `IssueInfo` with labels `["bug"]`
+    When it is converted to `JsonIssue` and serialized with serde_json
+    Then the serialized object contains `"phase": null`
+
+  @unit
+  Scenario: JsonIssue serializes phase as the matched label
+    Given an `IssueInfo` with labels `["in-progress", "bug"]`
+    When it is converted to `JsonIssue` and serialized with serde_json
+    Then the serialized object contains `"phase": "in-progress"`
+
+  @unit
+  Scenario: JsonPr serializes phase as null when no phase label is set
+    Given a `PrState` with labels `["enhancement"]`
+    When it is converted to `JsonPr` and serialized with serde_json
+    Then the serialized object contains `"phase": null`
+
+  @unit
+  Scenario: JsonPr serializes phase as the matched label
+    Given a `PrState` with labels `["pr-ready"]`
+    When it is converted to `JsonPr` and serialized with serde_json
+    Then the serialized object contains `"phase": "pr-ready"`
+
+  @unit
+  Scenario: JsonPr resolves multi-phase labels by priority
+    Given a `PrState` with labels `["in-progress", "blocked"]`
+    When it is converted to `JsonPr` and serialized with serde_json
+    Then the serialized object contains `"phase": "blocked"`
+
+  @unit
+  Scenario: JsonIssue phase key is present even when value is null
+    Given an `IssueInfo` with empty labels
+    When it is serialized with serde_json
+    Then the serialized object contains the key `"phase"` with value `null`
+    And the key is always present (not omitted via skip_serializing_if)
+
+  @unit
+  Scenario: JsonPr phase key is present even when value is null
+    Given a `PrState` with empty labels
+    When it is serialized with serde_json
+    Then the serialized object contains the key `"phase"` with value `null`
+
+  @unit
+  Scenario: JsonIssue preserves existing fields when phase is added
+    Given an `IssueInfo` numbered 219, titled "phase field", state "open", labels `["planned"]`
+    When it is serialized with serde_json
+    Then the output contains `"phase": "planned"`
+    And the output contains `"number": 219`
+    And the output contains `"title": "phase field"`
+    And the output contains `"state": "open"`
+
+  @unit
+  Scenario: JsonPr preserves existing fields when phase is added
+    Given a `PrState` with number 220, branch "issue219/phase-field", labels `["in-ai-review"]`
+    When it is serialized with serde_json
+    Then the output contains `"phase": "in-ai-review"`
+    And the output contains `"number": 220`
+    And the output contains `"branch": "issue219/phase-field"`
+    And the output contains keys `reviewDecision`, `checksState`, `hasConflicts`, `unresolvedThreads`
+
+  # ===================================================================
+  # End-to-end integration — orchard --json binary output
+  # ===================================================================
+  # These scenarios share a single fixture cache with many worktrees
+  # and assert each phase variant in one binary invocation per scenario
+  # group. Harness may bootstrap one cache per feature run.
+
+  @integration
+  Scenario: orchard --json exposes phase on an issue with a single phase label
+    Given a fixture cache with issue #47 having labels `["in-progress"]`
+    When `orchard --json` is run against the fixture
+    Then the output contains a worktree whose `issue.phase` is `"in-progress"`
+    And `issue.state` and `issue.title` are unchanged from the input cache
+
+  @integration
+  Scenario: orchard --json exposes phase on a PR with a single phase label
+    Given a fixture cache with PR #55 having labels `["pr-ready"]`
+    When `orchard --json` is run against the fixture
+    Then the output contains a worktree whose `pr.phase` is `"pr-ready"`
+
+  @integration
+  Scenario: orchard --json emits phase null when an issue has no phase labels
+    Given a fixture cache with issue #10 having labels `["bug"]`
+    When `orchard --json` is run against the fixture
+    Then the output contains a worktree whose `issue.phase` is `null`
+
+  @integration
+  Scenario: orchard --json resolves a multi-phase PR by priority
+    Given a fixture cache with PR #60 having labels `["in-progress", "blocked"]`
+    When `orchard --json` is run against the fixture
+    Then the output contains a worktree whose `pr.phase` is `"blocked"`
+
+  @integration
+  Scenario: orchard --json exposes phase on a PR with no linked issue
+    Given a fixture cache with PR #70 having `linked_issue: null` and labels `["in-ai-review"]`
+    When `orchard --json` is run against the fixture
+    Then the output contains a worktree whose `pr.phase` is `"in-ai-review"`
+
+  @integration
+  Scenario: orchard --json allows issue and PR on the same worktree to have different phases
+    Given a fixture cache where issue #47 has labels `["planned"]`
+    And PR #55 on the same branch has labels `["in-ai-review"]`
+    When `orchard --json` is run against the fixture
+    Then `issue.phase` on that worktree is `"planned"`
+    And `pr.phase` on that worktree is `"in-ai-review"`


### PR DESCRIPTION
## Summary

Adds a `phase` field to `JsonIssue` and `JsonPr` in `orchard --json`, parsed from GitHub labels. Closes #219.

## Why

The `/gh-tag` skill applies mutually-exclusive phase labels (`investigating`, `needs-plan`, `needs-repro`, `planned`, `in-progress`, `in-ai-review`, `pr-ready`, `blocked`) that are the backbone of the AI-approved workflow. Until now, those labels lived inside the generic `labels[]` array, forcing every downstream consumer (the orchardist, monitor scripts, Slack automation) to re-implement label intersection. This PR lifts `phase` to a first-class derived field so queries like "which PRs are in `pr-ready`?" become a single filter.

## Design decisions

- **Parser lives in `derive.rs`**, not `json_output.rs`. The JSON layer is a dumb mapper per its module doc; derive.rs is where projection logic belongs. Same parser will be shared by the TUI when focus-driven sorting lands.
- **Priority order for multi-phase resolution:** `blocked > in-ai-review > pr-ready > in-progress > needs-repro > needs-plan > investigating > planned`. Returning `null` on overlap would silently hide `blocked` PRs from filter consumers — the exact opposite of what the orchardist wants.
- **Projection, not storage.** `phase` is computed at JSON serialization time from `labels`. Not a field on `OrchardState`, `IssueInfo`, `PrState`, or any cache struct.
- **Migration-safe cache.** `CachedPr.labels` uses `#[serde(default)]` so pre-upgrade `prs.json` files deserialize to an empty vec without error.
- **No JSON version bump.** Additive field, backward-compatible with existing consumers.

## Scope

**Included:**
- `PHASE_PRIORITY` constant + `phase_from_labels` parser in `derive.rs`
- `labels: Vec<String>` on `CachedPr`, `PrInfo`, `WorktreeRow.issue_labels`, `PrState`, `IssueInfo`
- Extended GraphQL PR query to fetch `labels(first: 100) { nodes { name } }`
- `phase: Option<&'static str>` on `JsonPr` and `JsonIssue`
- 29 scenarios covered by tests + 4 additional unit tests on `parse_prs_graphql`

**Deferred to separate issues (tracked, not lost):**
- #221 — `--filter phase=X` CLI flag
- #222 — monitor emits phase-transition events
- #227 — refactor to `enum Phase` for compile-time exhaustive matching

## Notable bug caught during review

The initial implementation read `v["labels"].as_array()` in `parse_prs_graphql`, but GraphQL returns `labels: { nodes: [...] }` — not a flat array. Every real `gh api` response was silently extracting zero labels. Integration tests missed this because test fixtures wrote the cache directly as `Vec<String>`, bypassing the parser. Unit tests added during review fixed the bug and prevent regression.

## Test coverage

- 886 total `cargo test` pass (up from 882 baseline)
- 29 feature-file scenarios all covered by named tests
- 4 new `parse_prs_graphql_*` unit tests
- 6 end-to-end integration tests running the real `orchard --json` binary against a fixture cache
- `cargo build --release` clean, no warnings
- Every acceptance criterion mapped to a passing test in `/prove-it` (ALL PASS)

## Test plan
- [x] All 29 scenarios in `specs/features/phase-field-in-json.feature` have matching passing tests
- [x] `cargo test` green (886 passing)
- [x] `cargo build --release` succeeds, no warnings
- [x] `/prove-it` maps every criterion to evidence (29/29 PASS)
- [x] `/review` findings addressed (must-fix) or deferred to follow-up issues (nice-to-have)
- [x] `/sweep` clean — no duplicate label-check logic elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #219

# Related issue

- #219

# Related issue

- #219