### PR TITLE
refactor(tui): unify host reachability tri-state across list.rs

### DIFF
--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -16,7 +16,7 @@ use crate::remote;
 use crate::tmux;
 use crate::tui::state::{CleanupState, InputPhase, Phase, ViewState};
 use crate::tui::theme::{Theme, display_group_color, repo_color};
-use crate::tui::{ATTRIBUTION_URL, App, WARNING_DURATION_SECS, Reachability, filter_stale};
+use crate::tui::{ATTRIBUTION_URL, App, Reachability, WARNING_DURATION_SECS, filter_stale};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -558,11 +558,15 @@ impl App {
                         match self.reachability(h) {
                             Reachability::Reachable => {}
                             Reachability::Unreachable => {
-                                self.warning = Some((format!("@{} is unreachable", h), Instant::now()));
+                                self.warning =
+                                    Some((format!("@{} is unreachable", h), Instant::now()));
                                 return false;
                             }
                             Reachability::Unknown => {
-                                self.warning = Some((format!("@{} -- checking connectivity...", h), Instant::now()));
+                                self.warning = Some((
+                                    format!("@{} -- checking connectivity...", h),
+                                    Instant::now(),
+                                ));
                                 return false;
                             }
                         }
@@ -639,7 +643,10 @@ impl App {
                             return false;
                         }
                         Reachability::Unknown => {
-                            self.warning = Some((format!("@{} -- checking connectivity...", h), Instant::now()));
+                            self.warning = Some((
+                                format!("@{} -- checking connectivity...", h),
+                                Instant::now(),
+                            ));
                             return false;
                         }
                     }
@@ -672,7 +679,10 @@ impl App {
                             return false;
                         }
                         Reachability::Unknown => {
-                            self.warning = Some((format!("@{} -- checking connectivity...", h), Instant::now()));
+                            self.warning = Some((
+                                format!("@{} -- checking connectivity...", h),
+                                Instant::now(),
+                            ));
                             return false;
                         }
                     }

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1714,8 +1714,15 @@ impl App {
                     crate::session::Host::Local => None,
                 })
                 .or(vt.row.worktree_host.as_deref());
+            // Dim rows whose host is not confirmed reachable — Unknown is
+            // treated as "not yet reachable" during startup.
             let host_unreachable = task_host
-                .map(|h| !matches!(self.reachability(h), Reachability::Reachable))
+                .map(|h| {
+                    matches!(
+                        self.reachability(h),
+                        Reachability::Unreachable | Reachability::Unknown
+                    )
+                })
                 .unwrap_or(false);
 
             // Base row style: dim merged rows and unreachable hosts.

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -16,7 +16,7 @@ use crate::remote;
 use crate::tmux;
 use crate::tui::state::{CleanupState, InputPhase, Phase, ViewState};
 use crate::tui::theme::{Theme, display_group_color, repo_color};
-use crate::tui::{ATTRIBUTION_URL, App, WARNING_DURATION_SECS, filter_stale};
+use crate::tui::{ATTRIBUTION_URL, App, WARNING_DURATION_SECS, Reachability, filter_stale};
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -554,16 +554,18 @@ impl App {
                     };
                     drop(tasks);
                     // Guard: refuse to join a session on a host not confirmed reachable.
