### PR TITLE
fix: SSH ControlPath too long for macOS Unix socket limit

### DIFF
--- a/crates/orchard/src/remote.rs
+++ b/crates/orchard/src/remote.rs
@@ -32,7 +32,7 @@ pub fn shell_escape(s: &str) -> String {
 /// The ControlPath is placed under the system temp directory (`$TMPDIR` / `std::env::temp_dir`)
 /// rather than a hardcoded `/tmp`.
 fn ssh_flags() -> Vec<String> {
-    let control_path = std::env::temp_dir().join("orchard-ssh-%r@%h:%p");
+    let control_path = std::env::temp_dir().join("orchard-ssh-%C");
     vec![
         "-o".to_string(),
         "ConnectTimeout=5".to_string(),


### PR DESCRIPTION
## Summary

Replace `%r@%h:%p` with `%C` (SSH built-in hash token) in the ControlPath pattern to avoid exceeding macOS's 104-char Unix domain socket path limit.

Fixes #241

## Changes

One-line change in `crates/orchard/src/remote.rs`: `orchard-ssh-%r@%h:%p` → `orchard-ssh-%C`

## Test plan

- [ ] SSH to hosts with long names (e.g., `boxd@orchard-rs.boxd.sh`) works
- [ ] SSH to short hosts (e.g., `ubuntu@10.0.3.56`) still works
- [ ] `orchard --json` shows Boxd hosts as reachable

# Related issue

- #241