### PR TITLE
feat(tui): smart sorting, priority indicators, and label badges

### DIFF
--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -231,6 +231,86 @@ impl Default for PrInfo {
 }
 
 // ---------------------------------------------------------------------------
+// Sort key
+// ---------------------------------------------------------------------------
+
+/// Sort key extracted from a worktree for consistent ordering.
+/// Implements Ord so both WorktreeRow and WorktreeState can use the same comparator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorktreeSortKey<'a> {
+    /// Primary: display group (ascending).
+    pub display_group: DisplayGroup,
+    /// Secondary: rows where any session has ClaudeState::Input sort first.
+    pub has_claude_input: bool,
+    /// Tertiary: best available timestamp (ISO 8601, descending — most recent first).
+    pub best_timestamp: Option<&'a str>,
+    /// Quaternary: rows with a PR sort before rows without.
+    pub has_pr: bool,
+    /// Quinary: issue number ascending; Some before None.
+    pub issue_number: Option<u32>,
+    /// Senary: branch name alphabetical.
+    pub branch: &'a str,
+}
+
+impl<'a> PartialOrd for WorktreeSortKey<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<'a> Ord for WorktreeSortKey<'a> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Primary: display_group ascending
+        self.display_group
+            .cmp(&other.display_group)
+            // Secondary: claude input first (true before false)
+            .then_with(|| other.has_claude_input.cmp(&self.has_claude_input))
+            // Tertiary: best_timestamp descending (most recent first); None sorts last
+            .then_with(|| match (self.best_timestamp, other.best_timestamp) {
+                (Some(a), Some(b)) => b.cmp(a), // reverse: larger timestamp = more recent
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            })
+            // Quaternary: has_pr true before false
+            .then_with(|| other.has_pr.cmp(&self.has_pr))
+            // Quinary: issue number ascending; Some before None
+            .then_with(|| match (self.issue_number, other.issue_number) {
+                (Some(a), Some(b)) => a.cmp(&b),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            })
+            // Senary: branch alphabetical
+            .then_with(|| self.branch.cmp(other.branch))
+    }
+}
+
+impl WorktreeRow {
+    /// Builds a sort key from this row for use in multi-criteria ordering.
+    pub fn sort_key(&self) -> WorktreeSortKey<'_> {
+        let has_claude_input = self.sessions.iter().any(|s| {
+            s.claude
+                .as_ref()
+                .is_some_and(|c| c.status == crate::claude_state::ClaudeState::Input)
+        });
+        let best_timestamp = self
+            .pr
+            .as_ref()
+            .and_then(|pr| pr.last_commit_pushed_at.as_deref())
+            .or(self.worktree_last_commit_at.as_deref());
+        WorktreeSortKey {
+            display_group: self.display_group,
+            has_claude_input,
+            best_timestamp,
+            has_pr: self.pr.is_some(),
+            issue_number: self.issue_number,
+            branch: &self.branch,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Staleness helpers
 // ---------------------------------------------------------------------------
 
@@ -432,5 +512,134 @@ mod tests {
     #[test]
     fn is_state_stale_returns_true_for_unparseable_timestamp() {
         assert!(is_state_stale("not-a-timestamp", 300));
+    }
+
+    // -----------------------------------------------------------------------
+    // WorktreeSortKey tests
+    // -----------------------------------------------------------------------
+
+    fn base_key<'a>(branch: &'a str) -> WorktreeSortKey<'a> {
+        WorktreeSortKey {
+            display_group: DisplayGroup::Other,
+            has_claude_input: false,
+            best_timestamp: None,
+            has_pr: false,
+            issue_number: None,
+            branch,
+        }
+    }
+
+    #[test]
+    fn sort_key_display_group_is_primary_sort() {
+        let main = WorktreeSortKey {
+            display_group: DisplayGroup::RepoMain,
+            ..base_key("main")
+        };
+        let other = WorktreeSortKey {
+            display_group: DisplayGroup::Other,
+            ..base_key("feature")
+        };
+        assert!(main < other, "RepoMain should sort before Other");
+    }
+
+    #[test]
+    fn sort_key_claude_input_sorts_first_within_group() {
+        let with_input = WorktreeSortKey {
+            has_claude_input: true,
+            ..base_key("feature-a")
+        };
+        let without_input = WorktreeSortKey {
+            has_claude_input: false,
+            ..base_key("feature-b")
+        };
+        assert!(with_input < without_input, "claude input should sort before no input");
+    }
+
+    #[test]
+    fn sort_key_recent_timestamp_sorts_before_stale() {
+        let recent = WorktreeSortKey {
+            best_timestamp: Some("2024-06-01T10:00:00Z"),
+            ..base_key("branch-a")
+        };
+        let stale = WorktreeSortKey {
+            best_timestamp: Some("2024-01-01T10:00:00Z"),
+            ..base_key("branch-b")
+        };
+        assert!(recent < stale, "more recent timestamp should sort first");
+    }
+
+    #[test]
+    fn sort_key_none_timestamp_sorts_last() {
+        let has_ts = WorktreeSortKey {
+            best_timestamp: Some("2024-01-01T10:00:00Z"),
+            ..base_key("branch-a")
+        };
+        let no_ts = WorktreeSortKey {
+            best_timestamp: None,
+            ..base_key("branch-b")
+        };
+        assert!(has_ts < no_ts, "row with timestamp should sort before row without");
+    }
+
+    #[test]
+    fn sort_key_same_timestamp_falls_back_to_issue_number() {
+        let low_issue = WorktreeSortKey {
+            best_timestamp: Some("2024-06-01T10:00:00Z"),
+            issue_number: Some(10),
+            ..base_key("branch-a")
+        };
+        let high_issue = WorktreeSortKey {
+            best_timestamp: Some("2024-06-01T10:00:00Z"),
+            issue_number: Some(20),
+            ..base_key("branch-b")
+        };
+        assert!(low_issue < high_issue, "lower issue number should sort first");
+    }
+
+    #[test]
+    fn sort_key_has_pr_sorts_before_no_pr() {
+        let with_pr = WorktreeSortKey {
+            has_pr: true,
+            ..base_key("branch-a")
+        };
+        let without_pr = WorktreeSortKey {
+            has_pr: false,
+            ..base_key("branch-b")
+        };
+        assert!(with_pr < without_pr, "row with PR should sort before row without");
+    }
+
+    #[test]
+    fn sort_key_issue_number_some_before_none() {
+        let with_issue = WorktreeSortKey {
+            issue_number: Some(5),
+            ..base_key("branch-a")
+        };
+        let without_issue = WorktreeSortKey {
+            issue_number: None,
+            ..base_key("branch-b")
+        };
+        assert!(with_issue < without_issue, "row with issue number should sort before row without");
+    }
+
+    #[test]
+    fn sort_key_branch_alphabetical_as_final_tiebreaker() {
+        let aardvark = base_key("aardvark");
+        let zebra = base_key("zebra");
+        assert!(aardvark < zebra, "alphabetically earlier branch should sort first");
+    }
+
+    #[test]
+    fn sort_key_ord_equality() {
+        let a = WorktreeSortKey {
+            display_group: DisplayGroup::ClaudeWorking,
+            has_claude_input: true,
+            best_timestamp: Some("2024-06-01T10:00:00Z"),
+            has_pr: true,
+            issue_number: Some(42),
+            branch: "feature/42",
+        };
+        let b = a.clone();
+        assert_eq!(a.cmp(&b), std::cmp::Ordering::Equal);
     }
 }

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -243,6 +243,8 @@ pub struct WorktreeSortKey<'a> {
     /// Secondary: rows where any session has ClaudeState::Input sort first.
     pub has_claude_input: bool,
     /// Tertiary: best available timestamp (ISO 8601, descending — most recent first).
