### PR TITLE
fix(tui): parallelize reconnect_unreachable_hosts probes

### DIFF
--- a/crates/orchard/src/sources/hosts.rs
+++ b/crates/orchard/src/sources/hosts.rs
@@ -23,9 +23,6 @@ pub fn probe_reachability(host: &str) -> bool {
 /// Deduplicates the input, spawns one probe thread per host, joins them all,
 /// and returns a `host -> reachable` map. Dead hosts can't block healthy
 /// ones because each probe runs on its own thread.
-///
-/// Uses `probe_reachability` under the hood; see [`probe_with`] for a
-/// dependency-injected version used in tests.
 pub fn probe_reachability_all<I, S>(hosts: I) -> HashMap<String, bool>
 where
     I: IntoIterator<Item = S>,
@@ -34,12 +31,7 @@ where
     probe_with(hosts, probe_reachability)
 }
 
-/// Probes many hosts concurrently using a caller-supplied probe function.
-///
-/// Crate-private: exists so tests can inject a fake (e.g. time-based) probe
-/// without touching SSH. Callers outside this module should use
-/// [`probe_reachability_all`].
-pub(crate) fn probe_with<I, S, F>(hosts: I, probe: F) -> HashMap<String, bool>
+fn probe_with<I, S, F>(hosts: I, probe: F) -> HashMap<String, bool>
 where
     I: IntoIterator<Item = S>,
     S: Into<String>,

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -830,11 +830,10 @@ impl App {
         } else {
             let tx = self.tx.clone();
             std::thread::spawn(move || {
-                probe_and_fan_reachability(
-                    unreachable,
-                    tx,
-                    crate::sources::hosts::probe_reachability,
-                );
+                let results = crate::sources::hosts::probe_reachability_all(unreachable);
+                for (host, reachable) in results {
+                    let _ = tx.send(crate::tui::state::AppMsg::HostReachability(host, reachable));
+                }
             });
             self.warning = Some(("Reconnecting...".to_string(), Instant::now()));
         }
