### PR TITLE
refactor(signal): cleanup — dead code, dedup, and hygiene

### DIFF
--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -346,13 +346,9 @@ impl From<&crate::derive::PrInfo> for PrState {
     }
 }
 
-impl From<&EnrichedSession> for SessionState {
-    fn from(s: &EnrichedSession) -> Self {
-        let host = match &s.tmux.host {
-            Host::Local => None,
-            Host::Remote(h) => Some(h.clone()),
-        };
-        let claude = s.claude.as_ref().map(|c| ClaudeEnrichment {
+impl From<&crate::session::ClaudeSessionInfo> for ClaudeEnrichment {
+    fn from(c: &crate::session::ClaudeSessionInfo) -> Self {
+        Self {
             status: c.status,
             model: c.model.clone(),
             last_tool: c.last_tool.clone(),
@@ -369,7 +365,17 @@ impl From<&EnrichedSession> for SessionState {
             stop_reason: c.stop_reason.clone(),
             turn_count: c.turn_count,
             state_changed_at: c.state_changed_at,
-        });
+        }
+    }
+}
+
+impl From<&EnrichedSession> for SessionState {
+    fn from(s: &EnrichedSession) -> Self {
+        let host = match &s.tmux.host {
+            Host::Local => None,
+            Host::Remote(h) => Some(h.clone()),
+        };
+        let claude = s.claude.as_ref().map(ClaudeEnrichment::from);
         let windows = s
             .windows
             .iter()

--- a/crates/orchard/src/signal.rs
+++ b/crates/orchard/src/signal.rs
@@ -500,11 +500,14 @@ pub fn sort_key_row(row: &WorktreeRow) -> RowSortKey<'_> {
 
 /// Merges issue and PR labels into a single deduped vector, preserving first-seen order.
 ///
-/// Issue labels come first, then any PR labels not already present. Comparison is
+/// `issue_labels` come first, then any `pr_labels` not already present. Comparison is
 /// case-insensitive so `Bug` and `bug` dedupe to one. The workflow-phase labels
 /// (handled by `derive::phase_from_labels`) are intentionally *not* filtered out —
 /// they're still worth surfacing as a badge so users can see them at a glance.
-pub fn unified_labels(issue: Option<&IssueInfo>, pr: Option<&PrState>) -> Vec<String> {
+///
+/// Accepts plain slices so call sites can pass the labels they already have
+/// without constructing wrapper `IssueInfo`/`PrState` structs.
+pub fn unified_labels(issue_labels: &[String], pr_labels: &[String]) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
@@ -515,15 +518,11 @@ pub fn unified_labels(issue: Option<&IssueInfo>, pr: Option<&PrState>) -> Vec<St
         }
     };
 
-    if let Some(i) = issue {
-        for l in &i.labels {
-            push(l);
-        }
+    for l in issue_labels {
+        push(l);
     }
-    if let Some(p) = pr {
-        for l in &p.labels {
-            push(l);
-        }
+    for l in pr_labels {
+        push(l);
     }
     out
 }
@@ -990,20 +989,20 @@ mod tests {
     fn unified_labels_dedupes_case_insensitively() {
         let i = issue(|i| i.labels = vec!["Bug".into(), "priority".into()]);
         let p = pr(|p| p.labels = vec!["bug".into(), "backend".into()]);
-        let out = unified_labels(Some(&i), Some(&p));
+        let out = unified_labels(&i.labels, &p.labels);
         assert_eq!(out, vec!["Bug", "priority", "backend"]);
     }
 
     #[test]
     fn unified_labels_empty_inputs() {
-        assert!(unified_labels(None, None).is_empty());
+        assert!(unified_labels(&[], &[]).is_empty());
     }
 
     #[test]
     fn unified_labels_preserves_order_issue_first() {
         let i = issue(|i| i.labels = vec!["a".into(), "b".into()]);
         let p = pr(|p| p.labels = vec!["c".into(), "a".into()]);
-        let out = unified_labels(Some(&i), Some(&p));
+        let out = unified_labels(&i.labels, &p.labels);
         assert_eq!(out, vec!["a", "b", "c"]);
     }
 

--- a/crates/orchard/src/signal.rs
+++ b/crates/orchard/src/signal.rs
@@ -463,24 +463,7 @@ pub fn rollup_activity_row(row: &WorktreeRow) -> Activity {
         .filter_map(|s| s.claude.as_ref())
         .map(|c| {
             // Bridge from session::ClaudeSessionInfo through the enrichment shape.
-            let ce = ClaudeEnrichment {
-                status: c.status,
-                model: c.model.clone(),
-                last_tool: c.last_tool.clone(),
-                current_task: c.current_task.clone(),
-                session_start_ts: c.session_start_ts,
-                input_tokens: c.input_tokens,
-                output_tokens: c.output_tokens,
-                cache_creation_input_tokens: c.cache_creation_input_tokens,
-                cache_read_input_tokens: c.cache_read_input_tokens,
-                context_window_pct: c.context_window_pct,
-                cost_usd: c.cost_usd,
-                total_duration_ms: c.total_duration_ms,
-                rate_limits: c.rate_limits.clone(),
-                stop_reason: c.stop_reason.clone(),
-                turn_count: c.turn_count,
-                state_changed_at: c.state_changed_at,
-            };
+            let ce = ClaudeEnrichment::from(c);
             activity_from_claude(&ce)
         })
         .max()

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1819,8 +1819,7 @@ impl App {
 
             // LABELS cell — unified issue + PR labels, deduped (case-insensitive).
             let pr_labels: &[String] = vt.row.pr.as_ref().map_or(&[], |p| &p.labels);
-            let unified =
-                crate::signal::unified_labels(&vt.row.issue_labels, pr_labels);
+            let unified = crate::signal::unified_labels(&vt.row.issue_labels, pr_labels);
             let unified_refs: Vec<&str> = unified.iter().map(|s| s.as_str()).collect();
             let labels_cell = {
                 let spans = label_badges(&unified_refs, labels_width);

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1818,25 +1818,9 @@ impl App {
             let since_cell = Cell::from(since_str).style(Style::default().fg(theme.dimmed));
 
             // LABELS cell — unified issue + PR labels, deduped (case-insensitive).
-            // Inline the merge so we don't allocate wrapper structs just to
-            // satisfy the signal::unified_labels signature.
-            let unified: Vec<String> = {
-                let mut out: Vec<String> = Vec::new();
-                let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-                for l in &vt.row.issue_labels {
-                    if seen.insert(l.to_ascii_lowercase()) {
-                        out.push(l.clone());
-                    }
-                }
-                if let Some(pr) = vt.row.pr.as_ref() {
-                    for l in &pr.labels {
-                        if seen.insert(l.to_ascii_lowercase()) {
-                            out.push(l.clone());
-                        }
-                    }
-                }
-                out
-            };
+            let pr_labels: &[String] = vt.row.pr.as_ref().map_or(&[], |p| &p.labels);
+            let unified =
+                crate::signal::unified_labels(&vt.row.issue_labels, pr_labels);
             let unified_refs: Vec<&str> = unified.iter().map(|s| s.as_str()).collect();
             let labels_cell = {
                 let spans = label_badges(&unified_refs, labels_width);

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -1518,24 +1518,7 @@ impl App {
                 .claude
                 .as_ref()
                 .map(|c| {
-                    let ce = crate::orchard_state::ClaudeEnrichment {
-                        status: c.status,
-                        model: c.model.clone(),
-                        last_tool: c.last_tool.clone(),
-                        current_task: c.current_task.clone(),
-                        session_start_ts: c.session_start_ts,
-                        input_tokens: c.input_tokens,
-                        output_tokens: c.output_tokens,
-                        cache_creation_input_tokens: c.cache_creation_input_tokens,
-                        cache_read_input_tokens: c.cache_read_input_tokens,
-                        context_window_pct: c.context_window_pct,
-                        cost_usd: c.cost_usd,
-                        total_duration_ms: c.total_duration_ms,
-                        rate_limits: c.rate_limits.clone(),
-                        stop_reason: c.stop_reason.clone(),
-                        turn_count: c.turn_count,
-                        state_changed_at: c.state_changed_at,
-                    };
+                    let ce = crate::orchard_state::ClaudeEnrichment::from(c);
                     crate::signal::activity_from_claude(&ce)
                 })
                 .unwrap_or(crate::signal::Activity::None);
@@ -1923,24 +1906,7 @@ impl App {
                         .claude
                         .as_ref()
                         .map(|c| {
-                            let ce = crate::orchard_state::ClaudeEnrichment {
-                                status: c.status,
-                                model: c.model.clone(),
-                                last_tool: c.last_tool.clone(),
-                                current_task: c.current_task.clone(),
-                                session_start_ts: c.session_start_ts,
-                                input_tokens: c.input_tokens,
-                                output_tokens: c.output_tokens,
-                                cache_creation_input_tokens: c.cache_creation_input_tokens,
-                                cache_read_input_tokens: c.cache_read_input_tokens,
-                                context_window_pct: c.context_window_pct,
-                                cost_usd: c.cost_usd,
-                                total_duration_ms: c.total_duration_ms,
-                                rate_limits: c.rate_limits.clone(),
-                                stop_reason: c.stop_reason.clone(),
-                                turn_count: c.turn_count,
-                                state_changed_at: c.state_changed_at,
-                            };
+                            let ce = crate::orchard_state::ClaudeEnrichment::from(c);
                             crate::signal::activity_from_claude(&ce)
                         })
                         .unwrap_or(crate::signal::Activity::None);


### PR DESCRIPTION
## Why

Closes #255.

Follow-up to #251 / PR #253. Multi-reviewer audit surfaced code-quality, dead-code, and design-hygiene items that would have bloated #253 if addressed inline. This PR works through them in priority order.

## What changed

Cleanup of the signal lexicon and surrounding TUI/state code. External behavior is unchanged — all existing tests continue to pass. Each item lands as its own commit.

### Progress (updated per pass)

- [x] **Item 1** — Dedupe `ClaudeSessionInfo → ClaudeEnrichment` rebuilds via `From` impl
- [ ] **Item 3** — Make `signal::unified_labels` the single source of truth (accept `&[String]` slices)
- [ ] **Item 4** — Consolidate triplicated `parse_iso8601` onto `signal`
- [ ] **Item 7** — Cache `WorktreeState::from(row)` once per `sort_key_row` call
- [ ] **Item 2a** — Delete `cfg(test)`-gated production helpers in `tui/list.rs`
- [ ] **Item 5** — Move I/O (`is_first_launch` / `mark_legend_seen`) out of pure `signal` module
- [ ] **Item 6** — Replace derived `Ord` on `PipelineStatus`/`Activity` with explicit `severity()` helper
- [ ] **Item 12** — Fix `id_cell_text` inconsistent truncation
- [ ] **Item 2b** — Migrate `OrchardState::all_worktrees` to `signal::sort_key_row` (with JSON snapshot test)
- [ ] **Item 9** — Split `tui/list.rs` (4292 lines) into submodules
- [ ] **Item 11 (partial)** — Remove duplicated integration tests in `signal_lexicon_integration.rs`

### Deferred (with rationale)

- **Item 8** — Collapsing `ClaudeSessionInfo` and `ClaudeEnrichment`: risk of breaking serde wire contract (both types may serialize in different paths); needs its own ADR. Item 1's `From` impl removes the immediate drift risk.
- **Item 10 (most)** — Cosmetic deviations (BAR column dot, BRANCH column, `"ST"` header). Arguable design calls, not correctness. Group-section-header question (contradicts single-sort intent) handled separately.
- **Item 11 (most)** — Coverage gap backfills (SINCE mappings, `id_cell_text` units, first-launch flow, tiebreakers). Not blocking; not part of the audit's "correctness" items.

## Test plan

- `cargo test` — all 1200+ tests pass at each commit (baseline green; no new failures introduced by any item)
- `cargo clippy` / `cargo fmt` — no new warnings
- For item 2b: add a JSON-output ordering snapshot test to verify `--json` sort parity before deleting `WorktreeSortKey`
- Manual: run the TUI after item 9 split to confirm rendering parity

## Anything surprising?

- Item 1 found **4** manual rebuild sites, not 2 as the issue cites (extra one in `orchard_state.rs`'s `From<&EnrichedSession>` impl).
- Item 9 (`list.rs` split) is larger than the issue suggests — file has grown to 4292 lines since #255 was filed. May need intra-file call-graph mapping before cutting cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #255

# Related issue

- #255

# Related issue

- #255