-                    if let Some(ref h) = host
-                        && self.host_reachable.get(h.as_str()) != Some(&true)
-                    {
-                        let msg = if self.host_reachable.contains_key(h.as_str()) {
-                            format!("@{} is unreachable", h)
-                        } else {
-                            format!("@{} -- checking connectivity...", h)
-                        };
-                        self.warning = Some((msg, Instant::now()));
-                        return false;
+                    if let Some(ref h) = host {
+                        match self.reachability(h) {
+                            Reachability::Reachable => {}
+                            Reachability::Unreachable => {
+                                self.warning = Some((format!("@{} is unreachable", h), Instant::now()));
+                                return false;
+                            }
+                            Reachability::Unknown => {
+                                self.warning = Some((format!("@{} -- checking connectivity...", h), Instant::now()));
+                                return false;
+                            }
+                        }
                     }
                     self.join_or_create_session(
                         &session_name,
@@ -629,16 +631,18 @@ impl App {
                 pane_target,
             }) => {
                 // Guard: refuse to join a session on a host not confirmed reachable.
-                if let Some(ref h) = host
-                    && self.host_reachable.get(h.as_str()) != Some(&true)
-                {
-                    let msg = if self.host_reachable.contains_key(h.as_str()) {
-                        format!("@{} is unreachable", h)
-                    } else {
-                        format!("@{} -- checking connectivity...", h)
-                    };
-                    self.warning = Some((msg, Instant::now()));
-                    return false;
+                if let Some(ref h) = host {
+                    match self.reachability(h) {
+                        Reachability::Reachable => {}
+                        Reachability::Unreachable => {
+                            self.warning = Some((format!("@{} is unreachable", h), Instant::now()));
+                            return false;
+                        }
+                        Reachability::Unknown => {
+                            self.warning = Some((format!("@{} -- checking connectivity...", h), Instant::now()));
+                            return false;
+                        }
+                    }
                 }
                 self.join_or_create_session(
                     &session_name,
@@ -660,16 +664,18 @@ impl App {
                 host,
             }) => {
                 // Guard: refuse to create a session on a host not confirmed reachable.
-                if let Some(ref h) = host
-                    && self.host_reachable.get(h.as_str()) != Some(&true)
-                {
-                    let msg = if self.host_reachable.contains_key(h.as_str()) {
-                        format!("@{} is unreachable", h)
-                    } else {
-                        format!("@{} -- checking connectivity...", h)
-                    };
-                    self.warning = Some((msg, Instant::now()));
-                    return false;
+                if let Some(ref h) = host {
+                    match self.reachability(h) {
+                        Reachability::Reachable => {}
+                        Reachability::Unreachable => {
+                            self.warning = Some((format!("@{} is unreachable", h), Instant::now()));
+                            return false;
+                        }
+                        Reachability::Unknown => {
+                            self.warning = Some((format!("@{} -- checking connectivity...", h), Instant::now()));
+                            return false;
+                        }
+                    }
                 }
                 let repo_name = self.repo_name.clone();
                 let session_name =
@@ -1708,8 +1714,9 @@ impl App {
                     crate::session::Host::Local => None,
                 })
                 .or(vt.row.worktree_host.as_deref());
-            let host_unreachable = task_host.is_some()
-                && task_host.and_then(|h| self.host_reachable.get(h)).copied() != Some(true);
+            let host_unreachable = task_host
+                .map(|h| !matches!(self.reachability(h), Reachability::Reachable))
+                .unwrap_or(false);
 
             // Base row style: dim merged rows and unreachable hosts.
             let row_style = if selected {
@@ -1893,12 +1900,12 @@ impl App {
 
             if has_remote {
                 let host_cell = if let Some(h) = task_host {
-                    match self.host_reachable.get(h) {
-                        Some(&false) => Cell::from(format!("@{} \u{2717}", h))
+                    match self.reachability(h) {
+                        Reachability::Unreachable => Cell::from(format!("@{} \u{2717}", h))
                             .style(Style::default().fg(theme.error)),
-                        Some(&true) => Cell::from(format!("@{} \u{25cf}", h))
+                        Reachability::Reachable => Cell::from(format!("@{} \u{25cf}", h))
                             .style(Style::default().fg(theme.success)),
-                        None => Cell::from(format!("@{}", h))
+                        Reachability::Unknown => Cell::from(format!("@{}", h))
                             .style(Style::default().fg(theme.host_unknown)),
                     }
                 } else {

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -56,6 +56,26 @@ pub(crate) enum SubCursor {
     Pane { window: usize, pane: usize },
 }
 
+// ---------------------------------------------------------------------------
+// Reachability
+// ---------------------------------------------------------------------------
+
+/// Tri-state SSH reachability for a remote host.
+///
+/// `Unknown` means no probe has completed yet (e.g. startup before the first
+/// background check). `Reachable` / `Unreachable` reflect the most recent
+/// probe result. Callers should treat `Unknown` as "don't show a connectivity
+/// warning yet" rather than "assume reachable".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Reachability {
+    /// No probe result available yet.
+    Unknown,
+    /// The host responded to the last SSH reachability probe.
+    Reachable,
+    /// The host did not respond to the last SSH reachability probe.
+    Unreachable,
+}
+
 use message::{Message, UpdateResult};
 use state::{AppMsg, CleanupState, InputPhase, Phase, ViewState};
 use std::path::Path;
@@ -273,6 +293,19 @@ impl App {
         }
         let idx = self.active_repo_index.saturating_sub(1);
         self.global_config.repos.get(idx).map(|r| r.slug.as_str())
+    }
+
+    /// Returns the [`Reachability`] of `host` based on the most recent probe.
+    ///
+    /// - No entry in `host_reachable` → [`Reachability::Unknown`] (probe not yet run)
+    /// - `Some(true)` → [`Reachability::Reachable`]
+    /// - `Some(false)` → [`Reachability::Unreachable`]
+    pub(crate) fn reachability(&self, host: &str) -> Reachability {
+        match self.host_reachable.get(host) {
+            None => Reachability::Unknown,
+            Some(true) => Reachability::Reachable,
+            Some(false) => Reachability::Unreachable,
+        }
     }
 
     // -------------------------------------------------------------------
@@ -2702,6 +2735,26 @@ mod tests {
             output.contains('\u{2717}'),
             "expected ✗ for unreachable host"
         );
+    }
+
+    #[test]
+    fn reachability_returns_unknown_when_no_probe_result() {
+        let app = App::new_test(vec![]);
+        assert_eq!(app.reachability("gpu1"), Reachability::Unknown);
+    }
+
+    #[test]
+    fn reachability_returns_reachable_when_probe_succeeded() {
+        let mut app = App::new_test(vec![]);
+        app.host_reachable.insert("gpu1".to_string(), true);
+        assert_eq!(app.reachability("gpu1"), Reachability::Reachable);
+    }
+
+    #[test]
+    fn reachability_returns_unreachable_when_probe_failed() {
+        let mut app = App::new_test(vec![]);
+        app.host_reachable.insert("gpu1".to_string(), false);
+        assert_eq!(app.reachability("gpu1"), Reachability::Unreachable);
     }
 
     #[test]


### PR DESCRIPTION
## Why

Closes #286

`App.host_reachable: HashMap<String, bool>` encodes a tri-state signal (unknown / reachable / unreachable) as a primitive map. Every caller in `tui/list.rs` re-decoded it by hand (`.get() == Some(&false)`, `.copied() != Some(true)`, tri-state `match`) and they historically disagreed (what #280 patched). The representation itself was still primitive-obsessed, a latent bug for anyone adding a new call site.

## What changed

Introduced a named `Reachability` enum (`Unknown` / `Reachable` / `Unreachable`) and a single `App::reachability(&self, host: &str) -> Reachability` accessor. Subsequent commits on this branch migrate the ad-hoc call sites in `tui/list.rs` to use the accessor, so reads of the tri-state go through one place with a named variant.

Per the issue's non-goal, the internal `HashMap<String, bool>` and the probe transport are unchanged — the enum lives at the `App`/UI boundary only.

## Test plan

- Baseline: `cargo test --lib -p orchard` → 1123 pass, 0 fail
- After accessor added: 1126 pass (+3 new tests covering each `None` / `Some(true)` / `Some(false)` mapping)
- Subsequent commits re-run the suite; zero behavioral change is the contract.

## Anything surprising?

Progress is incremental — additional commits land as the loop runs.


# Related issue

- #286

# Related issue

- #286

# Related issue

- #286

# Related issue

- #286