+    /// Compared lexicographically, which is correct for ISO 8601 with Z suffix.
+    /// All timestamps from GitHub and git use UTC with Z suffix.
     pub best_timestamp: Option<&'a str>,
     /// Quaternary: rows with a PR sort before rows without.
     pub has_pr: bool,

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -554,7 +554,10 @@ mod tests {
             has_claude_input: false,
             ..base_key("feature-b")
         };
-        assert!(with_input < without_input, "claude input should sort before no input");
+        assert!(
+            with_input < without_input,
+            "claude input should sort before no input"
+        );
     }
 
     #[test]
@@ -580,7 +583,10 @@ mod tests {
             best_timestamp: None,
             ..base_key("branch-b")
         };
-        assert!(has_ts < no_ts, "row with timestamp should sort before row without");
+        assert!(
+            has_ts < no_ts,
+            "row with timestamp should sort before row without"
+        );
     }
 
     #[test]
@@ -595,7 +601,10 @@ mod tests {
             issue_number: Some(20),
             ..base_key("branch-b")
         };
-        assert!(low_issue < high_issue, "lower issue number should sort first");
+        assert!(
+            low_issue < high_issue,
+            "lower issue number should sort first"
+        );
     }
 
     #[test]
@@ -608,7 +617,10 @@ mod tests {
             has_pr: false,
             ..base_key("branch-b")
         };
-        assert!(with_pr < without_pr, "row with PR should sort before row without");
+        assert!(
+            with_pr < without_pr,
+            "row with PR should sort before row without"
+        );
     }
 
     #[test]
@@ -621,14 +633,20 @@ mod tests {
             issue_number: None,
             ..base_key("branch-b")
         };
-        assert!(with_issue < without_issue, "row with issue number should sort before row without");
+        assert!(
+            with_issue < without_issue,
+            "row with issue number should sort before row without"
+        );
     }
 
     #[test]
     fn sort_key_branch_alphabetical_as_final_tiebreaker() {
         let aardvark = base_key("aardvark");
         let zebra = base_key("zebra");
-        assert!(aardvark < zebra, "alphabetically earlier branch should sort first");
+        assert!(
+            aardvark < zebra,
+            "alphabetically earlier branch should sort first"
+        );
     }
 
     #[test]

--- a/crates/orchard/src/join.rs
+++ b/crates/orchard/src/join.rs
@@ -150,16 +150,7 @@ pub fn derive_all_repos(
         })
         .collect();
 
-    rows.sort_by(|a, b| {
-        a.display_group
-            .cmp(&b.display_group)
-            .then_with(|| match (a.issue_number, b.issue_number) {
-                (Some(a_num), Some(b_num)) => a_num.cmp(&b_num),
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => a.branch.cmp(&b.branch),
-            })
-    });
+    rows.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
 
     rows
 }

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -91,6 +91,10 @@ pub struct JsonWorktree {
     pub display_group: String,
     /// True when this is the repo's main worktree.
     pub is_main_worktree: bool,
+    /// ISO 8601 timestamp of the most recent activity: `pr.last_commit_pushed_at` if set,
+    /// otherwise the worktree's own `last_commit_at`. `null` when neither exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_activity_at: Option<String>,
 }
 
 /// A child issue nested under a parent in JSON output.
@@ -560,6 +564,11 @@ impl From<&WorktreeState> for JsonWorktree {
             sessions: ws.sessions.iter().map(Into::into).collect(),
             display_group: display_group_str(ws.display_group).to_string(),
             is_main_worktree: ws.is_main_worktree,
+            last_activity_at: ws
+                .pr
+                .as_ref()
+                .and_then(|pr| pr.last_commit_pushed_at.clone())
+                .or_else(|| ws.last_commit_at.clone()),
         }
     }
 }
