### PR TITLE
fix(scripts): bookend send-keys Enter to flush stuck orchardist signals

### DIFF
--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -205,7 +205,7 @@ pub(crate) fn visible_tasks_filtered<'a>(
     }
 
     // Sort by descending score so best match appears first.
-    scored.sort_by(|a, b| b.0.cmp(&a.0));
+    scored.sort_by_key(|b| std::cmp::Reverse(b.0));
 
     // Compose: main worktrees first (preserving their order), then scored rows.
     let mut result = main_rows;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,64 @@
+# Orchard Monitor Scripts
+
+Background helpers used by the **orchardist** tmux session to monitor the orchard
+and drive long-running work to green.
+
+| Script | Purpose |
+|--------|---------|
+| `orchard-monitor.sh` | Polls `orchard --json`, detects state changes, signals the orchardist pane via `tmux send-keys`. Also throttles a watchlist check. |
+| `orchard-decide.sh`  | State-diff decision tree: classifies per-PR transitions (auto-merge, nudge, alert) and signals the orchardist. |
+
+## Running
+
+```sh
+nohup scripts/orchard-monitor.sh > /tmp/orchard-monitor.log 2>&1 &
+echo $! > /tmp/orchard-monitor.pid
+```
+
+`orchard-decide.sh` is resolved relative to `orchard-monitor.sh`, so both files
+must live in the same directory.
+
+## Requirements
+
+- `bash`, `python3` on PATH
+- `orchard` CLI on PATH (produces `--json` output)
+- a tmux session named `orchardist` with at least one pane
+
+## Environment
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `ORCHARDIST_PANE` | `orchardist:0.0` | tmux target for signals. Use a session-name target — pane IDs (`%0`) are not stable across tmux restarts. |
+| `POLL_INTERVAL` | `60` | Seconds between orchard polls. |
+| `WATCH_INTERVAL` | `300` | Seconds between watchlist alert checks. |
+| `REPORT_INTERVAL` | `300` | Seconds between `ORCHARD_REPORT_CMD` refreshes. |
+| `ORCHARD_REPORT_CMD` | _(unset)_ | Optional path to an executable that publishes a dashboard (e.g. to Telegram, Slack). Invoked on every state change and every `REPORT_INTERVAL` seconds. If unset, no dashboard is published. |
+
+## tmux send-keys
+
+Every signal send is bookended with a leading `Enter`:
+
+```sh
+tmux send-keys -t "$ORCHARDIST_PANE" Enter       # drain any stuck prior signal
+tmux send-keys -t "$ORCHARDIST_PANE" -l "$MSG"   # deliver text literally
+tmux send-keys -t "$ORCHARDIST_PANE" Enter       # submit this signal
+```
+
+**Why the leading Enter:** Claude Code's input prompt buffers text + newline if a
+turn is in progress when the signal arrives. The `\n` is not converted to a
+submit when the turn finishes — the text sits in the prompt until a later Enter
+drains it. The leading Enter flushes whatever was buffered before; `Enter` on an
+empty buffer is a no-op in Claude Code, so this is always safe.
+
+**The old fix wasn't enough.** A previous attempt replaced single-call
+`send-keys "$MSG" Enter` with two-call `send-keys -l "$MSG"` + `send-keys Enter`,
+reasoning that the single-call form sometimes failed to submit. A wire-level
+PTY trace proved both forms produce byte-identical output; the buffering bug is
+in Claude Code's input handling, not in tmux. The bookend is the actual fix.
+
+## Runtime state
+
+Both scripts persist state under `${HOME}/.claude/state/`. This default is a
+historical artifact — see the follow-up issue tracking the canonical source
+of truth for these scripts. Override via env vars documented at the top of
+each script if you need a different location.

--- a/scripts/orchard-decide.sh
+++ b/scripts/orchard-decide.sh
@@ -1,0 +1,264 @@
+#!/bin/bash
+# Orchard decision engine — classifies every open PR and raises signals
+# for the orchardist to triage. Never takes action itself.
+#
+# Signals read:
+#   - orchard --json (PR state, CI, labels, threads, session, activity)
+#   - gh GraphQL reviewThreads (per PR, on demand when thread count changes)
+#   - per-PR state diff file at ~/.claude/state/orchard-decide-state.json
+#
+# Signals raised (to orchardist tmux pane, tagged [orchard-decide]):
+#   - READY: approved + green CI + 0 threads — candidate to merge
+#   - CHANGES_REQUESTED / THREADS: review feedback needs session attention
+#   - CI_FAILING: real code check failure (ignores approval-or-label gate)
+#   - CONFLICTS: branch conflicts with main
+#   - DRAFT w/ dead session: investigate
+#   - STALL: session idle with no state change >10min
+#
+# The orchardist reads these and decides what to do.
+#
+# Usage:
+#   orchard-decide.sh            # full pass
+#   orchard-decide.sh --dry-run  # classify + print, no signals
+#   orchard-decide.sh --verbose  # include debug
+
+set -euo pipefail
+
+STATE_DIR="${HOME}/.claude/state"
+DECIDE_STATE="${STATE_DIR}/orchard-decide-state.json"
+STALL_THRESHOLD="${STALL_THRESHOLD:-600}"  # seconds
+
+DRY_RUN=0
+VERBOSE=0
+for a in "$@"; do
+  case "$a" in
+    --dry-run) DRY_RUN=1 ;;
+    --verbose) VERBOSE=1 ;;
+  esac
+done
+
+mkdir -p "$STATE_DIR"
+[ -f "$DECIDE_STATE" ] || echo '{}' > "$DECIDE_STATE"
+
+JSON=$(orchard --json 2>/dev/null)
+if [ -z "$JSON" ]; then
+  echo "orchard --json empty" >&2
+  exit 1
+fi
+
+# Python does the classification + signal dispatch
+ORCHARD_JSON="$JSON" \
+DECIDE_STATE="$DECIDE_STATE" \
+DRY_RUN="$DRY_RUN" \
+VERBOSE="$VERBOSE" \
+STALL_THRESHOLD="$STALL_THRESHOLD" \
+python3 <<'PY'
+import os, json, subprocess, datetime, sys
+
+DRY = os.environ.get('DRY_RUN') == '1'
+VERBOSE = os.environ.get('VERBOSE') == '1'
+STALL = int(os.environ['STALL_THRESHOLD'])
+STATE_FILE = os.environ['DECIDE_STATE']
+BOTS = {'coderabbitai', 'github-code-quality', 'github-actions', 'claude[bot]', 'dependabot[bot]'}
+
+data = json.loads(os.environ['ORCHARD_JSON'])
+
+try:
+    prev_state = json.load(open(STATE_FILE))
+except Exception:
+    prev_state = {}
+
+now_ts = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+
+def log(msg):
+    if VERBOSE:
+        print(f'[decide] {msg}', file=sys.stderr)
+
+def signal_orchardist(text):
+    if DRY:
+        print(f'[dry] would signal orchardist: {text}')
+        return
+    # Bookend Enter to flush any signal that arrived while Claude was mid-turn
+    # and is now sitting buffered in the prompt. Enter with an empty buffer is
+    # a no-op, so the leading Enter is always safe.
+    target = 'orchardist:0.0'
+    subprocess.run(['tmux', 'send-keys', '-t', target, 'Enter'],
+                   capture_output=True)
+    subprocess.run(['tmux', 'send-keys', '-t', target, '-l', text],
+                   capture_output=True)
+    subprocess.run(['tmux', 'send-keys', '-t', target, 'Enter'],
+                   capture_output=True)
+
+# --- classifier ---
+def classify(wt, repo_slug):
+    pr = wt.get('pr')
+    issue = wt.get('issue') or {}
+    if not pr or pr.get('state') != 'open':
+        return None
+
+    draft = pr.get('isDraft', False)
+    checks = pr.get('checksState', '')
+    conflicts = pr.get('hasConflicts', False)
+    threads = pr.get('unresolvedThreads', 0) or pr.get('unresolvedThreadCount', 0) or 0
+    pr_labels = set()
+    for l in (pr.get('labels') or []):
+        pr_labels.add(l['name'] if isinstance(l, dict) else str(l))
+
+    # Blocked PRs: skip entirely. Orchardist stops spinning on them.
+    if 'blocked' in pr_labels:
+        return None
+
+    latest_by_author = {}
+    for r in (pr.get('reviews') or []):
+        a = r.get('author')
+        login = a.get('login') if isinstance(a, dict) else a
+        if not login or login in BOTS:
+            continue
+        if r.get('state') in ('APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'):
+            latest_by_author[login] = r.get('state')
+    human_approved = any(v == 'APPROVED' for v in latest_by_author.values())
+    changes_requested = any(v == 'CHANGES_REQUESTED' for v in latest_by_author.values())
+
+    ci_failing = False
+    if checks == 'failing':
+        # But ignore if only failure is check-approval-or-label and PR has a label that bypasses it
+        non_gate_fails = [c for c in (pr.get('ciChecks', {}).get('code') or [])
+                          if c.get('state') == 'failing' and c.get('name') != 'check-approval-or-label']
+        if non_gate_fails:
+            ci_failing = True
+
+    sessions = wt.get('sessions') or []
+    sess = sessions[0] if sessions else None
+    sess_status = (sess.get('claude') or {}).get('status') if sess else None
+    sess_name = sess.get('name') if sess else None
+    last_activity = sess.get('lastActivityAt') if sess else None
+
+    if conflicts:
+        state = 'CONFLICTS'
+    elif ci_failing:
+        state = 'CI_FAILING'
+    elif threads > 0:
+        state = 'THREADS'
+    elif draft:
+        state = 'DRAFT'
+    elif changes_requested:
+        state = 'CHANGES_REQUESTED'
+    elif human_approved:
+        state = 'READY'
+    elif 'pr-ready' in pr_labels or 'low-risk-change' in pr_labels:
+        state = 'AWAITING_APPROVAL_LABELED'
+    else:
+        state = 'AWAITING_REVIEW'
+
+    return {
+        'repo': repo_slug,
+        'pr_num': pr.get('number'),
+        'pr_title': pr.get('title', '')[:80],
+        'pr_url': pr.get('url') or f'https://github.com/{repo_slug}/pull/{pr.get("number")}',
+        'state': state,
+        'draft': draft,
+        'threads': threads,
+        'human_approved': human_approved,
+        'changes_requested': changes_requested,
+        'ci_failing': ci_failing,
+        'labels': sorted(pr_labels),
+        'sess_name': sess_name,
+        'sess_status': sess_status,
+        'last_activity': last_activity,
+    }
+
+rows = []
+for repo in data.get('repos', []):
+    slug = repo.get('slug', 'unknown/unknown')
+    for wt in repo.get('worktrees', []):
+        if wt.get('isMainWorktree'):
+            continue
+        r = classify(wt, slug)
+        if r:
+            rows.append(r)
+
+# --- actions ---
+actions = []
+
+def session_alive(r):
+    return r['sess_status'] in ('working', 'idle', 'input')
+
+def session_dead(r):
+    return r['sess_name'] and r['sess_status'] in (None, 'no-claude')
+
+def session_working(r):
+    return r['sess_status'] == 'working'
+
+for r in rows:
+    key = f"{r['repo']}#{r['pr_num']}"
+    prev = prev_state.get(key, {})
+    prev_state_val = prev.get('state', '')
+
+    # State transitions are the interesting events. Re-signaling the same
+    # state every tick would flood the orchardist. Only raise signals when:
+    #   - the PR just entered this state, OR
+    #   - the PR has been in this state longer than REPEAT_INTERVAL and the
+    #     orchardist hasn't acted on it yet (configurable per-signal).
+    state_changed = r['state'] != prev_state_val
+    last_signal = prev.get('last_signal_ts', 0)
+    REPEAT = 1800  # remind orchardist every 30min on stuck states
+
+    session_tag = f"sess={r['sess_name'] or '-'}:{r['sess_status'] or '-'}"
+    pr_tag = f"{r['repo']}#{r['pr_num']}"
+
+    # Signal 1: READY — human approved + green CI + no threads → merge candidate
+    if r['state'] == 'READY' and (state_changed or now_ts - last_signal > REPEAT):
+        actions.append(f"READY {pr_tag} — human-approved, green CI, 0 threads — {r['pr_title']}")
+        prev['last_signal_ts'] = now_ts
+
+    # Signal 2: CHANGES_REQUESTED / THREADS → author needs to address feedback
+    elif r['state'] in ('CHANGES_REQUESTED', 'THREADS') and (state_changed or now_ts - last_signal > REPEAT):
+        actions.append(f"{r['state']} {pr_tag} threads={r['threads']} {session_tag} — {r['pr_title']}")
+        prev['last_signal_ts'] = now_ts
+
+    # Signal 3: CI_FAILING (real code check, not approval gate)
+    elif r['state'] == 'CI_FAILING' and (state_changed or now_ts - last_signal > REPEAT):
+        actions.append(f"CI_FAILING {pr_tag} {session_tag} — {r['pr_title']}")
+        prev['last_signal_ts'] = now_ts
+
+    # Signal 4: DRAFT with no live session → investigate
+    elif r['state'] == 'DRAFT' and (not r['sess_name'] or session_dead(r)):
+        if state_changed or now_ts - last_signal > REPEAT:
+            actions.append(f"DRAFT-ORPHAN {pr_tag} {session_tag} — {r['pr_title']}")
+            prev['last_signal_ts'] = now_ts
+
+    # Signal 5: CONFLICTS (branch needs rebase)
+    elif r['state'] == 'CONFLICTS' and (state_changed or now_ts - last_signal > REPEAT):
+        actions.append(f"CONFLICTS {pr_tag} {session_tag} — {r['pr_title']}")
+        prev['last_signal_ts'] = now_ts
+
+    # Stall detection: idle/working session with no state change >10min → probe
+    if r['sess_status'] in ('idle', 'working'):
+        last_change = prev.get('last_change_ts', now_ts)
+        if state_changed:
+            prev['last_change_ts'] = now_ts
+        elif now_ts - last_change > STALL:
+            last_probe = prev.get('last_probe_ts', 0)
+            if now_ts - last_probe > STALL:
+                actions.append(f"STALL {pr_tag} state={r['state']} {session_tag} duration={now_ts - last_change}s")
+                prev['last_probe_ts'] = now_ts
+
+    # Save per-PR state
+    prev['state'] = r['state']
+    prev_state[key] = prev
+
+# Prune state for PRs no longer present
+current_keys = {f"{r['repo']}#{r['pr_num']}" for r in rows}
+prev_state = {k: v for k, v in prev_state.items() if k in current_keys}
+
+with open(STATE_FILE, 'w') as f:
+    json.dump(prev_state, f, indent=2)
+
+# Raise signals to orchardist pane (one line per signal, prefixed)
+if actions:
+    for a in actions:
+        print(a)
+        signal_orchardist(f"[orchard-decide] {a}")
+else:
+    print('[decide] no signals')
+PY

--- a/scripts/orchard-monitor.sh
+++ b/scripts/orchard-monitor.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+# Orchard session monitor — polls orchard --json, sends changes to orchardist tmux session
+# Also checks a watchlist for issues that should be driven to green
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ORCHARDIST_PANE="${ORCHARDIST_PANE:-orchardist:0.0}"
+STATE_FILE="/tmp/orchard-monitor-state.txt"
+WATCH_FILE="/tmp/orchard-monitor-watch.txt"
+DURATION_FILE="/tmp/orchard-monitor-durations.json"
+WATCH_INTERVAL="${WATCH_INTERVAL:-300}"
+LAST_WATCH_FILE="/tmp/orchard-monitor-last-watch"
+REPORT_INTERVAL="${REPORT_INTERVAL:-300}"
+LAST_REPORT_FILE="/tmp/orchard-monitor-last-report"
+
+# Initialize duration file if missing
+[ -f "$DURATION_FILE" ] || echo '{}' > "$DURATION_FILE"
+[ -f "$LAST_WATCH_FILE" ] || echo "0" > "$LAST_WATCH_FILE"
+
+while true; do
+  CURRENT=$(orchard --json 2>/dev/null)
+  if [ -z "$CURRENT" ]; then
+    sleep 60
+    continue
+  fi
+
+  NOW=$(date +%s)
+
+  # Extract stable state fields — exclude volatile ones (cost, context%, timestamps)
+  CURRENT_SESSIONS=$(echo "$CURRENT" | python3 -c "
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    lines = []
+    for repo in data.get('repos', []):
+        for wt in repo.get('worktrees', []):
+            if wt.get('isMainWorktree'):
+                continue
+            issue = wt.get('issue') or {}
+            issue_num = issue.get('number', '')
+            pr = wt.get('pr') or {}
+            pr_state = pr.get('state', 'none')
+            pr_checks = pr.get('checksState', '')
+            pr_conflicts = pr.get('hasConflicts', False)
+            pr_threads = pr.get('unresolvedThreads', 0)
+            session_info = []
+            for s in wt.get('sessions', []):
+                claude = s.get('claude') or {}
+                cs = claude.get('status', 'no-claude') if claude else 'no-claude'
+                session_info.append(f'{s[\"name\"]}={cs}')
+            sessions_str = ','.join(session_info) if session_info else 'no-session'
+            lines.append(f'#{issue_num}|{sessions_str}|pr:{pr_state}|ci:{pr_checks}|conflicts:{pr_conflicts}|threads:{pr_threads}')
+    print('\n'.join(sorted(lines)))
+except:
+    pass
+" 2>/dev/null)
+
+  # --- State change detection ---
+  if [ -f "$STATE_FILE" ]; then
+    PREV_SESSIONS=$(cat "$STATE_FILE")
+    if [ "$CURRENT_SESSIONS" != "$PREV_SESSIONS" ]; then
+      MSG=$(diff <(echo "$PREV_SESSIONS") <(echo "$CURRENT_SESSIONS") 2>/dev/null | python3 -c "
+import sys
+lines = sys.stdin.read().strip().split('\n')
+removed = [l[2:] for l in lines if l.startswith('< ')]
+added = [l[2:] for l in lines if l.startswith('> ')]
+changes = []
+rm_by_issue = {l.split('|')[0]: l for l in removed}
+add_by_issue = {l.split('|')[0]: l for l in added}
+for issue in set(list(rm_by_issue.keys()) + list(add_by_issue.keys())):
+    old = rm_by_issue.get(issue, '')
+    new = add_by_issue.get(issue, '')
+    if old and new:
+        old_parts = dict(p.split(':',1) if ':' in p else (p,'') for p in old.split('|')[1:])
+        new_parts = dict(p.split(':',1) if ':' in p else (p,'') for p in new.split('|')[1:])
+        diffs = []
+        for k in set(list(old_parts.keys()) + list(new_parts.keys())):
+            if old_parts.get(k) != new_parts.get(k):
+                diffs.append(f'{k}:{old_parts.get(k,\"?\")}→{new_parts.get(k,\"?\")}')
+        if diffs:
+            changes.append(f'{issue} {\" \".join(diffs)}')
+    elif new:
+        changes.append(f'{issue} NEW')
+    elif old:
+        changes.append(f'{issue} REMOVED')
+if changes:
+    print('[orchard-monitor] ' + '; '.join(changes[:5]))
+" 2>/dev/null)
+
+      # Filter to only report watched issues
+      if [ -f "$WATCH_FILE" ] && [ -n "$MSG" ]; then
+        WATCHED_NUMS=$(grep -v '^#' "$WATCH_FILE" | tr '\n' '|' | sed 's/|$//')
+        if [ -n "$WATCHED_NUMS" ]; then
+          MSG=$(echo "$MSG" | python3 -c "
+import sys, re
+line = sys.stdin.read().strip()
+watched = set(['#$w' for w in '''$WATCHED_NUMS'''.split('|')])
+# Parse changes from the message
+prefix = '[orchard-monitor] '
+if line.startswith(prefix):
+    body = line[len(prefix):]
+    parts = [p.strip() for p in body.split(';')]
+    filtered = [p for p in parts if any(p.startswith(w) for w in watched)]
+    if filtered:
+        print(prefix + '; '.join(filtered))
+" 2>/dev/null)
+        fi
+      fi
+      if [ -n "$MSG" ]; then
+        # Bookend Enter to flush any signal that arrived while Claude was mid-turn
+        # and is now sitting buffered in the prompt. Enter with an empty buffer is
+        # a no-op, so the leading Enter is always safe.
+        tmux send-keys -t "$ORCHARDIST_PANE" Enter 2>/dev/null
+        tmux send-keys -t "$ORCHARDIST_PANE" -l "$MSG" 2>/dev/null
+        tmux send-keys -t "$ORCHARDIST_PANE" Enter 2>/dev/null
+      fi
+
+      # Optional dashboard refresh. Point ORCHARD_REPORT_CMD at an executable
+      # (e.g. a user-specific Telegram poster) to receive state-change nudges.
+      if [ -n "${ORCHARD_REPORT_CMD:-}" ] && [ -x "$ORCHARD_REPORT_CMD" ]; then
+        ( "$ORCHARD_REPORT_CMD" >> /tmp/orchard-report.log 2>&1 ) &
+        echo "$NOW" > "$LAST_REPORT_FILE"
+      fi
+
+      # State changed → run decision tree (auto-merge, nudge sessions, etc.)
+      ( "$SCRIPT_DIR/orchard-decide.sh" >> /tmp/orchard-decide.log 2>&1 ) &
+
+      # Update duration tracking — reset timers for issues whose state changed
+      python3 -c "
+import json, sys
+
+now = $NOW
+prev_lines = '''$PREV_SESSIONS'''.strip().split('\n')
+curr_lines = '''$CURRENT_SESSIONS'''.strip().split('\n')
+prev_by_issue = {l.split('|')[0]: l for l in prev_lines if l.strip()}
+curr_by_issue = {l.split('|')[0]: l for l in curr_lines if l.strip()}
+
+try:
+    with open('$DURATION_FILE') as f:
+        durations = json.load(f)
+except:
+    durations = {}
+
+for issue, state in curr_by_issue.items():
+    if state != prev_by_issue.get(issue, ''):
+        durations[issue] = now
+    elif issue not in durations:
+        durations[issue] = now
+
+# Remove issues no longer present
+durations = {k: v for k, v in durations.items() if k in curr_by_issue}
+
+with open('$DURATION_FILE', 'w') as f:
+    json.dump(durations, f)
+" 2>/dev/null
+    fi
+  else
+    # First run — initialize all durations to now
+    python3 -c "
+import json
+now = $NOW
+lines = '''$CURRENT_SESSIONS'''.strip().split('\n')
+durations = {l.split('|')[0]: now for l in lines if l.strip()}
+with open('$DURATION_FILE', 'w') as f:
+    json.dump(durations, f)
+" 2>/dev/null
+  fi
+
+  echo "$CURRENT_SESSIONS" > "$STATE_FILE"
+
+  # --- Watchlist check (throttled to WATCH_INTERVAL) ---
+  LAST_WATCH=$(cat "$LAST_WATCH_FILE" 2>/dev/null || echo 0)
+  WATCH_ELAPSED=$((NOW - LAST_WATCH))
+  if [ -f "$WATCH_FILE" ] && [ "$WATCH_ELAPSED" -ge "$WATCH_INTERVAL" ]; then
+    WATCH_ALERT=$(echo "$CURRENT_SESSIONS" | python3 -c "
+import sys, json, time
+
+now = $NOW
+timestamp = time.strftime('%H:%M', time.localtime(now))
+
+# Read durations
+try:
+    with open('$DURATION_FILE') as f:
+        durations = json.load(f)
+except:
+    durations = {}
+
+def fmt_duration(seconds):
+    if seconds < 60:
+        return '<1m'
+    elif seconds < 3600:
+        return f'{seconds // 60}m'
+    else:
+        h = seconds // 3600
+        m = (seconds % 3600) // 60
+        return f'{h}h{m}m' if m else f'{h}h'
+
+# Read current state from stdin
+state_lines = sys.stdin.read().strip().split('\n')
+state_by_issue = {}
+for line in state_lines:
+    parts = line.split('|')
+    if parts:
+        state_by_issue[parts[0]] = line
+
+# Read watchlist
+alerts = []
+try:
+    with open('$WATCH_FILE') as f:
+        watched = [l.strip() for l in f if l.strip() and not l.startswith('#')]
+except:
+    watched = []
+
+for issue_num in watched:
+    key = f'#{issue_num}'
+    state = state_by_issue.get(key, '')
+    if not state:
+        alerts.append(f'{key}: not found in orchard')
+        continue
+
+    parts = dict(p.split(':',1) if ':' in p else (p,'') for p in state.split('|')[1:])
+    ci = parts.get('ci', '')
+    threads = parts.get('threads', '0')
+    sessions = state.split('|')[1] if '|' in state else ''
+
+    # Calculate how long in current state
+    since = durations.get(key, now)
+    elapsed = now - since
+    dur = fmt_duration(elapsed)
+
+    problems = []
+    if ci == 'failing':
+        problems.append('CI failing')
+    if threads != '0':
+        problems.append(f'{threads} unresolved threads')
+    if 'no-session' in sessions or 'no-claude' in sessions:
+        problems.append('no active session')
+    elif 'idle' in sessions or 'input' in sessions:
+        problems.append('session idle/waiting')
+
+    if not problems and ci == 'passing' and threads == '0':
+        alerts.append(f'{key}: GREEN \u2713')
+    elif problems:
+        alerts.append(f'{key}: {\" | \".join(problems)} ({dur})')
+
+if alerts:
+    print(f'[watch {timestamp}] ' + '; '.join(alerts))
+" 2>/dev/null)
+
+    if [ -n "$WATCH_ALERT" ]; then
+      # See note at top send site — leading Enter drains any stuck buffered signal.
+      tmux send-keys -t "$ORCHARDIST_PANE" Enter 2>/dev/null
+      tmux send-keys -t "$ORCHARDIST_PANE" -l "$WATCH_ALERT" 2>/dev/null
+      tmux send-keys -t "$ORCHARDIST_PANE" Enter 2>/dev/null
+      echo "$NOW" > "$LAST_WATCH_FILE"
+    fi
+  fi
+
+  # --- Periodic report refresh (keeps timestamp fresh even without state change) ---
+  LAST_REPORT=$(cat "$LAST_REPORT_FILE" 2>/dev/null || echo 0)
+  REPORT_ELAPSED=$((NOW - LAST_REPORT))
+  if [ "$REPORT_ELAPSED" -ge "$REPORT_INTERVAL" ] \
+      && [ -n "${ORCHARD_REPORT_CMD:-}" ] \
+      && [ -x "$ORCHARD_REPORT_CMD" ]; then
+    ( "$ORCHARD_REPORT_CMD" >> /tmp/orchard-report.log 2>&1 ) &
+    echo "$NOW" > "$LAST_REPORT_FILE"
+  fi
+
+  sleep ${POLL_INTERVAL:-60}
+done


### PR DESCRIPTION
## Summary

Bookend every `tmux send-keys` signal with a leading `Enter` to flush any signal sitting stuck in the orchardist's Claude Code input buffer.

## What went wrong with the previous attempt

The first version of this PR replaced single-call `send-keys "$MSG" Enter` with two-call `send-keys -l "$MSG"` + `send-keys Enter`, citing an "Enter lands as newline" pattern. That framing was wrong.

Wire-level PTY trace (Python reader logging stdin bytes) showed both forms produce byte-identical output (`$MSG\n` in the same burst, sub-ms timing). The two-call form was a no-op.

Reproduced the real phenomenon live on the orchardist pane with the "fix" running: 8+ signal lines prefixed with `❯` buffered in the input area, never submitted. Status bar `-- INSERT --` (so not vim mode).

**Real root cause:** Claude Code's input prompt buffers text + newline when a signal arrives mid-turn. The `\n` is not converted to a submit when the turn finishes. The text sits in the prompt until a later Enter drains it.

## The fix

```sh
tmux send-keys -t "$ORCHARDIST_PANE" Enter       # drain any stuck prior signal
tmux send-keys -t "$ORCHARDIST_PANE" -l "$MSG"   # deliver text literally
tmux send-keys -t "$ORCHARDIST_PANE" Enter       # submit this signal
```

Enter on an empty Claude Code prompt is a no-op, so the leading Enter is always safe. Self-healing — drains stuck signals from any source (monitor, decide, Telegram plugin, manual sends). Applied at all three send sites: `monitor.sh` state-change, `monitor.sh` `[watch]` alert, `decide.sh` `signal_orchardist()`.

## Secondary changes

- Vendor `orchard-monitor.sh` + `orchard-decide.sh` into `scripts/`. Previously they lived only in `~/.claude/scripts/`, making bugs invisible to the project.
- Default pane target `%0` → `orchardist:0.0` (pane IDs are unstable across tmux restarts).
- Drop hardcoded `orchard-report.sh` dependency. Replace with optional `ORCHARD_REPORT_CMD` env var so dashboard publishing stays user-configurable.

## Test plan

- [x] Wire-level PTY trace confirming single-call and two-call forms are byte-identical (invalidated earlier diagnosis).
- [x] Live reproduction of buffered unsubmitted signals on orchardist pane with "two-call" fix running.
- [x] Bash syntax check: `bash -n scripts/orchard-monitor.sh` / `bash -n scripts/orchard-decide.sh` both OK.
- [x] PII/secrets scan: no personal identifiers in vendored scripts.
- [ ] **Live verification:** monitor restarted with bookend fix. Next 2–3 polling cycles will confirm stuck signals drain and new signals submit cleanly. Do not merge until verified live.

## Out of scope

- The broader single-call `send-keys ... Enter` anti-pattern lives in ~15+ places across `~/.claude/skills/` (launch, launch-remote, manage-sessions, delegate, ssh-remote, tui-testing, remmy, recover) and `~/.claude/agents/session-manager.md`. These drive *working* sessions — Drew's original complaint pointed there. Sweep + separate PR.
- Rust `send_to_orchardist` in `crates/orchard/src/chat.rs` uses the two-call pattern without bookend; likely has the same bug. Separate PR.
- Canonical source of truth between `~/.claude/scripts/` and `git-orchard-rs/scripts/`: #279.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #266

# Related issue

- #266