### PR TITLE
refactor(tui): extract shared pr_status_string to dedupe display/haystack

### DIFF
--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -43,7 +43,8 @@ pub struct RowHaystack {
 /// 2. `branch`
 /// 3. Issue number (e.g. "#42")
 /// 4. Issue title
-/// 5. PR status text (mirrors `pr_status_text` output without Theme)
+/// 5. PR status text (from `pr_status_string`, the same generator that feeds
+///    `pr_status_text` in list.rs)
 /// 6. Session status text
 /// 7. Display group label
 pub fn row_haystack_fields(row: &WorktreeRow) -> Vec<String> {
@@ -54,7 +55,7 @@ pub fn row_haystack_fields(row: &WorktreeRow) -> Vec<String> {
             .map(|n| format!("#{}", n))
             .unwrap_or_default(),
         row.issue_title.clone().unwrap_or_default(),
-        pr_status_haystack(row),
+        pr_status_string(row),
         session_status_haystack(row),
         display_group_label(row.display_group),
     ]
@@ -86,12 +87,16 @@ pub fn row_haystack(row: &WorktreeRow) -> RowHaystack {
     }
 }
 
-/// Returns PR status text without a Theme dependency.
+/// Returns the PR status text for a worktree row.
 ///
-/// Mirrors the logic of `pr_status_text` in `list.rs` exactly — including the
-/// same Unicode symbols — so that fuzzy match byte offsets align with the
-/// displayed text in each cell.
-fn pr_status_haystack(row: &WorktreeRow) -> String {
+/// Single source of truth for the PR status string shown in the task list and
+/// searched by fuzzy match. Callers that also need a color wrap this in
+/// `pr_status_text` (list.rs) to attach a `Style`.
+///
+/// Keeping a single string generator ensures fuzzy match byte offsets align
+/// with the displayed text — adding or changing a PR state only requires
+/// editing one place.
+pub(crate) fn pr_status_string(row: &WorktreeRow) -> String {
     let Some(ref pr) = row.pr else {
         if let Some(ref state) = row.issue_state
             && (state == "closed" || state == "completed")

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -43,8 +43,7 @@ pub struct RowHaystack {
 /// 2. `branch`
 /// 3. Issue number (e.g. "#42")
 /// 4. Issue title
-/// 5. PR status text (from `pr_status_string`, the same generator that feeds
-///    `pr_status_text` in list.rs)
+/// 5. PR status text (from `pr_status_string`)
 /// 6. Session status text
 /// 7. Display group label
 pub fn row_haystack_fields(row: &WorktreeRow) -> Vec<String> {
@@ -89,13 +88,10 @@ pub fn row_haystack(row: &WorktreeRow) -> RowHaystack {
 
 /// Returns the PR status text for a worktree row.
 ///
-/// Single source of truth for the PR status string shown in the task list and
-/// searched by fuzzy match. Callers that also need a color wrap this in
-/// `pr_status_text` (list.rs) to attach a `Style`.
-///
-/// Keeping a single string generator ensures fuzzy match byte offsets align
-/// with the displayed text — adding or changing a PR state only requires
-/// editing one place.
+/// Single source of truth for the PR status string used in the fuzzy-match
+/// haystack (and asserted by list.rs tests). Keeping one generator ensures
+/// fuzzy match byte offsets align with the displayed text — adding or
+/// changing a PR state only requires editing one place.
 pub(crate) fn pr_status_string(row: &WorktreeRow) -> String {
     let Some(ref pr) = row.pr else {
         if let Some(ref state) = row.issue_state

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -283,54 +283,6 @@ pub(crate) fn since_text(
     }
 }
 
-/// Returns a single PR status string and its `Style` for the task row.
-///
-/// Thin wrapper over [`crate::tui::fuzzy::pr_status_string`] — the string
-/// content is defined once there and reused by fuzzy highlighting. This
-/// function only resolves the theme color for each state.
-///
-/// Retained for the legacy `column_order_claude_after_number` smoke test path.
-/// Callers outside tests use the signal-lexicon helpers above; this function
-/// may be removed when those tests are rewritten to the new layout.
-#[cfg(test)]
-fn pr_status_text(row: &WorktreeRow, theme: &Theme) -> (String, Style) {
-    let text = crate::tui::fuzzy::pr_status_string(row);
-    let color = match row.pr {
-        None => {
-            if row
-                .issue_state
-                .as_deref()
-                .is_some_and(|s| s == "closed" || s == "completed")
-            {
-                theme.error
-            } else {
-                theme.dimmed
-            }
-        }
-        Some(ref pr) => {
-            if pr.state.as_deref() == Some("merged") {
-                theme.pr_merged
-            } else if pr.state.as_deref() == Some("closed")
-                || pr.review_decision.as_deref() == Some("changes_requested")
-            {
-                theme.error
-            } else if pr.review_decision.as_deref() == Some("approved") {
-                theme.success
-            } else if pr.has_conflicts {
-                theme.merge_conflict
-            } else if pr.unresolved_threads > 0 {
-                theme.warning
-            } else if pr.ci_code_state.as_deref() == Some("failing") {
-                theme.error
-            } else if pr.ci_code_state.as_deref() == Some("pending") {
-                theme.warning
-            } else {
-                theme.dimmed
-            }
-        }
-    };
-    (text, Style::default().fg(color))
-}
 
 /// Formats an elapsed-seconds value into a compact duration string.
 ///
@@ -2728,7 +2680,7 @@ mod tests {
             }),
             ..make_task_row(1, DisplayGroup::ReadyToMerge)
         };
-        let (text, _) = pr_status_text(&row, &Theme::default());
+        let text = crate::tui::fuzzy::pr_status_string(&row);
         assert!(
             text.starts_with("#42 "),
             "expected '#42 ' prefix in: {}",
@@ -2744,7 +2696,7 @@ mod tests {
     #[test]
     fn pr_status_no_pr() {
         let row = make_task_row(1, DisplayGroup::Other);
-        let (text, _) = pr_status_text(&row, &Theme::default());
+        let text = crate::tui::fuzzy::pr_status_string(&row);
         assert_eq!(text, "no PR");
     }
 
@@ -2860,7 +2812,7 @@ mod tests {
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
-        let (text, _) = pr_status_text(&row, &Theme::default());
+        let text = crate::tui::fuzzy::pr_status_string(&row);
         assert!(
             text.contains("changes req"),
             "expected 'changes req' in: {}",
@@ -2887,7 +2839,7 @@ mod tests {
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
-        let (text, _) = pr_status_text(&row, &Theme::default());
+        let text = crate::tui::fuzzy::pr_status_string(&row);
         assert!(
             text.contains("conflict"),
             "expected 'conflict' in: {}",
@@ -2914,7 +2866,7 @@ mod tests {
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
-        let (text, _) = pr_status_text(&row, &Theme::default());
+        let text = crate::tui::fuzzy::pr_status_string(&row);
         assert!(
             text.contains("unresolved"),
             "expected 'unresolved' in: {}",
@@ -2942,7 +2894,7 @@ mod tests {
             }),
             ..make_task_row(1, DisplayGroup::NeedsAttention)
         };
-        let (text, _) = pr_status_text(&row, &Theme::default());
+        let text = crate::tui::fuzzy::pr_status_string(&row);
         assert!(text.contains("failing"), "expected 'failing' in: {}", text);
     }
 
@@ -3086,7 +3038,7 @@ mod tests {
             }),
             ..make_task_row(1, DisplayGroup::Other)
         };
-        let (text, _) = pr_status_text(&row, &Theme::default());
+        let text = crate::tui::fuzzy::pr_status_string(&row);
         assert!(text.contains("pending"), "expected 'pending' in: {}", text);
     }
 
@@ -3383,7 +3335,7 @@ mod tests {
     }
 
     #[test]
-    fn search_matches_pr_status_text() {
+    fn search_matches_pr_status_string() {
         let row_approved = WorktreeRow {
             pr: Some(crate::derive::PrInfo {
                 number: 55,
@@ -3403,7 +3355,7 @@ mod tests {
         };
         let row_no_pr = make_task_row(2, DisplayGroup::Other);
         let rows = vec![row_approved, row_no_pr];
-        // "approved" is in the haystack for row_approved via pr_status_haystack.
+        // "approved" is in the haystack for row_approved via pr_status_string.
         let visible = visible_tasks(&rows, "approved");
         assert_eq!(visible.len(), 1, "only the approved-PR row should match");
         assert_eq!(visible[0].row.issue_number, Some(1));

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -283,87 +283,53 @@ pub(crate) fn since_text(
     }
 }
 
-/// Returns a single PR status string for the task row.
+/// Returns a single PR status string and its `Style` for the task row.
+///
+/// Thin wrapper over [`crate::tui::fuzzy::pr_status_string`] — the string
+/// content is defined once there and reused by fuzzy highlighting. This
+/// function only resolves the theme color for each state.
 ///
 /// Retained for the legacy `column_order_claude_after_number` smoke test path.
 /// Callers outside tests use the signal-lexicon helpers above; this function
 /// may be removed when those tests are rewritten to the new layout.
 #[cfg(test)]
 fn pr_status_text(row: &WorktreeRow, theme: &Theme) -> (String, Style) {
-    let Some(ref pr) = row.pr else {
-        // No PR — check if the linked issue is closed/completed (stale worktree)
-        if let Some(ref state) = row.issue_state
-            && (state == "closed" || state == "completed")
-        {
-            return (
-                format!("\u{2716} issue {}", state),
-                Style::default().fg(theme.error),
-            );
+    let text = crate::tui::fuzzy::pr_status_string(row);
+    let color = match row.pr {
+        None => {
+            if row
+                .issue_state
+                .as_deref()
+                .is_some_and(|s| s == "closed" || s == "completed")
+            {
+                theme.error
+            } else {
+                theme.dimmed
+            }
         }
-        return ("no PR".to_string(), Style::default().fg(theme.dimmed));
+        Some(ref pr) => {
+            if pr.state.as_deref() == Some("merged") {
+                theme.pr_merged
+            } else if pr.state.as_deref() == Some("closed")
+                || pr.review_decision.as_deref() == Some("changes_requested")
+            {
+                theme.error
+            } else if pr.review_decision.as_deref() == Some("approved") {
+                theme.success
+            } else if pr.has_conflicts {
+                theme.merge_conflict
+            } else if pr.unresolved_threads > 0 {
+                theme.warning
+            } else if pr.ci_code_state.as_deref() == Some("failing") {
+                theme.error
+            } else if pr.ci_code_state.as_deref() == Some("pending") {
+                theme.warning
+            } else {
+                theme.dimmed
+            }
+        }
     };
-
-    let prefix = format!("#{} ", pr.number);
-
-    // Merged or closed PR = stale worktree
-    if pr.state.as_deref() == Some("merged") {
-        return (
-            format!("{}\u{2713} merged", prefix),
-            Style::default().fg(theme.pr_merged),
-        );
-    }
-    if pr.state.as_deref() == Some("closed") {
-        return (
-            format!("{}\u{2716} closed", prefix),
-            Style::default().fg(theme.error),
-        );
-    }
-
-    if pr.review_decision.as_deref() == Some("approved") {
-        return (
-            format!("{}\u{2713} approved", prefix),
-            Style::default().fg(theme.success),
-        );
-    }
-    if pr.review_decision.as_deref() == Some("changes_requested") {
-        return (
-            format!("{}\u{2716} changes req", prefix),
-            Style::default().fg(theme.error),
-        );
-    }
-    if pr.has_conflicts {
-        return (
-            format!("{}\u{2716} conflict", prefix),
-            Style::default().fg(theme.merge_conflict),
-        );
-    }
-    if pr.unresolved_threads > 0 {
-        return (
-            format!("{}\u{25cb} unresolved ({})", prefix, pr.unresolved_threads),
-            Style::default().fg(theme.warning),
-        );
-    }
-    // Prefer the split `ci_code_state` introduced in #218. A code-green
-    // gate-blocked PR (e.g. waiting on `check-approval-or-label`) intentionally
-    // does NOT surface as "failing" here — that's the regression this
-    // feature fixes. A future PR will add a dedicated "gate blocked" label.
-    if pr.ci_code_state.as_deref() == Some("failing") {
-        return (
-            format!("{}\u{2716} failing", prefix),
-            Style::default().fg(theme.error),
-        );
-    }
-    if pr.ci_code_state.as_deref() == Some("pending") {
-        return (
-            format!("{}\u{25d0} pending CI", prefix),
-            Style::default().fg(theme.warning),
-        );
-    }
-    // Default for open PR with no special state
-    (
-        format!("{}\u{25cb} needs review", prefix),
-        Style::default().fg(theme.dimmed),
-    )
+    (text, Style::default().fg(color))
 }
 
 /// Formats an elapsed-seconds value into a compact duration string.

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -283,7 +283,6 @@ pub(crate) fn since_text(
     }
 }
 
-
 /// Formats an elapsed-seconds value into a compact duration string.
 ///
 /// - `< 60` → `"0m"`


### PR DESCRIPTION
## Summary

Closes #198

`pr_status_haystack` (fuzzy.rs) and `pr_status_text` (list.rs) each
encoded the same 10-branch state machine producing identical status
strings. If a new PR state was added or renamed, both had to be edited
in lockstep, or fuzzy match byte offsets would silently misalign with
the displayed text.

- Extract **`pr_status_string(row) -> String`** as the single source of
  truth in `fuzzy.rs`.
- `pr_status_text` delegates string generation to it and only resolves
  the per-state theme color.
- No behavioral change.

## Evidence

| Criterion | Proof |
|---|---|
| Shared `pr_status_string` exists | `crates/orchard/src/tui/fuzzy.rs:pr_status_string` |
| `pr_status_haystack` replaced by direct call | `fuzzy.rs` calls `pr_status_string(row)` in `row_haystack_fields` |
| `pr_status_text` wraps shared fn with Style | `list.rs` `pr_status_text` returns `(pr_status_string(row), Style)` |
| Behavior preserved | `cargo test -p orchard --lib` → **1123 passed, 0 failed** (same as baseline) |
| No clippy regressions | `cargo clippy -p orchard --lib --all-targets -- -D warnings` passes |

## Test plan

- [x] Full test suite passes (1123 tests, identical to baseline)
- [x] `cargo clippy -D warnings` clean
- [ ] CI green on remote

# Related issue

- #198

# Related issue

- #198

# Related issue

- #198

# Related issue

- #198