@@ -1669,5 +1678,67 @@ mod tests {
         let v = serde_json::to_value(&jp).unwrap();
         assert_eq!(v["phase"], "blocked");
         assert_eq!(v["labels"], serde_json::json!(["blocked", "in-progress"]));
+    }
+
+    // -----------------------------------------------------------------------
+    // last_activity_at field tests (issue #240)
+    // -----------------------------------------------------------------------
+
+    /// Builds a minimal PrState with the given `last_commit_pushed_at` value.
+    #[allow(deprecated)]
+    fn make_pr_with_last_commit_pushed_at(pushed_at: Option<&str>) -> PrState {
+        use crate::ci_state::CiChecks;
+        PrState {
+            number: 99,
+            branch: "feat/activity".to_string(),
+            state: Some("OPEN".to_string()),
+            title: None,
+            is_draft: None,
+            author: None,
+            requested_reviewers: vec![],
+            reviews: vec![],
+            review_decision: None,
+            checks_state: None,
+            ci_code_state: None,
+            ci_gate_state: None,
+            ci_checks: CiChecks::default(),
+            has_conflicts: false,
+            unresolved_threads: 0,
+            labels: vec![],
+            additions: None,
+            deletions: None,
+            created_at: None,
+            updated_at: None,
+            last_commit_pushed_at: pushed_at.map(|s| s.to_string()),
+        }
+    }
+
+    /// `last_activity_at` is taken from `pr.last_commit_pushed_at` when set.
+    #[test]
+    fn json_worktree_last_activity_at_from_pr() {
+        let ts = "2024-06-01T12:00:00Z";
+        let mut wt = make_worktree(DisplayGroup::Other);
+        wt.pr = Some(make_pr_with_last_commit_pushed_at(Some(ts)));
+        wt.last_commit_at = Some("2024-01-01T00:00:00Z".to_string());
+        let jw = JsonWorktree::from(&wt);
+        assert_eq!(jw.last_activity_at.as_deref(), Some(ts));
+    }
+
+    /// `last_activity_at` is `None` when there is no PR and no `last_commit_at`.
+    #[test]
+    fn json_worktree_last_activity_at_null_when_no_timestamps() {
+        let wt = make_worktree(DisplayGroup::Other);
+        let jw = JsonWorktree::from(&wt);
+        assert!(jw.last_activity_at.is_none());
+    }
+
+    /// `last_activity_at` falls back to `last_commit_at` when no PR is present.
+    #[test]
+    fn json_worktree_last_activity_at_from_worktree_commit() {
+        let ts = "2024-03-15T08:30:00Z";
+        let mut wt = make_worktree(DisplayGroup::Other);
+        wt.last_commit_at = Some(ts.to_string());
+        let jw = JsonWorktree::from(&wt);
+        assert_eq!(jw.last_activity_at.as_deref(), Some(ts));
     }
 }

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -37,24 +37,13 @@ impl OrchardState {
     }
 
     /// Returns a flat list of all worktrees across all repos, sorted by
-    /// display_group then by issue number (worktrees without issues sort last
-    /// within their group, then by branch name).
+    /// display_group then by smart criteria (claude input, recency, PR presence,
+    /// issue number, branch name).
     pub fn all_worktrees(&self) -> Vec<&WorktreeState> {
         let mut all: Vec<&WorktreeState> =
             self.repos.iter().flat_map(|r| r.worktrees.iter()).collect();
 
-        all.sort_by(|a, b| {
-            a.display_group.cmp(&b.display_group).then_with(|| {
-                let a_num = a.issue.as_ref().map(|i| i.number);
-                let b_num = b.issue.as_ref().map(|i| i.number);
-                match (a_num, b_num) {
-                    (Some(an), Some(bn)) => an.cmp(&bn),
-                    (Some(_), None) => std::cmp::Ordering::Less,
-                    (None, Some(_)) => std::cmp::Ordering::Greater,
-                    (None, None) => a.branch.cmp(&b.branch),
-                }
-            })
-        });
+        all.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
 
         all
     }
@@ -108,6 +97,30 @@ pub struct WorktreeState {
     pub ahead_behind: Option<(u32, u32)>,
     /// ISO 8601 timestamp of the most recent commit in this worktree.
     pub last_commit_at: Option<String>,
+}
+
+impl WorktreeState {
+    /// Builds a sort key for multi-criteria ordering of worktree rows.
+    pub fn sort_key(&self) -> crate::derive::WorktreeSortKey<'_> {
+        let has_claude_input = self.sessions.iter().any(|s| {
+            s.claude
+                .as_ref()
+                .is_some_and(|c| c.status == crate::claude_state::ClaudeState::Input)
+        });
+        let best_timestamp = self
+            .pr
+            .as_ref()
+            .and_then(|pr| pr.last_commit_pushed_at.as_deref())
+            .or(self.last_commit_at.as_deref());
+        crate::derive::WorktreeSortKey {
+            display_group: self.display_group,
+            has_claude_input,
+            best_timestamp,
+            has_pr: self.pr.is_some(),
+            issue_number: self.issue.as_ref().map(|i| i.number),
+            branch: &self.branch,
+        }
+    }
 }
 
 /// Lightweight issue summary attached to a worktree.

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1478,7 +1478,7 @@ impl App {
             };
             // Compute label badge spans for non-phase labels, giving them space
             // that remains after the title text is rendered.
-            let non_phase_label_strs: Vec<&str> = vt
+            let issue_label_strs: Vec<&str> = vt
                 .row
                 .issue_labels
                 .iter()
@@ -1487,7 +1487,7 @@ impl App {
             // Title occupies at most min(title_raw_chars, title_width) chars.
             let title_raw_chars = title_raw.chars().count().min(title_width);
             let badges_available = title_width.saturating_sub(title_raw_chars);
-            let badge_spans = label_badges(&non_phase_label_strs, badges_available);
+            let badge_spans = label_badges(&issue_label_strs, badges_available);
             let badge_chars: usize = badge_spans
                 .iter()
                 .map(|s| s.content.chars().count())

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1476,7 +1476,25 @@ impl App {
                     _ => branch_tail(&vt.row.branch),
                 }
             };
-            let title_display = crate::paths::truncate_left(title_raw, title_width);
+            // Compute label badge spans for non-phase labels, giving them space
+            // that remains after the title text is rendered.
+            let non_phase_label_strs: Vec<&str> = vt
+                .row
+                .issue_labels
+                .iter()
+                .map(|s| s.as_str())
+                .collect();
+            // Title occupies at most min(title_raw_chars, title_width) chars.
+            let title_raw_chars = title_raw.chars().count().min(title_width);
+            let badges_available = title_width.saturating_sub(title_raw_chars);
+            let badge_spans = label_badges(&non_phase_label_strs, badges_available);
+            let badge_chars: usize = badge_spans
+                .iter()
+                .map(|s| s.content.chars().count())
+                .sum();
+            // Allocate remaining title budget after reserving badge space.
+            let title_budget = title_width.saturating_sub(badge_chars);
+            let title_display = crate::paths::truncate_left(title_raw, title_budget);
 
             let task_host: Option<&str> = vt
                 .row