@@ -2454,22 +2453,6 @@ impl App {
 // ---------------------------------------------------------------------------
 // Task view helpers (free functions)
 // ---------------------------------------------------------------------------
-
-/// Probes `unreachable` hosts concurrently and fans `HostReachability` messages to `tx`.
-///
-/// Parameterized over `probe` so tests can inject a fake without touching SSH.
-pub(crate) fn probe_and_fan_reachability<F>(
-    unreachable: Vec<String>,
-    tx: std::sync::mpsc::Sender<crate::tui::state::AppMsg>,
-    probe: F,
-) where
-    F: Fn(&str) -> bool + Clone + Send + 'static,
-{
-    let results = crate::sources::hosts::probe_with(unreachable, probe);
-    for (host, reachable) in results {
-        let _ = tx.send(crate::tui::state::AppMsg::HostReachability(host, reachable));
-    }
-}
 
 /// Appends an expand/collapse indicator to a status string when pane count > 1.
 ///
@@ -4303,93 +4286,6 @@ mod tests {
             !text.contains("[b]"),
             "unexpected '[b]' in badge text: {:?}",
             text
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // probe_and_fan_reachability — concurrency regression tests (issue #273)
-    // -----------------------------------------------------------------------
-
-    /// Regression test for issue #273: `reconnect_unreachable_hosts` probed hosts
-    /// serially, so N dead hosts → N × ConnectTimeout wait. `probe_and_fan_reachability`
-    /// must dispatch probes concurrently.
-    #[test]
-    fn reconnect_probes_hosts_concurrently() {
-        use std::sync::mpsc;
-        use std::time::{Duration, Instant};
-        let hosts = vec![
-            "alpha".to_string(),
-            "bravo".to_string(),
-            "charlie".to_string(),
-        ];
-        let (tx, rx) = mpsc::channel();
-        let delay = Duration::from_millis(200);
-
-        let start = Instant::now();
-        probe_and_fan_reachability(hosts, tx, move |_host| {
-            std::thread::sleep(delay);
-            false
-        });
-        let elapsed = start.elapsed();
-
-        assert!(
-            elapsed < Duration::from_millis(500),
-            "expected concurrent dispatch (<500ms, serial would be ~600ms), got {:?}",
-            elapsed
-        );
-        let msgs: Vec<_> = rx.try_iter().collect();
-        assert_eq!(
-            msgs.len(),
-            3,
-            "expected one HostReachability message per host"
-        );
-        for msg in msgs {
-            match msg {
-                crate::tui::state::AppMsg::HostReachability(_, reachable) => {
-                    assert!(!reachable);
-                }
-                _ => panic!("unexpected message variant"),
-            }
-        }
-    }
-
-    /// Dead host must not delay the live host's probe start — same guarantee as
-    /// the issue #263 fix, applied to the reconnect path.
-    #[test]
-    fn reconnect_dead_host_does_not_block_live_probe() {
-        use std::sync::{Arc, Mutex, mpsc};
-        use std::time::{Duration, Instant};
-        let (tx, _rx) = mpsc::channel();
-        let start_times: Arc<Mutex<Vec<(String, Duration)>>> = Arc::new(Mutex::new(Vec::new()));
-        let start_times_clone = start_times.clone();
-        let t0 = Instant::now();
-
-        let hosts = vec!["dead".to_string(), "live".to_string()];
-        probe_and_fan_reachability(hosts, tx, move |host| {
-            start_times_clone
-                .lock()
-                .unwrap()
-                .push((host.to_string(), t0.elapsed()));
-            if host == "dead" {
-                std::thread::sleep(Duration::from_millis(500));
-                false
-            } else {
-                std::thread::sleep(Duration::from_millis(10));
-                true
-            }
-        });
-
-        let times = start_times.lock().unwrap();
-        let live_start = times
-            .iter()
-            .find(|(h, _)| h == "live")
-            .map(|(_, t)| *t)
-            .expect("live probe should have started");
-        assert!(
-            live_start < Duration::from_millis(100),
-            "live probe must start within 100ms of dispatch (serial would delay it ~500ms), \
-             started at {:?}",
-            live_start
         );
     }
 }

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -830,10 +830,11 @@ impl App {
         } else {
             let tx = self.tx.clone();
             std::thread::spawn(move || {
-                for host in unreachable {
-                    let reachable = crate::remote::ssh_exec(&host, "true").is_ok();
-                    let _ = tx.send(crate::tui::state::AppMsg::HostReachability(host, reachable));
-                }
+                probe_and_fan_reachability(
+                    unreachable,
+                    tx,
+                    crate::sources::hosts::probe_reachability,
+                );
             });
             self.warning = Some(("Reconnecting...".to_string(), Instant::now()));
         }
@@ -2453,6 +2454,22 @@ impl App {
 // ---------------------------------------------------------------------------
 // Task view helpers (free functions)
 // ---------------------------------------------------------------------------
+
+/// Probes `unreachable` hosts concurrently and fans `HostReachability` messages to `tx`.
+///
+/// Parameterized over `probe` so tests can inject a fake without touching SSH.
+pub(crate) fn probe_and_fan_reachability<F>(
+    unreachable: Vec<String>,
+    tx: std::sync::mpsc::Sender<crate::tui::state::AppMsg>,
+    probe: F,
+) where
+    F: Fn(&str) -> bool + Clone + Send + 'static,
+{
+    let results = crate::sources::hosts::probe_with(unreachable, probe);
+    for (host, reachable) in results {
+        let _ = tx.send(crate::tui::state::AppMsg::HostReachability(host, reachable));
+    }
+}
 
 /// Appends an expand/collapse indicator to a status string when pane count > 1.
 ///
@@ -4286,6 +4303,93 @@ mod tests {
             !text.contains("[b]"),
             "unexpected '[b]' in badge text: {:?}",
             text
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // probe_and_fan_reachability — concurrency regression tests (issue #273)
+    // -----------------------------------------------------------------------
+
+    /// Regression test for issue #273: `reconnect_unreachable_hosts` probed hosts
+    /// serially, so N dead hosts → N × ConnectTimeout wait. `probe_and_fan_reachability`
+    /// must dispatch probes concurrently.
+    #[test]
+    fn reconnect_probes_hosts_concurrently() {
+        use std::sync::mpsc;
+        use std::time::{Duration, Instant};
+        let hosts = vec![
+            "alpha".to_string(),
+            "bravo".to_string(),
+            "charlie".to_string(),
+        ];
+        let (tx, rx) = mpsc::channel();
+        let delay = Duration::from_millis(200);
+
+        let start = Instant::now();
+        probe_and_fan_reachability(hosts, tx, move |_host| {
+            std::thread::sleep(delay);
+            false
+        });
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "expected concurrent dispatch (<500ms, serial would be ~600ms), got {:?}",
+            elapsed
+        );
+        let msgs: Vec<_> = rx.try_iter().collect();
+        assert_eq!(
+            msgs.len(),
+            3,
+            "expected one HostReachability message per host"
+        );
+        for msg in msgs {
+            match msg {
+                crate::tui::state::AppMsg::HostReachability(_, reachable) => {
+                    assert!(!reachable);
+                }
+                _ => panic!("unexpected message variant"),
+            }
+        }
+    }
+
+    /// Dead host must not delay the live host's probe start — same guarantee as
+    /// the issue #263 fix, applied to the reconnect path.
+    #[test]
+    fn reconnect_dead_host_does_not_block_live_probe() {
+        use std::sync::{Arc, Mutex, mpsc};
+        use std::time::{Duration, Instant};
+        let (tx, _rx) = mpsc::channel();
+        let start_times: Arc<Mutex<Vec<(String, Duration)>>> = Arc::new(Mutex::new(Vec::new()));
+        let start_times_clone = start_times.clone();
+        let t0 = Instant::now();
+
+        let hosts = vec!["dead".to_string(), "live".to_string()];
+        probe_and_fan_reachability(hosts, tx, move |host| {
+            start_times_clone
+                .lock()
+                .unwrap()
+                .push((host.to_string(), t0.elapsed()));
+            if host == "dead" {
+                std::thread::sleep(Duration::from_millis(500));
+                false
+            } else {
+                std::thread::sleep(Duration::from_millis(10));
+                true
+            }
+        });
+
+        let times = start_times.lock().unwrap();
+        let live_start = times
+            .iter()
+            .find(|(h, _)| h == "live")
+            .map(|(_, t)| *t)
+            .expect("live probe should have started");
+        assert!(
+            live_start < Duration::from_millis(100),
+            "live probe must start within 100ms of dispatch (serial would delay it ~500ms), \
+             started at {:?}",
+            live_start
         );
     }
 }

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -2665,6 +2665,24 @@ mod tests {
     }
 
     #[test]
+    fn reconnect_unreachable_hosts_all_reachable_sets_warning() {
+        let mut app = App::new_test(vec![]);
+        app.host_reachable.insert("gpu1".to_string(), true);
+        app.reconnect_unreachable_hosts();
+        let warning = app.warning.as_ref().map(|(s, _)| s.as_str());
+        assert_eq!(warning, Some("All hosts reachable"));
+    }
+
+    #[test]
+    fn reconnect_unreachable_hosts_unreachable_sets_reconnecting_warning() {
+        let mut app = App::new_test(vec![]);
+        app.host_reachable.insert("gpu1".to_string(), false);
+        app.reconnect_unreachable_hosts();
+        let warning = app.warning.as_ref().map(|(s, _)| s.as_str());
+        assert_eq!(warning, Some("Reconnecting..."));
+    }
+
+    #[test]
     fn header_renders_host_connectivity() {
         let mut app = App::new_test(vec![]);
         app.host_reachable.insert("gpu1".to_string(), true);


### PR DESCRIPTION
## Summary

- `reconnect_unreachable_hosts` probed hosts serially inside a single background thread, making the TUI's "reconnect" action block for `N × 5s` ConnectTimeout per dead host (10s for two, 15s for three).
- Inline a fan loop over `sources::hosts::probe_reachability_all` — same shape as `start_full_refresh` post-#271. Dead hosts can no longer block probes for healthy hosts behind them.
- Same bug class as #263, different code path.

## Acceptance Criteria

| AC | Status | Evidence |
|----|--------|----------|
| `reconnect_unreachable_hosts` uses `probe_reachability_all` | ✅ | `crates/orchard/src/tui/list.rs:833` |
| No direct `ssh_exec(host, "true")` calls in `tui/list.rs` | ✅ | `grep ssh_exec crates/orchard/src/tui/list.rs` → no matches |
| Unit test covers the concurrent reconnect path | ✅ (layered) | See "Test coverage boundary" below |
| Manual: 2 dead remotes, reconnect finishes in ~5s not 10s | ✅ (by construction) | `probe_reachability_all` spawns one thread per host; guarantee unchanged from #271 |

### Test coverage boundary

The concurrency guarantee is asserted **one layer down**, not at the TUI call site. Specifically:

- `sources::hosts::tests::probes_run_concurrently` asserts 3-host dispatch completes in <500ms (serial would be ≥600ms).
- `sources::hosts::tests::dead_host_does_not_delay_live_host_probe` asserts the live probe starts within 100ms of dispatch even when a dead probe blocks for 500ms.
- `tui::tests::reconnect_unreachable_hosts_*` asserts only the TUI-specific wiring (warning-string branches) on the real method.

This is intentional. The first pass on this PR duplicated the timing tests inside `tui/list.rs`; three reviewers converged that this re-proved the same `probe_with` invariant under a different function name. The follow-up commit inlined the call site (no more helper in `tui/list.rs`) and deleted the duplicate tests. Concurrency is now a single-source-of-truth property of `probe_reachability_all`, and every caller (including this one) inherits it.

A regression that reverts the serial loop inside the spawned thread would be caught by the existing `sources/hosts.rs` tests if it touched the helper, or by manual test + CI observation if someone re-rolled SSH probing. The residual risk (someone adds a new serial probe loop that *doesn't* go through the helper) is addressed by the `grep ssh_exec` check in AC #2.

## Review Round

Three reviewer passes (principles, hygiene, tests + security) ran on this PR. Findings applied:
- Helper belonged next to its sibling, not in `tui/list.rs` → deleted helper, inlined fan loop.
- Calling `probe_with` (documented as "tests only") from production violated the contract → reverted `probe_with` to private.
- Duplicate timing tests re-proved `sources/hosts` invariants → deleted, replaced with warning-wiring tests.

## Out of Scope (Follow-ups)

- `start_full_refresh` in `tui/mod.rs:574-583` has the same fan loop manually; its loop also builds a `reachable_hosts: HashSet` used downstream, so the shapes don't consolidate cleanly.
- No debounce on rapid "reconnect" key presses — each press spawns a fresh probe batch. With 3 dead hosts × 4 rapid presses, 12 concurrent SSH probes in flight. Probably fine; worth a throttle if it ever surfaces.
- Messages fan *after* all probes join (same as `start_full_refresh`), not per-host. Could be progressive in the future.

## Test plan

- [x] `cargo test -p orchard --lib reconnect_unreachable` — both new tests pass
- [x] `cargo test -p orchard --lib sources::hosts` — 3 pre-existing concurrency tests still pass (unchanged)
- [x] `cargo clippy -p orchard --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p orchard --check` — clean

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #273