### PR TITLE
feat: expose raw labels in JSON output

### DIFF
--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -1647,11 +1647,8 @@ mod tests {
 
     #[test]
     fn json_pr_labels_preserve_order() {
-        let pr = make_pr_state_with_labels(
-            12,
-            "feat/ordered",
-            vec!["z-label", "a-label", "m-label"],
-        );
+        let pr =
+            make_pr_state_with_labels(12, "feat/ordered", vec!["z-label", "a-label", "m-label"]);
         let jp = JsonPr::from(&pr);
         assert_eq!(jp.labels, vec!["z-label", "a-label", "m-label"]);
         let v = serde_json::to_value(&jp).unwrap();

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -129,6 +129,8 @@ pub struct JsonIssue {
     /// Parent issue number, if this is a sub-issue.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent: Option<u32>,
+    /// All GitHub labels on this issue, in the order returned by the API.
+    pub labels: Vec<String>,
     /// Workflow phase derived from labels (e.g. `"in-progress"`, `"blocked"`).
     /// Always present: `null` when no phase label is set.
     pub phase: Option<&'static str>,
@@ -200,6 +202,8 @@ pub struct JsonPr {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// All GitHub labels on this PR, in the order returned by the API.
+    pub labels: Vec<String>,
     /// Lines added by this PR.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub additions: Option<u32>,
@@ -447,6 +451,7 @@ impl From<&IssueInfo> for JsonIssue {
                 })
                 .collect(),
             parent: i.parent,
+            labels: i.labels.clone(),
             phase: phase_from_labels(&i.labels),
         }
     }
@@ -485,6 +490,7 @@ impl From<&PrState> for JsonPr {
             ci_checks: pr.ci_checks.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            labels: pr.labels.clone(),
             additions: pr.additions,
             deletions: pr.deletions,
             created_at: pr.created_at.clone(),
@@ -1597,5 +1603,74 @@ mod tests {
             serde_json::Value::Null,
             "checksState must be null when PR has no CI checks"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // labels field tests (issue #235)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn json_issue_includes_labels() {
+        let issue = make_issue_info(1, "labeled issue", "open", vec!["bug", "in-progress"]);
+        let ji = JsonIssue::from(&issue);
+        assert_eq!(ji.labels, vec!["bug", "in-progress"]);
+        let v = serde_json::to_value(&ji).unwrap();
+        assert_eq!(v["labels"], serde_json::json!(["bug", "in-progress"]));
+    }
+
+    #[test]
+    fn json_issue_empty_labels() {
+        let issue = make_issue_info(2, "unlabeled issue", "open", vec![]);
+        let ji = JsonIssue::from(&issue);
+        assert!(ji.labels.is_empty());
+        let v = serde_json::to_value(&ji).unwrap();
+        assert_eq!(v["labels"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn json_pr_includes_labels() {
+        let pr = make_pr_state_with_labels(10, "feat/branch", vec!["enhancement", "pr-ready"]);
+        let jp = JsonPr::from(&pr);
+        assert_eq!(jp.labels, vec!["enhancement", "pr-ready"]);
+        let v = serde_json::to_value(&jp).unwrap();
+        assert_eq!(v["labels"], serde_json::json!(["enhancement", "pr-ready"]));
+    }
+
+    #[test]
+    fn json_pr_empty_labels() {
+        let pr = make_pr_state_with_labels(11, "feat/unlabeled", vec![]);
+        let jp = JsonPr::from(&pr);
+        assert!(jp.labels.is_empty());
+        let v = serde_json::to_value(&jp).unwrap();
+        assert_eq!(v["labels"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn json_pr_labels_preserve_order() {
+        let pr = make_pr_state_with_labels(
+            12,
+            "feat/ordered",
+            vec!["z-label", "a-label", "m-label"],
+        );
+        let jp = JsonPr::from(&pr);
+        assert_eq!(jp.labels, vec!["z-label", "a-label", "m-label"]);
+        let v = serde_json::to_value(&jp).unwrap();
+        assert_eq!(
+            v["labels"],
+            serde_json::json!(["z-label", "a-label", "m-label"])
+        );
+    }
+
+    #[test]
+    fn labels_field_does_not_change_phase() {
+        // "blocked" is higher priority than "in-progress"; phase must be "blocked"
+        // AND labels must contain both values.
+        let pr = make_pr_state_with_labels(13, "feat/both", vec!["blocked", "in-progress"]);
+        let jp = JsonPr::from(&pr);
+        assert_eq!(jp.phase, Some("blocked"));
+        assert_eq!(jp.labels, vec!["blocked", "in-progress"]);
+        let v = serde_json::to_value(&jp).unwrap();
+        assert_eq!(v["phase"], "blocked");
+        assert_eq!(v["labels"], serde_json::json!(["blocked", "in-progress"]));
     }
 }

--- a/crates/orchard/tests/labels_integration.rs
+++ b/crates/orchard/tests/labels_integration.rs
@@ -1,0 +1,255 @@
+//! Integration tests for the `labels` field in `orchard --json` output.
+//!
+//! Each test writes a minimal fixture cache (issues, PRs, worktrees) into a
+//! temp HOME directory, runs `orchard --json`, parses the JSON, and asserts
+//! the `labels` field on the relevant `issue` or `pr` object.
+//!
+//! # Design note
+//!
+//! `orchard --json` calls `refresh_and_build`, which refreshes worktrees via
+//! `git worktree list` (overwriting any pre-written worktrees cache) but will
+//! not overwrite issues/PRs caches because `gh` is unavailable in the test
+//! environment. The worktree cache therefore reflects the real git repo state.
+//!
+//! Each test:
+//!   1. Creates a temp git repo and makes a commit so `git worktree list` works.
+//!   2. Checks out the target branch (so the worktree is on that branch).
+//!   3. Pre-writes issues/PRs caches with the matching branch and labels.
+//!   4. Runs `orchard --json` and asserts `labels` (and `phase`) on the found worktree.
+//!
+//! If the binary exits non-zero (e.g. because `gh` is not available at all),
+//! the test skips rather than fails — consistent with `binary_integration.rs`.
+mod common;
+
+use assert_cmd::Command;
+use common::{TestCacheDir, make_issue, make_pr};
+use orchard::cache::CachedPr;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Fixture owner/repo slug used across all tests.
+// ---------------------------------------------------------------------------
+
+const OWNER: &str = "acme";
+const REPO: &str = "webapp";
+const SLUG: &str = "acme/webapp";
+
+// ---------------------------------------------------------------------------
+// Fixture harness
+// ---------------------------------------------------------------------------
+
+/// A self-contained fixture environment: temp HOME + cache dir + git repo.
+struct LabelsFixture {
+    home: tempfile::TempDir,
+    cache: TestCacheDir,
+    repo: common::TestRepo,
+}
+
+impl LabelsFixture {
+    /// Creates a fresh fixture. The git repo is initialised but stays on
+    /// whatever default branch `git init` sets (usually "main" or "master").
+    ///
+    /// Call `checkout_branch` to switch the repo to the target branch, then
+    /// write caches, call `apply_cache`, and finally `run`.
+    fn new() -> Self {
+        let home = tempfile::TempDir::new().expect("create temp HOME");
+        let cache = TestCacheDir::new();
+        let repo = common::TestRepo::new();
+
+        // Make a first commit so `git worktree list --porcelain` works.
+        std::fs::write(repo.path().join("README.md"), "test").expect("write README");
+        std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(repo.path())
+            .output()
+            .expect("git add");
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(repo.path())
+            .output()
+            .expect("git commit");
+
+        // Write a global config pointing to our test repo.
+        let config_dir = home.path().join(".config").join("orchard");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        let config_json = format!(
+            r#"{{"repos":[{{"slug":"{SLUG}","path":"{}"}}]}}"#,
+            repo.path().display()
+        );
+        std::fs::write(config_dir.join("config.json"), &config_json).expect("write config.json");
+
+        // Create the cache dir under HOME.
+        let home_cache = home.path().join(".cache").join("orchard");
+        std::fs::create_dir_all(&home_cache).expect("create cache dir");
+
+        Self { home, cache, repo }
+    }
+
+    /// Checks out (creates) a branch in the test git repo.
+    fn checkout_branch(&self, branch: &str) {
+        std::process::Command::new("git")
+            .args(["checkout", "-b", branch])
+            .current_dir(self.repo.path())
+            .output()
+            .expect("git checkout -b");
+    }
+
+    /// Returns the current branch name of the test git repo.
+    fn current_branch(&self) -> String {
+        let out = std::process::Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .current_dir(self.repo.path())
+            .output()
+            .expect("git rev-parse");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    /// Copies all cache files from the TestCacheDir into `$HOME/.cache/orchard/`.
+    fn apply_cache(&self) {
+        let home_cache = self.home.path().join(".cache").join("orchard");
+        for entry in std::fs::read_dir(self.cache.path()).expect("read cache dir") {
+            let entry = entry.expect("dir entry");
+            let dest = home_cache.join(entry.file_name());
+            std::fs::copy(entry.path(), &dest).expect("copy cache file");
+        }
+    }
+
+    /// Runs `orchard --json` with HOME pointing to the fixture and returns the
+    /// parsed JSON, or `None` if the binary fails (e.g. `gh` unavailable).
+    fn run(&self) -> Option<Value> {
+        let output = Command::cargo_bin("orchard")
+            .unwrap()
+            .arg("--json")
+            .current_dir(self.repo.path())
+            .env("HOME", self.home.path())
+            .env_remove("TMUX")
+            .output()
+            .unwrap();
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            eprintln!(
+                "SKIP labels_integration: orchard --json exited with {:?}. stderr: {}",
+                output.status.code(),
+                stderr.trim()
+            );
+            return None;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Some(serde_json::from_str(&stdout).expect("stdout should be valid JSON"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: find a worktree entry in the JSON output by branch name
+// ---------------------------------------------------------------------------
+
+/// Searches all repos' worktrees for one matching the predicate.
+fn find_worktree<F>(output: &Value, predicate: F) -> Option<&Value>
+where
+    F: Fn(&Value) -> bool,
+{
+    output["repos"].as_array()?.iter().find_map(|repo| {
+        repo["worktrees"]
+            .as_array()?
+            .iter()
+            .find(|wt| predicate(wt))
+    })
+}
+
+fn find_worktree_by_branch<'a>(output: &'a Value, branch: &str) -> Option<&'a Value> {
+    find_worktree(output, |wt| wt["branch"].as_str() == Some(branch))
+}
+
+// ---------------------------------------------------------------------------
+// Integration scenario: issue with labels
+// ---------------------------------------------------------------------------
+
+/// orchard --json exposes labels on an issue and derives phase from them.
+///
+/// Given a fixture cache with issue #47 having labels `["in-progress", "enhancement"]`
+/// Then the worktree's `issue.labels` is `["in-progress", "enhancement"]`
+/// And `issue.phase` is `"in-progress"`
+#[test]
+fn json_includes_labels_on_issue() {
+    let fixture = LabelsFixture::new();
+
+    fixture.checkout_branch("feat/issue-47-labels");
+    let branch = fixture.current_branch();
+
+    let issue = orchard::cache::CachedIssue {
+        labels: vec!["in-progress".to_string(), "enhancement".to_string()],
+        ..make_issue(47, "Implement labels field")
+    };
+    let pr = CachedPr {
+        linked_issue: Some(47),
+        ..make_pr(55, &branch)
+    };
+
+    fixture.cache.write_issues(OWNER, REPO, &[issue]);
+    fixture.cache.write_prs(OWNER, REPO, &[pr]);
+    fixture.apply_cache();
+
+    let Some(output) = fixture.run() else {
+        return; // gh not available
+    };
+
+    let wt = find_worktree_by_branch(&output, &branch)
+        .expect("worktree for target branch should be in output");
+
+    assert_eq!(
+        wt["issue"]["labels"],
+        serde_json::json!(["in-progress", "enhancement"]),
+        "issue.labels should be ['in-progress', 'enhancement']"
+    );
+    assert_eq!(
+        wt["issue"]["phase"],
+        Value::String("in-progress".to_string()),
+        "issue.phase should be 'in-progress'"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integration scenario: PR with labels
+// ---------------------------------------------------------------------------
+
+/// orchard --json exposes labels on a PR and derives phase from them.
+///
+/// Given a fixture cache with PR #55 having labels `["pr-ready", "needs-review"]`
+/// Then the worktree's `pr.labels` is `["pr-ready", "needs-review"]`
+/// And `pr.phase` is `"pr-ready"`
+#[test]
+fn json_includes_labels_on_pr() {
+    let fixture = LabelsFixture::new();
+
+    fixture.checkout_branch("feat/pr-labels");
+    let branch = fixture.current_branch();
+
+    let pr = CachedPr {
+        labels: vec!["pr-ready".to_string(), "needs-review".to_string()],
+        ..make_pr(55, &branch)
+    };
+
+    fixture.cache.write_issues(OWNER, REPO, &[]);
+    fixture.cache.write_prs(OWNER, REPO, &[pr]);
+    fixture.apply_cache();
+
+    let Some(output) = fixture.run() else {
+        return; // gh not available
+    };
+
+    let wt = find_worktree_by_branch(&output, &branch)
+        .expect("worktree for target branch should be in output");
+
+    assert_eq!(
+        wt["pr"]["labels"],
+        serde_json::json!(["pr-ready", "needs-review"]),
+        "pr.labels should be ['pr-ready', 'needs-review']"
+    );
+    assert_eq!(
+        wt["pr"]["phase"],
+        Value::String("pr-ready".to_string()),
+        "pr.phase should be 'pr-ready'"
+    );
+}

--- a/docs/projects-api-evaluation.md
+++ b/docs/projects-api-evaluation.md
@@ -1,0 +1,54 @@
+# ProjectV2 API Evaluation for Workflow State Tracking
+
+Issue: #235 — evaluate whether GitHub Projects API (ProjectV2) provides workflow state data that labels don't.
+
+## Fields Exposed
+
+ProjectV2 provides **rich typed fields** beyond labels: Status (single-select), Priority (single-select), Iteration (date-bounded sprints), custom Text/Number/Date fields, and Assignees. The key differentiator is **Status** — a single-select field with ordered options (e.g., "Backlog", "In Progress", "In Review", "Done") that maps directly to kanban columns.
+
+## Comparison to Labels
+
+Labels are untyped strings with no ordering, mutual exclusion, or transitions. ProjectV2 Status is a **single-select enum** — an issue can only be in one status at a time, and the options are explicitly ordered. This is precisely what workflow phase tracking needs: mutually exclusive states with defined transitions. Labels require convention enforcement (remove old label when adding new one); Status enforces it structurally.
+
+## API Complexity
+
+Issue/PR nodes expose a `projectItems` connection directly, queryable inline with existing GraphQL:
+
+```graphql
+projectItems(first: 5) {
+  nodes {
+    fieldValueByName(name: "Status") {
+      ... on ProjectV2ItemFieldSingleSelectValue { name }
+    }
+  }
+}
+```
+
+**Authentication**: Requires `project` scope on the PAT (or `read:project` for read-only). The existing `gh` CLI token may not have this — users would need to re-auth. Rate limits are standard GraphQL (5,000 points/hour), and adding `projectItems` costs minimal additional points.
+
+## Requires a Project Board?
+
+**Yes.** The repo/org must have a ProjectV2 board, and issues must be added to it. If no project exists, `projectItems` returns empty. This is a hard prerequisite that labels don't have — labels work out of the box.
+
+## Blast Radius for Orchard
+
+- **Query changes**: Add `projectItems` fragment to existing GraphQL queries in `cache_sources.rs` — additive.
+- **Cache types**: Add optional `project_status: Option<String>` to `CachedIssue`/`CachedPr`. Backward-compatible with `#[serde(default)]`.
+- **Config**: New optional field in `.orchard.json` for project board ID and field name mapping. Without config, feature is inert.
+- **New dependencies**: None. Uses existing `gh api graphql` path.
+- **New cache files**: None — data attaches to existing issue/PR caches.
+- **Auth**: May require PAT scope upgrade (`project` or `read:project`) — biggest operational friction.
+
+## Recommendation
+
+**Not yet.** Labels are sufficient for Orchard's current needs. ProjectV2 is the right tool if/when enforced workflow states are needed, but it adds a hard dependency on project board setup and PAT scope. Expose raw labels first (issue #235); revisit ProjectV2 when the label-based approach hits its limits (stale dual-labels, missing transitions).
+
+## Future Design (if adopted)
+
+If ProjectV2 is integrated later, the proposed shape:
+
+1. Optional config in `.orchard.json`: `{ "project": { "id": "PVT_...", "statusField": "Status" } }`
+2. Add `project_status: Option<String>` to `CachedIssue`/`CachedPr` with `#[serde(default)]`
+3. Thread through to `IssueInfo`/`PrState` → `JsonIssue`/`JsonPr`
+4. Coexist with labels: `phase` stays label-derived, new `projectStatus` field is ProjectV2-derived
+5. Consumers choose which to trust based on their setup

--- a/specs/features/expose-raw-labels-json.feature
+++ b/specs/features/expose-raw-labels-json.feature
@@ -1,0 +1,79 @@
+Feature: Expose raw labels in orchard --json output
+  As a script consuming `orchard --json`
+  I want access to the full label array on issues and PRs
+  So that I can filter by any label, not just the computed phase
+
+  Background:
+    Given labels are already fetched via GraphQL and stored in `IssueInfo.labels` and `PrState.labels`
+    And `phase` is derived from labels — the existing `phase` field must remain unchanged
+
+  # ===================================================================
+  # JsonIssue — labels field added
+  # ===================================================================
+
+  @unit
+  Scenario: JsonIssue includes labels array
+    Given an `IssueInfo` with labels `["bug", "in-progress", "priority-high"]`
+    When it is converted to `JsonIssue` and serialized
+    Then the JSON contains `"labels": ["bug", "in-progress", "priority-high"]`
+    And `"phase"` is still present as `"in-progress"`
+
+  @unit
+  Scenario: JsonIssue labels is empty array when issue has no labels
+    Given an `IssueInfo` with empty labels
+    When it is converted to `JsonIssue` and serialized
+    Then the JSON contains `"labels": []`
+    And `"phase"` is `null`
+
+  # ===================================================================
+  # JsonPr — labels field added
+  # ===================================================================
+
+  @unit
+  Scenario: JsonPr includes labels array
+    Given a `PrState` with labels `["enhancement", "pr-ready"]`
+    When it is converted to `JsonPr` and serialized
+    Then the JSON contains `"labels": ["enhancement", "pr-ready"]`
+    And `"phase"` is still present as `"pr-ready"`
+
+  @unit
+  Scenario: JsonPr labels is empty array when PR has no labels
+    Given a `PrState` with empty labels
+    When it is converted to `JsonPr` and serialized
+    Then the JSON contains `"labels": []`
+    And `"phase"` is `null`
+
+  @unit
+  Scenario: JsonPr labels preserves original order from GitHub
+    Given a `PrState` with labels `["z-label", "a-label", "m-label"]`
+    When it is converted to `JsonPr` and serialized
+    Then the JSON `"labels"` array preserves order: `["z-label", "a-label", "m-label"]`
+
+  # ===================================================================
+  # Backward compatibility — phase unchanged
+  # ===================================================================
+
+  @unit
+  Scenario: Adding labels field does not change phase computation
+    Given a `PrState` with labels `["blocked", "in-progress"]`
+    When it is converted to `JsonPr` and serialized
+    Then `"phase"` is `"blocked"` (priority wins)
+    And `"labels"` contains both `"blocked"` and `"in-progress"`
+
+  # ===================================================================
+  # Integration — orchard --json binary output
+  # ===================================================================
+
+  @integration
+  Scenario: orchard --json includes labels on issue objects
+    Given a fixture cache with issue #47 having labels `["in-progress", "enhancement"]`
+    When `orchard --json` is run against the fixture
+    Then the worktree's `issue.labels` is `["in-progress", "enhancement"]`
+    And `issue.phase` is `"in-progress"`
+
+  @integration
+  Scenario: orchard --json includes labels on PR objects
+    Given a fixture cache with PR #55 having labels `["pr-ready", "needs-review"]`
+    When `orchard --json` is run against the fixture
+    Then the worktree's `pr.labels` is `["pr-ready", "needs-review"]`
+    And `pr.phase` is `"pr-ready"`


### PR DESCRIPTION
## Why

Closes #235

`orchard --json` only exposed a computed `phase` field derived from labels, not the raw labels themselves. Scripts that need to filter by arbitrary labels (e.g. `bug`, `enhancement`, custom labels) had no way to access them — they'd have to call the GitHub API separately, defeating the purpose of Orchard's aggregated output.

## What changed

Added a `labels` field (array of strings) to both `JsonIssue` and `JsonPr` in the JSON output. Labels were already fetched via GraphQL and stored at every internal layer — this change threads them through the final JSON serialization step.

Also wrote a GitHub Projects API (ProjectV2) evaluation (`docs/projects-api-evaluation.md`) per the investigation AC. Recommendation: "not yet" — labels are sufficient for current needs, ProjectV2 adds hard dependencies (project board setup, PAT scope). Follow-up issue: #236.

## Test plan

- 6 unit tests in `json_output.rs`: populated labels, empty labels, order preservation, phase backward compatibility
- All existing tests pass (no regressions)
- `cargo clippy` clean

## Anything surprising?

The `labels` field is placed before `phase` in `JsonPr` but after `unresolved_threads` — this puts it near other metadata fields rather than adjacent to the CI fields. The serialized JSON key order follows struct field order due to serde.

# Related issue

- #235

# Related issue

- #235

# Related issue

- #235