### PR TITLE
feat: GitHub webhook receiver + event stream (#215)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1774,6 +1775,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,6 +1845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,6 +1863,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2841,6 +2858,11 @@ dependencies = [
  "ctrlc",
  "dirs",
  "glob",
+ "hex",
+ "hmac",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "nucleo-matcher",
  "open",
  "predicates",
@@ -2848,6 +2870,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "shellexpand",
  "tempfile",
  "throbber-widgets-tui",
@@ -4269,6 +4292,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2860,6 +2860,7 @@ dependencies = [
  "glob",
  "hex",
  "hmac",
+ "http",
  "http-body-util",
  "hyper",
  "hyper-util",

--- a/crates/orchard/Cargo.toml
+++ b/crates/orchard/Cargo.toml
@@ -35,6 +35,12 @@ throbber-widgets-tui = "0.11.0"
 tui-scrollview = "0.6.2"
 nucleo-matcher = "0.3.1"
 ctrlc = "3"
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["tokio", "server"] }
+http-body-util = "0.1"
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/orchard/Cargo.toml
+++ b/crates/orchard/Cargo.toml
@@ -35,8 +35,9 @@ throbber-widgets-tui = "0.11.0"
 tui-scrollview = "0.6.2"
 nucleo-matcher = "0.3.1"
 ctrlc = "3"
+http = "1"
 hyper = { version = "1", features = ["server", "http1"] }
-hyper-util = { version = "0.1", features = ["tokio", "server"] }
+hyper-util = { version = "0.1", features = ["tokio", "server", "http1"] }
 http-body-util = "0.1"
 hmac = "0.12"
 sha2 = "0.10"

--- a/crates/orchard/src/events.rs
+++ b/crates/orchard/src/events.rs
@@ -55,25 +55,7 @@ fn append_event(path: &Path, event_type: &str, fields: &[(&str, Value)]) {
         Err(_) => return,
     };
 
-    if let Some(parent) = path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
-
-    // Rotate before writing if the existing file is over the size limit.
-    if let Ok(meta) = fs::metadata(path)
-        && meta.len() >= MAX_SIZE_BYTES
-    {
-        rotate(path);
-    }
-
-    let mut file = match OpenOptions::new().create(true).append(true).open(path) {
-        Ok(f) => f,
-        Err(_) => return,
-    };
-
-    let _ = file.write_all(line.as_bytes());
-    let _ = file.write_all(b"\n");
-    let _ = file.flush();
+    append_line(path, &line);
 }
 
 /// Rotates the events file:
@@ -225,6 +207,47 @@ pub fn log_watch_event(event_type: &str, details: &str) {
         &format!("watch.{}", event_type),
         &[("details", Value::String(details.to_string()))],
     );
+}
+
+/// Appends a webhook-sourced event line to events.jsonl using the #215 schema:
+/// `{ts, source:"webhook", kind, repo?, pr?, issue?, actor?, data}`.
+///
+/// This lives in the same file as the existing `log_event` but writes a
+/// DIFFERENT JSON shape. Consumers (the watch tailer) distinguish webhook
+/// lines from task/session lines by the presence of the `source` field.
+///
+/// Both writers go through the same `OpenOptions::append` + 50MB rotation
+/// path so writes are atomic and rotation applies uniformly.
+pub fn log_webhook_event(event: &crate::webhook::normalize::NormalizedEvent) {
+    let path = default_events_path();
+    let line = match serde_json::to_string(event) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    append_line(&path, &line);
+}
+
+/// Appends a single JSON line to `path`, creating the file and its parent
+/// directories as needed. Rotates if the file exceeds 50 MB before writing.
+fn append_line(path: &Path, line: &str) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    if let Ok(meta) = fs::metadata(path)
+        && meta.len() >= MAX_SIZE_BYTES
+    {
+        rotate(path);
+    }
+
+    let mut file = match OpenOptions::new().create(true).append(true).open(path) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+
+    let _ = file.write_all(line.as_bytes());
+    let _ = file.write_all(b"\n");
+    let _ = file.flush();
 }
 
 // ---------------------------------------------------------------------------
@@ -484,5 +507,41 @@ mod tests {
                 i
             );
         }
+    }
+
+    #[test]
+    fn webhook_event_line_has_source_and_kind_fields() {
+        use crate::webhook::normalize::build_event;
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("events.jsonl");
+
+        let event = build_event(
+            "pull_request.opened".to_string(),
+            Some("acme/webapp".to_string()),
+            Some(42),
+            None,
+            Some("some-actor".to_string()),
+            &serde_json::json!({"action": "opened"}),
+        );
+
+        let line = serde_json::to_string(&event).expect("must serialize");
+        append_line(&path, &line);
+
+        let lines = read_lines(&path);
+        assert_eq!(lines.len(), 1, "expected exactly one line");
+
+        let parsed: serde_json::Map<String, Value> =
+            serde_json::from_str(&lines[0]).expect("line must be valid JSON");
+        assert_eq!(
+            parsed.get("source").and_then(Value::as_str),
+            Some("webhook"),
+            "source field must be 'webhook'"
+        );
+        assert!(parsed.contains_key("kind"), "kind field must be present");
+        assert_eq!(
+            parsed.get("kind").and_then(Value::as_str),
+            Some("pull_request.opened"),
+        );
     }
 }

--- a/crates/orchard/src/events.rs
+++ b/crates/orchard/src/events.rs
@@ -27,7 +27,10 @@ pub struct Event {
 }
 
 /// Returns the path to the events.jsonl file.
-fn default_events_path() -> PathBuf {
+///
+/// Used by the watch daemon tailer to know which file to tail, and by
+/// the events module internally for all writes.
+pub fn events_path() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(std::env::temp_dir)
         .join(".local")
@@ -97,7 +100,7 @@ fn rotated_path(base: &Path, n: u32) -> PathBuf {
 /// Appends an event to `~/.local/state/git-orchard/events.jsonl`.
 /// Creates the file/dir if needed. Rotates at 50 MB. Never returns an error.
 pub fn log_event(event_type: &str, fields: &[(&str, Value)]) {
-    append_event(&default_events_path(), event_type, fields);
+    append_event(&events_path(), event_type, fields);
 }
 
 /// Logs a `task.created` event.
@@ -219,7 +222,7 @@ pub fn log_watch_event(event_type: &str, details: &str) {
 /// Both writers go through the same `OpenOptions::append` + 50MB rotation
 /// path so writes are atomic and rotation applies uniformly.
 pub fn log_webhook_event(event: &crate::webhook::normalize::NormalizedEvent) {
-    let path = default_events_path();
+    let path = events_path();
     let line = match serde_json::to_string(event) {
         Ok(s) => s,
         Err(_) => return,

--- a/crates/orchard/src/global_config.rs
+++ b/crates/orchard/src/global_config.rs
@@ -89,6 +89,10 @@ pub struct WatchConfig {
     /// Whether to send desktop notifications for watch events.
     #[serde(default = "default_notifications")]
     pub notifications: bool,
+    /// Optional override for the webhook server's bound port.
+    /// Precedence: CLI --port > ORCHARD_WEBHOOK_PORT env > this field > 8477 default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub webhook_port: Option<u16>,
 }
 
 fn default_local_poll_secs() -> u64 {
@@ -111,6 +115,7 @@ impl Default for WatchConfig {
             full_poll_secs: default_full_poll_secs(),
             threshold_cooldown_secs: default_threshold_cooldown_secs(),
             notifications: default_notifications(),
+            webhook_port: None,
         }
     }
 }

--- a/crates/orchard/src/lib.rs
+++ b/crates/orchard/src/lib.rs
@@ -36,3 +36,4 @@ pub mod tmux;
 pub mod tui;
 pub mod types;
 pub mod watch;
+pub mod webhook;

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -85,6 +85,7 @@ fn main() {
         "chat" => handle_chat(chat_target.as_deref(), chat_message.as_deref()),
         "watch" => handle_watch(&args),
         "hook-enrich" => handle_hook_enrich(transcript_path.as_deref()),
+        "webhook-serve" => handle_webhook_serve(&args),
         _ => {
             if json_flag {
                 handle_json();
@@ -353,6 +354,9 @@ fn print_usage() {
                                    Register a tmux subscriber for watch events
   orchard watch --unsubscribe --id <id>
                                    Unregister a tmux subscriber
+  orchard webhook-serve [--port <n>]
+                                   Receive GitHub webhooks and append to events.jsonl
+                                   Requires ORCHARD_WEBHOOK_SECRET env var
 
 Options:
   --version, -V  Print version and exit
@@ -447,6 +451,59 @@ fn handle_watch(args: &[String]) {
 
     // Default: run the daemon.
     if let Err(e) = orchard::watch::daemon::run(&config) {
+        eprintln!("{e}");
+        std::process::exit(1);
+    }
+}
+
+/// Handles the `orchard webhook-serve` command.
+///
+/// Parses `--port <n>`, resolves the final port via
+/// `webhook::port::resolve_port(flag, env, config)`, validates
+/// ORCHARD_WEBHOOK_SECRET is set and non-empty, and runs the hyper server.
+fn handle_webhook_serve(args: &[String]) {
+    // 1. Parse --port flag from args.
+    let mut port_flag: Option<u16> = None;
+    let mut skip_next = false;
+    for (i, arg) in args.iter().enumerate() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if arg == "--port"
+            && let Some(v) = args.get(i + 1)
+        {
+            port_flag = v.parse::<u16>().ok();
+            skip_next = true;
+        }
+    }
+
+    // 2. Read ORCHARD_WEBHOOK_PORT env var.
+    let port_env: Option<u16> = env::var("ORCHARD_WEBHOOK_PORT")
+        .ok()
+        .and_then(|v| v.parse::<u16>().ok());
+
+    // 3. Load global config, read config.watch.webhook_port.
+    let config = global_config::load_global_config();
+    let port_config: Option<u16> = config.watch.webhook_port;
+
+    // 4. Resolve port.
+    let port = orchard::webhook::port::resolve_port(port_flag, port_env, port_config);
+
+    // 5. Read ORCHARD_WEBHOOK_SECRET env var.
+    let secret = match env::var("ORCHARD_WEBHOOK_SECRET") {
+        Ok(s) if !s.is_empty() => s,
+        _ => {
+            eprintln!(
+                "webhook-serve: ORCHARD_WEBHOOK_SECRET is not set. \
+                 Set it to your GitHub webhook secret."
+            );
+            std::process::exit(1);
+        }
+    };
+
+    // 6. Run the server.
+    if let Err(e) = orchard::webhook::server::run(port, secret.into_bytes()) {
         eprintln!("{e}");
         std::process::exit(1);
     }

--- a/crates/orchard/src/watch/daemon.rs
+++ b/crates/orchard/src/watch/daemon.rs
@@ -10,11 +10,13 @@ use std::time::{Duration, Instant};
 
 use crate::build_state;
 use crate::cache_sources;
+use crate::events::events_path;
 use crate::global_config::GlobalConfig;
 use crate::orchard_state::OrchardState;
 use crate::watch::diff;
 use crate::watch::event::{EventKind, WatchEvent};
 use crate::watch::subscription;
+use crate::webhook::tailer::Tailer;
 
 // ---------------------------------------------------------------------------
 // Public entry point
@@ -42,6 +44,11 @@ pub fn run(config: &GlobalConfig) -> anyhow::Result<()> {
     let mut last_local = Instant::now();
     let mut last_full = Instant::now();
 
+    // Tailer tracks new webhook lines in events.jsonl and forces an immediate
+    // full refresh when any arrive. The 1s sleep + tailer check guarantees
+    // webhook-triggered refreshes happen within ~2s of the append (AC #35).
+    let mut tailer = Tailer::new(events_path());
+
     // Force a full refresh on startup.
     refresh_all_sources(config);
     let initial = build_state::build_state(config);
@@ -51,7 +58,12 @@ pub fn run(config: &GlobalConfig) -> anyhow::Result<()> {
         std::thread::sleep(Duration::from_secs(1));
 
         let now = Instant::now();
-        let do_full = now.duration_since(last_full).as_secs() >= config.watch.full_poll_secs;
+        // Webhook lines force an immediate full refresh regardless of poll
+        // intervals. Multiple lines arriving between iterations collapse to
+        // one refresh (AC #36 debounce).
+        let webhook_fired = webhook_triggered_refresh(&mut tailer);
+        let do_full = webhook_fired
+            || now.duration_since(last_full).as_secs() >= config.watch.full_poll_secs;
         let do_local = now.duration_since(last_local).as_secs() >= config.watch.local_poll_secs;
 
         if do_full {
@@ -169,6 +181,16 @@ pub fn fire_notifications(events: &[WatchEvent], config: &GlobalConfig) {
     }
 }
 
+/// Returns true if the tailer found new webhook lines that should force an
+/// immediate full refresh. Always returns false when the tailer sees nothing.
+///
+/// Multiple webhook lines arriving between iterations all collapse into a
+/// single `true` return (AC #36 debounce): we call `tailer.poll()` once,
+/// collect all new lines, and return `!lines.is_empty()`.
+fn webhook_triggered_refresh(tailer: &mut Tailer) -> bool {
+    !tailer.poll().is_empty()
+}
+
 /// Logs a watch event to the structured event log.
 ///
 /// Extracts the `type` field from the serialized tagged enum instead of
@@ -180,4 +202,83 @@ fn log_watch_event(event: &WatchEvent) {
         .and_then(|v| v.get("type").and_then(|t| t.as_str().map(String::from)))
         .unwrap_or_else(|| "unknown".to_string());
     crate::events::log_watch_event(&event_type, &details);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn webhook_line(kind: &str) -> String {
+        format!(
+            r#"{{"source":"webhook","kind":"{}","ts":"2024-01-01T00:00:00Z","data":{{}}}}"#,
+            kind
+        )
+    }
+
+    /// AC #35: webhook helper returns true when a new webhook line is present.
+    /// The daemon loop wires this into do_full=true, so a refresh happens within
+    /// the next 1s sleep iteration — well within the 2s guarantee.
+    #[test]
+    fn webhook_triggered_refresh_returns_true_when_line_present() {
+        let mut f = NamedTempFile::new().unwrap();
+        let mut tailer = Tailer::new(f.path().to_path_buf());
+
+        writeln!(f, "{}", webhook_line("pull_request.opened")).unwrap();
+        f.flush().unwrap();
+
+        assert!(
+            webhook_triggered_refresh(&mut tailer),
+            "helper returns true when webhook line appended"
+        );
+    }
+
+    /// AC #36: multiple webhook lines between iterations debounce to one refresh.
+    /// `webhook_triggered_refresh` drains all new lines in one poll call and
+    /// returns a single bool — the daemon only calls refresh_all_sources once.
+    #[test]
+    fn webhook_triggered_refresh_debounces_multiple_lines() {
+        let mut f = NamedTempFile::new().unwrap();
+        let mut tailer = Tailer::new(f.path().to_path_buf());
+
+        for _ in 0..5 {
+            writeln!(f, "{}", webhook_line("push")).unwrap();
+        }
+        f.flush().unwrap();
+
+        // All 5 lines consumed in one call; helper returns true (not 5 trues).
+        assert!(
+            webhook_triggered_refresh(&mut tailer),
+            "5 lines still one true"
+        );
+        // Subsequent poll finds nothing — offset advanced past all 5.
+        assert!(
+            !webhook_triggered_refresh(&mut tailer),
+            "offset advanced past all lines"
+        );
+    }
+
+    /// AC #37: missing events.jsonl → helper returns false, daemon falls back to
+    /// poll-only intervals.
+    #[test]
+    fn fallback_when_events_file_missing() {
+        let path = std::env::temp_dir()
+            .join("orchard_daemon_test_missing_events.jsonl");
+        let _ = std::fs::remove_file(&path);
+
+        let mut tailer = Tailer::new(path.clone());
+        assert!(
+            !webhook_triggered_refresh(&mut tailer),
+            "missing file → false, no panic"
+        );
+        assert!(
+            !webhook_triggered_refresh(&mut tailer),
+            "still false on repeat"
+        );
+    }
 }

--- a/crates/orchard/src/watch/daemon.rs
+++ b/crates/orchard/src/watch/daemon.rs
@@ -62,8 +62,8 @@ pub fn run(config: &GlobalConfig) -> anyhow::Result<()> {
         // intervals. Multiple lines arriving between iterations collapse to
         // one refresh (AC #36 debounce).
         let webhook_fired = webhook_triggered_refresh(&mut tailer);
-        let do_full = webhook_fired
-            || now.duration_since(last_full).as_secs() >= config.watch.full_poll_secs;
+        let do_full =
+            webhook_fired || now.duration_since(last_full).as_secs() >= config.watch.full_poll_secs;
         let do_local = now.duration_since(last_local).as_secs() >= config.watch.local_poll_secs;
 
         if do_full {
@@ -267,8 +267,7 @@ mod tests {
     /// poll-only intervals.
     #[test]
     fn fallback_when_events_file_missing() {
-        let path = std::env::temp_dir()
-            .join("orchard_daemon_test_missing_events.jsonl");
+        let path = std::env::temp_dir().join("orchard_daemon_test_missing_events.jsonl");
         let _ = std::fs::remove_file(&path);
 
         let mut tailer = Tailer::new(path.clone());

--- a/crates/orchard/src/webhook/handler.rs
+++ b/crates/orchard/src/webhook/handler.rs
@@ -123,10 +123,7 @@ mod tests {
 
     fn headers_with_sig(body: &[u8], secret: &[u8], event: &str) -> HashMap<String, String> {
         let mut h = HashMap::new();
-        h.insert(
-            "x-hub-signature-256".to_string(),
-            make_sig(body, secret),
-        );
+        h.insert("x-hub-signature-256".to_string(), make_sig(body, secret));
         h.insert("x-github-event".to_string(), event.to_string());
         h
     }

--- a/crates/orchard/src/webhook/handler.rs
+++ b/crates/orchard/src/webhook/handler.rs
@@ -1,0 +1,297 @@
+//! Request handling pipeline: size cap → signature → normalize → append.
+//!
+//! The `handle_request` function takes the pieces extracted from a hyper
+//! Request (method, path, headers, raw body bytes) and returns a response
+//! status code. No hyper types leak in — this makes the handler trivially
+//! unit-testable without spawning a server.
+
+use crate::webhook::normalize::{NormalizeResult, normalize};
+use crate::webhook::signature::verify_signature;
+use http::StatusCode;
+use std::collections::HashMap;
+
+/// Maximum allowed request body size (30 MiB).
+pub const MAX_BODY_BYTES: usize = 30 * 1024 * 1024;
+
+/// The parts of an HTTP request needed by the webhook handler.
+pub struct WebhookRequest<'a> {
+    /// HTTP method, e.g. `"GET"` or `"POST"`.
+    pub method: &'a str,
+    /// Request path, e.g. `"/webhook"`.
+    pub path: &'a str,
+    /// Request headers with lowercased keys.
+    pub headers: HashMap<String, String>,
+    /// Raw request body bytes.
+    pub body: &'a [u8],
+}
+
+/// Process a webhook request and return the appropriate HTTP status code.
+///
+/// Routes:
+/// - `GET /health` → 200 (no signature required)
+/// - `POST /webhook` → size cap → signature check → normalize → append
+/// - Any other route/method → 404
+pub fn handle_request(req: WebhookRequest<'_>, secret: &[u8]) -> StatusCode {
+    handle_request_with_writer(req, secret, &mut |event| {
+        crate::events::log_webhook_event(event);
+    })
+}
+
+/// Lower-level version that accepts an injectable writer for testability.
+///
+/// The `writer` closure is called with a `NormalizedEvent` when a valid,
+/// recognised webhook arrives. The top-level `handle_request` wires this
+/// to `events::log_webhook_event`.
+pub fn handle_request_with_writer<F>(
+    req: WebhookRequest<'_>,
+    secret: &[u8],
+    writer: &mut F,
+) -> StatusCode
+where
+    F: FnMut(&crate::webhook::normalize::NormalizedEvent),
+{
+    match (req.method, req.path) {
+        ("GET", "/health") => StatusCode::OK,
+        ("POST", "/webhook") => handle_post_webhook(req.headers, req.body, secret, writer),
+        _ => StatusCode::NOT_FOUND,
+    }
+}
+
+fn handle_post_webhook<F>(
+    headers: HashMap<String, String>,
+    body: &[u8],
+    secret: &[u8],
+    writer: &mut F,
+) -> StatusCode
+where
+    F: FnMut(&crate::webhook::normalize::NormalizedEvent),
+{
+    // 1. Size cap — fail fast before signature or JSON parsing.
+    if body.len() > MAX_BODY_BYTES {
+        return StatusCode::PAYLOAD_TOO_LARGE;
+    }
+
+    // 2. Signature verification over raw bytes.
+    let sig_header = match headers.get("x-hub-signature-256") {
+        Some(v) => v.as_str(),
+        None => return StatusCode::UNAUTHORIZED,
+    };
+    if verify_signature(sig_header, body, secret).is_err() {
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    // 3. Parse JSON (after signature — do NOT reparse for sig).
+    let payload: serde_json::Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(_) => return StatusCode::BAD_REQUEST,
+    };
+
+    // 4. Read event type header.
+    let event_type = match headers.get("x-github-event") {
+        Some(v) => v.as_str(),
+        None => return StatusCode::BAD_REQUEST,
+    };
+
+    // 5. Normalize and dispatch.
+    match normalize(event_type, &payload) {
+        NormalizeResult::Event(e) => {
+            writer(&e);
+            StatusCode::OK
+        }
+        NormalizeResult::Unsupported | NormalizeResult::Unknown => StatusCode::NO_CONTENT,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::webhook::normalize::NormalizedEvent;
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    fn make_sig(body: &[u8], secret: &[u8]) -> String {
+        let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+        mac.update(body);
+        format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+    }
+
+    fn headers_with_sig(body: &[u8], secret: &[u8], event: &str) -> HashMap<String, String> {
+        let mut h = HashMap::new();
+        h.insert(
+            "x-hub-signature-256".to_string(),
+            make_sig(body, secret),
+        );
+        h.insert("x-github-event".to_string(), event.to_string());
+        h
+    }
+
+    fn pr_opened_body() -> Vec<u8> {
+        serde_json::json!({
+            "action": "opened",
+            "number": 42,
+            "pull_request": { "number": 42, "merged": false },
+            "repository": { "full_name": "acme/webapp" },
+            "sender": { "login": "some-actor" }
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[test]
+    fn get_health_returns_200() {
+        let req = WebhookRequest {
+            method: "GET",
+            path: "/health",
+            headers: HashMap::new(),
+            body: b"",
+        };
+        assert_eq!(handle_request(req, b"secret"), StatusCode::OK);
+    }
+
+    #[test]
+    fn post_webhook_with_valid_signature_and_pr_opened_returns_200() {
+        let secret = b"test-secret";
+        let body = pr_opened_body();
+        let headers = headers_with_sig(&body, secret, "pull_request");
+
+        let mut written: Vec<NormalizedEvent> = Vec::new();
+        let req = WebhookRequest {
+            method: "POST",
+            path: "/webhook",
+            headers,
+            body: &body,
+        };
+        let status = handle_request_with_writer(req, secret, &mut |e| written.push(e.clone()));
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(written.len(), 1);
+        assert_eq!(written[0].kind, "pull_request.opened");
+    }
+
+    #[test]
+    fn post_webhook_with_invalid_signature_returns_401() {
+        let body = pr_opened_body();
+        let mut headers = HashMap::new();
+        headers.insert(
+            "x-hub-signature-256".to_string(),
+            "sha256=deadbeef".to_string(),
+        );
+        headers.insert("x-github-event".to_string(), "pull_request".to_string());
+
+        let req = WebhookRequest {
+            method: "POST",
+            path: "/webhook",
+            headers,
+            body: &body,
+        };
+        assert_eq!(handle_request(req, b"secret"), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn post_webhook_with_missing_signature_returns_401() {
+        let body = pr_opened_body();
+        let mut headers = HashMap::new();
+        headers.insert("x-github-event".to_string(), "pull_request".to_string());
+
+        let req = WebhookRequest {
+            method: "POST",
+            path: "/webhook",
+            headers,
+            body: &body,
+        };
+        assert_eq!(handle_request(req, b"secret"), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn post_webhook_with_body_larger_than_max_returns_413() {
+        let secret = b"secret";
+        let body = vec![0u8; MAX_BODY_BYTES + 1];
+        // Even with a valid signature the size check fires first.
+        let headers = headers_with_sig(&body, secret, "pull_request");
+
+        let req = WebhookRequest {
+            method: "POST",
+            path: "/webhook",
+            headers,
+            body: &body,
+        };
+        assert_eq!(handle_request(req, secret), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[test]
+    fn post_webhook_with_unknown_event_returns_204() {
+        let secret = b"secret";
+        let body = b"{}";
+        let headers = headers_with_sig(body, secret, "star");
+
+        let req = WebhookRequest {
+            method: "POST",
+            path: "/webhook",
+            headers,
+            body,
+        };
+        assert_eq!(handle_request(req, secret), StatusCode::NO_CONTENT);
+    }
+
+    #[test]
+    fn post_webhook_with_ping_event_returns_204() {
+        let secret = b"secret";
+        let body = b"{}";
+        let headers = headers_with_sig(body, secret, "ping");
+
+        let req = WebhookRequest {
+            method: "POST",
+            path: "/webhook",
+            headers,
+            body,
+        };
+        assert_eq!(handle_request(req, secret), StatusCode::NO_CONTENT);
+    }
+
+    #[test]
+    fn post_webhook_with_unsupported_action_returns_204() {
+        let secret = b"secret";
+        let body = serde_json::json!({
+            "action": "assigned",
+            "pull_request": { "number": 1 },
+            "repository": { "full_name": "acme/webapp" },
+            "sender": { "login": "actor" }
+        })
+        .to_string()
+        .into_bytes();
+        let headers = headers_with_sig(&body, secret, "pull_request");
+
+        let req = WebhookRequest {
+            method: "POST",
+            path: "/webhook",
+            headers,
+            body: &body,
+        };
+        assert_eq!(handle_request(req, secret), StatusCode::NO_CONTENT);
+    }
+
+    #[test]
+    fn wrong_route_returns_404() {
+        let req = WebhookRequest {
+            method: "GET",
+            path: "/webhook",
+            headers: HashMap::new(),
+            body: b"",
+        };
+        assert_eq!(handle_request(req, b"secret"), StatusCode::NOT_FOUND);
+
+        let req2 = WebhookRequest {
+            method: "POST",
+            path: "/other",
+            headers: HashMap::new(),
+            body: b"",
+        };
+        assert_eq!(handle_request(req2, b"secret"), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/orchard/src/webhook/mod.rs
+++ b/crates/orchard/src/webhook/mod.rs
@@ -10,4 +10,4 @@ pub mod normalize;
 pub mod port;
 pub mod server;
 pub mod signature;
-// tailer comes in pass 3
+pub mod tailer;

--- a/crates/orchard/src/webhook/mod.rs
+++ b/crates/orchard/src/webhook/mod.rs
@@ -5,6 +5,9 @@
 //!
 //! See `specs/features/webhook-event-stream.feature` for the full contract.
 
+pub mod handler;
 pub mod normalize;
 pub mod port;
+pub mod server;
 pub mod signature;
+// tailer comes in pass 3

--- a/crates/orchard/src/webhook/mod.rs
+++ b/crates/orchard/src/webhook/mod.rs
@@ -1,0 +1,10 @@
+//! Webhook server for receiving GitHub events.
+//!
+//! Receives signed GitHub webhook payloads, verifies HMAC-SHA256 signatures,
+//! normalizes events into a common schema, and appends them to events.jsonl.
+//!
+//! See `specs/features/webhook-event-stream.feature` for the full contract.
+
+pub mod normalize;
+pub mod port;
+pub mod signature;

--- a/crates/orchard/src/webhook/normalize.rs
+++ b/crates/orchard/src/webhook/normalize.rs
@@ -114,7 +114,14 @@ fn normalize_pull_request(
     };
 
     let pr = u64_field(payload, &["pull_request", "number"]);
-    NormalizeResult::Event(build_event(kind.to_string(), repo, pr, None, actor, payload))
+    NormalizeResult::Event(build_event(
+        kind.to_string(),
+        repo,
+        pr,
+        None,
+        actor,
+        payload,
+    ))
 }
 
 fn normalize_pull_request_review(

--- a/crates/orchard/src/webhook/normalize.rs
+++ b/crates/orchard/src/webhook/normalize.rs
@@ -1,0 +1,270 @@
+//! GitHub webhook payload normalisation.
+//!
+//! Converts raw GitHub webhook payloads into a compact, uniform schema
+//! that downstream consumers (events.jsonl tailer, watch daemon) can handle
+//! without needing to understand every GitHub event type.
+//!
+//! See `specs/features/webhook-event-stream.feature` lines 121–227 for the
+//! full acceptance contract.
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// A normalised GitHub webhook event ready to be written as a JSONL line.
+#[derive(Debug, Clone, Serialize)]
+pub struct NormalizedEvent {
+    /// UTC timestamp when the event was received.
+    pub ts: DateTime<Utc>,
+    /// Always `"webhook"` — distinguishes these lines from task/session events.
+    pub source: &'static str,
+    /// Event kind identifier, e.g. `"pull_request.opened"`.
+    pub kind: String,
+    /// GitHub repository full name (`owner/repo`), when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    /// Pull request number, when the event is PR-related.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr: Option<u64>,
+    /// Issue number, when the event is issue-related.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue: Option<u64>,
+    /// GitHub login of the actor who triggered the event.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
+    /// Full raw GitHub payload, passed through verbatim.
+    pub data: Value,
+}
+
+/// Result of normalising a GitHub webhook payload.
+pub enum NormalizeResult {
+    /// The event was recognised and normalised successfully.
+    Event(NormalizedEvent),
+    /// The event type is known but the specific action is not in scope
+    /// (e.g. `pull_request.assigned`). Nothing should be written to the log.
+    Unsupported,
+    /// The event type is not recognised at all (e.g. `"star"`, `"fork"`).
+    Unknown,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Normalise a GitHub webhook into a [`NormalizedEvent`].
+///
+/// `event_type` is the value of the `X-GitHub-Event` header.
+/// `payload` is the parsed JSON body — passed through verbatim into `data`.
+///
+/// Returns [`NormalizeResult::Unsupported`] for known-but-out-of-scope
+/// actions and [`NormalizeResult::Unknown`] for unrecognised event types.
+pub fn normalize(event_type: &str, payload: &Value) -> NormalizeResult {
+    let repo = string_field(payload, &["repository", "full_name"]);
+    let actor = string_field(payload, &["sender", "login"]);
+    let action = string_field(payload, &["action"]).unwrap_or_default();
+
+    match event_type {
+        "pull_request" => normalize_pull_request(&action, payload, repo, actor),
+        "pull_request_review" => normalize_pull_request_review(&action, payload, repo, actor),
+        "pull_request_review_comment" => {
+            normalize_pull_request_review_comment(&action, payload, repo, actor)
+        }
+        "issue_comment" => normalize_issue_comment(&action, payload, repo, actor),
+        "issues" => normalize_issues(&action, payload, repo, actor),
+        "push" => normalize_push(payload, repo, actor),
+        "check_run" | "check_suite" | "workflow_run" => {
+            normalize_ci_event(event_type, &action, payload, repo, actor)
+        }
+        _ => NormalizeResult::Unknown,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-event normalisers
+// ---------------------------------------------------------------------------
+
+fn normalize_pull_request(
+    action: &str,
+    payload: &Value,
+    repo: Option<String>,
+    actor: Option<String>,
+) -> NormalizeResult {
+    let kind = match action {
+        "opened" => "pull_request.opened",
+        "reopened" => "pull_request.reopened",
+        "ready_for_review" => "pull_request.ready_for_review",
+        "converted_to_draft" => "pull_request.converted_to_draft",
+        "closed" => {
+            let merged = payload
+                .get("pull_request")
+                .and_then(|pr| pr.get("merged"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if merged {
+                "pull_request.merged"
+            } else {
+                "pull_request.closed"
+            }
+        }
+        _ => return NormalizeResult::Unsupported,
+    };
+
+    let pr = u64_field(payload, &["pull_request", "number"]);
+    NormalizeResult::Event(build_event(kind.to_string(), repo, pr, None, actor, payload))
+}
+
+fn normalize_pull_request_review(
+    action: &str,
+    payload: &Value,
+    repo: Option<String>,
+    actor: Option<String>,
+) -> NormalizeResult {
+    if action != "submitted" {
+        return NormalizeResult::Unsupported;
+    }
+    let pr = u64_field(payload, &["pull_request", "number"]);
+    NormalizeResult::Event(build_event(
+        "pull_request.review.submitted".to_string(),
+        repo,
+        pr,
+        None,
+        actor,
+        payload,
+    ))
+}
+
+fn normalize_pull_request_review_comment(
+    action: &str,
+    payload: &Value,
+    repo: Option<String>,
+    actor: Option<String>,
+) -> NormalizeResult {
+    if action != "created" {
+        return NormalizeResult::Unsupported;
+    }
+    let pr = u64_field(payload, &["pull_request", "number"]);
+    NormalizeResult::Event(build_event(
+        "pull_request.review_comment.created".to_string(),
+        repo,
+        pr,
+        None,
+        actor,
+        payload,
+    ))
+}
+
+fn normalize_issue_comment(
+    action: &str,
+    payload: &Value,
+    repo: Option<String>,
+    actor: Option<String>,
+) -> NormalizeResult {
+    if action != "created" {
+        return NormalizeResult::Unsupported;
+    }
+    let issue_number = u64_field(payload, &["issue", "number"]);
+    let is_pr = payload
+        .get("issue")
+        .and_then(|i| i.get("pull_request"))
+        .is_some();
+    let pr = if is_pr { issue_number } else { None };
+
+    NormalizeResult::Event(build_event(
+        "issue_comment.created".to_string(),
+        repo,
+        pr,
+        issue_number,
+        actor,
+        payload,
+    ))
+}
+
+fn normalize_issues(
+    action: &str,
+    payload: &Value,
+    repo: Option<String>,
+    actor: Option<String>,
+) -> NormalizeResult {
+    let kind = match action {
+        "opened" | "closed" | "labeled" | "unlabeled" => format!("issues.{}", action),
+        _ => return NormalizeResult::Unsupported,
+    };
+    let issue = u64_field(payload, &["issue", "number"]);
+    NormalizeResult::Event(build_event(kind, repo, None, issue, actor, payload))
+}
+
+fn normalize_push(payload: &Value, repo: Option<String>, actor: Option<String>) -> NormalizeResult {
+    NormalizeResult::Event(build_event(
+        "push".to_string(),
+        repo,
+        None,
+        None,
+        actor,
+        payload,
+    ))
+}
+
+fn normalize_ci_event(
+    event_type: &str,
+    action: &str,
+    payload: &Value,
+    repo: Option<String>,
+    actor: Option<String>,
+) -> NormalizeResult {
+    if action != "completed" {
+        return NormalizeResult::Unsupported;
+    }
+    let kind = format!("{}.completed", event_type);
+    NormalizeResult::Event(build_event(kind, repo, None, None, actor, payload))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a [`NormalizedEvent`] with the current UTC timestamp.
+pub(crate) fn build_event(
+    kind: String,
+    repo: Option<String>,
+    pr: Option<u64>,
+    issue: Option<u64>,
+    actor: Option<String>,
+    payload: &Value,
+) -> NormalizedEvent {
+    NormalizedEvent {
+        ts: Utc::now(),
+        source: "webhook",
+        kind,
+        repo,
+        pr,
+        issue,
+        actor,
+        data: payload.clone(),
+    }
+}
+
+/// Extract a nested string field from `value` by following the `path` keys.
+pub(crate) fn string_field(value: &Value, path: &[&str]) -> Option<String> {
+    let mut current = value;
+    for key in path {
+        current = current.get(key)?;
+    }
+    current.as_str().map(|s| s.to_string())
+}
+
+/// Extract a nested `u64` field from `value` by following the `path` keys.
+pub(crate) fn u64_field(value: &Value, path: &[&str]) -> Option<u64> {
+    let mut current = value;
+    for key in path {
+        current = current.get(key)?;
+    }
+    current.as_u64()
+}
+
+#[cfg(test)]
+#[path = "normalize_tests.rs"]
+mod tests;

--- a/crates/orchard/src/webhook/normalize_tests.rs
+++ b/crates/orchard/src/webhook/normalize_tests.rs
@@ -3,9 +3,9 @@
 //! Covers all scenarios from `specs/features/webhook-event-stream.feature`
 //! lines 121–227 (criterion tasks #16–#24).
 
-use super::{normalize, NormalizeResult, NormalizedEvent};
+use super::{NormalizeResult, NormalizedEvent, normalize};
 use chrono::{DateTime, Utc};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -49,7 +49,11 @@ fn pull_request_opened_has_all_fields() {
     assert_eq!(event.repo.as_deref(), Some("acme/webapp"));
     assert_eq!(event.pr, Some(42));
     assert_eq!(event.actor.as_deref(), Some("octocat"));
-    let ts_str = serde_json::to_value(event.ts).unwrap().as_str().unwrap().to_string();
+    let ts_str = serde_json::to_value(event.ts)
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_string();
     ts_str.parse::<DateTime<Utc>>().expect("ts is ISO 8601 UTC");
     assert_eq!(event.data, payload);
 }
@@ -60,31 +64,46 @@ fn pull_request_opened_has_all_fields() {
 
 #[test]
 fn pull_request_closed_not_merged() {
-    let event = assert_event(normalize("pull_request", &pr_payload("closed", false, 1, "a/b", "x")));
+    let event = assert_event(normalize(
+        "pull_request",
+        &pr_payload("closed", false, 1, "a/b", "x"),
+    ));
     assert_eq!(event.kind, "pull_request.closed");
 }
 
 #[test]
 fn pull_request_closed_and_merged() {
-    let event = assert_event(normalize("pull_request", &pr_payload("closed", true, 1, "a/b", "x")));
+    let event = assert_event(normalize(
+        "pull_request",
+        &pr_payload("closed", true, 1, "a/b", "x"),
+    ));
     assert_eq!(event.kind, "pull_request.merged");
 }
 
 #[test]
 fn pull_request_reopened() {
-    let event = assert_event(normalize("pull_request", &pr_payload("reopened", false, 1, "a/b", "x")));
+    let event = assert_event(normalize(
+        "pull_request",
+        &pr_payload("reopened", false, 1, "a/b", "x"),
+    ));
     assert_eq!(event.kind, "pull_request.reopened");
 }
 
 #[test]
 fn pull_request_ready_for_review() {
-    let event = assert_event(normalize("pull_request", &pr_payload("ready_for_review", false, 1, "a/b", "x")));
+    let event = assert_event(normalize(
+        "pull_request",
+        &pr_payload("ready_for_review", false, 1, "a/b", "x"),
+    ));
     assert_eq!(event.kind, "pull_request.ready_for_review");
 }
 
 #[test]
 fn pull_request_converted_to_draft() {
-    let event = assert_event(normalize("pull_request", &pr_payload("converted_to_draft", false, 1, "a/b", "x")));
+    let event = assert_event(normalize(
+        "pull_request",
+        &pr_payload("converted_to_draft", false, 1, "a/b", "x"),
+    ));
     assert_eq!(event.kind, "pull_request.converted_to_draft");
 }
 
@@ -180,17 +199,26 @@ fn issues_opened() {
 
 #[test]
 fn issues_closed() {
-    assert_eq!(assert_event(normalize("issues", &issues_payload("closed"))).kind, "issues.closed");
+    assert_eq!(
+        assert_event(normalize("issues", &issues_payload("closed"))).kind,
+        "issues.closed"
+    );
 }
 
 #[test]
 fn issues_labeled() {
-    assert_eq!(assert_event(normalize("issues", &issues_payload("labeled"))).kind, "issues.labeled");
+    assert_eq!(
+        assert_event(normalize("issues", &issues_payload("labeled"))).kind,
+        "issues.labeled"
+    );
 }
 
 #[test]
 fn issues_unlabeled() {
-    assert_eq!(assert_event(normalize("issues", &issues_payload("unlabeled"))).kind, "issues.unlabeled");
+    assert_eq!(
+        assert_event(normalize("issues", &issues_payload("unlabeled"))).kind,
+        "issues.unlabeled"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -252,7 +280,10 @@ fn workflow_run_completed() {
 
 #[test]
 fn pull_request_assigned_is_unsupported() {
-    assert_unsupported(normalize("pull_request", &pr_payload("assigned", false, 1, "a/b", "x")));
+    assert_unsupported(normalize(
+        "pull_request",
+        &pr_payload("assigned", false, 1, "a/b", "x"),
+    ));
 }
 
 #[test]

--- a/crates/orchard/src/webhook/normalize_tests.rs
+++ b/crates/orchard/src/webhook/normalize_tests.rs
@@ -1,0 +1,279 @@
+//! Unit tests for [`crate::webhook::normalize`].
+//!
+//! Covers all scenarios from `specs/features/webhook-event-stream.feature`
+//! lines 121–227 (criterion tasks #16–#24).
+
+use super::{normalize, NormalizeResult, NormalizedEvent};
+use chrono::{DateTime, Utc};
+use serde_json::{json, Value};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn pr_payload(action: &str, merged: bool, pr_number: u64, repo: &str, actor: &str) -> Value {
+    json!({
+        "action": action,
+        "pull_request": { "number": pr_number, "merged": merged },
+        "repository": { "full_name": repo },
+        "sender": { "login": actor }
+    })
+}
+
+fn assert_event(result: NormalizeResult) -> NormalizedEvent {
+    match result {
+        NormalizeResult::Event(e) => e,
+        NormalizeResult::Unsupported => panic!("expected Event, got Unsupported"),
+        NormalizeResult::Unknown => panic!("expected Event, got Unknown"),
+    }
+}
+
+fn assert_unsupported(result: NormalizeResult) {
+    match result {
+        NormalizeResult::Unsupported => {}
+        NormalizeResult::Event(_) => panic!("expected Unsupported, got Event"),
+        NormalizeResult::Unknown => panic!("expected Unsupported, got Unknown"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #16: full-fields scenario
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pull_request_opened_has_all_fields() {
+    let payload = pr_payload("opened", false, 42, "acme/webapp", "octocat");
+    let event = assert_event(normalize("pull_request", &payload));
+    assert_eq!(event.source, "webhook");
+    assert_eq!(event.kind, "pull_request.opened");
+    assert_eq!(event.repo.as_deref(), Some("acme/webapp"));
+    assert_eq!(event.pr, Some(42));
+    assert_eq!(event.actor.as_deref(), Some("octocat"));
+    let ts_str = serde_json::to_value(event.ts).unwrap().as_str().unwrap().to_string();
+    ts_str.parse::<DateTime<Utc>>().expect("ts is ISO 8601 UTC");
+    assert_eq!(event.data, payload);
+}
+
+// ---------------------------------------------------------------------------
+// #17: pull_request action map
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pull_request_closed_not_merged() {
+    let event = assert_event(normalize("pull_request", &pr_payload("closed", false, 1, "a/b", "x")));
+    assert_eq!(event.kind, "pull_request.closed");
+}
+
+#[test]
+fn pull_request_closed_and_merged() {
+    let event = assert_event(normalize("pull_request", &pr_payload("closed", true, 1, "a/b", "x")));
+    assert_eq!(event.kind, "pull_request.merged");
+}
+
+#[test]
+fn pull_request_reopened() {
+    let event = assert_event(normalize("pull_request", &pr_payload("reopened", false, 1, "a/b", "x")));
+    assert_eq!(event.kind, "pull_request.reopened");
+}
+
+#[test]
+fn pull_request_ready_for_review() {
+    let event = assert_event(normalize("pull_request", &pr_payload("ready_for_review", false, 1, "a/b", "x")));
+    assert_eq!(event.kind, "pull_request.ready_for_review");
+}
+
+#[test]
+fn pull_request_converted_to_draft() {
+    let event = assert_event(normalize("pull_request", &pr_payload("converted_to_draft", false, 1, "a/b", "x")));
+    assert_eq!(event.kind, "pull_request.converted_to_draft");
+}
+
+// ---------------------------------------------------------------------------
+// #18: pull_request_review
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pull_request_review_submitted() {
+    let payload = json!({
+        "action": "submitted",
+        "pull_request": { "number": 99 },
+        "repository": { "full_name": "acme/webapp" },
+        "sender": { "login": "reviewer" }
+    });
+    let event = assert_event(normalize("pull_request_review", &payload));
+    assert_eq!(event.kind, "pull_request.review.submitted");
+    assert_eq!(event.pr, Some(99));
+}
+
+// ---------------------------------------------------------------------------
+// #19: pull_request_review_comment
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pull_request_review_comment_created() {
+    let payload = json!({
+        "action": "created",
+        "pull_request": { "number": 3099 },
+        "repository": { "full_name": "acme/webapp" },
+        "sender": { "login": "coderabbitai[bot]" }
+    });
+    let event = assert_event(normalize("pull_request_review_comment", &payload));
+    assert_eq!(event.kind, "pull_request.review_comment.created");
+    assert_eq!(event.pr, Some(3099));
+    assert_eq!(event.actor.as_deref(), Some("coderabbitai[bot]"));
+}
+
+// ---------------------------------------------------------------------------
+// #20: issue_comment
+// ---------------------------------------------------------------------------
+
+#[test]
+fn issue_comment_on_pr_populates_pr_and_issue() {
+    let payload = json!({
+        "action": "created",
+        "issue": {
+            "number": 42,
+            "pull_request": { "url": "https://api.github.com/repos/acme/webapp/pulls/42" }
+        },
+        "repository": { "full_name": "acme/webapp" },
+        "sender": { "login": "commenter" }
+    });
+    let event = assert_event(normalize("issue_comment", &payload));
+    assert_eq!(event.kind, "issue_comment.created");
+    assert_eq!(event.pr, Some(42));
+    assert_eq!(event.issue, Some(42));
+}
+
+#[test]
+fn issue_comment_on_plain_issue_omits_pr() {
+    let payload = json!({
+        "action": "created",
+        "issue": { "number": 77 },
+        "repository": { "full_name": "acme/webapp" },
+        "sender": { "login": "commenter" }
+    });
+    let event = assert_event(normalize("issue_comment", &payload));
+    assert_eq!(event.kind, "issue_comment.created");
+    assert_eq!(event.issue, Some(77));
+    assert!(event.pr.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// #21: issues action map
+// ---------------------------------------------------------------------------
+
+fn issues_payload(action: &str) -> Value {
+    json!({
+        "action": action,
+        "issue": { "number": 77 },
+        "repository": { "full_name": "acme/webapp" },
+        "sender": { "login": "actor" }
+    })
+}
+
+#[test]
+fn issues_opened() {
+    let event = assert_event(normalize("issues", &issues_payload("opened")));
+    assert_eq!(event.kind, "issues.opened");
+    assert_eq!(event.issue, Some(77));
+}
+
+#[test]
+fn issues_closed() {
+    assert_eq!(assert_event(normalize("issues", &issues_payload("closed"))).kind, "issues.closed");
+}
+
+#[test]
+fn issues_labeled() {
+    assert_eq!(assert_event(normalize("issues", &issues_payload("labeled"))).kind, "issues.labeled");
+}
+
+#[test]
+fn issues_unlabeled() {
+    assert_eq!(assert_event(normalize("issues", &issues_payload("unlabeled"))).kind, "issues.unlabeled");
+}
+
+// ---------------------------------------------------------------------------
+// #22: push
+// ---------------------------------------------------------------------------
+
+#[test]
+fn push_carries_ref_and_commits() {
+    let payload = json!({
+        "ref": "refs/heads/main",
+        "commits": [{"id": "a"}, {"id": "b"}, {"id": "c"}],
+        "repository": { "full_name": "acme/webapp" },
+        "sender": { "login": "pusher" }
+    });
+    let event = assert_event(normalize("push", &payload));
+    assert_eq!(event.kind, "push");
+    assert_eq!(event.repo.as_deref(), Some("acme/webapp"));
+    assert_eq!(event.data["ref"].as_str(), Some("refs/heads/main"));
+    assert_eq!(event.data["commits"].as_array().map(|a| a.len()), Some(3));
+}
+
+// ---------------------------------------------------------------------------
+// #23: CI completions
+// ---------------------------------------------------------------------------
+
+fn ci_completed_payload(conclusion: &str) -> Value {
+    json!({
+        "action": "completed",
+        "conclusion": conclusion,
+        "repository": { "full_name": "acme/webapp" },
+        "sender": { "login": "actor" }
+    })
+}
+
+#[test]
+fn check_run_completed() {
+    let event = assert_event(normalize("check_run", &ci_completed_payload("failure")));
+    assert_eq!(event.kind, "check_run.completed");
+    assert_eq!(event.data["conclusion"].as_str(), Some("failure"));
+}
+
+#[test]
+fn check_suite_completed() {
+    let event = assert_event(normalize("check_suite", &ci_completed_payload("success")));
+    assert_eq!(event.kind, "check_suite.completed");
+    assert_eq!(event.data["conclusion"].as_str(), Some("success"));
+}
+
+#[test]
+fn workflow_run_completed() {
+    let event = assert_event(normalize("workflow_run", &ci_completed_payload("success")));
+    assert_eq!(event.kind, "workflow_run.completed");
+    assert_eq!(event.data["conclusion"].as_str(), Some("success"));
+}
+
+// ---------------------------------------------------------------------------
+// #24: unsupported actions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pull_request_assigned_is_unsupported() {
+    assert_unsupported(normalize("pull_request", &pr_payload("assigned", false, 1, "a/b", "x")));
+}
+
+#[test]
+fn check_run_created_is_unsupported() {
+    assert_unsupported(normalize("check_run", &json!({ "action": "created" })));
+}
+
+#[test]
+fn check_suite_requested_is_unsupported() {
+    assert_unsupported(normalize("check_suite", &json!({ "action": "requested" })));
+}
+
+#[test]
+fn workflow_run_requested_is_unsupported() {
+    assert_unsupported(normalize("workflow_run", &json!({ "action": "requested" })));
+}
+
+#[test]
+fn unknown_event_type_is_unknown() {
+    match normalize("star", &json!({ "action": "created" })) {
+        NormalizeResult::Unknown => {}
+        _ => panic!("expected Unknown for 'star' event"),
+    }
+}

--- a/crates/orchard/src/webhook/port.rs
+++ b/crates/orchard/src/webhook/port.rs
@@ -1,0 +1,60 @@
+//! Port resolution for the webhook server.
+//!
+//! Resolves the port to bind from multiple sources in precedence order:
+//! CLI flag > environment variable > config file > built-in default (8477).
+
+/// The default port the webhook server binds to when no other source provides one.
+pub const DEFAULT_WEBHOOK_PORT: u16 = 8477;
+
+/// Resolve the webhook server port from flag > env > config > default (8477).
+///
+/// All inputs are `Option<u16>`; `None` means "fall through to the next
+/// precedence level". Returns the first `Some` value encountered, or
+/// [`DEFAULT_WEBHOOK_PORT`] if all are `None`.
+///
+/// # Examples
+///
+/// ```
+/// use orchard::webhook::port::{resolve_port, DEFAULT_WEBHOOK_PORT};
+///
+/// // Flag wins when present.
+/// assert_eq!(resolve_port(Some(9000), Some(9001), Some(9002)), 9000);
+///
+/// // Falls through to env when flag is absent.
+/// assert_eq!(resolve_port(None, Some(9001), Some(9002)), 9001);
+///
+/// // Falls through to config when flag and env are absent.
+/// assert_eq!(resolve_port(None, None, Some(9002)), 9002);
+///
+/// // Falls through to default when all are absent.
+/// assert_eq!(resolve_port(None, None, None), DEFAULT_WEBHOOK_PORT);
+/// ```
+pub fn resolve_port(flag: Option<u16>, env: Option<u16>, config: Option<u16>) -> u16 {
+    flag.or(env).or(config).unwrap_or(DEFAULT_WEBHOOK_PORT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_wins_over_env_and_config() {
+        assert_eq!(resolve_port(Some(9000), Some(9001), Some(9002)), 9000);
+    }
+
+    #[test]
+    fn env_wins_when_flag_absent() {
+        assert_eq!(resolve_port(None, Some(9001), Some(9002)), 9001);
+    }
+
+    #[test]
+    fn config_wins_when_flag_and_env_absent() {
+        assert_eq!(resolve_port(None, None, Some(9002)), 9002);
+    }
+
+    #[test]
+    fn default_used_when_all_absent() {
+        assert_eq!(resolve_port(None, None, None), DEFAULT_WEBHOOK_PORT);
+        assert_eq!(resolve_port(None, None, None), 8477);
+    }
+}

--- a/crates/orchard/src/webhook/server.rs
+++ b/crates/orchard/src/webhook/server.rs
@@ -1,0 +1,132 @@
+//! Hyper server that drives the webhook handler.
+//!
+//! Binds a TCP listener on the resolved port, accepts connections with
+//! hyper-util's `auto::Builder`, and routes each request through
+//! `handler::handle_request`. The server is blocking from the caller's
+//! perspective (runs the tokio runtime inline) and returns when it receives
+//! SIGINT/SIGTERM.
+
+use crate::webhook::handler::{MAX_BODY_BYTES, WebhookRequest, handle_request};
+use anyhow::{Context, Result};
+use http::StatusCode;
+use http_body_util::{BodyExt, Full, Limited};
+use hyper::body::{Bytes, Incoming};
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use hyper_util::server::conn::auto;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+/// Runs the webhook server on the given port with the given secret.
+///
+/// Binds to `127.0.0.1:<port>`. If `port` is 0, the OS assigns an ephemeral
+/// port. Prints the startup line to stderr with the actual bound port.
+///
+/// Blocks until the process receives SIGINT (Ctrl-C).
+pub fn run(port: u16, secret: Vec<u8>) -> Result<()> {
+    let rt = tokio::runtime::Runtime::new().context("failed to create tokio runtime")?;
+    rt.block_on(async_main(port, secret))
+}
+
+async fn async_main(port: u16, secret: Vec<u8>) -> Result<()> {
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind to {addr}"))?;
+
+    let bound_port = listener.local_addr()?.port();
+    let events_path = events_path_for_display();
+
+    eprintln!(
+        "orchard webhook-serve: listening on http://127.0.0.1:{bound_port}/webhook (events → {events_path})"
+    );
+
+    let secret = Arc::new(secret);
+
+    loop {
+        let (stream, _peer) = tokio::select! {
+            result = listener.accept() => result?,
+            _ = tokio::signal::ctrl_c() => break,
+        };
+
+        let secret = Arc::clone(&secret);
+        let io = TokioIo::new(stream);
+
+        tokio::spawn(async move {
+            let secret = Arc::clone(&secret);
+            let svc = service_fn(move |req: Request<Incoming>| {
+                let secret = Arc::clone(&secret);
+                async move { serve_request(req, secret).await }
+            });
+            let _ = auto::Builder::new(hyper_util::rt::TokioExecutor::new())
+                .serve_connection(io, svc)
+                .await;
+        });
+    }
+
+    Ok(())
+}
+
+async fn serve_request(
+    req: Request<Incoming>,
+    secret: Arc<Vec<u8>>,
+) -> Result<Response<Full<Bytes>>, std::convert::Infallible> {
+    let method = req.method().as_str().to_string();
+    let path = req.uri().path().to_string();
+
+    // Build lowercase header map.
+    let mut headers: HashMap<String, String> = HashMap::new();
+    for (name, value) in req.headers() {
+        if let Ok(v) = value.to_str() {
+            headers.insert(name.as_str().to_lowercase(), v.to_string());
+        }
+    }
+
+    // Check Content-Length upfront before collecting body.
+    let content_length = headers
+        .get("content-length")
+        .and_then(|v| v.parse::<usize>().ok());
+
+    if let Some(len) = content_length
+        && len > MAX_BODY_BYTES
+    {
+        return Ok(status_response(StatusCode::PAYLOAD_TOO_LARGE));
+    }
+
+    // Collect body with a size cap.
+    let limited = Limited::new(req.into_body(), MAX_BODY_BYTES);
+    let bytes = match limited.collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(_) => return Ok(status_response(StatusCode::PAYLOAD_TOO_LARGE)),
+    };
+
+    let webhook_req = WebhookRequest {
+        method: &method,
+        path: &path,
+        headers,
+        body: &bytes,
+    };
+
+    let status = handle_request(webhook_req, &secret);
+    Ok(status_response(status))
+}
+
+fn status_response(status: StatusCode) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .body(Full::new(Bytes::new()))
+        .unwrap()
+}
+
+fn events_path_for_display() -> String {
+    dirs::home_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join(".local")
+        .join("state")
+        .join("git-orchard")
+        .join("events.jsonl")
+        .to_string_lossy()
+        .to_string()
+}

--- a/crates/orchard/src/webhook/signature.rs
+++ b/crates/orchard/src/webhook/signature.rs
@@ -62,10 +62,10 @@ pub fn verify_signature(header: &str, body: &[u8], secret: &[u8]) -> Result<(), 
 
     let expected = hex::decode(hex_digest).map_err(|_| SignatureError::InvalidHex)?;
 
-    let mut mac =
-        HmacSha256::new_from_slice(secret).expect("HMAC accepts keys of any length");
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC accepts keys of any length");
     mac.update(body);
-    mac.verify_slice(&expected).map_err(|_| SignatureError::Mismatch)
+    mac.verify_slice(&expected)
+        .map_err(|_| SignatureError::Mismatch)
 }
 
 #[cfg(test)]

--- a/crates/orchard/src/webhook/signature.rs
+++ b/crates/orchard/src/webhook/signature.rs
@@ -1,0 +1,146 @@
+//! HMAC-SHA256 signature verification for GitHub webhooks.
+//!
+//! GitHub signs every webhook request with an HMAC-SHA256 digest computed over
+//! the **raw** request body bytes and sends it in the `X-Hub-Signature-256`
+//! header as `sha256=<hex>`. This module verifies that header in constant time.
+//!
+//! # Correctness note
+//!
+//! Verification MUST happen over the raw body bytes received from the network,
+//! *before* any JSON parsing. If the body is deserialised and re-serialised the
+//! signature will not match because JSON key order and whitespace may change.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const SHA256_PREFIX: &str = "sha256=";
+
+/// Errors that can occur during signature verification.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SignatureError {
+    /// The header does not start with `"sha256="`.
+    MissingPrefix,
+    /// The hex-encoded digest in the header could not be decoded.
+    InvalidHex,
+    /// The computed HMAC does not match the header value.
+    Mismatch,
+}
+
+impl std::fmt::Display for SignatureError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingPrefix => write!(f, "signature header missing 'sha256=' prefix"),
+            Self::InvalidHex => write!(f, "signature header contains invalid hex"),
+            Self::Mismatch => write!(f, "signature mismatch"),
+        }
+    }
+}
+
+impl std::error::Error for SignatureError {}
+
+/// Verify the GitHub `X-Hub-Signature-256` header against the raw request body.
+///
+/// `header` is the full header value (e.g. `"sha256=abc123..."`).
+/// `body` is the **raw, unmodified** request body bytes.
+/// `secret` is the webhook secret bytes used to initialise the HMAC key.
+///
+/// Uses a constant-time comparison via [`Mac::verify_slice`] so this function
+/// is safe against timing side-channel attacks.
+///
+/// # Errors
+///
+/// Returns [`SignatureError::MissingPrefix`] when the header does not start
+/// with `"sha256="`, [`SignatureError::InvalidHex`] when the hex portion
+/// cannot be decoded, and [`SignatureError::Mismatch`] when the digest is
+/// well-formed but does not match the computed HMAC.
+pub fn verify_signature(header: &str, body: &[u8], secret: &[u8]) -> Result<(), SignatureError> {
+    let hex_digest = header
+        .strip_prefix(SHA256_PREFIX)
+        .ok_or(SignatureError::MissingPrefix)?;
+
+    let expected = hex::decode(hex_digest).map_err(|_| SignatureError::InvalidHex)?;
+
+    let mut mac =
+        HmacSha256::new_from_slice(secret).expect("HMAC accepts keys of any length");
+    mac.update(body);
+    mac.verify_slice(&expected).map_err(|_| SignatureError::Mismatch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hmac::Mac;
+
+    fn make_signature(body: &[u8], secret: &[u8]) -> String {
+        let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+        mac.update(body);
+        let result = mac.finalize().into_bytes();
+        format!("sha256={}", hex::encode(result))
+    }
+
+    #[test]
+    fn valid_signature_is_accepted() {
+        let body = b"hello world";
+        let secret = b"supersecret";
+        let header = make_signature(body, secret);
+        assert_eq!(verify_signature(&header, body, secret), Ok(()));
+    }
+
+    #[test]
+    fn wrong_hex_digest_is_rejected() {
+        let body = b"hello world";
+        let secret = b"supersecret";
+        assert_eq!(
+            verify_signature("sha256=deadbeef", body, secret),
+            Err(SignatureError::Mismatch)
+        );
+    }
+
+    #[test]
+    fn hmac_computed_with_wrong_secret_is_rejected() {
+        let body = b"hello world";
+        let header = make_signature(body, b"wrong");
+        assert_eq!(
+            verify_signature(&header, body, b"supersecret"),
+            Err(SignatureError::Mismatch)
+        );
+    }
+
+    #[test]
+    fn header_missing_prefix_is_rejected() {
+        let body = b"hello world";
+        let secret = b"supersecret";
+        // Compute a valid HMAC but strip the "sha256=" prefix.
+        let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+        mac.update(body);
+        let hex = hex::encode(mac.finalize().into_bytes());
+        assert_eq!(
+            verify_signature(&hex, body, secret),
+            Err(SignatureError::MissingPrefix)
+        );
+    }
+
+    #[test]
+    fn empty_body_with_correct_hmac_is_accepted() {
+        let body = b"";
+        let secret = b"supersecret";
+        let header = make_signature(body, secret);
+        assert_eq!(verify_signature(&header, body, secret), Ok(()));
+    }
+
+    #[test]
+    fn non_ascii_utf8_payload_verified_over_raw_bytes() {
+        // The payload contains multi-byte UTF-8 (é = 0xC3 0xA9).
+        // This tests that we hash the raw bytes, not a reparsed/reserialized form.
+        let body = r#"{"actor":{"login":"café-bot"}}"#.as_bytes();
+        let secret = b"supersecret";
+        let header = make_signature(body, secret);
+        assert_eq!(
+            verify_signature(&header, body, secret),
+            Ok(()),
+            "HMAC over raw UTF-8 bytes must succeed"
+        );
+    }
+}

--- a/crates/orchard/src/webhook/tailer.rs
+++ b/crates/orchard/src/webhook/tailer.rs
@@ -1,0 +1,158 @@
+//! Events.jsonl tailer for the watch daemon.
+//!
+//! The tailer tracks a byte offset into events.jsonl and reads only new
+//! lines on each poll. It filters for lines with `source="webhook"` and
+//! forwards them to the daemon as triggers for an immediate refresh.
+//!
+//! Correctness rules (see specs/features/webhook-event-stream.feature):
+//! - Read rule: `file_size > stored_offset OR mtime_changed`. mtime-only
+//!   short-circuit is a BUG at 1s mtime resolution.
+//! - Advance rule: offset advances only past the last complete newline.
+//!   Partial trailing bytes are re-read on the next iteration.
+//! - Truncation: if file_size < stored_offset, reset offset to 0.
+//! - Cold start: initial offset = current file size. Historical lines are
+//!   not replayed.
+//! - Graceful degradation: missing file = silent; unreadable file = single
+//!   warning, continue.
+
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use serde_json::Value;
+
+/// State for tailing events.jsonl across daemon loop iterations.
+pub struct Tailer {
+    path: PathBuf,
+    offset: u64,
+    mtime: Option<SystemTime>,
+    /// Whether we've already logged the "unreadable" warning.
+    /// Missing file is silent; unreadable existing file warns once.
+    unreadable_warned: bool,
+}
+
+impl Tailer {
+    /// Create a new tailer initialized to the CURRENT end of the file.
+    /// Historical lines in events.jsonl at cold-start are NOT replayed.
+    /// If the file does not exist, offset=0 and the first append will be read.
+    pub fn new(path: PathBuf) -> Self {
+        match fs::metadata(&path) {
+            Ok(meta) => Tailer {
+                offset: meta.len(),
+                mtime: meta.modified().ok(),
+                path,
+                unreadable_warned: false,
+            },
+            Err(_) => Tailer {
+                path,
+                offset: 0,
+                mtime: None,
+                unreadable_warned: false,
+            },
+        }
+    }
+
+    /// Poll for new webhook lines. Returns a Vec of parsed webhook events
+    /// (JSON Values with source="webhook"). Non-webhook lines and malformed
+    /// JSON are silently skipped.
+    ///
+    /// Advances the internal offset only past the last complete newline;
+    /// any trailing partial bytes are NOT consumed and will be retried.
+    ///
+    /// If the file is missing, returns an empty Vec silently.
+    /// If the file exists but is unreadable, logs a single warning via
+    /// the crate logger and returns an empty Vec.
+    pub fn poll(&mut self) -> Vec<Value> {
+        let meta = match fs::metadata(&self.path) {
+            Ok(m) => m,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Vec::new();
+            }
+            Err(_) => {
+                if !self.unreadable_warned {
+                    crate::logger::LOG.warn(&format!(
+                        "tailer: cannot read metadata for {}",
+                        self.path.display()
+                    ));
+                    self.unreadable_warned = true;
+                }
+                return Vec::new();
+            }
+        };
+
+        let size = meta.len();
+        let new_mtime = meta.modified().ok();
+
+        // Decide whether to read: size grew OR mtime changed (but only if
+        // we have a prior mtime — avoids spurious read on first cold-start
+        // where mtime=None).
+        let should_read = size > self.offset
+            || (new_mtime != self.mtime && self.mtime.is_some());
+
+        if !should_read {
+            return Vec::new();
+        }
+
+        // Truncation guard: file shrank since last read.
+        if size < self.offset {
+            self.offset = 0;
+        }
+
+        let mut file = match OpenOptions::new().read(true).open(&self.path) {
+            Ok(f) => f,
+            Err(_) => {
+                if !self.unreadable_warned {
+                    crate::logger::LOG.warn(&format!(
+                        "tailer: cannot open {} for reading",
+                        self.path.display()
+                    ));
+                    self.unreadable_warned = true;
+                }
+                return Vec::new();
+            }
+        };
+
+        if file.seek(SeekFrom::Start(self.offset)).is_err() {
+            return Vec::new();
+        }
+
+        let mut bytes = Vec::new();
+        if file.read_to_end(&mut bytes).is_err() {
+            return Vec::new();
+        }
+
+        // Find the last newline — only consume complete lines.
+        let last_nl = match bytes.iter().rposition(|&b| b == b'\n') {
+            Some(pos) => pos,
+            None => {
+                // No complete lines; update mtime but don't advance offset.
+                self.mtime = new_mtime;
+                return Vec::new();
+            }
+        };
+
+        let complete = &bytes[..=last_nl];
+        let mut results = Vec::new();
+
+        for line in complete.split(|&b| b == b'\n') {
+            if line.is_empty() {
+                continue;
+            }
+            if let Ok(v) = serde_json::from_slice::<Value>(line)
+                && v.get("source") == Some(&Value::String("webhook".to_string()))
+            {
+                results.push(v);
+            }
+        }
+
+        self.offset += (last_nl + 1) as u64;
+        self.mtime = new_mtime;
+        self.unreadable_warned = false;
+        results
+    }
+}
+
+#[cfg(test)]
+#[path = "tailer_tests.rs"]
+mod tests;

--- a/crates/orchard/src/webhook/tailer.rs
+++ b/crates/orchard/src/webhook/tailer.rs
@@ -87,8 +87,7 @@ impl Tailer {
         // Decide whether to read: size grew OR mtime changed (but only if
         // we have a prior mtime — avoids spurious read on first cold-start
         // where mtime=None).
-        let should_read = size > self.offset
-            || (new_mtime != self.mtime && self.mtime.is_some());
+        let should_read = size > self.offset || (new_mtime != self.mtime && self.mtime.is_some());
 
         if !should_read {
             return Vec::new();

--- a/crates/orchard/src/webhook/tailer_tests.rs
+++ b/crates/orchard/src/webhook/tailer_tests.rs
@@ -1,0 +1,165 @@
+//! Unit tests for the events.jsonl tailer.
+//!
+//! Covers: cold-start EOF (AC #34), non-webhook/malformed skipping (AC #33),
+//! partial-line advance (AC #30), size-growth trigger (AC #31),
+//! truncation reset (AC #32), missing-file silence (AC #37).
+
+use super::*;
+use std::fs;
+use std::io::Write;
+use tempfile::NamedTempFile;
+
+fn webhook_line(kind: &str) -> String {
+    format!(
+        r#"{{"source":"webhook","kind":"{}","ts":"2024-01-01T00:00:00Z","data":{{}}}}"#,
+        kind
+    )
+}
+
+fn task_line() -> String {
+    r#"{"ts":"2024-01-01T00:00:00Z","event":"task.created","task":"repo#1"}"#.to_string()
+}
+
+/// AC #34: historical lines present at cold start are NOT replayed.
+#[test]
+fn cold_start_skips_historical_lines() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "{}", webhook_line("push")).unwrap();
+    writeln!(f, "{}", webhook_line("push")).unwrap();
+    writeln!(f, "{}", webhook_line("push")).unwrap();
+    f.flush().unwrap();
+
+    let mut tailer = Tailer::new(f.path().to_path_buf());
+
+    assert!(tailer.poll().is_empty(), "cold start must return empty");
+
+    writeln!(f, "{}", webhook_line("pull_request.opened")).unwrap();
+    f.flush().unwrap();
+
+    let results = tailer.poll();
+    assert_eq!(results.len(), 1, "only the newly appended line");
+}
+
+/// AC #33: task lines and malformed JSON are silently skipped; only webhook
+/// lines are forwarded.
+#[test]
+fn poll_returns_new_webhook_lines_only() {
+    let mut f = NamedTempFile::new().unwrap();
+    let mut tailer = Tailer::new(f.path().to_path_buf());
+
+    writeln!(f, "{}", task_line()).unwrap();
+    writeln!(f, "{{malformed json").unwrap();
+    writeln!(f, "{}", webhook_line("pull_request.opened")).unwrap();
+    f.flush().unwrap();
+
+    let results = tailer.poll();
+    assert_eq!(results.len(), 1, "only the webhook line");
+    assert_eq!(results[0]["kind"].as_str(), Some("pull_request.opened"));
+}
+
+/// AC #30: offset advances only past the last complete newline; trailing
+/// partial bytes are retried on the next poll.
+#[test]
+fn poll_advances_offset_only_past_last_newline() {
+    let mut f = NamedTempFile::new().unwrap();
+    let mut tailer = Tailer::new(f.path().to_path_buf());
+
+    let line1 = webhook_line("push.one");
+    let line2 = webhook_line("push.two");
+    let partial = webhook_line("push.partial");
+    // Write two complete lines and one partial (no trailing newline).
+    write!(f, "{}\n{}\n{}", line1, line2, &partial[..partial.len() - 1]).unwrap();
+    f.flush().unwrap();
+
+    let results = tailer.poll();
+    assert_eq!(results.len(), 2, "only complete lines returned");
+
+    // Complete the partial line.
+    let suffix = &partial[partial.len() - 1..];
+    writeln!(f, "{}", suffix).unwrap();
+    f.flush().unwrap();
+
+    let results2 = tailer.poll();
+    assert_eq!(results2.len(), 1, "the completed partial line");
+}
+
+/// AC #31: a read is triggered whenever size > stored offset, regardless of
+/// whether mtime changed (mtime resolution is 1s on macOS/NFS).
+#[test]
+fn poll_reads_when_size_grows_even_if_mtime_unchanged() {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "{}", task_line()).unwrap();
+    f.flush().unwrap();
+
+    // Create tailer at current EOF.
+    let mut tailer = Tailer::new(f.path().to_path_buf());
+
+    // Append a webhook line — size is now > offset.
+    writeln!(f, "{}", webhook_line("pull_request.opened")).unwrap();
+    f.flush().unwrap();
+
+    let results = tailer.poll();
+    assert_eq!(results.len(), 1, "new line returned because size > offset");
+}
+
+/// AC #32: when the file is shorter than the stored offset (truncation),
+/// the offset resets to 0 and the new content is read from the start.
+#[test]
+fn truncation_resets_offset_to_zero() {
+    let mut f = NamedTempFile::new().unwrap();
+    for _ in 0..3 {
+        writeln!(f, "{}", task_line()).unwrap();
+    }
+    f.flush().unwrap();
+
+    let mut tailer = Tailer::new(f.path().to_path_buf());
+    assert!(tailer.offset > 20, "offset should be large after cold start");
+
+    // Truncate and write fresh content.
+    let path = f.path().to_path_buf();
+    let mut fresh = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&path)
+        .unwrap();
+    writeln!(fresh, "{}", webhook_line("pull_request.opened")).unwrap();
+    fresh.flush().unwrap();
+
+    let results = tailer.poll();
+    assert_eq!(results.len(), 1, "new line after truncation");
+    assert!(tailer.offset <= 200, "offset reset and advanced past new content");
+}
+
+/// AC #37: polling a path that never existed returns empty silently (no panic,
+/// no warning logged for missing file).
+#[test]
+fn missing_file_is_silent() {
+    let path = std::env::temp_dir().join("orchard_tailer_test_missing_file.jsonl");
+    let _ = fs::remove_file(&path);
+
+    let mut tailer = Tailer::new(path);
+    assert!(tailer.poll().is_empty(), "first poll: empty");
+    assert!(tailer.poll().is_empty(), "second poll: empty");
+    assert!(tailer.poll().is_empty(), "third poll: empty");
+}
+
+/// AC #33 (continued): malformed JSON does not stall the offset; subsequent
+/// valid lines are still returned.
+#[test]
+fn poll_skips_malformed_json_without_losing_progress() {
+    let mut f = NamedTempFile::new().unwrap();
+    let mut tailer = Tailer::new(f.path().to_path_buf());
+
+    write!(
+        f,
+        "{{malformed}}\n{}\n",
+        webhook_line("pull_request.opened")
+    )
+    .unwrap();
+    f.flush().unwrap();
+
+    let results = tailer.poll();
+    assert_eq!(results.len(), 1, "only the valid webhook line");
+
+    assert!(tailer.poll().is_empty(), "no leftover lines");
+}

--- a/crates/orchard/src/webhook/tailer_tests.rs
+++ b/crates/orchard/src/webhook/tailer_tests.rs
@@ -113,7 +113,10 @@ fn truncation_resets_offset_to_zero() {
     f.flush().unwrap();
 
     let mut tailer = Tailer::new(f.path().to_path_buf());
-    assert!(tailer.offset > 20, "offset should be large after cold start");
+    assert!(
+        tailer.offset > 20,
+        "offset should be large after cold start"
+    );
 
     // Truncate and write fresh content.
     let path = f.path().to_path_buf();
@@ -127,7 +130,10 @@ fn truncation_resets_offset_to_zero() {
 
     let results = tailer.poll();
     assert_eq!(results.len(), 1, "new line after truncation");
-    assert!(tailer.offset <= 200, "offset reset and advanced past new content");
+    assert!(
+        tailer.offset <= 200,
+        "offset reset and advanced past new content"
+    );
 }
 
 /// AC #37: polling a path that never existed returns empty silently (no panic,

--- a/crates/orchard/tests/webhook_integration.rs
+++ b/crates/orchard/tests/webhook_integration.rs
@@ -1,0 +1,353 @@
+//! Integration tests for `orchard webhook-serve`.
+//!
+//! Each test spawns the release binary with `--port 0` to get an ephemeral
+//! port, exercises the HTTP API, and inspects events.jsonl in a temp directory.
+
+use assert_cmd::cargo::cargo_bin;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+use tempfile::TempDir;
+
+type HmacSha256 = Hmac<Sha256>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Spawns `orchard webhook-serve --port 0` with a temp HOME and given secret.
+/// Returns `(child, bound_port, temp_dir)`.
+fn spawn_server(secret: &str) -> (Child, u16, TempDir) {
+    let temp = TempDir::new().unwrap();
+    let bin = cargo_bin("orchard");
+
+    let mut child = Command::new(bin)
+        .args(["webhook-serve", "--port", "0"])
+        .env("HOME", temp.path())
+        .env("ORCHARD_WEBHOOK_SECRET", secret)
+        // Redirect stderr so we can read the startup line.
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null())
+        .spawn()
+        .expect("failed to spawn orchard webhook-serve");
+
+    // Read the startup line from stderr to discover the bound port.
+    let port = read_bound_port(child.stderr.as_mut().unwrap());
+
+    (child, port, temp)
+}
+
+/// Reads bytes from `stderr` line by line until we find the "listening on"
+/// startup line, then returns the port number embedded in it.
+///
+/// After finding the port, the function returns immediately without consuming
+/// more bytes — the remaining stderr output is left for the OS to buffer.
+fn read_bound_port(stderr: &mut impl Read) -> u16 {
+    let reader = BufReader::new(stderr);
+    for line in reader.lines() {
+        match line {
+            Ok(l) if l.contains("listening on") => {
+                // Line format: "orchard webhook-serve: listening on http://127.0.0.1:<port>/webhook ..."
+                if let Some(port_str) = l
+                    .split("http://127.0.0.1:")
+                    .nth(1)
+                    .and_then(|s| s.split('/').next())
+                    && let Ok(p) = port_str.parse::<u16>()
+                {
+                    return p;
+                }
+            }
+            Ok(_) => continue,
+            Err(_) => break,
+        }
+    }
+    panic!("never read bound port from server stderr");
+}
+
+/// Compute HMAC-SHA256 signature in the `sha256=<hex>` format GitHub uses.
+fn make_sig(body: &[u8], secret: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+    mac.update(body);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}
+
+/// Send a POST to /webhook with a properly signed body and `X-GitHub-Event`.
+/// Returns `(status_code, response_text)`.
+fn post_with_hmac(port: u16, event: &str, body: &[u8], secret: &[u8]) -> (u16, String) {
+    let sig = make_sig(body, secret);
+
+    let request = format!(
+        "POST /webhook HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nX-GitHub-Event: {event}\r\nX-Hub-Signature-256: {sig}\r\nContent-Length: {len}\r\nConnection: close\r\n\r\n",
+        len = body.len()
+    );
+
+    let mut stream = connect_with_retry(port);
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.write_all(body).unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+
+    let status = response
+        .lines()
+        .next()
+        .unwrap()
+        .split(' ')
+        .nth(1)
+        .unwrap()
+        .parse::<u16>()
+        .unwrap();
+    (status, response)
+}
+
+/// Send a GET request to the given path.
+fn get(port: u16, path: &str) -> u16 {
+    let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    let mut stream = connect_with_retry(port);
+    stream.write_all(request.as_bytes()).unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+
+    response
+        .lines()
+        .next()
+        .unwrap()
+        .split(' ')
+        .nth(1)
+        .unwrap()
+        .parse::<u16>()
+        .unwrap()
+}
+
+/// Connect to the server with a short retry loop to handle startup latency.
+fn connect_with_retry(port: u16) -> TcpStream {
+    for _ in 0..20 {
+        if let Ok(stream) = TcpStream::connect(("127.0.0.1", port)) {
+            stream.set_read_timeout(Some(Duration::from_secs(5))).ok();
+            return stream;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    panic!("could not connect to 127.0.0.1:{port} after retries");
+}
+
+/// Read all non-empty lines from `events.jsonl`.
+fn read_events(home: &Path) -> Vec<String> {
+    let path = home
+        .join(".local")
+        .join("state")
+        .join("git-orchard")
+        .join("events.jsonl");
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => contents
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect(),
+        Err(_) => vec![],
+    }
+}
+
+/// Kill the child process cleanly.
+fn kill(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// AC #7: webhook-serve starts, listens, and accepts GET /health.
+#[test]
+fn webhook_serve_starts_on_default_port_and_accepts_post() {
+    let (mut child, port, _tmp) = spawn_server("test-secret");
+
+    let status = get(port, "/health");
+    assert_eq!(status, 200, "GET /health should return 200");
+
+    kill(&mut child);
+}
+
+/// AC #8: --port 0 binds an ephemeral port and the startup line prints it.
+#[test]
+fn port_zero_binds_ephemeral_port_and_prints_it() {
+    let (mut child, port, _tmp) = spawn_server("test-secret");
+
+    assert!(port > 0, "bound port must be non-zero, got {port}");
+
+    // Server must actually accept connections on that port.
+    let status = get(port, "/health");
+    assert_eq!(status, 200);
+
+    kill(&mut child);
+}
+
+/// AC #10: refuses to start when ORCHARD_WEBHOOK_SECRET is missing or empty.
+#[test]
+fn refuses_to_start_without_secret() {
+    let temp = TempDir::new().unwrap();
+    let bin = cargo_bin("orchard");
+
+    let output = Command::new(bin)
+        .args(["webhook-serve", "--port", "0"])
+        .env("HOME", temp.path())
+        .env_remove("ORCHARD_WEBHOOK_SECRET")
+        .output()
+        .expect("failed to run orchard");
+
+    assert!(
+        !output.status.success(),
+        "process must exit non-zero without secret"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ORCHARD_WEBHOOK_SECRET"),
+        "stderr must mention ORCHARD_WEBHOOK_SECRET, got: {stderr}"
+    );
+}
+
+/// AC #11: GET /health returns 200 (integration — proves server wiring works).
+#[test]
+fn get_health_returns_200() {
+    let (mut child, port, _tmp) = spawn_server("test-secret");
+
+    let status = get(port, "/health");
+    assert_eq!(status, 200);
+
+    kill(&mut child);
+}
+
+/// AC #14: invalid signature returns 401 and nothing is written to events.jsonl.
+#[test]
+fn invalid_signature_returns_401() {
+    let (mut child, port, tmp) = spawn_server("supersecret");
+
+    let body = b"{\"action\":\"opened\"}";
+    let bad_sig = "sha256=deadbeef";
+
+    let request = format!(
+        "POST /webhook HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nX-GitHub-Event: pull_request\r\nX-Hub-Signature-256: {bad_sig}\r\nContent-Length: {len}\r\nConnection: close\r\n\r\n",
+        len = body.len()
+    );
+    let mut stream = connect_with_retry(port);
+    stream.write_all(request.as_bytes()).unwrap();
+    stream.write_all(body).unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+
+    let status: u16 = response
+        .lines()
+        .next()
+        .unwrap()
+        .split(' ')
+        .nth(1)
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(status, 401);
+
+    // Give the server a moment to flush, then check no line was written.
+    std::thread::sleep(Duration::from_millis(100));
+    let lines = read_events(tmp.path());
+    assert!(lines.is_empty(), "no line should be written on 401");
+
+    kill(&mut child);
+}
+
+/// AC #15: body larger than 30 MB returns 413.
+///
+/// Sends only the Content-Length header (no actual oversized body) so the
+/// server can reject based on Content-Length alone — this avoids the EPIPE
+/// risk of streaming 30 MB to a server that has already closed its write side.
+#[test]
+fn body_larger_than_30mb_returns_413() {
+    let (mut child, port, _tmp) = spawn_server("supersecret");
+
+    // Claim a body 1 byte over the limit. We won't actually send the body —
+    // the server rejects on Content-Length alone.
+    let claimed_len = 30 * 1024 * 1024 + 1;
+    let fake_sig = format!("sha256={}", "a".repeat(64)); // invalid but doesn't matter — size check is first
+
+    let request = format!(
+        "POST /webhook HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nX-GitHub-Event: pull_request\r\nX-Hub-Signature-256: {fake_sig}\r\nContent-Length: {claimed_len}\r\nConnection: close\r\n\r\n"
+    );
+
+    let mut stream = connect_with_retry(port);
+    stream.write_all(request.as_bytes()).unwrap();
+    // Don't write the body — let the server respond to the Content-Length header.
+    // Shut down the write side so hyper sees EOF on the request body.
+    stream.shutdown(std::net::Shutdown::Write).ok();
+
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+
+    let status: u16 = response
+        .lines()
+        .next()
+        .unwrap()
+        .split(' ')
+        .nth(1)
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert_eq!(status, 413);
+
+    kill(&mut child);
+}
+
+/// AC #25: valid signed webhook appends exactly one JSONL line.
+#[test]
+fn valid_signed_webhook_appends_jsonl_line() {
+    let secret = b"supersecret";
+    let (mut child, port, tmp) = spawn_server("supersecret");
+
+    let body = serde_json::json!({
+        "action": "opened",
+        "number": 42,
+        "pull_request": { "number": 42, "merged": false },
+        "repository": { "full_name": "acme/webapp" },
+        "sender": { "login": "some-actor" }
+    })
+    .to_string()
+    .into_bytes();
+
+    let (status, _) = post_with_hmac(port, "pull_request", &body, secret);
+    assert_eq!(status, 200, "valid webhook must return 200");
+
+    // Give the server a moment to flush.
+    std::thread::sleep(Duration::from_millis(200));
+
+    let lines = read_events(tmp.path());
+    assert_eq!(lines.len(), 1, "expected exactly one line in events.jsonl");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&lines[0]).expect("line must be valid JSON");
+    assert_eq!(parsed["source"], "webhook");
+    assert_eq!(parsed["kind"], "pull_request.opened");
+
+    kill(&mut child);
+}
+
+/// AC #26: unknown X-GitHub-Event returns 204 and writes nothing.
+#[test]
+fn unknown_event_returns_204() {
+    let secret = b"supersecret";
+    let (mut child, port, tmp) = spawn_server("supersecret");
+
+    let body = b"{}";
+    let (status, _) = post_with_hmac(port, "star", body, secret);
+    assert_eq!(status, 204);
+
+    std::thread::sleep(Duration::from_millis(100));
+    let lines = read_events(tmp.path());
+    assert!(
+        lines.is_empty(),
+        "no line should be written for unknown event"
+    );
+
+    kill(&mut child);
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,6 +204,55 @@ time from `pr.state` and `issue.state`.
 6. **Derive display group**: from the joined data (shepherd, needs attention,
    claude working, ready to merge, other).
 
+## Event-Driven Watch (Hybrid Poll + Webhook)
+
+The watch daemon uses a hybrid model: periodic polling as the baseline with
+webhook-triggered refreshes for near-instant reactivity.
+
+### How it works
+
+1. **`orchard webhook-serve`** is a separate process that receives GitHub
+   webhooks via HTTP, validates HMAC-SHA256 signatures, and appends normalized
+   JSONL lines to `~/.local/state/git-orchard/events.jsonl`.
+
+2. **`orchard watch`** (the daemon) tails `events.jsonl` between poll
+   iterations. When new webhook lines appear, the daemon triggers an immediate
+   full refresh — bypassing the 60-second poll interval.
+
+3. Both processes share **only the local `events.jsonl` file**. There is no IPC
+   socket, no shared memory, no coordination protocol. The file is the queue.
+
+### Why file-as-queue over unix-socket IPC
+
+- **Persistence**: events survive daemon restarts. A daemon starting fresh
+  skips historical lines (tail-from-end), but if needed, the full log is there.
+- **Multi-consumer**: multiple processes can tail the same file independently,
+  each tracking their own offset.
+- **Simpler operational model**: `cat`, `tail -f`, `jq` all work. No protocol
+  to debug.
+
+### Two-shape coexistence
+
+`events.jsonl` contains two kinds of lines:
+
+| Shape | Discriminator | Writer |
+|-------|--------------|--------|
+| Webhook events | `"source": "webhook"` + `"kind"` field | `webhook-serve` |
+| Task/session events | `"event"` field (e.g. `"task.created"`) | watch daemon, task logger |
+
+Consumers distinguish webhook lines by the presence of `"source": "webhook"`.
+
+### Tailer behaviour
+
+The tailer tracks its read offset by file size (not mtime — mtime resolution
+is 1 second on macOS/NFS, which would miss sub-second writes). It:
+
+- Starts from end-of-file on cold start (no historical replay)
+- Advances offset only past complete newline-terminated lines
+- Resets to offset 0 when the file shrinks (rotation detected)
+- Skips non-webhook and malformed lines without losing progress
+- Falls back to poll-only when `events.jsonl` is missing or unreadable
+
 ## Caching
 
 Per ADR-001: each source writes its own cache file. Cache files are JSON with

--- a/docs/webhook-setup.md
+++ b/docs/webhook-setup.md
@@ -1,0 +1,139 @@
+# Webhook Setup
+
+Orchard's webhook receiver (`orchard webhook-serve`) accepts GitHub webhook
+deliveries and appends normalized events to `events.jsonl`. The watch daemon
+tails this file to short-circuit the 60-second poll cycle, reacting to GitHub
+activity within 1–2 seconds.
+
+**Important:** `webhook-serve` and `watch` are separate processes that share
+only the local `events.jsonl` file. Both must run on the same host.
+
+## Prerequisites
+
+- `orchard` binary built and on your PATH
+- A GitHub repository you have admin or webhook-management access to
+
+## Environment
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `ORCHARD_WEBHOOK_SECRET` | **Yes** | Shared secret for HMAC-SHA256 signature validation. Must match the secret configured in GitHub. |
+| `ORCHARD_WEBHOOK_PORT` | No | Override the default port (8477). CLI `--port` flag takes precedence. |
+
+The server **refuses to start** if `ORCHARD_WEBHOOK_SECRET` is unset or empty.
+
+## Port resolution
+
+The port is resolved in this order: `--port` flag > `ORCHARD_WEBHOOK_PORT` env
+> `config.watch.webhook_port` > default `8477`.
+
+Use `--port 0` to bind an ephemeral port (printed to stderr on startup).
+
+## Running the server
+
+```bash
+export ORCHARD_WEBHOOK_SECRET="your-secret-here"
+orchard webhook-serve              # binds to 127.0.0.1:8477
+orchard webhook-serve --port 9000  # custom port
+orchard webhook-serve --port 0     # ephemeral port
+```
+
+The server speaks **plain HTTP only**. TLS termination is the operator's
+responsibility (see Production below).
+
+## Local development with smee.io
+
+[smee.io](https://smee.io) forwards GitHub webhooks to your local machine
+through a WebSocket relay — no public IP or port forwarding required.
+
+1. Visit https://smee.io/new to create a channel. Copy the URL.
+2. Install the smee client: `npm install -g smee-client`
+3. Start the relay:
+   ```bash
+   smee --url https://smee.io/YOUR_CHANNEL --target http://127.0.0.1:8477/webhook
+   ```
+4. In your GitHub repo → Settings → Webhooks → Add webhook:
+   - **Payload URL**: your smee.io channel URL
+   - **Content type**: `application/json`
+   - **Secret**: same value as `ORCHARD_WEBHOOK_SECRET`
+   - **Events**: select the events listed below
+
+### Recommended events
+
+- Pull requests
+- Pull request reviews
+- Pull request review comments
+- Issue comments
+- Issues
+- Pushes
+- Check runs
+- Check suites
+- Workflow runs
+
+### Troubleshooting smee
+
+- **Smee disconnects**: the WebSocket connection is long-lived but will drop
+  on network changes or laptop sleep. Restart `smee` after waking.
+- **Signature mismatch (401)**: verify the secret in GitHub matches
+  `ORCHARD_WEBHOOK_SECRET` exactly (no trailing whitespace). The server
+  validates HMAC-SHA256 over the raw request bytes before any JSON parsing.
+- **No events appearing**: check GitHub's webhook delivery log (Settings →
+  Webhooks → Recent Deliveries) for HTTP status codes. A 204 means the event
+  type is intentionally ignored (e.g., `ping`, `star`, `fork`).
+
+## Production setup
+
+For a production deployment, place the webhook server behind a TLS-terminating
+reverse proxy (nginx, Caddy, etc.) with a public hostname.
+
+1. Start the server on a local port:
+   ```bash
+   orchard webhook-serve --port 8477
+   ```
+2. Configure your reverse proxy to forward `POST /webhook` to
+   `http://127.0.0.1:8477/webhook`.
+3. In GitHub, set the Payload URL to your public endpoint
+   (e.g., `https://hooks.example.com/webhook`).
+
+### Example nginx config
+
+```nginx
+location /webhook {
+    proxy_pass http://127.0.0.1:8477;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+```
+
+## How it works
+
+1. GitHub POSTs a signed JSON payload to `/webhook`.
+2. The server validates the HMAC-SHA256 signature against the raw body bytes.
+3. The payload is normalized into a compact JSONL line with fields: `ts`,
+   `source` ("webhook"), `kind`, `repo`, `pr`, `issue`, `actor`, `data`.
+4. The line is appended to `~/.local/state/git-orchard/events.jsonl`.
+5. The watch daemon's tailer detects the new line and triggers a refresh.
+
+Unsupported event types (e.g., `ping`, `star`) return 204 and write nothing.
+Bodies larger than 30 MB are rejected with 413 before being fully read.
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/webhook` | Receives GitHub webhook payloads (requires signature) |
+| GET | `/health` | Liveness probe — returns 200, no signature required |
+
+## Setting ORCHARD_WEBHOOK_SECRET
+
+Generate a strong secret:
+
+```bash
+openssl rand -hex 32
+```
+
+Add it to your shell profile or a `.env` file sourced before running:
+
+```bash
+export ORCHARD_WEBHOOK_SECRET="$(cat ~/.config/orchard/webhook-secret)"
+```

--- a/specs/features/webhook-event-stream.feature
+++ b/specs/features/webhook-event-stream.feature
@@ -1,0 +1,410 @@
+Feature: GitHub webhook receiver and event stream
+  As an orchard operator running the watch daemon
+  I want orchard to receive GitHub webhooks and append them to the event log
+  So that the watch daemon reacts to GitHub activity within 1-2 seconds instead of waiting on the 60s poll cycle
+
+  Background:
+    Given the event log path is "~/.local/state/git-orchard/events.jsonl"
+    And the default webhook port is 8477
+    And the webhook secret is read only from the environment variable "ORCHARD_WEBHOOK_SECRET" (no flag, no config file)
+    And "orchard webhook-serve" and "orchard watch" are separate processes that share only the local events.jsonl file
+    And the design is local-only: both processes must run on the same host because events.jsonl is not synchronized
+
+  # ===================================================================
+  # Subcommand wiring — orchard webhook-serve
+  # ===================================================================
+
+  @integration
+  Scenario: webhook-serve starts and listens on the default port
+    Given ORCHARD_WEBHOOK_SECRET is set to "test-secret"
+    When the user runs "orchard webhook-serve"
+    Then an HTTP server listens on port 8477
+    And the server accepts POST requests at "/webhook"
+    And a startup message prints the bound port and events.jsonl path to stderr
+
+  @integration
+  Scenario: --port 0 binds an ephemeral port and prints the chosen port
+    Given ORCHARD_WEBHOOK_SECRET is set to "test-secret"
+    When the user runs "orchard webhook-serve --port 0"
+    Then the startup message prints a non-zero port discovered at runtime
+    And the server accepts POST requests on that port
+
+  @unit
+  Scenario Outline: port resolution precedence is flag > env > config > default
+    Given the candidate inputs <flag>, <env>, <config>
+    When port resolution runs
+    Then the resolved port is <resolved>
+
+    Examples:
+      | flag | env  | config | resolved |
+      | 9000 | 9001 | 9002   | 9000     |
+      | none | 9001 | 9002   | 9001     |
+      | none | none | 9002   | 9002     |
+      | none | none | none   | 8477     |
+
+  @integration
+  Scenario: webhook-serve refuses to start when ORCHARD_WEBHOOK_SECRET is missing or empty
+    Given ORCHARD_WEBHOOK_SECRET is unset or empty
+    When the user runs "orchard webhook-serve"
+    Then the process exits with a non-zero status
+    And stderr contains a message directing the user to set ORCHARD_WEBHOOK_SECRET
+
+  @integration
+  Scenario: GET /health returns 200 for a trivial liveness probe
+    Given ORCHARD_WEBHOOK_SECRET is set to "test-secret"
+    And the webhook server is running
+    When a GET request arrives at "/health"
+    Then the response status is 200
+    And the health response does not require a signature
+
+  # ===================================================================
+  # HMAC-SHA256 signature validation
+  #
+  # The server verifies HMAC over the RAW request bytes before any JSON
+  # parsing. This is the single most failure-prone part of GitHub webhook
+  # receivers and these scenarios guard the byte-identical path.
+  # ===================================================================
+
+  @unit
+  Scenario Outline: HMAC verification accepts and rejects the expected cases
+    Given the webhook secret is "supersecret"
+    And the raw body bytes are <body>
+    And the signature header is <header>
+    When verification runs
+    Then the result is <result>
+
+    Examples:
+      | body                       | header                      | result |
+      | "hello world"              | correct sha256=<hmac>       | accept |
+      | "hello world"              | sha256=deadbeef             | reject |
+      | "hello world"              | hmac computed with "wrong"  | reject |
+      | "hello world"              | header missing sha256= prefix | reject |
+      | ""                         | correct sha256=<hmac of ""> | accept |
+
+  @unit
+  Scenario: HMAC verification succeeds for a payload containing non-ASCII bytes
+    Given the webhook secret is "supersecret"
+    And a payload whose actor login is "café-bot" (multi-byte UTF-8)
+    And the signature header was computed over the exact raw bytes of the payload
+    When verification runs against the raw bytes
+    Then verification succeeds
+    # Why this matters: this is the canonical regression for "HMAC computed
+    # over reparsed JSON" bugs. Any implementation that deserializes the body
+    # before verifying will fail this scenario because reserialization drops
+    # key ordering and whitespace.
+
+  @integration
+  Scenario: Invalid or missing signature returns HTTP 401 and nothing is written
+    Given ORCHARD_WEBHOOK_SECRET is set to "supersecret"
+    And the webhook server is running
+    When a POST to "/webhook" arrives with an invalid or missing X-Hub-Signature-256
+    Then the response status is 401
+    And no line is appended to events.jsonl
+
+  # ===================================================================
+  # Body size cap — DoS protection
+  # ===================================================================
+
+  @integration
+  Scenario: Request bodies larger than 30 MB are rejected with 413
+    Given ORCHARD_WEBHOOK_SECRET is set to "supersecret"
+    And the webhook server is running
+    When a POST to "/webhook" arrives with a body larger than 30 MB
+    Then the response status is 413
+    And the server does not allocate the full body into memory before rejecting
+    And no line is appended to events.jsonl
+
+  # ===================================================================
+  # Event normalization
+  # ===================================================================
+
+  @unit
+  Scenario: Normalized line contains source, kind, repo, pr, actor, ts, data
+    Given a valid pull_request payload with action "opened" for repo "acme/webapp" PR 42 by user "octocat"
+    When the payload is normalized
+    Then the resulting JSON line contains:
+      | field  | value                 |
+      | source | "webhook"             |
+      | kind   | "pull_request.opened" |
+      | repo   | "acme/webapp"         |
+      | pr     | 42                    |
+      | actor  | "octocat"             |
+    And "ts" is a valid ISO 8601 UTC timestamp
+    And "data" is the full raw GitHub payload passed through verbatim
+
+  @unit
+  Scenario Outline: pull_request actions map to pull_request.<action> kinds
+    Given a valid pull_request payload with action "<action>" and merged <merged>
+    When the payload is normalized
+    Then the "kind" field is "<expected_kind>"
+
+    # Note: action "opened" is covered by the full-fields scenario above;
+    # this outline only enumerates the remaining actions.
+    Examples:
+      | action              | merged | expected_kind                    |
+      | closed              | false  | pull_request.closed              |
+      | closed              | true   | pull_request.merged              |
+      | reopened            | false  | pull_request.reopened            |
+      | ready_for_review    | false  | pull_request.ready_for_review    |
+      | converted_to_draft  | false  | pull_request.converted_to_draft  |
+
+  @unit
+  Scenario: pull_request_review submitted maps to pull_request.review.submitted
+    Given a valid pull_request_review payload with action "submitted" for PR 99
+    When the payload is normalized
+    Then "kind" is "pull_request.review.submitted"
+    And "pr" is 99
+
+  @unit
+  Scenario: pull_request_review_comment created maps to pull_request.review_comment.created
+    Given a valid pull_request_review_comment payload for PR 3099 by "coderabbitai[bot]"
+    When the payload is normalized
+    Then "kind" is "pull_request.review_comment.created"
+    And "pr" is 3099
+    And "actor" is "coderabbitai[bot]"
+
+  @unit
+  Scenario Outline: issue_comment populates pr when the issue is a PR
+    Given an issue_comment payload with action "created" on issue <number> where is_pr is <is_pr>
+    When the payload is normalized
+    Then "kind" is "issue_comment.created"
+    And "issue" is <number>
+    And "pr" is <pr_field>
+
+    Examples:
+      | number | is_pr | pr_field |
+      | 42     | true  | 42       |
+      | 77     | false | absent   |
+
+  @unit
+  Scenario Outline: issues actions map to issues.<action> kinds
+    Given an issues payload with action "<action>" on issue 77
+    When the payload is normalized
+    Then "kind" is "issues.<action>"
+    And "issue" is 77
+
+    Examples:
+      | action    |
+      | opened    |
+      | closed    |
+      | labeled   |
+      | unlabeled |
+
+  @unit
+  Scenario: push event carries ref and commit count
+    Given a push payload on ref "refs/heads/main" for "acme/webapp" with 3 commits
+    When the payload is normalized
+    Then "kind" is "push"
+    And "repo" is "acme/webapp"
+    And "data.ref" is "refs/heads/main"
+    And "data.commits" has length 3
+
+  @unit
+  Scenario Outline: check_run, check_suite, and workflow_run completions carry the conclusion
+    Given a <event> payload with action "completed" and conclusion "<conclusion>"
+    When the payload is normalized
+    Then "kind" is "<event>.completed"
+    And "data.conclusion" is "<conclusion>"
+
+    Examples:
+      | event        | conclusion |
+      | check_run    | failure    |
+      | check_suite  | success    |
+      | workflow_run | success    |
+
+  @unit
+  Scenario Outline: Unsupported actions on a known event type are normalized as unsupported
+    Given a <event> payload with action "<action>"
+    When the payload is normalized
+    Then normalization returns "unsupported"
+    And no line is written to events.jsonl
+
+    Examples:
+      | event        | action     |
+      | pull_request | assigned   |
+      | check_run    | created    |
+      | check_suite  | requested  |
+      | workflow_run | requested  |
+
+  @integration
+  Scenario: A valid signed webhook appends exactly one line to events.jsonl
+    Given ORCHARD_WEBHOOK_SECRET is set to "supersecret"
+    And the webhook server is running
+    When a POST to "/webhook" arrives with a valid signature and X-GitHub-Event "pull_request"
+    And the JSON body is a pull_request payload with action "opened" for "acme/webapp" PR 42
+    Then the response status is 2xx
+    And exactly one new line is appended to events.jsonl
+    And the line parses as JSON containing source "webhook" and kind "pull_request.opened"
+
+  # ===================================================================
+  # Unknown and unsupported events
+  # ===================================================================
+
+  @integration
+  Scenario Outline: Unknown or ignored X-GitHub-Event types return 204 and write nothing
+    Given ORCHARD_WEBHOOK_SECRET is set to "supersecret"
+    And the webhook server is running
+    When a POST with a valid signature and X-GitHub-Event "<event>" arrives
+    Then the response status is 204
+    And no line is appended to events.jsonl
+    And no error is logged
+
+    Examples:
+      | event |
+      | ping  |
+      | star  |
+      | fork  |
+
+  # ===================================================================
+  # Co-existence with existing events.jsonl writers (task/session events)
+  # ===================================================================
+
+  @integration
+  Scenario: Webhook line uses source/kind while task line uses event, both in the same events.jsonl
+    Given an empty events.jsonl
+    When a webhook event and a task.created event are appended in sequence
+    Then the webhook line has "source" equal to "webhook" and a "kind" field
+    And the task line has "event" equal to "task.created" and no "source" field
+    And both lines parse as valid JSON objects on separate lines
+
+  @integration
+  Scenario: Interleaved writes from webhook-serve and task logger produce one line per write
+    Given ORCHARD_WEBHOOK_SECRET is set to "supersecret"
+    And the webhook server is running
+    When 20 webhook POSTs and 20 task.created log calls are interleaved
+    Then events.jsonl contains exactly 40 additional lines
+    And every line parses as valid JSON on a single line
+    And no line is truncated or merged with another
+
+  @integration
+  Scenario: Webhook appends trigger the existing 50 MB rotation
+    Given events.jsonl is already 50 MB or larger
+    And ORCHARD_WEBHOOK_SECRET is set to "supersecret"
+    And the webhook server is running
+    When a valid signed webhook is received
+    Then events.jsonl is rotated to events.jsonl.1
+    And the new events.jsonl contains the freshly appended webhook line
+
+  # ===================================================================
+  # Watch daemon — events.jsonl tailer integration
+  #
+  # The tailer is inside the existing sync daemon. It must be correct
+  # under these adversarial conditions: sub-second writes, rotation,
+  # partial lines, daemon restart, and file missing.
+  # ===================================================================
+
+  @unit
+  Scenario: Tailer advances offset only past the last complete newline
+    Given events.jsonl contains "line1\nline2\npartial" with no trailing newline
+    When the tailer reads from offset 0
+    Then "line1" and "line2" are emitted
+    And the stored offset is at the byte just after the second "\n"
+    And "partial" is NOT emitted
+    And on the next read with "partial" now completed by "\n", "partial" is emitted
+
+  @unit
+  Scenario: Tailer triggers a read whenever the file size exceeds the stored offset, regardless of mtime
+    Given the tailer stored offset 500 and mtime T
+    And events.jsonl is now 800 bytes with mtime still T
+    When the tailer runs
+    Then bytes 500..800 are read
+    And the stored offset is 800
+    # Reason: mtime resolution is 1 second on macOS/NFS; a write within
+    # the same second would be missed if mtime-equality were a short-circuit.
+
+  @unit
+  Scenario: Tailer resets to offset 0 when the file is shorter than the stored offset
+    Given the tailer stored offset 1000
+    When the tailer sees events.jsonl at 200 bytes
+    Then the stored offset is reset to 0 and a read starts from 0
+
+  @unit
+  Scenario: Tailer ignores non-webhook lines and malformed JSON without losing progress
+    Given events.jsonl contains a task.created line, a malformed JSON line, and a webhook line
+    When the tailer reads all three
+    Then only the webhook line is forwarded to the refresh trigger
+    And the task and malformed lines are skipped silently
+    And the offset advances past all three
+
+  @unit
+  Scenario: Tailer starts from end-of-file on a cold start
+    Given the watch daemon is starting
+    And events.jsonl already contains 100 historical lines
+    When the tailer initializes
+    Then the stored offset is set to the current file size
+    And the 100 historical lines are NOT replayed
+    # Reason: events.jsonl is an append-only log of realtime activity;
+    # a daemon starting fresh wants the current state of the world,
+    # not a replay of history.
+
+  @integration
+  Scenario: A webhook line triggers a daemon refresh within 2 seconds
+    Given the watch daemon is running with local_poll_secs 10 and full_poll_secs 60
+    And the tailer is active
+    When a webhook-source line is appended to events.jsonl
+    Then within 2 seconds the daemon performs a refresh
+    And the refresh happens regardless of the poll interval
+
+  @integration
+  Scenario: Multiple webhook lines between iterations debounce to one refresh
+    Given the watch daemon is running
+    When 5 webhook lines are appended to events.jsonl between two loop iterations
+    Then the daemon performs exactly one refresh for the batch
+    And the offset advances past all 5 lines
+
+  @integration
+  Scenario: Watch daemon falls back to poll-only when events.jsonl is missing or unreadable
+    Given the watch daemon is running
+    And events.jsonl does not exist OR exists but is unreadable
+    When the daemon loop iterates repeatedly
+    Then the daemon continues polling on its configured intervals
+    And the daemon does not crash
+    And if the file is unreadable, a single warning is logged; if it has never existed the daemon stays silent
+
+  # ===================================================================
+  # End-to-end — hermetic integration test
+  # ===================================================================
+
+  @e2e
+  Scenario: Hermetic test spawns webhook-serve, POSTs a signed payload, sees JSONL append
+    Given ORCHARD_WEBHOOK_SECRET is set in the test environment
+    When the test spawns "orchard webhook-serve --port 0"
+    And the test discovers the bound port from the server's startup output
+    And the test POSTs a signed pull_request "opened" payload
+    Then the response is 2xx
+    And a new line appears in the test events.jsonl within 1 second
+    And the line parses as JSON with source "webhook" and kind "pull_request.opened"
+
+  @e2e
+  Scenario: Full loop — webhook-serve + watch daemon + tailer + subscriber
+    Given ORCHARD_WEBHOOK_SECRET is set
+    And "orchard webhook-serve" is running on a random port
+    And "orchard watch" is running in event-tailing mode
+    And a tmux subscriber is registered
+    When GitHub POSTs a signed pull_request_review_comment webhook
+    Then the webhook is written to events.jsonl
+    And the watch daemon triggers a refresh within 2 seconds
+    And the subscriber receives a watch event
+
+  # ===================================================================
+  # Documentation
+  # ===================================================================
+
+  @unit
+  Scenario: docs/webhook-setup.md documents dev and prod setup
+    Then the file "docs/webhook-setup.md" exists
+    And it describes configuring a GitHub webhook (payload URL, content type, secret, events)
+    And it describes local dev setup via smee.io
+    And it describes production setup via a public endpoint behind a TLS reverse proxy
+    And it states the server speaks plain HTTP only (TLS is the operator's responsibility)
+    And it explains how to set ORCHARD_WEBHOOK_SECRET
+    And it documents that webhook-serve and watch must run on the same host (local events.jsonl)
+    And it includes a troubleshooting section covering signature mismatches, smee disconnects, and laptop sleep
+
+  @unit
+  Scenario: docs/architecture.md describes the hybrid poll + webhook watch model
+    Then "docs/architecture.md" contains a section describing the event-driven watch hybrid
+    And it explains webhook-serve writes normalized JSONL to events.jsonl
+    And it explains the watch daemon tails events.jsonl to short-circuit the 60s poll cycle
+    And it documents the rationale for file-as-queue over unix-socket IPC (persistence across daemon restarts, multi-consumer tailing, simpler operational model)
+    And it documents the two-shape coexistence rule: consumers distinguish webhook lines by presence of "source" = "webhook"


### PR DESCRIPTION
## Summary

Foundational implementation of a GitHub webhook receiver for orchard, part of #215 and parent #214.

A new `orchard webhook-serve` subcommand runs an HTTP server that validates HMAC-SHA256 signed GitHub webhooks and appends normalized events to `~/.local/state/git-orchard/events.jsonl`. The existing watch daemon is extended with a tailer that reads events.jsonl each loop iteration and triggers immediate refreshes — reducing the feedback loop from up to 60s (polling) to 1-2s (webhook delivery).

**This PR is a draft and ships progressively.** See the task list and spec for the full acceptance surface.

## What's landed so far

- **Spec** — `specs/features/webhook-event-stream.feature` (28 scenarios; challenged and pyramid-reviewed before implementation)
- **Pass 1 — pure-function foundation** (AC #9, #12, #13, #16–#24)
  - `webhook::port::resolve_port` — precedence flag > env > config > 8477 default
  - `webhook::signature::verify_signature` — HMAC-SHA256 over raw bytes, constant-time compare via `hmac::Mac::verify_slice`
  - `webhook::normalize::normalize` — GitHub event → `NormalizedEvent { source, kind, repo, pr, issue, actor, ts, data }`
  - 33 unit tests, 1 doc test

## What's still to come

- **Pass 2** — `events::log_webhook_event` helper, `webhook::handler` (size cap + sig + normalize + append), `webhook::server` (hyper /webhook + /health), `handle_webhook_serve` CLI subcommand
- **Pass 3** — `webhook::tailer` (offset tracking, partial-line safety, graceful fallback) wired into `watch::daemon`
- **Pass 4** — Hermetic + full-loop e2e tests, `docs/webhook-setup.md`, `docs/architecture.md` hybrid-watch section

## Critical design decisions

1. **`hyper` directly, not `axum`** — hyper is already a transitive dep; axum would add 30-50 crates
2. **Coexistence, not migration** — webhook events use `{source:"webhook", kind, ...}`; existing task events keep `{event, ...}`; consumers switch on `source` presence
3. **Tailer rule: `size > offset OR mtime changed`** — mtime-only would drop sub-second webhook writes under 1s mtime resolution (macOS/NFS)
4. **Raw-body HMAC** — verify over exact request bytes before any JSON parsing; regression-tested against non-ASCII UTF-8 payload
5. **30 MB body cap → 413** — streaming rejection, not post-accumulation
6. **Cold-start tailer offset = EOF** — no historical replay
7. **Partial-line buffering** — offset advances only past the last complete newline
8. **Separate processes, local-only** — webhook-serve + watch run on the same host, share events.jsonl
9. **`ORCHARD_WEBHOOK_SECRET` env var only** — no flag, no config file

## Test plan

- [x] `cargo test --package orchard` — full suite green, 33 new webhook tests pass
- [x] `cargo build --release` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] All 35 AC task items completed (12/35 done so far — see task list)
- [ ] `/review` parallel reviewers (principles, hygiene, test, security)
- [ ] `/prove-it` maps every AC to evidence
- [ ] Docs for smee.io dev + TLS reverse-proxy prod
- [ ] Dogfooding: orchardist monitor consumes event stream for langwatch/langwatch and drewdrewthis/git-orchard-rs

Refs #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #215

# Related issue

- #215

# Related issue

- #215

# Related issue

- #215

# Related issue

- #215