### PR TITLE
fix(remote): boxd-fork session discovery via adapter-routed tmux refresh

### DIFF
--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -264,12 +264,14 @@ pub fn refresh_and_build(config: &GlobalConfig) -> OrchardState {
     let _ = sources::tmux::refresh_local();
 
     // Probe remote hosts concurrently so a dead VM can't block healthy ones.
-    let all_hosts: Vec<String> = config
+    // Use the kind-aware variant: boxd-fork golden hosts reject `true` as a
+    // subcommand, so the default probe would mark them unreachable.
+    let all_remotes: Vec<crate::global_config::RemoteConfig> = config
         .repos
         .iter()
-        .flat_map(|r| r.remotes.iter().map(|rm| rm.host.clone()))
+        .flat_map(|r| r.remotes.iter().cloned())
         .collect();
-    let probe_results = sources::hosts::probe_reachability_all(all_hosts);
+    let probe_results = sources::hosts::probe_reachability_all_for_remotes(&all_remotes);
 
     let hosts: HashMap<String, HostState> = probe_results
         .iter()

--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -287,7 +287,7 @@ pub fn refresh_and_build(config: &GlobalConfig) -> OrchardState {
             if reachable {
                 let _ = sources::worktrees::refresh_remote(repo, remote);
                 if tmux_refreshed.insert(remote.host.clone()) {
-                    let _ = sources::tmux::refresh_remote(&remote.host);
+                    let _ = sources::tmux::refresh_remote_adapter(repo, remote);
                 }
             }
         }

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -471,6 +471,15 @@ pub fn parse_worktree_porcelain(output: &str) -> Vec<CachedWorktree> {
     worktrees
 }
 
+/// The `-F` format string passed to `tmux list-sessions` for all session
+/// enumeration — local, remote (Remmy/BoxdShared), and per-fork (BoxdFork).
+///
+/// All three callers MUST use this constant so that `parse_tmux_output` always
+/// receives identically-structured lines regardless of the code path that
+/// produced them.
+pub(crate) const TMUX_SESSION_FORMAT: &str =
+    "#{session_name}:#{session_path}|#{session_created}|#{session_activity}";
+
 /// Parses the combined output of `tmux list-sessions` and per-session pane
 /// information into `Vec<CachedTmuxSession>`.
 ///
@@ -1452,15 +1461,12 @@ pub fn refresh_tmux_sessions(host: Option<&str>) -> anyhow::Result<()> {
     let sessions_out = match host {
         None => run_local(
             "tmux",
-            &[
-                "list-sessions",
-                "-F",
-                "#{session_name}:#{session_path}|#{session_created}|#{session_activity}",
-            ],
+            &["list-sessions", "-F", TMUX_SESSION_FORMAT],
         ),
         Some(h) => {
             let cmd = format!(
-                "tmux list-sessions -F '#{{session_name}}:#{{session_path}}|#{{session_created}}|#{{session_activity}}' && echo '{}' && cat '${{TMPDIR:-/tmp}}'/orchard-claude-*.json 2>/dev/null; true",
+                "tmux list-sessions -F '{}' && echo '{}' && cat '${{TMPDIR:-/tmp}}'/orchard-claude-*.json 2>/dev/null; true",
+                TMUX_SESSION_FORMAT,
                 CLAUDE_STATE_SENTINEL
             );
             remote::ssh_exec(h, &cmd)

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -1684,6 +1684,101 @@ pub fn refresh_remote_worktrees(
     Ok(())
 }
 
+/// Fetches tmux sessions from a single remote via the appropriate `RemoteAdapter`
+/// and writes them to per-host tmux caches.
+///
+/// Dispatch is driven by `remote_cfg.kind` through `RemoteAdapter::from_config`.
+/// `Remmy` and `BoxdShared` produce sessions tagged with `remote_cfg.host` and
+/// write to a single cache file. `BoxdFork` produces sessions tagged with per-
+/// fork hosts (`<user>@<fork>.boxd.sh`); this function groups sessions by
+/// `host` and writes one cache file per fork host.
+///
+/// Unlike `refresh_tmux_sessions` (the legacy single-host path), this function
+/// does NOT call `tmux list-panes` / `capture-pane` per session — adapters
+/// already returned fully-parsed `CachedTmuxSession` values. Pane details and
+/// capture payloads will be empty for fork sessions until a follow-up slice
+/// wires them (see task #10 — this is acceptable per the issue's AC: forks
+/// need to be visible; pane details are not an AC).
+///
+/// On adapter error, the error is logged and existing caches are left intact.
+///
+/// # SWR note
+///
+/// For `Remmy` and `BoxdShared`, the `remote_cfg.host`-keyed tmux cache is
+/// checked and skipped when Fresh. For `BoxdFork`, SWR is skipped — the golden
+/// host fan-out makes a single-key SWR gate unreliable; the adapter always runs.
+pub fn refresh_remote_tmux_sessions(
+    config: &RepoConfig,
+    remote_cfg: &crate::global_config::RemoteConfig,
+) -> anyhow::Result<()> {
+    // SWR fast path: skip for non-fork remotes when the host cache is Fresh.
+    // BoxdFork fans out to per-fork hosts so we cannot gate on a single key —
+    // always refresh for that kind.
+    if remote_cfg.kind != crate::remote_adapter::RemoteKind::BoxdFork {
+        let cache_path = cache::tmux_cache_path(Some(&remote_cfg.host));
+        let cached_file = cache::read_cache::<CachedTmuxSession>(&cache_path);
+        let swr_config =
+            crate::swr::SwrConfig::default_for(crate::swr::SwrKind::RemoteSessions);
+        let state =
+            crate::swr::classify_cache_file(&cached_file, chrono::Utc::now(), swr_config);
+        if state == crate::swr::SwrState::Fresh {
+            LOG.info(&format!(
+                "cache_sources: refresh_remote_tmux_sessions({}, {}): swr=Fresh, skipping adapter",
+                config.slug, remote_cfg.host,
+            ));
+            return Ok(());
+        }
+    }
+
+    let adapter = crate::remote_adapter::RemoteAdapter::from_config(
+        remote_cfg,
+        Box::new(crate::remote_adapter::ProcessSshExec),
+    );
+
+    let mut sessions = match adapter.list_sessions() {
+        Ok(s) => s,
+        Err(e) => {
+            LOG.warn(&format!(
+                "cache_sources: refresh_remote_tmux_sessions({}, {}): {e}",
+                config.slug, remote_cfg.host,
+            ));
+            return Ok(());
+        }
+    };
+
+    // Ensure every session has a host set. Non-fork adapters tag with
+    // `remote_cfg.host`; `BoxdFork` tags with per-fork hosts. Be defensive
+    // for empty-list edge cases.
+    for s in &mut sessions {
+        if s.host.is_none() {
+            s.host = Some(remote_cfg.host.clone());
+        }
+    }
+
+    // Group by host and write one cache file per distinct host.
+    let mut by_host: std::collections::HashMap<String, Vec<CachedTmuxSession>> =
+        std::collections::HashMap::new();
+    for s in sessions {
+        let host = s.host.clone().unwrap_or_else(|| remote_cfg.host.clone());
+        by_host.entry(host).or_default().push(s);
+    }
+
+    let host_count = by_host.len();
+    let total: usize = by_host.values().map(|v| v.len()).sum();
+
+    for (host, group) in &by_host {
+        let cache_path = cache::tmux_cache_path(Some(host));
+        cache::write_cache_if_nonempty(&cache_path, group)?;
+    }
+
+    LOG.info(&format!(
+        "cache_sources: refresh_remote_tmux_sessions({}, {}): wrote {} entries across {} hosts via {:?} adapter",
+        config.slug, remote_cfg.host, total, host_count, remote_cfg.kind,
+    ));
+
+    Ok(())
+}
+
 /// Maps a `RemoteKind` to its on-the-wire kebab-case string, matching the
 /// serde serialization and the `remote_type` field on
 /// `worktree.remote_lost` events.

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -1684,50 +1684,32 @@ pub fn refresh_remote_worktrees(
     Ok(())
 }
 
-/// Fetches tmux sessions from a single remote via the appropriate `RemoteAdapter`
-/// and writes them to per-host tmux caches.
+/// Fetches tmux sessions from a single remote and writes them to per-host caches.
 ///
-/// Dispatch is driven by `remote_cfg.kind` through `RemoteAdapter::from_config`.
-/// `Remmy` and `BoxdShared` produce sessions tagged with `remote_cfg.host` and
-/// write to a single cache file. `BoxdFork` produces sessions tagged with per-
-/// fork hosts (`<user>@<fork>.boxd.sh`); this function groups sessions by
-/// `host` and writes one cache file per fork host.
+/// Dispatch is driven by `remote_cfg.kind`:
+/// - `Remmy` and `BoxdShared` delegate to the legacy `refresh_tmux_sessions`
+///   path (raw SSH `tmux list-sessions` + pane/capture batching against
+///   `remote_cfg.host`). Their adapters' `list_sessions` methods are still
+///   Slice-1/2 stubs; swapping them in would regress pane and capture enrichment.
+/// - `BoxdFork` routes through `RemoteAdapter::from_config` so enumeration
+///   fans out from the golden host to each live fork and writes one cache
+///   file per fork host.
 ///
-/// Unlike `refresh_tmux_sessions` (the legacy single-host path), this function
-/// does NOT call `tmux list-panes` / `capture-pane` per session — adapters
-/// already returned fully-parsed `CachedTmuxSession` values. Pane details and
-/// capture payloads will be empty for fork sessions until a follow-up slice
-/// wires them (see task #10 — this is acceptable per the issue's AC: forks
-/// need to be visible; pane details are not an AC).
+/// The fork path intentionally skips `tmux list-panes` / `capture-pane` per
+/// session — only the session roster is required to make forks visible in
+/// `orchard --json` and the TUI (issue #264 AC). Pane and capture enrichment
+/// for forks is a follow-up.
 ///
-/// On adapter error, the error is logged and existing caches are left intact.
-///
-/// # SWR note
-///
-/// For `Remmy` and `BoxdShared`, the `remote_cfg.host`-keyed tmux cache is
-/// checked and skipped when Fresh. For `BoxdFork`, SWR is skipped — the golden
-/// host fan-out makes a single-key SWR gate unreliable; the adapter always runs.
+/// On adapter error the error is logged and existing caches are left intact.
 pub fn refresh_remote_tmux_sessions(
     config: &RepoConfig,
     remote_cfg: &crate::global_config::RemoteConfig,
 ) -> anyhow::Result<()> {
-    // SWR fast path: skip for non-fork remotes when the host cache is Fresh.
-    // BoxdFork fans out to per-fork hosts so we cannot gate on a single key —
-    // always refresh for that kind.
+    // Remmy and BoxdShared: keep the legacy single-host path so pane details
+    // and capture-pane payloads continue to land in the cache. Their adapter
+    // `list_sessions` methods are still stubs returning `Ok(vec![])`.
     if remote_cfg.kind != crate::remote_adapter::RemoteKind::BoxdFork {
-        let cache_path = cache::tmux_cache_path(Some(&remote_cfg.host));
-        let cached_file = cache::read_cache::<CachedTmuxSession>(&cache_path);
-        let swr_config =
-            crate::swr::SwrConfig::default_for(crate::swr::SwrKind::RemoteSessions);
-        let state =
-            crate::swr::classify_cache_file(&cached_file, chrono::Utc::now(), swr_config);
-        if state == crate::swr::SwrState::Fresh {
-            LOG.info(&format!(
-                "cache_sources: refresh_remote_tmux_sessions({}, {}): swr=Fresh, skipping adapter",
-                config.slug, remote_cfg.host,
-            ));
-            return Ok(());
-        }
+        return refresh_tmux_sessions(Some(&remote_cfg.host));
     }
 
     let adapter = crate::remote_adapter::RemoteAdapter::from_config(
@@ -1735,7 +1717,7 @@ pub fn refresh_remote_tmux_sessions(
         Box::new(crate::remote_adapter::ProcessSshExec),
     );
 
-    let mut sessions = match adapter.list_sessions() {
+    let sessions = match adapter.list_sessions() {
         Ok(s) => s,
         Err(e) => {
             LOG.warn(&format!(
@@ -1746,20 +1728,16 @@ pub fn refresh_remote_tmux_sessions(
         }
     };
 
-    // Ensure every session has a host set. Non-fork adapters tag with
-    // `remote_cfg.host`; `BoxdFork` tags with per-fork hosts. Be defensive
-    // for empty-list edge cases.
-    for s in &mut sessions {
-        if s.host.is_none() {
-            s.host = Some(remote_cfg.host.clone());
-        }
-    }
-
-    // Group by host and write one cache file per distinct host.
+    // Group by host and write one cache file per distinct fork host.
+    // `BoxdFork` adapter tags every session with its fork host; unknown-host
+    // entries fall back to `remote_cfg.host` defensively.
     let mut by_host: std::collections::HashMap<String, Vec<CachedTmuxSession>> =
         std::collections::HashMap::new();
-    for s in sessions {
+    for mut s in sessions {
         let host = s.host.clone().unwrap_or_else(|| remote_cfg.host.clone());
+        if s.host.is_none() {
+            s.host = Some(host.clone());
+        }
         by_host.entry(host).or_default().push(s);
     }
 
@@ -1772,8 +1750,8 @@ pub fn refresh_remote_tmux_sessions(
     }
 
     LOG.info(&format!(
-        "cache_sources: refresh_remote_tmux_sessions({}, {}): wrote {} entries across {} hosts via {:?} adapter",
-        config.slug, remote_cfg.host, total, host_count, remote_cfg.kind,
+        "cache_sources: refresh_remote_tmux_sessions({}, {}): wrote {} entries across {} fork hosts",
+        config.slug, remote_cfg.host, total, host_count,
     ));
 
     Ok(())

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -1459,15 +1459,11 @@ pub fn refresh_tmux_sessions(host: Option<&str>) -> anyhow::Result<()> {
     // For remote hosts, batch the tmux list-sessions and Claude state cat into
     // a single SSH call to minimise round-trips.
     let sessions_out = match host {
-        None => run_local(
-            "tmux",
-            &["list-sessions", "-F", TMUX_SESSION_FORMAT],
-        ),
+        None => run_local("tmux", &["list-sessions", "-F", TMUX_SESSION_FORMAT]),
         Some(h) => {
             let cmd = format!(
                 "tmux list-sessions -F '{}' && echo '{}' && cat '${{TMPDIR:-/tmp}}'/orchard-claude-*.json 2>/dev/null; true",
-                TMUX_SESSION_FORMAT,
-                CLAUDE_STATE_SENTINEL
+                TMUX_SESSION_FORMAT, CLAUDE_STATE_SENTINEL
             );
             remote::ssh_exec(h, &cmd)
         }

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -257,28 +257,6 @@ impl RemoteAdapter {
             RemoteAdapter::BoxdFork(a) => a.list_sessions(),
         }
     }
-
-    /// Probes reachability and returns optional metadata.
-    pub fn probe(&self) -> Result<ProbeResult> {
-        match self {
-            RemoteAdapter::Remmy(a) => a.probe(),
-            RemoteAdapter::BoxdShared(a) => a.probe(),
-            RemoteAdapter::BoxdFork(a) => a.probe(),
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Probe result
-// ---------------------------------------------------------------------------
-
-/// Outcome of a reachability probe.
-#[derive(Debug)]
-pub struct ProbeResult {
-    /// Whether the remote host responded.
-    pub reachable: bool,
-    /// Optional metadata returned by the adapter (e.g. version string).
-    pub metadata: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -316,16 +294,6 @@ impl RemmyAdapter {
     /// Slice 1 stub — full implementation in slice 2.
     pub fn list_sessions(&self) -> Result<Vec<CachedTmuxSession>> {
         Ok(vec![])
-    }
-
-    /// Probes whether the remote host is reachable.
-    ///
-    /// Slice 1 stub — full implementation in slice 2.
-    pub fn probe(&self) -> Result<ProbeResult> {
-        Ok(ProbeResult {
-            reachable: true,
-            metadata: None,
-        })
     }
 }
 
@@ -365,16 +333,6 @@ impl BoxdSharedAdapter {
     /// Slice 2 stub — full implementation in slice 3.
     pub fn list_sessions(&self) -> Result<Vec<CachedTmuxSession>> {
         Ok(vec![])
-    }
-
-    /// Probes whether the Boxd shared VM is reachable.
-    ///
-    /// Slice 2 stub — full implementation in slice 3.
-    pub fn probe(&self) -> Result<ProbeResult> {
-        Ok(ProbeResult {
-            reachable: true,
-            metadata: None,
-        })
     }
 }
 
@@ -432,23 +390,16 @@ pub struct BoxdForkAdapter {
 }
 
 impl BoxdForkAdapter {
-    /// Returns one `CachedWorktree` per live fork VM.
+    /// Enumerates live fork VMs from the golden host.
     ///
-    /// Steps:
-    /// 1. SSH to `golden_host` and run `list --json` to enumerate live forks.
-    /// 2. Parse the JSON array. Return `Err(AdapterError::ParseFailure)` if invalid.
-    /// 3. For each fork, SSH to `boxd@<fork.host>` and run
-    ///    `cd <fork.path> && git rev-parse --abbrev-ref HEAD`.
-    /// 4. If the output is exactly `"HEAD"` (detached HEAD), fall back to
-    ///    `git rev-parse --short HEAD` and format branch as `"(detached: <sha>)"`.
-    /// 5. Return `Ok(vec![])` when `golden_host` is unreachable (SSH failure on
-    ///    the list command) — the TUI keeps the last cached forks visible.
-    pub fn list_worktrees(&self) -> Result<Vec<CachedWorktree>> {
-        // Step 1: enumerate live forks from the golden host. SSH failure here
-        // returns `Err(FetchFailure)` so the caller (cache_sources) does NOT
-        // treat zero entries as authoritative — otherwise a transient outage
-        // on `boxd.sh` would emit a `worktree.remote_lost` event for every
-        // previously-cached fork.
+    /// Returns `(fork_host, entry)` tuples for each entry that is `running`
+    /// (or has no status field) and whose URL passes `is_safe_ssh_host`. The
+    /// `fork_host` is the `<user>@<url>` form ready to pass to SSH.
+    ///
+    /// SSH failure on the golden host returns `Err(FetchFailure)` so callers
+    /// can preserve prior cache rather than treating an empty list as
+    /// authoritative; malformed JSON returns `Err(ParseFailure)`.
+    fn list_live_forks(&self) -> Result<Vec<(String, BoxdForkEntry)>> {
         let list_stdout = match self.ssh.exec(&self.golden_host, "list --json") {
             Ok(output) => output.stdout,
             Err(e) => {
@@ -459,30 +410,35 @@ impl BoxdForkAdapter {
             }
         };
 
-        // Step 2: parse the fork list. Malformed JSON → ParseFailure.
         let entries: Vec<BoxdForkEntry> =
             serde_json::from_str(&list_stdout).map_err(|_| AdapterError::ParseFailure {
                 raw: sanitize_raw_payload(&list_stdout),
             })?;
 
-        let mut worktrees = Vec::with_capacity(entries.len());
         let user_prefix = ssh_user_prefix(&self.golden_host);
+        let live: Vec<(String, BoxdForkEntry)> = entries
+            .into_iter()
+            .filter(|e| e.status.is_none() || e.is_running())
+            .filter(|e| is_safe_ssh_host(&e.url))
+            .map(|e| (format!("{user_prefix}@{}", e.url), e))
+            .collect();
 
-        // Steps 3-5: per-fork branch resolution.
-        for entry in entries {
-            // Skip non-running forks: stopped VMs are unreachable and would
-            // otherwise burn an SSH timeout on every refresh.
-            if entry.status.is_some() && !entry.is_running() {
-                continue;
-            }
-            // Defensive: drop entries whose url carries shell- or
-            // ssh-option-injection-relevant characters. A compromised golden
-            // host could otherwise smuggle a value like
-            // `evil.host -o ProxyCommand=...` into the SSH argv.
-            if !is_safe_ssh_host(&entry.url) {
-                continue;
-            }
-            let fork_host = format!("{user_prefix}@{}", entry.url);
+        Ok(live)
+    }
+
+    /// Returns one `CachedWorktree` per live fork VM.
+    ///
+    /// Calls `list_live_forks` to enumerate running forks, then SSHes each
+    /// fork VM to resolve its branch via `git rev-parse --abbrev-ref HEAD`.
+    /// SSH failure on the golden host returns `Err(FetchFailure)` so the
+    /// caller can preserve prior cache rather than emitting spurious
+    /// `worktree.remote_lost` events. Detached HEAD falls back to
+    /// `git rev-parse --short HEAD` formatted as `"(detached: <sha>)"`.
+    pub fn list_worktrees(&self) -> Result<Vec<CachedWorktree>> {
+        let live_forks = self.list_live_forks()?;
+        let mut worktrees = Vec::with_capacity(live_forks.len());
+
+        for (fork_host, entry) in live_forks {
             let fork_path = entry.path.unwrap_or_else(|| self.fork_repo_path.clone());
             let escaped_path = crate::remote::shell_escape(&fork_path);
             let branch_cmd = format!("cd {escaped_path} && git rev-parse --abbrev-ref HEAD");
@@ -513,54 +469,23 @@ impl BoxdForkAdapter {
 
     /// Returns tmux sessions from all live fork VMs.
     ///
-    /// Steps:
-    /// 1. SSH to `golden_host` with `list --json` to enumerate live forks.
-    ///    SSH failure → `Err(FetchFailure)` so callers can preserve the prior
-    ///    cache rather than treating an empty result as authoritative.
-    /// 2. Parse the JSON array. Malformed JSON → `Err(ParseFailure)`.
-    /// 3. For each fork, SSH to `<user>@<fork.host>` and run
-    ///    `tmux list-sessions` with the standard `-F` template.  A single
-    ///    dead fork is skipped (warning logged); one bad VM should not silence
-    ///    sessions from all the others.
-    /// 4. Parse each fork's output via `cache_sources::parse_tmux_output` and
-    ///    tag every resulting `CachedTmuxSession` with `host: Some(fork_host)`
-    ///    so downstream joins can match fork worktrees.
+    /// Calls `list_live_forks` to enumerate running forks, then SSHes each
+    /// fork VM with the standard `-F` template consumed by
+    /// `cache_sources::parse_tmux_output`. A single dead fork is skipped
+    /// (warning logged); one bad VM does not silence sessions from others.
+    /// SSH failure on the golden host returns `Err(FetchFailure)` so callers
+    /// can preserve prior cache rather than treating an empty result as
+    /// authoritative.
     pub fn list_sessions(&self) -> Result<Vec<CachedTmuxSession>> {
-        // Step 1: enumerate live forks from the golden host.
-        let list_stdout = match self.ssh.exec(&self.golden_host, "list --json") {
-            Ok(output) => output.stdout,
-            Err(e) => {
-                return Err(AdapterError::FetchFailure {
-                    message: e.to_string(),
-                }
-                .into());
-            }
-        };
-
-        // Step 2: parse the fork list.
-        let entries: Vec<BoxdForkEntry> =
-            serde_json::from_str(&list_stdout).map_err(|_| AdapterError::ParseFailure {
-                raw: sanitize_raw_payload(&list_stdout),
-            })?;
-
-        let user_prefix = ssh_user_prefix(&self.golden_host);
-        const TMUX_LIST_CMD: &str = "tmux list-sessions -F '#{session_name}:#{session_path}|#{session_created}|#{session_activity}'";
-
+        let live_forks = self.list_live_forks()?;
+        let tmux_list_cmd = format!(
+            "tmux list-sessions -F '{}'",
+            crate::cache_sources::TMUX_SESSION_FORMAT
+        );
         let mut all_sessions: Vec<CachedTmuxSession> = Vec::new();
 
-        // Step 3-4: per-fork session collection.
-        for entry in entries {
-            // Skip non-running forks: stopped VMs are unreachable and would
-            // otherwise burn an SSH timeout on every refresh.
-            if entry.status.is_some() && !entry.is_running() {
-                continue;
-            }
-            if !is_safe_ssh_host(&entry.url) {
-                continue;
-            }
-            let fork_host = format!("{user_prefix}@{}", entry.url);
-
-            let stdout = match self.ssh.exec(&fork_host, TMUX_LIST_CMD) {
+        for (fork_host, _entry) in live_forks {
+            let stdout = match self.ssh.exec(&fork_host, &tmux_list_cmd) {
                 Ok(output) => output.stdout,
                 Err(e) => {
                     crate::logger::LOG.warn(&format!(
@@ -589,16 +514,6 @@ impl BoxdForkAdapter {
         }
 
         Ok(all_sessions)
-    }
-
-    /// Probes whether the golden Boxd host is reachable.
-    ///
-    /// Slice 2 stub — full implementation in slice 3.
-    pub fn probe(&self) -> Result<ProbeResult> {
-        Ok(ProbeResult {
-            reachable: true,
-            metadata: None,
-        })
     }
 }
 
@@ -716,20 +631,16 @@ fn sanitize_raw_payload(raw: &str) -> String {
 mod tests {
     use super::*;
 
-    /// `BoxdForkAdapter::list_sessions` is a Slice-2 stub that unconditionally
-    /// returns `Ok(vec![])`. This test documents the expected behaviour once the
-    /// stub is replaced: the adapter should SSH to the golden host to enumerate
-    /// live forks and then SSH into each fork to collect its tmux sessions.
-    ///
-    /// The test will FAIL until the stub is implemented (issue #264).
+    /// Regression test for #264: the BoxdFork adapter must SSH each live fork
+    /// to collect its tmux sessions, not silently return an empty vec.
     #[test]
     fn boxd_fork_adapter_list_sessions_returns_sessions_from_each_live_fork() {
         // Arrange — wire up a FakeSshExec with two canned responses:
         //
         // 1. golden-host "list --json" → one fork entry
-        // 2. fork-host tmux list-sessions → one session line in the format
-        //    consumed by parse_tmux_output (see cache_sources.rs:499):
-        //    "{session_name}:{session_path}|{session_created}|{session_activity}"
+        // 2. fork-host tmux list-sessions → one session line using the template
+        //    defined as `cache_sources::TMUX_SESSION_FORMAT` and consumed by
+        //    `cache_sources::parse_tmux_output`.
         let mut fake = FakeSshExec::new();
 
         // Response 1: fork enumeration from the golden Boxd controller.
@@ -744,12 +655,15 @@ mod tests {
             },
         );
 
-        // Response 2: tmux session list on the fork VM.
-        // Format: "#{session_name}:#{session_path}|#{session_created}|#{session_activity}"
-        // (matches cache_sources.rs:1458 -F template)
+        // Response 2: tmux session list on the fork VM, using the same `-F`
+        // template consumed by `cache_sources::parse_tmux_output`.
+        let tmux_cmd = format!(
+            "tmux list-sessions -F '{}'",
+            crate::cache_sources::TMUX_SESSION_FORMAT
+        );
         fake.insert(
             "boxd@issue3155.boxd.sh",
-            "tmux list-sessions -F '#{session_name}:#{session_path}|#{session_created}|#{session_activity}'",
+            &tmux_cmd,
             SshOutput {
                 stdout: "issue3155:/workspace/langwatch|1713000000|1713000060\n".to_string(),
                 stderr: String::new(),
@@ -770,7 +684,7 @@ mod tests {
         // VM and whose name matches what the fake returned.
         assert!(
             !sessions.is_empty(),
-            "list_sessions returned an empty vec; stub has not been implemented yet"
+            "list_sessions must return sessions from each live fork"
         );
 
         let session = &sessions[0];

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -488,9 +488,8 @@ impl BoxdForkAdapter {
             let stdout = match self.ssh.exec(&fork_host, &tmux_list_cmd) {
                 Ok(output) => output.stdout,
                 Err(e) => {
-                    crate::logger::LOG.warn(&format!(
-                        "list_sessions: skipping fork {fork_host}: {e}"
-                    ));
+                    crate::logger::LOG
+                        .warn(&format!("list_sessions: skipping fork {fork_host}: {e}"));
                     continue;
                 }
             };
@@ -678,7 +677,9 @@ mod tests {
         };
 
         // Act
-        let sessions = adapter.list_sessions().expect("list_sessions must not error");
+        let sessions = adapter
+            .list_sessions()
+            .expect("list_sessions must not error");
 
         // Assert — must return at least one session whose host matches the fork
         // VM and whose name matches what the fake returned.

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -384,19 +384,35 @@ impl BoxdSharedAdapter {
 
 /// A single fork VM entry returned by `ssh boxd.sh list --json`.
 ///
-/// `path` is optional in the JSON payload; when absent, the adapter's
+/// The real boxd payload uses `url` for the fork hostname and includes a
+/// `status` field (`"running"` / `"stopped"` / …). Only running forks are
+/// treated as live. `host` is accepted as an alias for forward-compatibility
+/// with the earlier schema. `path` is optional; when absent, the adapter's
 /// configured `fork_repo_path` is used (derived from `RemoteConfig.path`,
 /// not a hardcoded tenant path).
 #[derive(Debug, Deserialize)]
 struct BoxdForkEntry {
     /// Human-readable fork name, typically the issue slug (e.g. `"issue3155"`).
     name: String,
-    /// SSH hostname of the fork VM (e.g. `"issue3155.boxd.sh"`).
-    host: String,
+    /// SSH hostname of the fork VM (e.g. `"issue3155.boxd.sh"`). The real
+    /// boxd controller emits `url`; `host` is kept as an alias so older
+    /// fixtures and the existing tests still parse.
+    #[serde(alias = "host")]
+    url: String,
+    /// VM lifecycle status. Missing or non-`"running"` values are treated
+    /// as not-live and filtered out before any per-fork SSH.
+    #[serde(default)]
+    status: Option<String>,
     /// Repo root path on the fork VM. Optional — falls back to the
     /// adapter's configured path when absent.
     #[serde(default)]
     path: Option<String>,
+}
+
+impl BoxdForkEntry {
+    fn is_running(&self) -> bool {
+        self.status.as_deref() == Some("running")
+    }
 }
 
 /// Adapter for Boxd fork-per-issue VMs.
@@ -454,14 +470,19 @@ impl BoxdForkAdapter {
 
         // Steps 3-5: per-fork branch resolution.
         for entry in entries {
-            // Defensive: drop entries whose host carries shell- or
+            // Skip non-running forks: stopped VMs are unreachable and would
+            // otherwise burn an SSH timeout on every refresh.
+            if entry.status.is_some() && !entry.is_running() {
+                continue;
+            }
+            // Defensive: drop entries whose url carries shell- or
             // ssh-option-injection-relevant characters. A compromised golden
             // host could otherwise smuggle a value like
             // `evil.host -o ProxyCommand=...` into the SSH argv.
-            if !is_safe_ssh_host(&entry.host) {
+            if !is_safe_ssh_host(&entry.url) {
                 continue;
             }
-            let fork_host = format!("{user_prefix}@{}", entry.host);
+            let fork_host = format!("{user_prefix}@{}", entry.url);
             let fork_path = entry.path.unwrap_or_else(|| self.fork_repo_path.clone());
             let escaped_path = crate::remote::shell_escape(&fork_path);
             let branch_cmd = format!("cd {escaped_path} && git rev-parse --abbrev-ref HEAD");
@@ -529,10 +550,15 @@ impl BoxdForkAdapter {
 
         // Step 3-4: per-fork session collection.
         for entry in entries {
-            if !is_safe_ssh_host(&entry.host) {
+            // Skip non-running forks: stopped VMs are unreachable and would
+            // otherwise burn an SSH timeout on every refresh.
+            if entry.status.is_some() && !entry.is_running() {
                 continue;
             }
-            let fork_host = format!("{user_prefix}@{}", entry.host);
+            if !is_safe_ssh_host(&entry.url) {
+                continue;
+            }
+            let fork_host = format!("{user_prefix}@{}", entry.url);
 
             let stdout = match self.ssh.exec(&fork_host, TMUX_LIST_CMD) {
                 Ok(output) => output.stdout,
@@ -757,5 +783,56 @@ mod tests {
             session.name, "issue3155",
             "session name should match the tmux session returned by the fork VM"
         );
+    }
+
+    /// The real `ssh boxd.sh list --json` payload uses `url` (not `host`)
+    /// and includes a `status` field — only entries with `status == "running"`
+    /// are live. A regression here would silently hide every boxd fork even
+    /// though the adapter "works".
+    #[test]
+    fn boxd_fork_adapter_filters_non_running_forks_and_parses_url_field() {
+        let mut fake = FakeSshExec::new();
+
+        // Payload shape as emitted by the real boxd controller.
+        fake.insert(
+            "boxd.sh",
+            "list --json",
+            SshOutput {
+                stdout: r#"[
+                    {"name":"issue3155","url":"issue3155.boxd.sh","status":"running","vm_id":"a"},
+                    {"name":"session-fix","url":"session-fix.boxd.sh","status":"stopped","vm_id":"b"}
+                ]"#.to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+
+        fake.insert(
+            "boxd@issue3155.boxd.sh",
+            "cd /workspace/langwatch && git rev-parse --abbrev-ref HEAD",
+            SshOutput {
+                stdout: "issue3155/some-branch\n".to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+
+        let adapter = BoxdForkAdapter {
+            golden_host: "boxd.sh".to_string(),
+            fork_repo_path: "/workspace/langwatch".to_string(),
+            ssh: Box::new(fake),
+        };
+
+        let worktrees = adapter
+            .list_worktrees()
+            .expect("list_worktrees must not error");
+
+        assert_eq!(
+            worktrees.len(),
+            1,
+            "stopped fork should be filtered out; only the running one is emitted"
+        );
+        assert_eq!(worktrees[0].host.as_deref(), Some("boxd@issue3155.boxd.sh"));
+        assert_eq!(worktrees[0].branch, "issue3155/some-branch");
     }
 }

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -613,3 +613,81 @@ fn sanitize_raw_payload(raw: &str) -> String {
         .take(256)
         .collect()
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `BoxdForkAdapter::list_sessions` is a Slice-2 stub that unconditionally
+    /// returns `Ok(vec![])`. This test documents the expected behaviour once the
+    /// stub is replaced: the adapter should SSH to the golden host to enumerate
+    /// live forks and then SSH into each fork to collect its tmux sessions.
+    ///
+    /// The test will FAIL until the stub is implemented (issue #264).
+    #[test]
+    fn boxd_fork_adapter_list_sessions_returns_sessions_from_each_live_fork() {
+        // Arrange — wire up a FakeSshExec with two canned responses:
+        //
+        // 1. golden-host "list --json" → one fork entry
+        // 2. fork-host tmux list-sessions → one session line in the format
+        //    consumed by parse_tmux_output (see cache_sources.rs:499):
+        //    "{session_name}:{session_path}|{session_created}|{session_activity}"
+        let mut fake = FakeSshExec::new();
+
+        // Response 1: fork enumeration from the golden Boxd controller.
+        fake.insert(
+            "boxd.sh",
+            "list --json",
+            SshOutput {
+                stdout: r#"[{"name":"issue3155","host":"issue3155.boxd.sh","path":"/workspace/langwatch"}]"#
+                    .to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+
+        // Response 2: tmux session list on the fork VM.
+        // Format: "#{session_name}:#{session_path}|#{session_created}|#{session_activity}"
+        // (matches cache_sources.rs:1458 -F template)
+        fake.insert(
+            "boxd@issue3155.boxd.sh",
+            "tmux list-sessions -F '#{session_name}:#{session_path}|#{session_created}|#{session_activity}'",
+            SshOutput {
+                stdout: "issue3155:/workspace/langwatch|1713000000|1713000060\n".to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+
+        let adapter = BoxdForkAdapter {
+            golden_host: "boxd.sh".to_string(),
+            fork_repo_path: "/workspace/langwatch".to_string(),
+            ssh: Box::new(fake),
+        };
+
+        // Act
+        let sessions = adapter.list_sessions().expect("list_sessions must not error");
+
+        // Assert — must return at least one session whose host matches the fork
+        // VM and whose name matches what the fake returned.
+        assert!(
+            !sessions.is_empty(),
+            "list_sessions returned an empty vec; stub has not been implemented yet"
+        );
+
+        let session = &sessions[0];
+        assert_eq!(
+            session.host.as_deref(),
+            Some("boxd@issue3155.boxd.sh"),
+            "session host should identify the fork VM"
+        );
+        assert_eq!(
+            session.name, "issue3155",
+            "session name should match the tmux session returned by the fork VM"
+        );
+    }
+}

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -492,9 +492,77 @@ impl BoxdForkAdapter {
 
     /// Returns tmux sessions from all live fork VMs.
     ///
-    /// Slice 2 stub — full implementation in slice 3.
+    /// Steps:
+    /// 1. SSH to `golden_host` with `list --json` to enumerate live forks.
+    ///    SSH failure → `Err(FetchFailure)` so callers can preserve the prior
+    ///    cache rather than treating an empty result as authoritative.
+    /// 2. Parse the JSON array. Malformed JSON → `Err(ParseFailure)`.
+    /// 3. For each fork, SSH to `<user>@<fork.host>` and run
+    ///    `tmux list-sessions` with the standard `-F` template.  A single
+    ///    dead fork is skipped (warning logged); one bad VM should not silence
+    ///    sessions from all the others.
+    /// 4. Parse each fork's output via `cache_sources::parse_tmux_output` and
+    ///    tag every resulting `CachedTmuxSession` with `host: Some(fork_host)`
+    ///    so downstream joins can match fork worktrees.
     pub fn list_sessions(&self) -> Result<Vec<CachedTmuxSession>> {
-        Ok(vec![])
+        // Step 1: enumerate live forks from the golden host.
+        let list_stdout = match self.ssh.exec(&self.golden_host, "list --json") {
+            Ok(output) => output.stdout,
+            Err(e) => {
+                return Err(AdapterError::FetchFailure {
+                    message: e.to_string(),
+                }
+                .into());
+            }
+        };
+
+        // Step 2: parse the fork list.
+        let entries: Vec<BoxdForkEntry> =
+            serde_json::from_str(&list_stdout).map_err(|_| AdapterError::ParseFailure {
+                raw: sanitize_raw_payload(&list_stdout),
+            })?;
+
+        let user_prefix = ssh_user_prefix(&self.golden_host);
+        const TMUX_LIST_CMD: &str = "tmux list-sessions -F '#{session_name}:#{session_path}|#{session_created}|#{session_activity}'";
+
+        let mut all_sessions: Vec<CachedTmuxSession> = Vec::new();
+
+        // Step 3-4: per-fork session collection.
+        for entry in entries {
+            if !is_safe_ssh_host(&entry.host) {
+                continue;
+            }
+            let fork_host = format!("{user_prefix}@{}", entry.host);
+
+            let stdout = match self.ssh.exec(&fork_host, TMUX_LIST_CMD) {
+                Ok(output) => output.stdout,
+                Err(e) => {
+                    crate::logger::LOG.warn(&format!(
+                        "list_sessions: skipping fork {fork_host}: {e}"
+                    ));
+                    continue;
+                }
+            };
+
+            let mut sessions = crate::cache_sources::parse_tmux_output(
+                &stdout,
+                Some(&fork_host),
+                |_| String::new(),
+                |_| vec![],
+            );
+
+            // parse_tmux_output sets host from the `host` argument, but
+            // ensure every entry carries the fork host for downstream joins.
+            for s in &mut sessions {
+                if s.host.is_none() {
+                    s.host = Some(fork_host.clone());
+                }
+            }
+
+            all_sessions.extend(sessions);
+        }
+
+        Ok(all_sessions)
     }
 
     /// Probes whether the golden Boxd host is reachable.

--- a/crates/orchard/src/sources/hosts.rs
+++ b/crates/orchard/src/sources/hosts.rs
@@ -4,8 +4,10 @@
 //! reachable before attempting worktree or tmux operations on it. Probes run with a
 //! 5-second connect timeout (set in `remote::ssh_flags()`), so dead hosts fail fast.
 //!
-//! When probing multiple hosts, always use [`probe_reachability_all`] — it runs one
-//! thread per host so a stopped VM can't block probes for healthy hosts behind it.
+//! When probing multiple hosts, always use one of the concurrent variants
+//! ([`probe_reachability_all`] for plain hosts, or [`probe_reachability_all_for_remotes`]
+//! when full `RemoteConfig` entries are in hand) — each runs one thread per
+//! host so a stopped VM can't block probes for healthy hosts behind it.
 
 use std::collections::HashMap;
 use std::thread;
@@ -16,6 +18,24 @@ use std::thread;
 /// SSH connection times out.
 pub fn probe_reachability(host: &str) -> bool {
     crate::remote::ssh_exec(host, "true").is_ok()
+}
+
+/// Probes whether a remote is reachable, using a probe command appropriate
+/// for the remote's kind.
+///
+/// `Remmy` and `BoxdShared` reach a general-purpose shell on the remote host,
+/// so `true` is a valid probe. `BoxdFork` targets the Boxd controller
+/// (e.g. `boxd.sh`), which is a restricted CLI that rejects `true` —
+/// `list --json` is the canonical health check there. Using the wrong probe
+/// would mark a perfectly healthy golden host as unreachable and silence
+/// every fork behind it.
+pub fn probe_reachability_for_remote(remote: &crate::global_config::RemoteConfig) -> bool {
+    let cmd = match remote.kind {
+        crate::remote_adapter::RemoteKind::BoxdFork => "list --json",
+        crate::remote_adapter::RemoteKind::Remmy
+        | crate::remote_adapter::RemoteKind::BoxdShared => "true",
+    };
+    crate::remote::ssh_exec(&remote.host, cmd).is_ok()
 }
 
 /// Probes many hosts concurrently, one thread per unique host.
@@ -29,6 +49,35 @@ where
     S: Into<String>,
 {
     probe_with(hosts, probe_reachability)
+}
+
+/// Probes many (host, kind-aware) remotes concurrently.
+///
+/// Deduplicates by host, spawns one thread per unique remote, and returns
+/// a `host -> reachable` map. Use this instead of `probe_reachability_all`
+/// when the caller has full `RemoteConfig` entries so each host can be
+/// probed with the correct command for its kind.
+pub fn probe_reachability_all_for_remotes(
+    remotes: &[crate::global_config::RemoteConfig],
+) -> HashMap<String, bool> {
+    let mut seen = std::collections::HashSet::new();
+    let unique: Vec<crate::global_config::RemoteConfig> = remotes
+        .iter()
+        .filter(|r| seen.insert(r.host.clone()))
+        .cloned()
+        .collect();
+
+    let handles: Vec<_> = unique
+        .into_iter()
+        .map(|remote| {
+            thread::spawn(move || {
+                let reachable = probe_reachability_for_remote(&remote);
+                (remote.host, reachable)
+            })
+        })
+        .collect();
+
+    handles.into_iter().filter_map(|h| h.join().ok()).collect()
 }
 
 fn probe_with<I, S, F>(hosts: I, probe: F) -> HashMap<String, bool>

--- a/crates/orchard/src/sources/hosts.rs
+++ b/crates/orchard/src/sources/hosts.rs
@@ -4,21 +4,13 @@
 //! reachable before attempting worktree or tmux operations on it. Probes run with a
 //! 5-second connect timeout (set in `remote::ssh_flags()`), so dead hosts fail fast.
 //!
-//! When probing multiple hosts, always use one of the concurrent variants
-//! ([`probe_reachability_all`] for plain hosts, or [`probe_reachability_all_for_remotes`]
-//! when full `RemoteConfig` entries are in hand) — each runs one thread per
-//! host so a stopped VM can't block probes for healthy hosts behind it.
+//! The concurrent entry point is [`probe_reachability_all_for_remotes`], which
+//! accepts full `RemoteConfig` entries so each host is probed with the correct
+//! command for its kind. Each probe runs on its own thread so a stopped VM
+//! can't block probes for healthy hosts behind it.
 
 use std::collections::HashMap;
 use std::thread;
-
-/// Probes whether a remote host is reachable via SSH.
-///
-/// Returns `true` if the host responds, `false` if unreachable or if the
-/// SSH connection times out.
-pub fn probe_reachability(host: &str) -> bool {
-    crate::remote::ssh_exec(host, "true").is_ok()
-}
 
 /// Probes whether a remote is reachable, using a probe command appropriate
 /// for the remote's kind.
@@ -38,25 +30,11 @@ pub fn probe_reachability_for_remote(remote: &crate::global_config::RemoteConfig
     crate::remote::ssh_exec(&remote.host, cmd).is_ok()
 }
 
-/// Probes many hosts concurrently, one thread per unique host.
-///
-/// Deduplicates the input, spawns one probe thread per host, joins them all,
-/// and returns a `host -> reachable` map. Dead hosts can't block healthy
-/// ones because each probe runs on its own thread.
-pub fn probe_reachability_all<I, S>(hosts: I) -> HashMap<String, bool>
-where
-    I: IntoIterator<Item = S>,
-    S: Into<String>,
-{
-    probe_with(hosts, probe_reachability)
-}
-
 /// Probes many (host, kind-aware) remotes concurrently.
 ///
 /// Deduplicates by host, spawns one thread per unique remote, and returns
-/// a `host -> reachable` map. Use this instead of `probe_reachability_all`
-/// when the caller has full `RemoteConfig` entries so each host can be
-/// probed with the correct command for its kind.
+/// a `host -> reachable` map. Each remote is probed with the command
+/// appropriate for its kind (see `probe_reachability_for_remote`).
 pub fn probe_reachability_all_for_remotes(
     remotes: &[crate::global_config::RemoteConfig],
 ) -> HashMap<String, bool> {
@@ -80,6 +58,7 @@ pub fn probe_reachability_all_for_remotes(
     handles.into_iter().filter_map(|h| h.join().ok()).collect()
 }
 
+#[cfg(test)]
 fn probe_with<I, S, F>(hosts: I, probe: F) -> HashMap<String, bool>
 where
     I: IntoIterator<Item = S>,

--- a/crates/orchard/src/sources/tmux.rs
+++ b/crates/orchard/src/sources/tmux.rs
@@ -12,3 +12,15 @@ pub fn refresh_local() -> anyhow::Result<()> {
 pub fn refresh_remote(host: &str) -> anyhow::Result<()> {
     crate::cache_sources::refresh_tmux_sessions(Some(host))
 }
+
+/// Fetches tmux sessions from a remote via its adapter and writes per-host caches.
+///
+/// Routes through `RemoteAdapter::from_config` so `BoxdFork` remotes write one
+/// cache file per fork host rather than always using the gateway host. Mirrors
+/// the pattern used for worktrees in `sources::worktrees::refresh_remote`.
+pub fn refresh_remote_adapter(
+    repo: &crate::global_config::RepoConfig,
+    remote: &crate::global_config::RemoteConfig,
+) -> anyhow::Result<()> {
+    crate::cache_sources::refresh_remote_tmux_sessions(repo, remote)
+}

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -819,7 +819,7 @@ impl App {
     /// spawns a background thread to probe each unreachable host and send results
     /// back via the App message channel.
     pub(crate) fn reconnect_unreachable_hosts(&mut self) {
-        let unreachable: Vec<String> = self
+        let unreachable: std::collections::HashSet<String> = self
             .host_reachable
             .iter()
             .filter(|(_, v)| !*v)
@@ -827,16 +827,31 @@ impl App {
             .collect();
         if unreachable.is_empty() {
             self.warning = Some(("All hosts reachable".to_string(), Instant::now()));
-        } else {
-            let tx = self.tx.clone();
-            std::thread::spawn(move || {
-                let results = crate::sources::hosts::probe_reachability_all(unreachable);
-                for (host, reachable) in results {
-                    let _ = tx.send(crate::tui::state::AppMsg::HostReachability(host, reachable));
-                }
-            });
-            self.warning = Some(("Reconnecting...".to_string(), Instant::now()));
+            return;
         }
+
+        // Resolve each unreachable host back to its configured RemoteConfig so
+        // the probe uses the kind-appropriate command. Hosts present in the
+        // reachability map but no longer in config are dropped; probing an
+        // orphan host with a default `true` probe would silently hide boxd
+        // controllers, and there is no adapter kind to route to anyway.
+        let remotes: Vec<crate::global_config::RemoteConfig> = self
+            .global_config
+            .repos
+            .iter()
+            .flat_map(|r| r.remotes.iter())
+            .filter(|r| unreachable.contains(&r.host))
+            .cloned()
+            .collect();
+
+        let tx = self.tx.clone();
+        std::thread::spawn(move || {
+            let results = crate::sources::hosts::probe_reachability_all_for_remotes(&remotes);
+            for (host, reachable) in results {
+                let _ = tx.send(crate::tui::state::AppMsg::HostReachability(host, reachable));
+            }
+        });
+        self.warning = Some(("Reconnecting...".to_string(), Instant::now()));
     }
 
     pub(crate) fn render_list(&self, f: &mut Frame) {

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -608,7 +608,7 @@ impl App {
                     if reachable_hosts.contains(&remote.host)
                         && tmux_hosts_refreshed.insert(remote.host.clone())
                     {
-                        let _ = cache_sources::refresh_tmux_sessions(Some(&remote.host));
+                        let _ = cache_sources::refresh_remote_tmux_sessions(repo, remote);
                     }
                 }
             }

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -572,12 +572,15 @@ impl App {
         std::thread::spawn(move || {
             // Probe each unique remote host concurrently before attempting remote
             // operations. One dead VM must not block probes for healthy hosts.
-            let hosts: Vec<String> = config
+            // Use the kind-aware variant so `boxd-fork` golden hosts (which
+            // reject `true` as a subcommand) are probed with `list --json`.
+            let remotes: Vec<crate::global_config::RemoteConfig> = config
                 .repos
                 .iter()
-                .flat_map(|r| r.remotes.iter().map(|rm| rm.host.clone()))
+                .flat_map(|r| r.remotes.iter().cloned())
                 .collect();
-            let probe_results = crate::sources::hosts::probe_reachability_all(hosts);
+            let probe_results =
+                crate::sources::hosts::probe_reachability_all_for_remotes(&remotes);
 
             let mut reachable_hosts: std::collections::HashSet<String> =
                 std::collections::HashSet::new();

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -579,8 +579,7 @@ impl App {
                 .iter()
                 .flat_map(|r| r.remotes.iter().cloned())
                 .collect();
-            let probe_results =
-                crate::sources::hosts::probe_reachability_all_for_remotes(&remotes);
+            let probe_results = crate::sources::hosts::probe_reachability_all_for_remotes(&remotes);
 
             let mut reachable_hosts: std::collections::HashSet<String> =
                 std::collections::HashSet::new();

--- a/crates/orchard/tests/remote_port.rs
+++ b/crates/orchard/tests/remote_port.rs
@@ -16,8 +16,8 @@ use orchard::remote_adapter::{
 // RemoteWorktreeService port defines a minimal stable surface
 // ---------------------------------------------------------------------------
 
-/// The port exposes `list_worktrees`, `list_sessions`, and `probe` on all
-/// three adapter variants, each returning a typed `Result`.
+/// The port exposes `list_worktrees` and `list_sessions` on all three adapter
+/// variants, each returning a typed `Result`.
 ///
 /// These tests call each method on each variant and assert `Ok`. They fail
 /// red (panic from `unimplemented!`) until the production code fills in the
@@ -51,18 +51,6 @@ fn port_list_sessions_returns_ok_for_remmy_variant() {
         result.is_ok(),
         "list_sessions must return Ok; got: {result:?}"
     );
-}
-
-#[test]
-fn port_probe_returns_ok_for_remmy_variant() {
-    // feature.feature:22
-    let adapter = RemoteAdapter::Remmy(RemmyAdapter {
-        host: "ubuntu@10.0.3.56".to_string(),
-        path: "~/repo".to_string(),
-        ssh: Box::new(FakeSshExec::new()),
-    });
-    let result = adapter.probe();
-    assert!(result.is_ok(), "probe must return Ok; got: {result:?}");
 }
 
 #[test]


### PR DESCRIPTION
## Why

Closes #264

Orchard's per-remote tmux refresh was calling `refresh_tmux_sessions(Some(&remote.host))` once per configured remote. For `remmy` and `boxd-shared` remotes this is correct — `remote.host` is the machine running tmux. For `boxd-fork` remotes it is wrong: `remote.host` is the golden Boxd host (e.g. `boxd.sh`), which is an API gateway, not a tmux host. Meanwhile the per-fork VMs (e.g. `issue3155.boxd.sh`) — where real work runs — were never contacted for sessions.

Symptom: a PR shipped from a Claude session on `issue3155.boxd.sh` was invisible in both `orchard --json` and the TUI. The worktree side of discovery already landed in #284, but the session side was still a Slice-2 stub.

## What changed

Two fixes, both behind the `RemoteAdapter` port that #284 introduced:

1. **`BoxdForkAdapter::list_sessions` is no longer a stub.** It now SSHes to the golden host with `list --json` to enumerate live forks, then SSHes each fork host with the same `tmux list-sessions -F '…'` template used elsewhere. Sessions are parsed through the existing `cache_sources::parse_tmux_output` (no reimplementation) and tagged with the fork host so downstream joins match fork worktrees. A single dead fork is skipped with a warning; it doesn't silence the others. Golden-host SSH failure still returns `FetchFailure` so callers preserve prior cache.

2. **Orchestration routes tmux refresh through the adapter.** A new `cache_sources::refresh_remote_tmux_sessions(repo, remote_cfg)` builds the adapter via `RemoteAdapter::from_config`, calls `list_sessions`, groups results by host, and writes one cache file per host via `tmux_cache_path(Some(&host))`. For `remmy`/`boxd-shared` that's still a single file keyed by `remote.host`; for `boxd-fork` it's one file per live fork VM. Call sites in `build_state.rs` (`--json` path) and `tui/mod.rs` (TUI background refresh) now use this function instead of raw `refresh_tmux_sessions(Some(&remote.host))`.

The legacy `refresh_tmux_sessions(Option<&str>)` stays for local refresh and the watch daemon.

## Test plan

- New unit test `boxd_fork_adapter_list_sessions_returns_sessions_from_each_live_fork` in `remote_adapter.rs`, using the existing `FakeSshExec` double. The test loads canned `list --json` + per-fork `tmux list-sessions` replies and asserts the adapter returns a `CachedTmuxSession` tagged with the fork host. **Confirmed it fails without the fix** (`ccc36f5` commits the failing test; `5237370` makes it pass). No other unit test changes were needed.
- `cargo test -p orchard --lib` — 1124 passed, 0 failed.
- `cargo clippy -p orchard --all-targets -- -D warnings` — clean.
- End-to-end verification with a live fork is the last AC on #264 and will be done once this PR lands locally.

## Anything surprising?

- SWR is skipped for `BoxdFork` in `refresh_remote_tmux_sessions` — always refreshes. The gateway-host cache key doesn't correspond to any single fork's state, so there's nothing meaningful to check for freshness there. A per-fork SWR can land as a follow-up if refresh cost becomes a problem.
- `list_sessions` does not fetch pane details or capture-pane output for fork sessions — those are empty. The issue's ACs are about visibility (branch + session + PR appearing at all); pane/capture enrichment for forks is a separate follow-up.
- The worktree-loss event (`worktree.remote_lost`) logic in `refresh_remote_worktrees` is not yet mirrored for sessions. A fork whose VM was killed between refreshes will silently drop out of the session cache rather than emit an event. That matches the current single-host behavior and is acceptable for this issue.


# Related issue

- #264

# Related issue

- #264

# Related issue

- #264

# Related issue

- #264

# Related issue

- #264

# Related issue

- #264