@@ -1515,8 +1533,13 @@ impl App {
             // 5=session_status, 6=display_group.
             let fo = &vt.field_offsets;
 
+            let is_prioritized = vt.group == DisplayGroup::Prioritized;
             let issue_cell = if let Some(num) = vt.row.issue_number {
-                let issue_str = format!("#{}", num);
+                let issue_str = if is_prioritized {
+                    format!("\u{2605}{}", num) // ★N
+                } else {
+                    format!("#{}", num)
+                };
                 if !vt.match_indices.is_empty() && fo.len() > 2 {
                     let spans = crate::tui::fuzzy::highlight_spans(
                         &issue_str,
@@ -1526,6 +1549,15 @@ impl App {
                         highlight_style,
                     );
                     Cell::from(Line::from(spans))
+                } else if is_prioritized {
+                    // Color the star with the prioritized theme color.
+                    Cell::from(Line::from(vec![
+                        Span::styled(
+                            "\u{2605}",
+                            Style::default().fg(theme.prioritized),
+                        ),
+                        Span::raw(num.to_string()),
+                    ]))
                 } else {
                     Cell::from(issue_str)
                 }
@@ -1562,7 +1594,8 @@ impl App {
             // The TITLE field is issue_title (field index 3) or branch (field index 1).
             // We highlight against `title_raw` (the untruncated source) because field
             // offsets are computed from the original haystack text. After highlighting,
-            // we truncate the resulting spans to `title_width` chars.
+            // we truncate the resulting spans to `title_budget` chars (leaving room
+            // for label badge spans which are appended after the title text).
             let title_cell = if !vt.match_indices.is_empty() && !fo.is_empty() {
                 let field_idx = if vt.row.is_main_worktree {
                     usize::MAX
@@ -1580,13 +1613,19 @@ impl App {
                         Style::default(),
                         highlight_style,
                     );
-                    let truncated = crate::tui::fuzzy::truncate_spans_left(spans, title_width);
+                    let mut truncated =
+                        crate::tui::fuzzy::truncate_spans_left(spans, title_budget);
+                    truncated.extend(badge_spans);
                     Cell::from(Line::from(truncated))
                 } else {
-                    Cell::from(title_display)
+                    let mut line_spans = vec![Span::raw(title_display)];
+                    line_spans.extend(badge_spans);
+                    Cell::from(Line::from(line_spans))
                 }
             } else {
-                Cell::from(title_display)
+                let mut line_spans = vec![Span::raw(title_display)];
+                line_spans.extend(badge_spans);
+                Cell::from(Line::from(line_spans))
             };
 
             // Build status cell with fuzzy highlights (field index 4 = pr_status).
@@ -2201,6 +2240,70 @@ fn group_header_row(group: DisplayGroup, num_columns: usize, theme: &Theme) -> R
         cells.push(Cell::from(""));
     }
     Row::new(cells)
+}
+
+/// Builds dimmed `[label]` badge spans for non-phase issue labels.
+///
+/// Filters out any labels that appear in [`crate::derive::PHASE_PRIORITY`] (those are
+/// already represented by the display group) and formats the remainder as ` [label]`
+/// spans with a dimmed style.  When the accumulated badge text would exceed
+/// `available_width`, the remaining labels are collapsed into a ` +N` span.
+/// Returns an empty `Vec` when there are no non-phase labels or no space is available.
+pub(crate) fn label_badges(labels: &[&str], available_width: usize) -> Vec<Span<'static>> {
+    if available_width == 0 {
+        return vec![];
+    }
+
+    let non_phase: Vec<&str> = labels
+        .iter()
+        .copied()
+        .filter(|l| !crate::derive::PHASE_PRIORITY.contains(l))
+        .collect();
+
+    if non_phase.is_empty() {
+        return vec![];
+    }
+
+    let dim = Style::default().add_modifier(Modifier::DIM);
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut used: usize = 0;
+    let mut skipped: usize = 0;
+
+    for label in &non_phase {
+        // Badge text: " [label]"
+        let badge = format!(" [{}]", label);
+        let badge_len = badge.chars().count();
+
+        if used + badge_len <= available_width {
+            spans.push(Span::styled(badge, dim));
+            used += badge_len;
+        } else {
+            skipped += 1;
+        }
+    }
+
+    // If any labels were skipped, check if we can fit a " +N" overflow indicator.
+    if skipped > 0 {
+        let overflow = format!(" +{}", skipped);
+        let overflow_len = overflow.chars().count();
+        if used + overflow_len <= available_width {
+            spans.push(Span::styled(overflow, dim));
+        } else {
+            // Replace the last badge with the overflow indicator if it fits.
+            // If nothing fits at all, just return empty.
+            if let Some(last) = spans.pop() {
+                used -= last.content.chars().count();
+                skipped += 1;
+                let overflow2 = format!(" +{}", skipped);
+                let overflow2_len = overflow2.chars().count();
+                if used + overflow2_len <= available_width {
+                    spans.push(Span::styled(overflow2, dim));
+                }
+            }
+        }
+    }
+
+    spans
 }
 
 /// Returns the height (in terminal rows) to allocate for the header.
@@ -3449,6 +3552,70 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Priority star indicator
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn prioritized_row_shows_star_in_issue_cell() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let row = make_task_row(42, DisplayGroup::Prioritized);
+        let app = App::new_test(vec![row]);
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                app.render_task_list(f);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer().clone();
+        let mut full_text = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                full_text.push_str(buffer[(x, y)].symbol());
+            }
+        }
+        assert!(
+            full_text.contains('\u{2605}'),
+            "prioritized row should render ★ (U+2605) in the issue cell"
+        );
+    }
+
+    #[test]
+    fn non_prioritized_row_shows_hash_in_issue_cell() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let row = make_task_row(42, DisplayGroup::Other);
+        let app = App::new_test(vec![row]);
+        let backend = TestBackend::new(160, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                app.render_task_list(f);
+            })
+            .unwrap();
+
+        let buffer = terminal.backend().buffer().clone();
+        let mut full_text = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                full_text.push_str(buffer[(x, y)].symbol());
+            }
+        }
+        assert!(
+            full_text.contains("#42"),
+            "non-prioritized row should render #42, got no #42 in output"
+        );
+        assert!(
+            !full_text.contains('\u{2605}'),
+            "non-prioritized row should not render ★"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Hints bar — expand/collapse hints
     // -----------------------------------------------------------------------
 
@@ -3570,6 +3737,95 @@ mod tests {
         assert!(
             table_chunk_height >= TABLE_MIN_HEIGHT,
             "table chunk height {table_chunk_height} should be >= {TABLE_MIN_HEIGHT}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // label_badges tests
+    // -----------------------------------------------------------------------
+
+    fn badge_text(spans: &[Span<'_>]) -> String {
+        spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn label_badges_non_phase_labels_rendered_as_brackets() {
+        let labels = vec!["bug", "enhancement"];
+        let spans = label_badges(&labels, 80);
+        let text = badge_text(&spans);
+        assert!(
+            text.contains("[bug]"),
+            "expected '[bug]' in badge text: {:?}",
+            text
+        );
+        assert!(
+            text.contains("[enhancement]"),
+            "expected '[enhancement]' in badge text: {:?}",
+            text
+        );
+    }
+
+    #[test]
+    fn label_badges_phase_only_label_renders_nothing() {
+        let labels = vec!["in-progress"];
+        let spans = label_badges(&labels, 80);
+        assert!(
+            spans.is_empty(),
+            "expected no badges for phase-only label, got: {:?}",
+            badge_text(&spans)
+        );
+    }
+
+    #[test]
+    fn label_badges_mixed_phase_and_non_phase_renders_only_non_phase() {
+        let labels = vec!["bug", "in-progress", "planned"];
+        let spans = label_badges(&labels, 80);
+        let text = badge_text(&spans);
+        assert!(
+            text.contains("[bug]"),
+            "expected '[bug]' in badge text: {:?}",
+            text
+        );
+        assert!(
+            !text.contains("[in-progress]"),
+            "unexpected '[in-progress]' in badge text: {:?}",
+            text
+        );
+        assert!(
+            !text.contains("[planned]"),
+            "unexpected '[planned]' in badge text: {:?}",
+            text
+        );
+    }
+
+    #[test]
+    fn label_badges_returns_empty_when_no_space_available() {
+        let labels = vec!["bug"];
+        let spans = label_badges(&labels, 0);
+        assert!(spans.is_empty(), "expected no badges when available_width=0");
+    }
+
+    #[test]
+    fn label_badges_overflow_shows_plus_n() {
+        // " [a]" = 4 chars; only fits one badge in 4 chars, remaining 1 label → " +1" = 3 chars.
+        // With available_width=7: " [a]" (4) + " +1" (3) = 7 → fits.
+        let labels = vec!["a", "b"];
+        let spans = label_badges(&labels, 7);
+        let text = badge_text(&spans);
+        assert!(
+            text.contains("[a]"),
+            "expected '[a]' in badge text: {:?}",
+            text
+        );
+        assert!(
+            text.contains("+1"),
+            "expected '+1' overflow in badge text: {:?}",
+            text
+        );
+        assert!(
+            !text.contains("[b]"),
+            "unexpected '[b]' in badge text: {:?}",
+            text
         );
     }
 }

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1478,20 +1478,13 @@ impl App {
             };
             // Compute label badge spans for non-phase labels, giving them space
             // that remains after the title text is rendered.
-            let issue_label_strs: Vec<&str> = vt
-                .row
-                .issue_labels
-                .iter()
-                .map(|s| s.as_str())
-                .collect();
+            let issue_label_strs: Vec<&str> =
+                vt.row.issue_labels.iter().map(|s| s.as_str()).collect();
             // Title occupies at most min(title_raw_chars, title_width) chars.
             let title_raw_chars = title_raw.chars().count().min(title_width);
             let badges_available = title_width.saturating_sub(title_raw_chars);
             let badge_spans = label_badges(&issue_label_strs, badges_available);
-            let badge_chars: usize = badge_spans
-                .iter()
-                .map(|s| s.content.chars().count())
-                .sum();
+            let badge_chars: usize = badge_spans.iter().map(|s| s.content.chars().count()).sum();
             // Allocate remaining title budget after reserving badge space.
             let title_budget = title_width.saturating_sub(badge_chars);
             let title_display = crate::paths::truncate_left(title_raw, title_budget);
@@ -1552,10 +1545,7 @@ impl App {
                 } else if is_prioritized {
                     // Color the star with the prioritized theme color.
                     Cell::from(Line::from(vec![
-                        Span::styled(
-                            "\u{2605}",
-                            Style::default().fg(theme.prioritized),
-                        ),
+                        Span::styled("\u{2605}", Style::default().fg(theme.prioritized)),
                         Span::raw(num.to_string()),
                     ]))
                 } else {
@@ -1613,8 +1603,7 @@ impl App {
                         Style::default(),
                         highlight_style,
                     );
-                    let mut truncated =
-                        crate::tui::fuzzy::truncate_spans_left(spans, title_budget);
+                    let mut truncated = crate::tui::fuzzy::truncate_spans_left(spans, title_budget);
                     truncated.extend(badge_spans);
                     Cell::from(Line::from(truncated))
                 } else {
@@ -3802,7 +3791,10 @@ mod tests {
     fn label_badges_returns_empty_when_no_space_available() {
         let labels = vec!["bug"];
         let spans = label_badges(&labels, 0);
-        assert!(spans.is_empty(), "expected no badges when available_width=0");
+        assert!(
+            spans.is_empty(),
+            "expected no badges when available_width=0"
+        );
     }
 
     #[test]

--- a/crates/orchard/src/tui/theme.rs
+++ b/crates/orchard/src/tui/theme.rs
@@ -135,7 +135,7 @@ impl Default for Theme {
             text: Color::White,
             orchardist: Color::Magenta,
             merge_conflict: Color::Red,
-            prioritized: Color::White,
+            prioritized: Color::Yellow,
             pr_merged: Color::Magenta,
             host_unknown: Color::Magenta,
             preview_content: Color::Gray,
@@ -239,8 +239,8 @@ mod tests {
     }
 
     #[test]
-    fn default_prioritized_is_white() {
-        assert_eq!(Theme::default().prioritized, Color::White);
+    fn default_prioritized_is_yellow() {
+        assert_eq!(Theme::default().prioritized, Color::Yellow);
     }
 
     #[test]

--- a/crates/orchard/tests/derive_integration.rs
+++ b/crates/orchard/tests/derive_integration.rs
@@ -406,6 +406,138 @@ fn e2e_code_green_gate_blocked_pr_surfaces_in_json_output() {
     assert!(matches_triage_filter, "triage filter must surface this PR");
 }
 
+// ---------------------------------------------------------------------------
+// Smart sort: recency within same display group
+// ---------------------------------------------------------------------------
+
+/// Within the same `DisplayGroup`, worktrees with more recent PR activity
+/// (measured by `last_commit_pushed_at`) must sort before older ones.
+#[test]
+fn smart_sort_recent_activity_within_same_group() {
+    let repo_caches = vec![(
+        "owner/repo".to_string(),
+        vec![make_issue(10, "Issue ten"), make_issue(20, "Issue twenty")],
+        vec![
+            CachedPr {
+                last_commit_pushed_at: Some("2026-04-13T10:00:00Z".to_string()),
+                ..make_pr(10, "feat/issue-10")
+            },
+            CachedPr {
+                last_commit_pushed_at: Some("2026-04-01T10:00:00Z".to_string()),
+                ..make_pr(20, "feat/issue-20")
+            },
+        ],
+        vec![
+            make_worktree("/tmp/wt-main", "main"),
+            make_worktree("/tmp/wt-a", "feat/issue-10"),
+            make_worktree("/tmp/wt-b", "feat/issue-20"),
+        ],
+        vec![],
+    )];
+
+    let rows = derive_all_repos(&repo_caches, &[], &[]);
+
+    // rows[0] is RepoMain; rows[1] and rows[2] are the two feature worktrees
+    assert!(rows.len() >= 3, "expected at least 3 rows, got {}", rows.len());
+    assert_eq!(rows[0].display_group, DisplayGroup::RepoMain);
+
+    // Both feature rows must be in Other (plain PRs, no special review state)
+    assert_eq!(rows[1].display_group, DisplayGroup::Other);
+    assert_eq!(rows[2].display_group, DisplayGroup::Other);
+
+    // More recent activity (April 13) must appear before stale activity (April 1)
+    assert_eq!(
+        rows[1].branch, "feat/issue-10",
+        "feat/issue-10 (recent) should sort before feat/issue-20 (stale)"
+    );
+    assert_eq!(rows[2].branch, "feat/issue-20");
+}
+
+// ---------------------------------------------------------------------------
+// Smart sort: display group trumps recency
+// ---------------------------------------------------------------------------
+
+/// `DisplayGroup` is the primary sort key. A `NeedsAttention` row with an
+/// older timestamp must appear before an `Other` row with a newer timestamp.
+#[test]
+fn smart_sort_display_group_trumps_recency() {
+    let repo_caches = vec![(
+        "owner/repo".to_string(),
+        vec![],
+        vec![
+            // Worktree A: changes_requested → NeedsAttention; older timestamp
+            CachedPr {
+                last_commit_pushed_at: Some("2026-03-01T10:00:00Z".to_string()),
+                ..make_changes_requested_pr(1, "feat/needs-attention")
+            },
+            // Worktree B: plain PR → Other; newer timestamp
+            CachedPr {
+                last_commit_pushed_at: Some("2026-04-13T10:00:00Z".to_string()),
+                ..make_pr(2, "feat/plain")
+            },
+        ],
+        vec![
+            make_worktree("/tmp/wt-main", "main"),
+            make_worktree("/tmp/wt-needs-attention", "feat/needs-attention"),
+            make_worktree("/tmp/wt-plain", "feat/plain"),
+        ],
+        vec![],
+    )];
+
+    let rows = derive_all_repos(&repo_caches, &[], &[]);
+
+    assert!(rows.len() >= 3, "expected at least 3 rows, got {}", rows.len());
+    assert_eq!(rows[0].display_group, DisplayGroup::RepoMain);
+
+    // NeedsAttention must precede Other, regardless of timestamps
+    assert_eq!(
+        rows[1].display_group,
+        DisplayGroup::NeedsAttention,
+        "NeedsAttention (older timestamp) must sort before Other (newer timestamp)"
+    );
+    assert_eq!(rows[2].display_group, DisplayGroup::Other);
+}
+
+// ---------------------------------------------------------------------------
+// Smart sort: worktrees with PR before without PR
+// ---------------------------------------------------------------------------
+
+/// Within the same `DisplayGroup`, a worktree that has a PR must sort before
+/// a worktree with no PR at all.
+#[test]
+fn smart_sort_worktree_with_pr_before_without() {
+    let repo_caches = vec![(
+        "owner/repo".to_string(),
+        vec![],
+        vec![
+            // Only worktree B has a PR
+            make_pr(99, "feat/has-pr"),
+        ],
+        vec![
+            make_worktree("/tmp/wt-main", "main"),
+            make_worktree("/tmp/wt-no-pr", "feat/no-pr"),
+            make_worktree("/tmp/wt-has-pr", "feat/has-pr"),
+        ],
+        vec![],
+    )];
+
+    let rows = derive_all_repos(&repo_caches, &[], &[]);
+
+    assert!(rows.len() >= 3, "expected at least 3 rows, got {}", rows.len());
+    assert_eq!(rows[0].display_group, DisplayGroup::RepoMain);
+
+    // Both non-main rows are in Other
+    assert_eq!(rows[1].display_group, DisplayGroup::Other);
+    assert_eq!(rows[2].display_group, DisplayGroup::Other);
+
+    // Row with a PR must sort before row without
+    assert_eq!(
+        rows[1].branch, "feat/has-pr",
+        "worktree with PR should sort before worktree without PR"
+    );
+    assert_eq!(rows[2].branch, "feat/no-pr");
+}
+
 /// @e2e — task #7: a PR whose only gate check is still running (pending) must
 /// resolve to `ciGateState == "pending"`, not `"blocked"`, so the
 /// orchardist's triage filter (blocked only) does NOT surface it. This

--- a/crates/orchard/tests/derive_integration.rs
+++ b/crates/orchard/tests/derive_integration.rs
@@ -438,7 +438,11 @@ fn smart_sort_recent_activity_within_same_group() {
     let rows = derive_all_repos(&repo_caches, &[], &[]);
 
     // rows[0] is RepoMain; rows[1] and rows[2] are the two feature worktrees
-    assert!(rows.len() >= 3, "expected at least 3 rows, got {}", rows.len());
+    assert!(
+        rows.len() >= 3,
+        "expected at least 3 rows, got {}",
+        rows.len()
+    );
     assert_eq!(rows[0].display_group, DisplayGroup::RepoMain);
 
     // Both feature rows must be in Other (plain PRs, no special review state)
@@ -486,7 +490,11 @@ fn smart_sort_display_group_trumps_recency() {
 
     let rows = derive_all_repos(&repo_caches, &[], &[]);
 
-    assert!(rows.len() >= 3, "expected at least 3 rows, got {}", rows.len());
+    assert!(
+        rows.len() >= 3,
+        "expected at least 3 rows, got {}",
+        rows.len()
+    );
     assert_eq!(rows[0].display_group, DisplayGroup::RepoMain);
 
     // NeedsAttention must precede Other, regardless of timestamps
@@ -523,7 +531,11 @@ fn smart_sort_worktree_with_pr_before_without() {
 
     let rows = derive_all_repos(&repo_caches, &[], &[]);
 
-    assert!(rows.len() >= 3, "expected at least 3 rows, got {}", rows.len());
+    assert!(
+        rows.len() >= 3,
+        "expected at least 3 rows, got {}",
+        rows.len()
+    );
     assert_eq!(rows[0].display_group, DisplayGroup::RepoMain);
 
     // Both non-main rows are in Other

--- a/specs/features/smart-sorting-priority-labels.feature
+++ b/specs/features/smart-sorting-priority-labels.feature
@@ -1,0 +1,189 @@
+Feature: Smart sorting, priority indicators, and label badges
+  As a developer managing multiple worktrees
+  I want rows sorted by actionability, priorities visually distinct, and labels visible
+  So that I can quickly find what needs my attention without reading every row
+
+  Background:
+    Given the existing DisplayGroup enum controls primary sort order
+    And priority.rs stores prioritized worktree paths in priorities.json
+    And issue_labels and pr.labels are available on WorktreeRow (from #237)
+    And sort logic is extracted into a shared comparator used by derive_all_repos
+      and OrchardState::all_worktrees to prevent drift
+
+  # ===================================================================
+  # Smart Sorting — secondary sort within groups
+  # ===================================================================
+
+  @unit
+  Scenario: Within NeedsAttention group, rows with claude input sort first
+    Given two worktrees both in NeedsAttention group
+    And worktree A has a claude session in "input" state
+    And worktree B has no claude session
+    When derive_all_repos sorts the rows
+    Then worktree A appears before worktree B
+
+  @unit
+  Scenario: Within same group, rows with recent activity sort before stale rows
+    Given two worktrees both in Other group
+    And worktree A has last_commit_pushed_at "2026-04-13T10:00:00Z"
+    And worktree B has last_commit_pushed_at "2026-04-01T10:00:00Z"
+    When derive_all_repos sorts the rows
+    Then worktree A appears before worktree B
+
+  @unit
+  Scenario: Rows with None timestamps sort after rows with timestamps
+    Given two worktrees both in Other group
+    And worktree A has last_commit_pushed_at "2026-04-01T10:00:00Z"
+    And worktree B has last_commit_pushed_at None
+    When derive_all_repos sorts the rows
+    Then worktree A appears before worktree B
+
+  @unit
+  Scenario: Two rows with None timestamps fall back to issue number tiebreaker
+    Given two worktrees both in Other group
+    And both have last_commit_pushed_at None
+    And worktree A has issue_number 50
+    And worktree B has issue_number 30
+    When derive_all_repos sorts the rows
+    Then worktree B appears before worktree A (lower issue number first)
+
+  @unit
+  Scenario: Within same group and same recency, issue number is tiebreaker
+    Given two worktrees both in Other group
+    And both have last_commit_pushed_at "2026-04-13T10:00:00Z"
+    And worktree A has issue_number 50
+    And worktree B has issue_number 30
+    When derive_all_repos sorts the rows
+    Then worktree B appears before worktree A (lower issue number first)
+
+  @unit
+  Scenario: Worktrees with no PR sort after worktrees with a PR within same group
+    Given two worktrees both in Other group
+    And worktree A has a linked PR
+    And worktree B has no linked PR
+    When derive_all_repos sorts the rows
+    Then worktree A appears before worktree B
+
+  @unit
+  Scenario: DisplayGroup primary sort is unchanged
+    Given worktree A in NeedsAttention group
+    And worktree B in Other group with more recent activity
+    When derive_all_repos sorts the rows
+    Then worktree A still appears before worktree B (group trumps recency)
+
+  @unit
+  Scenario: Fuzzy filter overrides smart sort
+    Given multiple worktrees with smart sort ordering
+    When a fuzzy filter is active with non-empty text
+    Then rows are sorted by descending fuzzy score, not by smart sort
+    And main worktree rows remain pinned to the front
+
+  # ===================================================================
+  # Priority Indicators — visual distinction in TUI
+  # ===================================================================
+
+  @unit
+  Scenario: Prioritized row shows star indicator replacing hash in issue column
+    Given a worktree row with DisplayGroup::Prioritized and issue_number 42
+    When the row is rendered in the TUI
+    Then the issue cell shows "★42" (star replaces "#" prefix)
+
+  @unit
+  Scenario: Priority indicator uses themed priority color
+    Given a prioritized worktree row
+    When rendered in the TUI
+    Then the star indicator uses theme.prioritized color (Yellow)
+
+  @unit
+  Scenario: Non-prioritized rows have no star indicator
+    Given a worktree row with DisplayGroup::Other
+    When the row is rendered in the TUI
+    Then no star indicator appears in the issue cell
+
+  @unit
+  Scenario: Prioritized color updated from White to Yellow
+    When the Theme is constructed with defaults
+    Then theme.prioritized is Yellow
+
+  # ===================================================================
+  # Label Badges — inline in TUI rows
+  # ===================================================================
+
+  @unit
+  Scenario: Issue labels render as inline badges after the title
+    Given a worktree row with issue_labels ["bug", "enhancement"]
+    When the row is rendered in the TUI
+    Then the title cell contains badge text "[bug]" and "[enhancement]"
+
+  @unit
+  Scenario: Label badges use dimmed styling to not overwhelm the title
+    Given a worktree row with issue_labels ["bug"]
+    When the row is rendered in the TUI
+    Then the badge "[bug]" uses dimmed/muted style
+
+  @unit
+  Scenario: Phase labels are excluded from badge rendering
+    Given a worktree row with issue_labels ["bug", "in-progress", "planned"]
+    And phase labels are those in the PHASE_PRIORITY constant from derive.rs
+    When the row is rendered in the TUI
+    Then only "[bug]" badge renders (phase labels are already shown via display_group)
+
+  @unit
+  Scenario: No badges render when issue has no non-phase labels
+    Given a worktree row with issue_labels ["in-progress"]
+    When the row is rendered in the TUI
+    Then no label badges appear in the title cell
+
+  @unit
+  Scenario: Label badges truncate when title column is narrow
+    Given a worktree row with issue_labels ["bug", "enhancement", "documentation", "help-wanted"]
+    And the title column is only 40 characters wide
+    When the row is rendered in the TUI
+    Then labels are truncated to fit and remaining count shown as "+2"
+
+  @unit
+  Scenario: Labels suppressed entirely when title fills the column
+    Given a worktree row with a long title that fills the available column width
+    And issue_labels ["bug"]
+    When the row is rendered in the TUI
+    Then no label badges appear (title text takes priority over badges)
+
+  # ===================================================================
+  # JSON Output — last_activity_at exposed
+  # ===================================================================
+
+  @unit
+  Scenario: JSON output includes last_activity_at field on worktrees
+    Given a worktree with pr.last_commit_pushed_at "2026-04-13T10:00:00Z"
+    When orchard --json is run
+    Then the worktree object contains "last_activity_at": "2026-04-13T10:00:00Z"
+
+  @unit
+  Scenario: last_activity_at is null when no activity timestamps exist
+    Given a worktree with no PR and no worktree_last_commit_at
+    When orchard --json is run
+    Then the worktree object contains "last_activity_at": null
+
+  # ===================================================================
+  # Integration — full pipeline
+  # ===================================================================
+
+  @integration
+  Scenario: Smart sort order verified through orchard --json
+    Given fixture caches with multiple worktrees at different activity levels
+    When orchard --json is run
+    Then worktrees within the same display_group are ordered by recency
+    And the overall order respects DisplayGroup primary sort
+
+  @integration
+  Scenario: Priority indicator visible in TUI render
+    Given a fixture with one prioritized worktree with issue_number 42
+    When the TUI is rendered to a test backend
+    Then the buffer contains "★42" on the prioritized row
+    And the star is colored with the priority theme color
+
+  @integration
+  Scenario: Label badges visible in TUI render
+    Given a fixture with a worktree whose issue has labels ["bug", "wontfix"]
+    When the TUI is rendered to a test backend
+    Then the buffer contains "[bug]" and "[wontfix]" on that row


### PR DESCRIPTION
## Summary

- Extract shared `WorktreeSortKey` comparator with 6-level intra-group sorting (claude input → recency → PR presence → issue number → branch)
- Add priority star indicator (★ replaces #) with yellow theme color
- Render GitHub issue labels as dimmed inline `[label]` badges in TUI title column, filtering out phase labels
- Expose `last_activity_at` in JSON output for scripting consumers

## Changes

### Smart Sorting (`derive.rs`, `join.rs`, `orchard_state.rs`)
- New `WorktreeSortKey` with manual `Ord` impl: DisplayGroup → claude input → recency (descending) → has PR → issue number → branch
- Shared between `derive_all_repos` and `OrchardState::all_worktrees` to prevent drift
- 9 unit tests + 3 integration tests

### Priority Indicators (`tui/list.rs`, `tui/theme.rs`)
- `★42` replaces `#42` for prioritized rows in the issue column
- Theme color changed from White to Yellow for visual distinction
- 3 unit tests

### Label Badges (`tui/list.rs`)
- Non-phase issue labels rendered as dimmed `[label]` badges after title text
- Phase labels (from `PHASE_PRIORITY`) excluded to avoid redundancy with display_group
- Truncation with `+N` when space is limited; suppressed when title fills column
- 5 unit tests

### JSON Output (`json_output.rs`)
- New `last_activity_at` field: prefers `pr.last_commit_pushed_at`, falls back to `worktree.last_commit_at`
- 3 unit tests

## Test plan

- [x] 9 unit tests for `WorktreeSortKey` ordering (all 6 sort levels + equality)
- [x] 3 unit tests for priority indicator (star, yellow, non-prioritized)
- [x] 5 unit tests for label badges (rendering, phase exclusion, truncation, suppression)
- [x] 3 unit tests for `last_activity_at` JSON field
- [x] 3 integration tests for smart sort through `derive_all_repos` pipeline
- [x] 998/999 tests passing (1 pre-existing failure in `webhook::tailer`)

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #240

# Related issue

- #240