### PR TITLE
fix(scripts): zombie-proof orchardist-serial-driver (#243)

### DIFF
--- a/scripts/orchardist-serial-driver.sh
+++ b/scripts/orchardist-serial-driver.sh
@@ -34,7 +34,7 @@ STATE_FILE="${TMPDIR:-/tmp}/orchardist-driver-state-${FOCUS_PR}.txt"
 cleanup() {
   rm -f "${STATE_FILE}"
 }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
 
 # ---------------------------------------------------------------------------
 # Notify helper — send to orchardist pane if configured; never fatal if pane gone
@@ -50,9 +50,14 @@ notify() {
 }
 
 # ---------------------------------------------------------------------------
-# Initialise state file
+# Fail fast if the target session is already gone before we advertise startup.
 # ---------------------------------------------------------------------------
-echo "DRIVING #${FOCUS_PR} via ${FOCUS_SESSION}" > "${STATE_FILE}"
+if ! tmux has-session -t "${FOCUS_SESSION}" 2>/dev/null; then
+  echo "[driver] session ${FOCUS_SESSION} does not exist — nothing to drive" >&2
+  exit 0
+fi
+
+: > "${STATE_FILE}"
 notify "started — watching PR #${FOCUS_PR} in session ${FOCUS_SESSION}"
 
 # ---------------------------------------------------------------------------
@@ -61,10 +66,7 @@ notify "started — watching PR #${FOCUS_PR} in session ${FOCUS_SESSION}"
 err_count=0
 
 while true; do
-  # Sleep first so the process is observable before any liveness check fires.
-  sleep "${POLL_INTERVAL}"
-
-  # Session liveness check — prevents zombie drivers (#243)
+  # Liveness check first — prevents zombie drivers if the session died mid-poll (#243)
   if ! tmux has-session -t "${FOCUS_SESSION}" 2>/dev/null; then
     notify "session ${FOCUS_SESSION} gone — exiting"
     exit 0
@@ -74,7 +76,9 @@ while true; do
   raw=$(gh pr view "${FOCUS_PR}" -R "${REPO}" \
         --json statusCheckRollup,state 2>/dev/null) || raw=""
 
-  # Pass JSON via env var (not stdin) so the heredoc below is the only stdin
+  # Pass JSON via env var (not stdin) so the heredoc below is the only stdin.
+  # python3 always prints + exits 0, so $() always succeeds with a non-empty result;
+  # checks with neither conclusion nor status fall into PENDING.
   result=$(DRIVER_RAW="${raw}" python3 - <<'PYEOF'
 import json, os, sys
 
@@ -106,11 +110,7 @@ elif all(s in ("SUCCESS", "SKIPPED", "NEUTRAL") for s in statuses):
 else:
     print("PENDING")
 PYEOF
-  ) || result="ERR"
-
-  if [[ -z "${result}" ]]; then
-    result="ERR"
-  fi
+)
 
   # Track consecutive ERR — network-blip zombie prevention (#243)
   if [[ "${result}" == "ERR" ]]; then
@@ -137,4 +137,6 @@ PYEOF
       exit 0
       ;;
   esac
+
+  sleep "${POLL_INTERVAL}"
 done

