### PR TITLE
refactor(webhook): box NormalizeResult::Event to satisfy large_enum_variant

### DIFF
--- a/crates/orchard/src/webhook/normalize.rs
+++ b/crates/orchard/src/webhook/normalize.rs
@@ -41,17 +41,9 @@ pub struct NormalizedEvent {
 }
 
 /// Result of normalising a GitHub webhook payload.
-///
-/// `large_enum_variant` is allowed here because this result type is produced
-/// and consumed on the same call path without being stored long-term; the
-/// payload size asymmetry between variants doesn't matter in practice, and
-/// boxing the happy-path variant would add indirection everywhere for no
-/// runtime benefit. The lint began to fire with rust 1.94.
-/// See issue #268 for a follow-up if the trade-off ever warrants revisiting.
-#[allow(clippy::large_enum_variant)]
 pub enum NormalizeResult {
     /// The event was recognised and normalised successfully.
-    Event(NormalizedEvent),
+    Event(Box<NormalizedEvent>),
     /// The event type is known but the specific action is not in scope
     /// (e.g. `pull_request.assigned`). Nothing should be written to the log.
     Unsupported,
@@ -122,14 +114,14 @@ fn normalize_pull_request(
     };
 
     let pr = u64_field(payload, &["pull_request", "number"]);
-    NormalizeResult::Event(build_event(
+    NormalizeResult::Event(Box::new(build_event(
         kind.to_string(),
         repo,
         pr,
         None,
         actor,
         payload,
-    ))
+    )))
 }
 
 fn normalize_pull_request_review(
@@ -142,14 +134,14 @@ fn normalize_pull_request_review(
         return NormalizeResult::Unsupported;
     }
     let pr = u64_field(payload, &["pull_request", "number"]);
-    NormalizeResult::Event(build_event(
+    NormalizeResult::Event(Box::new(build_event(
         "pull_request.review.submitted".to_string(),
         repo,
         pr,
         None,
         actor,
         payload,
-    ))
+    )))
 }
 
 fn normalize_pull_request_review_comment(
@@ -162,14 +154,14 @@ fn normalize_pull_request_review_comment(
         return NormalizeResult::Unsupported;
     }
     let pr = u64_field(payload, &["pull_request", "number"]);
-    NormalizeResult::Event(build_event(
+    NormalizeResult::Event(Box::new(build_event(
         "pull_request.review_comment.created".to_string(),
         repo,
         pr,
         None,
         actor,
         payload,
-    ))
+    )))
 }
 
 fn normalize_issue_comment(
@@ -188,14 +180,14 @@ fn normalize_issue_comment(
         .is_some();
     let pr = if is_pr { issue_number } else { None };
 
-    NormalizeResult::Event(build_event(
+    NormalizeResult::Event(Box::new(build_event(
         "issue_comment.created".to_string(),
         repo,
         pr,
         issue_number,
         actor,
         payload,
-    ))
+    )))
 }
 
 fn normalize_issues(
@@ -209,18 +201,18 @@ fn normalize_issues(
         _ => return NormalizeResult::Unsupported,
     };
     let issue = u64_field(payload, &["issue", "number"]);
-    NormalizeResult::Event(build_event(kind, repo, None, issue, actor, payload))
+    NormalizeResult::Event(Box::new(build_event(kind, repo, None, issue, actor, payload)))
 }
 
 fn normalize_push(payload: &Value, repo: Option<String>, actor: Option<String>) -> NormalizeResult {
-    NormalizeResult::Event(build_event(
+    NormalizeResult::Event(Box::new(build_event(
         "push".to_string(),
         repo,
         None,
         None,
         actor,
         payload,
-    ))
+    )))
 }
 
 fn normalize_ci_event(
@@ -234,7 +226,7 @@ fn normalize_ci_event(
         return NormalizeResult::Unsupported;
     }
     let kind = format!("{}.completed", event_type);
-    NormalizeResult::Event(build_event(kind, repo, None, None, actor, payload))
+    NormalizeResult::Event(Box::new(build_event(kind, repo, None, None, actor, payload)))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/orchard/src/webhook/normalize.rs
+++ b/crates/orchard/src/webhook/normalize.rs
@@ -206,7 +206,9 @@ fn normalize_issues(
         _ => return NormalizeResult::Unsupported,
     };
     let issue = u64_field(payload, &["issue", "number"]);
-    NormalizeResult::Event(Box::new(build_event(kind, repo, None, issue, actor, payload)))
+    NormalizeResult::Event(Box::new(build_event(
+        kind, repo, None, issue, actor, payload,
+    )))
 }
 
 fn normalize_push(payload: &Value, repo: Option<String>, actor: Option<String>) -> NormalizeResult {
@@ -231,7 +233,9 @@ fn normalize_ci_event(
         return NormalizeResult::Unsupported;
     }
     let kind = format!("{}.completed", event_type);
-    NormalizeResult::Event(Box::new(build_event(kind, repo, None, None, actor, payload)))
+    NormalizeResult::Event(Box::new(build_event(
+        kind, repo, None, None, actor, payload,
+    )))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/orchard/src/webhook/normalize.rs
+++ b/crates/orchard/src/webhook/normalize.rs
@@ -41,6 +41,11 @@ pub struct NormalizedEvent {
 }
 
 /// Result of normalising a GitHub webhook payload.
+///
+/// The `Event` payload is boxed so the enum stays compact: `NormalizedEvent`
+/// is ~200 bytes while `Unsupported`/`Unknown` are unit — without the box,
+/// every variant carries the largest one's footprint (clippy's
+/// `large_enum_variant`, promoted in rust 1.94).
 pub enum NormalizeResult {
     /// The event was recognised and normalised successfully.
     Event(Box<NormalizedEvent>),

--- a/crates/orchard/src/webhook/normalize_tests.rs
+++ b/crates/orchard/src/webhook/normalize_tests.rs
@@ -22,7 +22,7 @@ fn pr_payload(action: &str, merged: bool, pr_number: u64, repo: &str, actor: &st
 
 fn assert_event(result: NormalizeResult) -> NormalizedEvent {
     match result {
-        NormalizeResult::Event(e) => e,
+        NormalizeResult::Event(e) => *e,
         NormalizeResult::Unsupported => panic!("expected Event, got Unsupported"),
         NormalizeResult::Unknown => panic!("expected Event, got Unknown"),
     }


### PR DESCRIPTION
## Summary

- Box `NormalizeResult::Event` variant to satisfy clippy's `large_enum_variant` lint (promoted in rust 1.94)
- Remove the scoped `#[allow(clippy::large_enum_variant)]` placeholder added in #265
- Auto-deref keeps `&NormalizedEvent` callers unchanged; test helper unboxes with `*e`

Closes #268

## Evidence

| Criterion | Proof |
|---|---|
| `NormalizeResult::Event` holds `Box<NormalizedEvent>` | `crates/orchard/src/webhook/normalize.rs:46` |
| `#[allow(clippy::large_enum_variant)]` removed | Diff: 8-line attribute + doc block deleted |
| `cargo clippy -p orchard --all-targets -- -D warnings` clean | Ran locally — 0 warnings |
| Existing webhook tests pass unchanged | 49 passed, 0 failed (same as baseline) |

## Test plan

- [x] `cargo clippy -p orchard --all-targets -- -D warnings`
- [x] `cargo test -p orchard --lib webhook::` (49 passed)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #268

# Related issue

- #268

# Related issue

- #268