--- a/scripts/orchardist-serial-driver.sh
+++ b/scripts/orchardist-serial-driver.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# orchardist-serial-driver.sh — Polls a PR and exits when the target tmux session dies.
+#
+# Usage: REPO=owner/repo [POLL_INTERVAL=120] [MAX_ERR=5] [ORCHARDIST_PANE=target]
+#        ./orchardist-serial-driver.sh <PR_NUMBER> <SESSION_NAME>
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Args & config
+# ---------------------------------------------------------------------------
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <PR_NUMBER> <SESSION_NAME>" >&2
+  exit 2
+fi
+
+FOCUS_PR="$1"
+FOCUS_SESSION="$2"
+
+REPO="${REPO:-}"
+if [[ -z "${REPO}" ]]; then
+  echo "error: REPO env var is required (e.g. REPO=owner/repo)" >&2
+  exit 2
+fi
+
+POLL_INTERVAL="${POLL_INTERVAL:-120}"
+MAX_ERR="${MAX_ERR:-5}"
+ORCHARDIST_PANE="${ORCHARDIST_PANE:-}"
+STATE_FILE="${TMPDIR:-/tmp}/orchardist-driver-state-${FOCUS_PR}.txt"
+
+# ---------------------------------------------------------------------------
+# Cleanup — remove state file on any exit (#243: no leftover files from zombies)
+# ---------------------------------------------------------------------------
+cleanup() {
+  rm -f "${STATE_FILE}"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Notify helper — send to orchardist pane if configured; never fatal if pane gone
+# ---------------------------------------------------------------------------
+notify() {
+  local msg="$1"
+  echo "[driver] ${msg}"
+  if [[ -n "${ORCHARDIST_PANE}" ]]; then
+    tmux send-keys -t "${ORCHARDIST_PANE}" Enter 2>/dev/null || true
+    tmux send-keys -t "${ORCHARDIST_PANE}" -l "[driver] ${msg}" 2>/dev/null || true
+    tmux send-keys -t "${ORCHARDIST_PANE}" Enter 2>/dev/null || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Initialise state file
+# ---------------------------------------------------------------------------
+echo "DRIVING #${FOCUS_PR} via ${FOCUS_SESSION}" > "${STATE_FILE}"
+notify "started — watching PR #${FOCUS_PR} in session ${FOCUS_SESSION}"
+
+# ---------------------------------------------------------------------------
+# Poll loop
+# ---------------------------------------------------------------------------
+err_count=0
+
+while true; do
+  # Sleep first so the process is observable before any liveness check fires.
+  sleep "${POLL_INTERVAL}"
+
+  # Session liveness check — prevents zombie drivers (#243)
+  if ! tmux has-session -t "${FOCUS_SESSION}" 2>/dev/null; then
+    notify "session ${FOCUS_SESSION} gone — exiting"
+    exit 0
+  fi
+
+  # Poll GitHub for PR state and CI rollup
+  raw=$(gh pr view "${FOCUS_PR}" -R "${REPO}" \
+        --json statusCheckRollup,state 2>/dev/null) || raw=""
+
+  # Pass JSON via env var (not stdin) so the heredoc below is the only stdin
+  result=$(DRIVER_RAW="${raw}" python3 - <<'PYEOF'
+import json, os, sys
+
+raw = os.environ.get("DRIVER_RAW", "")
+try:
+    data = json.loads(raw)
+except Exception:
+    print("ERR")
+    sys.exit(0)
+
+state = data.get("state", "")
+if state == "MERGED":
+    print("MERGED")
+    sys.exit(0)
+if state == "CLOSED":
+    print("CLOSED")
+    sys.exit(0)
+
+checks = data.get("statusCheckRollup") or []
+if not checks:
+    print("PENDING")
+    sys.exit(0)
+
+statuses = [c.get("conclusion") or c.get("status", "") for c in checks]
+if any(s in ("FAILURE", "ERROR", "TIMED_OUT", "CANCELLED") for s in statuses):
+    print("RED")
+elif all(s in ("SUCCESS", "SKIPPED", "NEUTRAL") for s in statuses):
+    print("GREEN")
+else:
+    print("PENDING")
+PYEOF
+  ) || result="ERR"
+
+  if [[ -z "${result}" ]]; then
+    result="ERR"
+  fi
+
+  # Track consecutive ERR — network-blip zombie prevention (#243)
+  if [[ "${result}" == "ERR" ]]; then
+    err_count=$(( err_count + 1 ))
+    if [[ "${err_count}" -ge "${MAX_ERR}" ]]; then
+      notify "PR #${FOCUS_PR}: ${MAX_ERR} consecutive errors — giving up"
+      exit 1
+    fi
+  else
+    err_count=0
+  fi
+
+  # Notify on state change
+  prev=$(cat "${STATE_FILE}" 2>/dev/null || echo "")
+  if [[ "${result}" != "${prev}" ]]; then
+    echo "${result}" > "${STATE_FILE}"
+    notify "PR #${FOCUS_PR}: ${result}"
+  fi
+
+  # Exit on terminal states
+  case "${result}" in
+    GREEN|MERGED|CLOSED)
+      notify "PR #${FOCUS_PR}: ${result} — done"
+      exit 0
+      ;;
+  esac
+done

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -1,0 +1,19 @@
+# scripts/tests
+
+Plain-bash regression tests for shell scripts in `scripts/`.
+
+## Running
+
+Each test is a self-contained executable. Run it directly:
+
+```
+./scripts/tests/orchardist-serial-driver.test.sh
+```
+
+Exit 0 = pass. Non-zero = fail with a message on stderr.
+
+## Tests
+
+| File | What it covers |
+|------|---------------|
+| `orchardist-serial-driver.test.sh` | Regression for issue #243: driver must exit within 5 s when its target tmux session is killed. |

--- a/scripts/tests/orchardist-serial-driver.test.sh
+++ b/scripts/tests/orchardist-serial-driver.test.sh
@@ -129,4 +129,74 @@ if kill -0 "${DRIVER_PID}" 2>/dev/null; then
   fail "driver process is still alive after wait loop — this should not happen"
 fi
 
-pass "driver exited within ${ELAPSED}s of session death (issue #243 not present)"
+pass "driver exited within ${ELAPSED}s of session death (issue #243 AC#1)"
+
+# ---------------------------------------------------------------------------
+# AC#2: driver exits when PR state is CLOSED
+# ---------------------------------------------------------------------------
+SESSION_NAME="test_driver_closed_$$"
+DRIVER_PID=""
+tmux new-session -d -s "${SESSION_NAME}" -x 80 -y 24
+
+# Swap the fake gh to one that returns CLOSED
+cat > "${FAKE_BIN_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo '{"state":"CLOSED","statusCheckRollup":[]}'
+EOF
+chmod +x "${FAKE_BIN_DIR}/gh"
+
+POLL_INTERVAL=1 \
+REPO="drewdrewthis/git-orchard-rs" \
+  "${DRIVER}" 999998 "${SESSION_NAME}" >"${DRIVER_LOG}" 2>&1 &
+DRIVER_PID=$!
+
+# Driver should hit CLOSED on its first poll (~1s) and exit
+TIMEOUT=4
+ELAPSED=0
+while kill -0 "${DRIVER_PID}" 2>/dev/null; do
+  if [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
+    cat "${DRIVER_LOG}" >&2
+    tmux kill-session -t "${SESSION_NAME}" 2>/dev/null || true
+    fail "driver did not exit on PR CLOSED within ${TIMEOUT}s"
+  fi
+  sleep 1
+  ELAPSED=$(( ELAPSED + 1 ))
+done
+tmux kill-session -t "${SESSION_NAME}" 2>/dev/null || true
+pass "driver exited on PR CLOSED within ${ELAPSED}s (issue #243 AC#2)"
+
+# ---------------------------------------------------------------------------
+# AC#3: driver exits after MAX_ERR consecutive parse failures
+# ---------------------------------------------------------------------------
+SESSION_NAME="test_driver_err_$$"
+DRIVER_PID=""
+tmux new-session -d -s "${SESSION_NAME}" -x 80 -y 24
+
+cat > "${FAKE_BIN_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo 'not-json'
+EOF
+chmod +x "${FAKE_BIN_DIR}/gh"
+
+POLL_INTERVAL=1 \
+MAX_ERR=3 \
+REPO="drewdrewthis/git-orchard-rs" \
+  "${DRIVER}" 999997 "${SESSION_NAME}" >"${DRIVER_LOG}" 2>&1 &
+DRIVER_PID=$!
+
+# 3 ERRs at 1s each → exit by ~3s; allow 6s
+TIMEOUT=6
+ELAPSED=0
+while kill -0 "${DRIVER_PID}" 2>/dev/null; do
+  if [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
+    cat "${DRIVER_LOG}" >&2
+    tmux kill-session -t "${SESSION_NAME}" 2>/dev/null || true
+    fail "driver did not exit after MAX_ERR=3 consecutive errors within ${TIMEOUT}s"
+  fi
+  sleep 1
+  ELAPSED=$(( ELAPSED + 1 ))
+done
+tmux kill-session -t "${SESSION_NAME}" 2>/dev/null || true
+pass "driver exited after MAX_ERR consecutive errors within ${ELAPSED}s (issue #243 AC#3)"
+
+echo "All issue #243 ACs verified."

--- a/scripts/tests/orchardist-serial-driver.test.sh
+++ b/scripts/tests/orchardist-serial-driver.test.sh
@@ -21,21 +21,21 @@ SESSION_NAME="test_driver_$$"
 FAKE_BIN_DIR="$(mktemp -d)"
 DRIVER_PID=""
 DRIVER_LOG="$(mktemp)"
+SESSIONS=("${SESSION_NAME}")
 
 # ---------------------------------------------------------------------------
-# Cleanup
+# Cleanup — tracks every session created so mid-test failures don't leak
 # ---------------------------------------------------------------------------
 cleanup() {
-  # Kill the driver if still alive
   if [[ -n "${DRIVER_PID}" ]] && kill -0 "${DRIVER_PID}" 2>/dev/null; then
     kill "${DRIVER_PID}" 2>/dev/null || true
   fi
-  # Kill the test tmux session if still alive
-  tmux kill-session -t "${SESSION_NAME}" 2>/dev/null || true
-  # Remove temp dirs/files
+  for s in "${SESSIONS[@]}"; do
+    tmux kill-session -t "${s}" 2>/dev/null || true
+  done
   rm -rf "${FAKE_BIN_DIR}" "${DRIVER_LOG}"
 }
-trap cleanup EXIT
+trap cleanup EXIT INT TERM
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -135,6 +135,7 @@ pass "driver exited within ${ELAPSED}s of session death (issue #243 AC#1)"
 # AC#2: driver exits when PR state is CLOSED
 # ---------------------------------------------------------------------------
 SESSION_NAME="test_driver_closed_$$"
+SESSIONS+=("${SESSION_NAME}")
 DRIVER_PID=""
 tmux new-session -d -s "${SESSION_NAME}" -x 80 -y 24
 
@@ -169,6 +170,7 @@ pass "driver exited on PR CLOSED within ${ELAPSED}s (issue #243 AC#2)"
 # AC#3: driver exits after MAX_ERR consecutive parse failures
 # ---------------------------------------------------------------------------
 SESSION_NAME="test_driver_err_$$"
+SESSIONS+=("${SESSION_NAME}")
 DRIVER_PID=""
 tmux new-session -d -s "${SESSION_NAME}" -x 80 -y 24
 

--- a/scripts/tests/orchardist-serial-driver.test.sh
+++ b/scripts/tests/orchardist-serial-driver.test.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Regression test for issue #243:
+#   orchardist-serial-driver.sh must exit when its target tmux session dies.
+#
+# The test verifies that the driver process terminates within 5 seconds of the
+# target session being killed, rather than running forever as a zombie.
+#
+# Run: ./scripts/tests/orchardist-serial-driver.test.sh
+# Exit 0 = pass, non-zero = fail.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Paths and names
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DRIVER="${REPO_ROOT}/scripts/orchardist-serial-driver.sh"
+
+SESSION_NAME="test_driver_$$"
+FAKE_BIN_DIR="$(mktemp -d)"
+DRIVER_PID=""
+DRIVER_LOG="$(mktemp)"
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+cleanup() {
+  # Kill the driver if still alive
+  if [[ -n "${DRIVER_PID}" ]] && kill -0 "${DRIVER_PID}" 2>/dev/null; then
+    kill "${DRIVER_PID}" 2>/dev/null || true
+  fi
+  # Kill the test tmux session if still alive
+  tmux kill-session -t "${SESSION_NAME}" 2>/dev/null || true
+  # Remove temp dirs/files
+  rm -rf "${FAKE_BIN_DIR}" "${DRIVER_LOG}"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+pass() { echo "PASS: $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Pre-flight: driver script must exist
+# ---------------------------------------------------------------------------
+if [[ ! -f "${DRIVER}" ]]; then
+  fail "driver script not found: ${DRIVER}  (expected scripts/orchardist-serial-driver.sh)"
+fi
+if [[ ! -x "${DRIVER}" ]]; then
+  fail "driver script is not executable: ${DRIVER}"
+fi
+
+# ---------------------------------------------------------------------------
+# Install a fake 'gh' on PATH that returns canned JSON so the driver never
+# blocks on a real GitHub API call.
+#
+# The fake gh responds to any invocation — issue fetch, PR fetch, etc. — with
+# a minimal valid payload that keeps the driver happy during its startup phase.
+# ---------------------------------------------------------------------------
+cat > "${FAKE_BIN_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+# Stub gh CLI — returns minimal canned responses regardless of arguments.
+# Used by orchardist-serial-driver.test.sh to avoid real API calls.
+echo '{"number":999999,"title":"test PR","state":"OPEN","isDraft":false}'
+EOF
+chmod +x "${FAKE_BIN_DIR}/gh"
+
+# Also stub 'orchard' in case the driver calls it
+cat > "${FAKE_BIN_DIR}/orchard" <<'EOF'
+#!/usr/bin/env bash
+echo '{}'
+EOF
+chmod +x "${FAKE_BIN_DIR}/orchard"
+
+export PATH="${FAKE_BIN_DIR}:${PATH}"
+
+# ---------------------------------------------------------------------------
+# 1. Create a disposable tmux session
+# ---------------------------------------------------------------------------
+tmux new-session -d -s "${SESSION_NAME}" -x 80 -y 24
+echo "Created tmux session: ${SESSION_NAME}"
+
+# ---------------------------------------------------------------------------
+# 2. Launch the driver in the background with fast poll interval
+#    Args: <pr-number> <session-name>  (matches expected driver interface)
+# ---------------------------------------------------------------------------
+POLL_INTERVAL=1 \
+REPO="drewdrewthis/git-orchard-rs" \
+  "${DRIVER}" 999999 "${SESSION_NAME}" >"${DRIVER_LOG}" 2>&1 &
+DRIVER_PID=$!
+echo "Started driver PID: ${DRIVER_PID}"
+
+# Give the driver a moment to start up and enter its polling loop
+sleep 1
+
+# Confirm the driver is actually running before we kill the session
+if ! kill -0 "${DRIVER_PID}" 2>/dev/null; then
+  fail "driver exited too early (before session was killed) — check ${DRIVER_LOG}"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Kill the target tmux session
+# ---------------------------------------------------------------------------
+tmux kill-session -t "${SESSION_NAME}" 2>/dev/null || true
+echo "Killed tmux session: ${SESSION_NAME}"
+
+# ---------------------------------------------------------------------------
+# 4. Wait up to 5 seconds for the driver to exit
+# ---------------------------------------------------------------------------
+TIMEOUT=5
+ELAPSED=0
+while kill -0 "${DRIVER_PID}" 2>/dev/null; do
+  if [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
+    echo "--- driver log ---"
+    cat "${DRIVER_LOG}" >&2
+    fail "driver (PID ${DRIVER_PID}) still alive ${TIMEOUT}s after session was killed — zombie bug reproduced"
+  fi
+  sleep 1
+  ELAPSED=$(( ELAPSED + 1 ))
+done
+
+# ---------------------------------------------------------------------------
+# 5. Assert: driver process is gone
+# ---------------------------------------------------------------------------
+if kill -0 "${DRIVER_PID}" 2>/dev/null; then
+  fail "driver process is still alive after wait loop — this should not happen"
+fi
+
+pass "driver exited within ${ELAPSED}s of session death (issue #243 not present)"


### PR DESCRIPTION
## Summary

- Promotes the ad-hoc `/tmp/orchardist-serial-driver.sh` heredoc into a durable `scripts/orchardist-serial-driver.sh` with proper exit conditions
- Driver now exits when its target tmux session dies, when the PR is CLOSED/MERGED, or after `MAX_ERR` consecutive fetch/parse failures
- Fixes a latent stdin-shadowing bug where the python block's heredoc was consuming stdin instead of the piped `gh` JSON, so every response parsed as `ERR`

Closes #243.

## Why

A zombie driver was observed running for 2+ days watching a long-dead PR #3008 / session `lw_issue2877`, spamming `[driver] PR #3008: ERR` into the orchardist pane forever. The original script only exited on `GREEN`/`MERGED` — any other state (including `ERR`) looped indefinitely, and it never checked whether its target session still existed.

## Test plan

- [x] `./scripts/tests/orchardist-serial-driver.test.sh` — covers all three ACs:
  - AC#1: driver exits within 1s of `tmux kill-session`
  - AC#2: driver exits when `gh` returns `state: CLOSED`
  - AC#3: driver exits after `MAX_ERR=3` consecutive parse failures
- [x] `bash -n scripts/orchardist-serial-driver.sh` — syntax clean
- [ ] Manual orchardist integration test (requires a live session; low risk since the old ad-hoc script is superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #243

# Related issue

- #243