### PR TITLE
feat(tui): pulse idle/input glyphs in column A; drop ❓ from status

### DIFF
--- a/crates/orchard/src/signal.rs
+++ b/crates/orchard/src/signal.rs
@@ -29,16 +29,22 @@
 //! Severity note: `Coding` (active work — watch the agent) outranks `AwaitingReview`
 //! (passive wait — nothing to do). Watching workers beats waiting on a reviewer.
 //!
-//! | Glyph | Activity | Meaning |
-//! |---|---|---|
-//! | ⚡ | Working | a Claude agent is actively working |
-//! | ○ | Idle | an agent exists but is idle |
-//! | 💀 | Exhausted | rate-limits depleted OR context_window_pct ≥ 95 |
-//! | (blank) | None | no agent / non-Claude pane |
+//! | Glyph | Activity | Meaning | Animation |
+//! |---|---|---|---|
+//! | ⚡ | Working | a Claude agent is actively working | static |
+//! | ○ ↔ ● | Idle | an agent exists but is idle | pulses 1s (orange) |
+//! | ○ ↔ ? | Input | agent waiting for a human | pulses 1s (red) |
+//! | 💀 | Exhausted | rate-limits depleted OR context_window_pct ≥ 95 | static |
+//! | (blank) | None | no agent / non-Claude pane | — |
 //!
 //! Activity rollup severity (highest wins): `Exhausted > Input > Working > Idle > None`.
 //! `Input` is an activity-level signal that also maps to the `NeedsInput` status. The
-//! rollup treats it as its own level so a single ⚡ working child cannot mask a ❓ sibling.
+//! rollup treats it as its own level so a single ⚡ working child cannot mask an Input sibling.
+//!
+//! Pulse cadence (issue #281): animated variants (Idle, Input) swap frames on a
+//! 1s cadence. Frame selection is stateless — callers pass a `tick: u8` that is
+//! even (0) or odd (1); the TUI samples [`pulse_tick`] once per render so all
+//! rows in a frame share the same phase.
 
 use crate::claude_state::ClaudeState;
 use crate::derive::WorktreeRow;
@@ -79,9 +85,18 @@ pub enum PipelineStatus {
 
 impl PipelineStatus {
     /// Single-glyph representation of this status.
+    ///
+    /// `NeedsInput` is intentionally blank (issue #281): the "waiting on a human"
+    /// signal is carried by the animated hourglass in the status column, driven
+    /// off rollup [`Activity::Input`] rather than off this variant. The variant
+    /// itself is retained because it still drives sort severity (first match in
+    /// the merge-blocker hierarchy). See [`status_glyph_at`] for the animated
+    /// status-column glyph.
     pub fn glyph(self) -> &'static str {
         match self {
-            Self::NeedsInput => "\u{2753}",            // ❓
+            // NeedsInput: blank — the ⏳/⌛ pulse in the status column (driven
+            // by Activity::Input rollup, not by this variant) carries the signal.
+            Self::NeedsInput => "",
             Self::CiFailing => "\u{1F6AB}",            // 🚫
             Self::MergeConflict => "\u{26A0}\u{FE0F}", // ⚠️
             Self::ChangesRequested => "\u{1F534}",     // 🔴
@@ -135,18 +150,52 @@ pub enum Activity {
 }
 
 impl Activity {
-    /// Single-glyph representation, or empty string for `None`.
+    /// Single-glyph representation at a specific pulse tick.
     ///
-    /// `Input` reuses the ⚡ working glyph in column A — the `NeedsInput`
-    /// *status* column is where the ❓ renders. Keeping column A to just three
-    /// activity glyphs (⚡ / ○ / 💀) matches the issue spec.
-    pub fn glyph(self) -> &'static str {
+    /// The `tick` is `0` or `1` (anything else is folded to `tick & 1`). Static
+    /// variants (`Working`, `Exhausted`, `None`) return the same glyph for both
+    /// ticks. Animated variants alternate frames per issue #281:
+    ///
+    /// | Activity | tick=0 | tick=1 |
+    /// |---|---|---|
+    /// | `Idle`     | `○` | `●` |
+    /// | `Input`    | `○` | `?` |
+    /// | `Working`  | `⚡` | `⚡` |
+    /// | `Exhausted`| `💀` | `💀` |
+    /// | `None`     | `""`| `""`|
+    ///
+    /// Tints are applied by the TUI layer via `activity_style` — `Idle` gets
+    /// `claude_idle_pulse` (orange), `Input` gets `claude_input_pulse` (red).
+    pub fn glyph_at(self, tick: u8) -> &'static str {
+        let even = tick & 1 == 0;
         match self {
             Self::None => "",
-            Self::Idle => "\u{25CB}",                  // ○
-            Self::Working | Self::Input => "\u{26A1}", // ⚡
-            Self::Exhausted => "\u{1F480}",            // 💀
+            Self::Idle => {
+                if even {
+                    "\u{25CB}" // ○
+                } else {
+                    "\u{25CF}" // ●
+                }
+            }
+            Self::Input => {
+                if even {
+                    "\u{25CB}" // ○
+                } else {
+                    "?"
+                }
+            }
+            Self::Working => "\u{26A1}",    // ⚡
+            Self::Exhausted => "\u{1F480}", // 💀
         }
+    }
+
+    /// Single-glyph representation (tick=0 frame).
+    ///
+    /// Kept as a shim for non-TUI callers (tests, JSON labels, watch events)
+    /// that don't animate. TUI callers should use [`Activity::glyph_at`] and
+    /// thread the per-render [`pulse_tick`] value.
+    pub fn glyph(self) -> &'static str {
+        self.glyph_at(0)
     }
 
     /// Short human-readable label (legend + accessibility/testing).
@@ -158,6 +207,48 @@ impl Activity {
             Self::Input => "input",
             Self::Exhausted => "exhausted",
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pulse animation (issue #281)
+// ---------------------------------------------------------------------------
+
+/// Current pulse phase, derived from wall-clock seconds.
+///
+/// Returns `0` or `1`; flips every second. Stateless by design — all callers
+/// sample the same tick within the same second, so every animated row in a
+/// frame stays in unison without any shared counter.
+///
+/// The TUI samples this **once per render** and threads the value through to
+/// row builders. Sampling it again per-row would risk producing a torn frame
+/// when a render straddles a second boundary.
+pub fn pulse_tick() -> u8 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| (d.as_secs() & 1) as u8)
+        .unwrap_or(0)
+}
+
+/// Glyph for the STATUS column at a specific pulse tick.
+///
+/// When the row's rollup activity is [`Activity::Input`], the status column
+/// renders a rotating hourglass (⏳/⌛ on a 1s cadence) to signal "waiting on
+/// you." Otherwise, falls through to the static [`PipelineStatus::glyph`].
+///
+/// This is how the "❓ needs input" signal is carried in the status column
+/// after issue #281 — the ❓ glyph itself is gone, but the Input rollup drives
+/// a more attention-grabbing animated hourglass in its place.
+pub fn status_glyph_at(activity: Activity, status: PipelineStatus, tick: u8) -> &'static str {
+    if activity == Activity::Input {
+        if tick & 1 == 0 {
+            "\u{23F3}" // ⏳
+        } else {
+            "\u{231B}" // ⌛
+        }
+    } else {
+        status.glyph()
     }
 }
 
@@ -769,11 +860,12 @@ mod tests {
 
     #[test]
     fn every_status_has_distinct_glyph() {
-        // `Coding` is intentionally blank (no blocker to show) — excluded here
-        // because an empty string can't be "distinct" from itself, and it's
-        // the only status that maps to no glyph by design.
+        // `Coding` is intentionally blank (no blocker to show). `NeedsInput` is
+        // also intentionally blank after issue #281 — the ⏳/⌛ pulse in the
+        // status column (driven by Activity::Input rollup) carries the "waiting
+        // on you" signal. Both are excluded from this distinctness check; all
+        // remaining statuses must produce unique non-empty glyphs.
         let all = [
-            PipelineStatus::NeedsInput,
             PipelineStatus::CiFailing,
             PipelineStatus::MergeConflict,
             PipelineStatus::ChangesRequested,
@@ -786,6 +878,15 @@ mod tests {
         ];
         let glyphs: std::collections::HashSet<_> = all.iter().map(|s| s.glyph()).collect();
         assert_eq!(glyphs.len(), all.len(), "glyphs must be unique");
+        assert!(
+            glyphs.iter().all(|g| !g.is_empty()),
+            "non-excluded statuses must have non-empty glyphs"
+        );
+    }
+
+    #[test]
+    fn needs_input_glyph_is_blank() {
+        assert_eq!(PipelineStatus::NeedsInput.glyph(), "");
     }
 
     #[test]
@@ -807,13 +908,138 @@ mod tests {
     }
 
     #[test]
-    fn activity_input_and_working_share_lightning_glyph() {
-        assert_eq!(Activity::Working.glyph(), Activity::Input.glyph());
+    fn activity_none_is_blank_glyph() {
+        assert_eq!(Activity::None.glyph(), "");
+    }
+
+    // -- glyph_at / pulse animation (issue #281) -----------------------------
+
+    #[test]
+    fn activity_working_is_static_across_ticks() {
+        assert_eq!(Activity::Working.glyph_at(0), "\u{26A1}");
+        assert_eq!(Activity::Working.glyph_at(1), "\u{26A1}");
     }
 
     #[test]
-    fn activity_none_is_blank_glyph() {
-        assert_eq!(Activity::None.glyph(), "");
+    fn activity_exhausted_is_static_across_ticks() {
+        assert_eq!(Activity::Exhausted.glyph_at(0), "\u{1F480}");
+        assert_eq!(Activity::Exhausted.glyph_at(1), "\u{1F480}");
+    }
+
+    #[test]
+    fn activity_none_is_static_blank_across_ticks() {
+        assert_eq!(Activity::None.glyph_at(0), "");
+        assert_eq!(Activity::None.glyph_at(1), "");
+    }
+
+    #[test]
+    fn activity_idle_pulses_between_circle_and_dot() {
+        assert_eq!(Activity::Idle.glyph_at(0), "\u{25CB}"); // ○
+        assert_eq!(Activity::Idle.glyph_at(1), "\u{25CF}"); // ●
+    }
+
+    #[test]
+    fn activity_input_pulses_between_circle_and_question_mark() {
+        assert_eq!(Activity::Input.glyph_at(0), "\u{25CB}"); // ○
+        assert_eq!(Activity::Input.glyph_at(1), "?");
+    }
+
+    #[test]
+    fn activity_animated_variants_wrap_every_two_ticks() {
+        for v in [Activity::Idle, Activity::Input] {
+            assert_eq!(v.glyph_at(0), v.glyph_at(2));
+            assert_eq!(v.glyph_at(0), v.glyph_at(4));
+            assert_eq!(v.glyph_at(1), v.glyph_at(3));
+            assert_eq!(v.glyph_at(1), v.glyph_at(5));
+        }
+    }
+
+    #[test]
+    fn activity_legacy_glyph_returns_tick_zero_frame() {
+        for v in [
+            Activity::None,
+            Activity::Idle,
+            Activity::Working,
+            Activity::Input,
+            Activity::Exhausted,
+        ] {
+            assert_eq!(v.glyph(), v.glyph_at(0));
+        }
+    }
+
+    // -- pulse_tick ----------------------------------------------------------
+
+    #[test]
+    fn pulse_tick_returns_zero_or_one() {
+        let t = pulse_tick();
+        assert!(t == 0 || t == 1, "expected 0 or 1, got {t}");
+    }
+
+    #[test]
+    fn pulse_tick_is_stable_within_same_second() {
+        // Two calls back-to-back are overwhelmingly likely to land in the same
+        // second. This test could theoretically flake if it straddles a second
+        // boundary; the flake rate is on the order of a few microseconds per
+        // second (well under 0.001%).
+        let a = pulse_tick();
+        let b = pulse_tick();
+        assert_eq!(a, b);
+    }
+
+    // -- status_glyph_at -----------------------------------------------------
+
+    #[test]
+    fn status_glyph_at_renders_hourglass_when_activity_is_input() {
+        assert_eq!(
+            status_glyph_at(Activity::Input, PipelineStatus::NeedsInput, 0),
+            "\u{23F3}" // ⏳
+        );
+        assert_eq!(
+            status_glyph_at(Activity::Input, PipelineStatus::NeedsInput, 1),
+            "\u{231B}" // ⌛
+        );
+    }
+
+    #[test]
+    fn status_glyph_at_hourglass_wraps_every_two_ticks() {
+        assert_eq!(
+            status_glyph_at(Activity::Input, PipelineStatus::NeedsInput, 0),
+            status_glyph_at(Activity::Input, PipelineStatus::NeedsInput, 2)
+        );
+        assert_eq!(
+            status_glyph_at(Activity::Input, PipelineStatus::NeedsInput, 1),
+            status_glyph_at(Activity::Input, PipelineStatus::NeedsInput, 3)
+        );
+    }
+
+    #[test]
+    fn status_glyph_at_falls_through_for_non_input_activity() {
+        assert_eq!(
+            status_glyph_at(Activity::Working, PipelineStatus::CiFailing, 0),
+            PipelineStatus::CiFailing.glyph()
+        );
+        assert_eq!(
+            status_glyph_at(Activity::Idle, PipelineStatus::MergeConflict, 1),
+            PipelineStatus::MergeConflict.glyph()
+        );
+    }
+
+    #[test]
+    fn status_glyph_at_returns_blank_for_coding_with_non_input_activity() {
+        assert_eq!(
+            status_glyph_at(Activity::Working, PipelineStatus::Coding, 0),
+            ""
+        );
+    }
+
+    #[test]
+    fn status_glyph_at_returns_blank_for_needs_input_with_non_input_activity() {
+        // Defensive: if a row somehow has status NeedsInput but activity != Input
+        // (should be unreachable via resolve_status, but keep the invariant).
+        assert_eq!(
+            status_glyph_at(Activity::Working, PipelineStatus::NeedsInput, 0),
+            ""
+        );
     }
 
     // -- resolve_status ------------------------------------------------------
@@ -1162,6 +1388,16 @@ mod tests {
         let merged = key(PipelineStatus::Merged, true, "a");
         let coding = key(PipelineStatus::Coding, false, "z");
         assert!(coding < merged);
+    }
+
+    #[test]
+    fn sort_needs_input_still_beats_ci_failing_after_glyph_blank() {
+        // Issue #281 blanks PipelineStatus::NeedsInput.glyph() but keeps the
+        // variant for sort severity. Rows resolving to NeedsInput must still
+        // outrank CiFailing rows.
+        let needs = key(PipelineStatus::NeedsInput, false, "a");
+        let ci = key(PipelineStatus::CiFailing, true, "b");
+        assert!(needs < ci);
     }
 
     #[test]

--- a/crates/orchard/src/signal.rs
+++ b/crates/orchard/src/signal.rs
@@ -214,21 +214,30 @@ impl Activity {
 // Pulse animation (issue #281)
 // ---------------------------------------------------------------------------
 
+/// Pulse phase for a specific instant (pure, testable).
+///
+/// Returns `0` or `1`; flips every second. Taking `SystemTime` as an argument
+/// keeps the function pure and deterministic — the `run_loop` wrapper passes
+/// `SystemTime::now()` in production while tests pass a fixed `UNIX_EPOCH + Δ`.
+pub fn pulse_tick_from(now: std::time::SystemTime) -> u8 {
+    now.duration_since(std::time::UNIX_EPOCH)
+        .map(|d| (d.as_secs() & 1) as u8)
+        .unwrap_or(0)
+}
+
 /// Current pulse phase, derived from wall-clock seconds.
 ///
+/// Thin wrapper over [`pulse_tick_from`] that samples `SystemTime::now()`.
 /// Returns `0` or `1`; flips every second. Stateless by design — all callers
 /// sample the same tick within the same second, so every animated row in a
 /// frame stays in unison without any shared counter.
 ///
-/// The TUI samples this **once per render** and threads the value through to
-/// row builders. Sampling it again per-row would risk producing a torn frame
-/// when a render straddles a second boundary.
+/// The TUI samples this **once per render** (the run loop writes it to
+/// `App.pulse_tick`) and threads that value through to row builders. Sampling
+/// again per-row would risk a torn frame when a render straddles a second
+/// boundary.
 pub fn pulse_tick() -> u8 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| (d.as_secs() & 1) as u8)
-        .unwrap_or(0)
+    pulse_tick_from(std::time::SystemTime::now())
 }
 
 /// Glyph for the STATUS column at a specific pulse tick.
@@ -552,11 +561,7 @@ pub fn rollup_activity_row(row: &WorktreeRow) -> Activity {
     row.sessions
         .iter()
         .filter_map(|s| s.claude.as_ref())
-        .map(|c| {
-            // Bridge from session::ClaudeSessionInfo through the enrichment shape.
-            let ce = ClaudeEnrichment::from(c);
-            activity_from_claude(&ce)
-        })
+        .map(|c| activity_from_claude(&ClaudeEnrichment::from(c)))
         .max()
         .unwrap_or(Activity::None)
 }
@@ -976,14 +981,18 @@ mod tests {
     }
 
     #[test]
-    fn pulse_tick_is_stable_within_same_second() {
-        // Two calls back-to-back are overwhelmingly likely to land in the same
-        // second. This test could theoretically flake if it straddles a second
-        // boundary; the flake rate is on the order of a few microseconds per
-        // second (well under 0.001%).
-        let a = pulse_tick();
-        let b = pulse_tick();
-        assert_eq!(a, b);
+    fn pulse_tick_from_is_pure_and_flips_every_second() {
+        use std::time::{Duration, UNIX_EPOCH};
+        // Even second → 0, odd second → 1.
+        assert_eq!(pulse_tick_from(UNIX_EPOCH), 0);
+        assert_eq!(pulse_tick_from(UNIX_EPOCH + Duration::from_secs(1)), 1);
+        assert_eq!(pulse_tick_from(UNIX_EPOCH + Duration::from_secs(2)), 0);
+        assert_eq!(pulse_tick_from(UNIX_EPOCH + Duration::from_secs(3)), 1);
+        // Sub-second offsets within the same second collapse to the same tick.
+        assert_eq!(
+            pulse_tick_from(UNIX_EPOCH + Duration::from_millis(1_200)),
+            pulse_tick_from(UNIX_EPOCH + Duration::from_millis(1_999))
+        );
     }
 
     // -- status_glyph_at -----------------------------------------------------

--- a/crates/orchard/src/tui/dialogs.rs
+++ b/crates/orchard/src/tui/dialogs.rs
@@ -349,10 +349,11 @@ impl App {
                 Style::default().add_modifier(Modifier::BOLD),
             )]),
             Line::from(""),
-            legend_row(
-                PipelineStatus::NeedsInput.glyph(),
-                PipelineStatus::NeedsInput.label(),
-            ),
+            // Issue #281: NeedsInput has no status glyph — a rotating ⏳/⌛ in
+            // the status column (driven by rollup Activity::Input) carries the
+            // "waiting on you" signal. Document the hourglass here so the
+            // legend reflects what the user actually sees on screen.
+            legend_row("\u{23F3}/\u{231B}", "waiting on user input"),
             legend_row(
                 PipelineStatus::CiFailing.glyph(),
                 PipelineStatus::CiFailing.label(),
@@ -390,9 +391,12 @@ impl App {
                 Style::default().add_modifier(Modifier::BOLD),
             )]),
             Line::from(""),
-            legend_row(Activity::Working.glyph(), Activity::Working.label()),
-            legend_row(Activity::Input.glyph(), Activity::Input.label()),
-            legend_row(Activity::Idle.glyph(), Activity::Idle.label()),
+            legend_row(Activity::Working.glyph(), "working"),
+            // Issue #281: Idle and Input pulse between frames at 1s cadence.
+            // Show both frames side-by-side so the legend matches what the
+            // user sees on screen.
+            legend_row("\u{25CB}/\u{25CF}", "idle (pulsing orange)"),
+            legend_row("\u{25CB}/?", "input (pulsing red — waiting on you)"),
             legend_row(Activity::Exhausted.glyph(), Activity::Exhausted.label()),
             Line::from(""),
             Line::from(vec![Span::styled(
@@ -527,15 +531,32 @@ mod tests {
             text.contains("w") && text.contains("New worktree"),
             "help overlay must include 'w' keybinding mapped to 'New worktree', got:\n{text}"
         );
-        // Pipeline-status legend section must appear (added in issue #251).
+        // Pipeline-status legend section must appear (issue #251). Issue #281
+        // replaced the "needs input" PipelineStatus row with an hourglass row
+        // labeled "waiting on user input" — the glyph now lives in the status
+        // column as ⏳/⌛ driven by rollup Activity::Input.
         assert!(
-            text.contains("needs input") && text.contains("merged"),
-            "help overlay must include pipeline-status lexicon rows"
+            text.contains("waiting on user input") && text.contains("merged"),
+            "help overlay must include pipeline-status lexicon rows, got:\n{text}"
         );
-        // Agent-activity legend section must appear.
+        assert!(
+            !text.contains("\u{2753}"),
+            "❓ glyph must not appear in legend after issue #281, got:\n{text}"
+        );
+        // Agent-activity legend section must appear. Idle/Input are labeled
+        // with their pulse frames (○/● and ○/?) since the row shows one frame
+        // statically in the legend while the live glyph animates.
         assert!(
             text.contains("working") && text.contains("exhausted"),
-            "help overlay must include agent-activity lexicon rows"
+            "help overlay must include agent-activity lexicon rows, got:\n{text}"
+        );
+        assert!(
+            text.contains("idle (pulsing orange)"),
+            "legend must describe Idle as pulsing orange, got:\n{text}"
+        );
+        assert!(
+            text.contains("input (pulsing red"),
+            "legend must describe Input as pulsing red, got:\n{text}"
         );
     }
 

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -256,13 +256,17 @@ pub(crate) fn status_style(status: crate::signal::PipelineStatus, theme: &Theme)
 }
 
 /// Returns the colored style used to tint the activity glyph in column A.
+///
+/// Pulse variants (Idle, Input) use the dedicated `claude_idle_pulse` and
+/// `claude_input_pulse` theme keys so themes can tune attention colors
+/// independently from the static Working/Exhausted slots. See issue #281.
 pub(crate) fn activity_style(activity: crate::signal::Activity, theme: &Theme) -> Style {
     use crate::signal::Activity as A;
     match activity {
         A::None => Style::default().fg(theme.dimmed),
-        A::Idle => Style::default().fg(theme.claude_idle),
+        A::Idle => Style::default().fg(theme.claude_idle_pulse),
         A::Working => Style::default().fg(theme.claude_active),
-        A::Input => Style::default().fg(theme.claude_needs_input),
+        A::Input => Style::default().fg(theme.claude_input_pulse),
         A::Exhausted => Style::default().fg(theme.error),
     }
 }
@@ -1022,6 +1026,10 @@ struct SubRowContext<'a> {
     /// so a pane inherits its session's activity glyph (issue #251 lossless
     /// rollup: 💀 in a session shows on each of its claude panes, not just ⚡).
     session_activity: crate::signal::Activity,
+    /// Pulse tick for this frame, sampled once at the top of `App::render`
+    /// (issue #281). Threaded here so pane/window sub-rows animate in unison
+    /// with their parent row without re-sampling wall-clock time per row.
+    pulse_tick: u8,
 }
 
 impl App {
@@ -1452,7 +1460,9 @@ impl App {
                     crate::signal::activity_from_claude(&ce)
                 })
                 .unwrap_or(crate::signal::Activity::None);
-            let activity_cell = Cell::from(activity.glyph()).style(activity_style(activity, theme));
+            let tick = self.pulse_tick.get();
+            let activity_cell =
+                Cell::from(activity.glyph_at(tick)).style(activity_style(activity, theme));
 
             // Standalone sessions have no pipeline status — STATUS is purely
             // "what's blocking this from merging?" and a shepherd/orchardist
@@ -1538,6 +1548,7 @@ impl App {
                     bar_color: Color::DarkGray,
                     prefix: "",
                     session_activity: activity,
+                    pulse_tick: self.pulse_tick.get(),
                 };
                 if ss.session.windows.len() > 1 {
                     self.push_window_sub_rows(
@@ -1678,14 +1689,30 @@ impl App {
             let hide_rollup = is_expanded && has_multi_children;
 
             // ACTIVITY cell (column A) — rollup glyph. Hidden when expanded.
-            let activity_glyph = if hide_rollup { "" } else { activity.glyph() };
+            // Issue #281: Idle and Input pulse at 1s cadence via `glyph_at(tick)`;
+            // Working/Exhausted/None remain static.
+            let tick = self.pulse_tick.get();
+            let activity_glyph = if hide_rollup {
+                ""
+            } else {
+                activity.glyph_at(tick)
+            };
             let activity_cell = Cell::from(activity_glyph).style(activity_style(activity, theme));
 
             // STATUS cell — merge-blocker glyph. Hidden when expanded, or
             // blank for `Coding` (no blocker yet — agent activity in column A
             // carries that signal). Keeps STATUS focused on "why isn't this
             // merged?" without mixing with agent activity semantics.
-            let status_glyph = if hide_rollup { "" } else { status.glyph() };
+            //
+            // Issue #281: when rollup activity is Input, the status column
+            // renders a rotating hourglass (⏳/⌛) instead of the static
+            // PipelineStatus glyph — drawing the eye to rows waiting on a
+            // human. `status_glyph_at` centralizes that routing.
+            let status_glyph = if hide_rollup {
+                ""
+            } else {
+                crate::signal::status_glyph_at(activity, status, tick)
+            };
             let status_cell = Cell::from(status_glyph).style(status_style(status, theme));
 
             // ID cell.
@@ -1838,6 +1865,7 @@ impl App {
                         bar_color,
                         prefix: "",
                         session_activity: this_session_activity,
+                        pulse_tick: self.pulse_tick.get(),
                     };
                     if session.windows.len() > 1 {
                         self.push_window_sub_rows(
@@ -1913,8 +1941,8 @@ impl App {
             } else {
                 crate::signal::Activity::None
             };
-            let activity_cell =
-                Cell::from(pane_activity.glyph()).style(activity_style(pane_activity, ctx.theme));
+            let activity_cell = Cell::from(pane_activity.glyph_at(ctx.pulse_tick))
+                .style(activity_style(pane_activity, ctx.theme));
 
             let row_style = if selected {
                 Style::default()
@@ -2038,7 +2066,7 @@ impl App {
                 })
                 .max()
                 .unwrap_or(crate::signal::Activity::None);
-            let window_activity = Cell::from(window_level_activity.glyph())
+            let window_activity = Cell::from(window_level_activity.glyph_at(ctx.pulse_tick))
                 .style(activity_style(window_level_activity, ctx.theme));
 
             let mut cells = vec![
@@ -2499,6 +2527,43 @@ mod tests {
     use crate::session::{
         ClaudeSessionInfo, EnrichedSession, Host, SessionStatus, TmuxSessionInfo,
     };
+
+    // -- activity_style (issue #281) -----------------------------------------
+
+    #[test]
+    fn activity_style_idle_uses_claude_idle_pulse() {
+        let theme = Theme::default();
+        let style = activity_style(crate::signal::Activity::Idle, &theme);
+        assert_eq!(style.fg, Some(theme.claude_idle_pulse));
+    }
+
+    #[test]
+    fn activity_style_input_uses_claude_input_pulse() {
+        let theme = Theme::default();
+        let style = activity_style(crate::signal::Activity::Input, &theme);
+        assert_eq!(style.fg, Some(theme.claude_input_pulse));
+    }
+
+    #[test]
+    fn activity_style_working_uses_claude_active() {
+        let theme = Theme::default();
+        let style = activity_style(crate::signal::Activity::Working, &theme);
+        assert_eq!(style.fg, Some(theme.claude_active));
+    }
+
+    #[test]
+    fn activity_style_exhausted_uses_error() {
+        let theme = Theme::default();
+        let style = activity_style(crate::signal::Activity::Exhausted, &theme);
+        assert_eq!(style.fg, Some(theme.error));
+    }
+
+    #[test]
+    fn activity_style_none_uses_dimmed() {
+        let theme = Theme::default();
+        let style = activity_style(crate::signal::Activity::None, &theme);
+        assert_eq!(style.fg, Some(theme.dimmed));
+    }
 
     fn make_task_row(issue_number: u32, group: DisplayGroup) -> WorktreeRow {
         WorktreeRow {

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -3308,10 +3308,7 @@ mod tests {
 
     #[test]
     fn has_animated_visible_row_false_when_no_claude_sessions() {
-        let app = App::new_test(vec![make_worktree_row(
-            "feat/none",
-            DisplayGroup::Other,
-        )]);
+        let app = App::new_test(vec![make_worktree_row("feat/none", DisplayGroup::Other)]);
         assert!(!app.has_animated_visible_row());
     }
 

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -173,16 +173,9 @@ pub struct App {
     ///
     /// All animated glyphs in a single frame read this field rather than calling
     /// [`crate::signal::pulse_tick`] directly — that way a render that straddles
-    /// a second boundary still produces a coherent frame.
+    /// a second boundary still produces a coherent frame. The run loop writes
+    /// this just before [`App::render`]; tests override it to pin a frame.
     pulse_tick: Cell<u8>,
-
-    /// Last pulse tick that the run loop forced a redraw on (issue #281).
-    ///
-    /// `run_loop` compares the current `pulse_tick()` against this after each
-    /// event-poll interval; when they differ AND at least one visible row is
-    /// animated, the loop forces `terminal.draw` and stores the new tick here.
-    /// When nothing animates, no forced redraw happens — idle terminals stay quiet.
-    last_pulse_tick: Cell<u8>,
 
     /// Expanded rows keyed by worktree path or standalone session name.
     ///
@@ -296,7 +289,6 @@ impl App {
             last_click: None,
             preview_scroll_state: std::cell::Cell::new(tui_scrollview::ScrollViewState::default()),
             pulse_tick: Cell::new(crate::signal::pulse_tick()),
-            last_pulse_tick: Cell::new(crate::signal::pulse_tick()),
             expanded: HashSet::new(),
             sub_cursor: SubCursor::None,
             window_expanded: HashSet::new(),
@@ -1887,37 +1879,35 @@ impl App {
         }
     }
 
-    /// Returns `true` when any visible row has a rollup activity that animates
+    /// Returns `true` when any row has a rollup activity that animates
     /// (`Activity::Idle` or `Activity::Input`) (issue #281).
     ///
-    /// The run loop uses this to decide whether a pulse-tick boundary warrants
-    /// a forced redraw. When nothing animates, the 100ms event-driven repaint
-    /// carries the UI on its own — no extra CPU burned on idle terminals.
+    /// The run loop uses this to pick its event-poll cadence: fast (100ms)
+    /// while any animation is on screen, slower otherwise. Called on every
+    /// poll-timeout calculation, so the scan is kept cheap — we short-circuit
+    /// as soon as the first animated row is seen, and we delegate the full
+    /// exhaustion/rollup check to [`crate::signal::activity_from_claude`] only
+    /// when a session's raw status is already in the animated set.
     pub(crate) fn has_animated_visible_row(&self) -> bool {
         use crate::signal::Activity;
 
+        // Cheap pre-check for standalone sessions: if the raw ClaudeState is
+        // already not Idle/Input, no need to build the enrichment at all.
         let standalone_animated = self.standalone_sessions.iter().any(|ss| {
             ss.session.claude.as_ref().is_some_and(|c| {
-                let ce = crate::orchard_state::ClaudeEnrichment {
-                    status: c.status,
-                    model: c.model.clone(),
-                    last_tool: c.last_tool.clone(),
-                    current_task: c.current_task.clone(),
-                    session_start_ts: c.session_start_ts,
-                    input_tokens: c.input_tokens,
-                    output_tokens: c.output_tokens,
-                    cache_creation_input_tokens: c.cache_creation_input_tokens,
-                    cache_read_input_tokens: c.cache_read_input_tokens,
-                    context_window_pct: c.context_window_pct,
-                    cost_usd: c.cost_usd,
-                    total_duration_ms: c.total_duration_ms,
-                    rate_limits: c.rate_limits.clone(),
-                    stop_reason: c.stop_reason.clone(),
-                    turn_count: c.turn_count,
-                    state_changed_at: c.state_changed_at,
-                };
+                if !matches!(
+                    c.status,
+                    crate::claude_state::ClaudeState::Idle
+                        | crate::claude_state::ClaudeState::Input
+                ) {
+                    return false;
+                }
+                // Context-window or rate-limit exhaustion could escalate this
+                // to Activity::Exhausted — a static glyph, not animated. Fall
+                // through to the full resolver to respect that escalation.
+                let enrichment = crate::orchard_state::ClaudeEnrichment::from(c);
                 matches!(
-                    crate::signal::activity_from_claude(&ce),
+                    crate::signal::activity_from_claude(&enrichment),
                     Activity::Idle | Activity::Input
                 )
             })
@@ -2118,7 +2108,6 @@ impl App {
             last_click: None,
             preview_scroll_state: std::cell::Cell::new(tui_scrollview::ScrollViewState::default()),
             pulse_tick: Cell::new(crate::signal::pulse_tick()),
-            last_pulse_tick: Cell::new(crate::signal::pulse_tick()),
             expanded: HashSet::new(),
             sub_cursor: SubCursor::None,
             window_expanded: HashSet::new(),
@@ -2202,6 +2191,31 @@ pub fn run(command: &str) -> anyhow::Result<Option<String>> {
     result
 }
 
+/// Idle-screen poll timeout (issue #281). Chosen to balance:
+/// - input latency: a keypress blocks for at most this long before reaching
+///   the event loop,
+/// - CPU: render cost is dominated by `has_animated_visible_row` + ratatui's
+///   diff render, so stretching past ~500ms past diminishing returns.
+///
+/// 500ms keeps keystrokes feeling snappy (users struggle to notice <500ms
+/// of delay on a single key) while cutting wasted renders ~5× vs the fast
+/// path. Exposed as `const` so it's obvious at the call site and tunable.
+pub(crate) const IDLE_POLL_TIMEOUT_MS: u64 = 500;
+
+/// Picks the event-poll cadence based on what's visible on screen (issue #281).
+///
+/// When any row animates (Idle/Input pulse) or a full-refresh spinner is
+/// running, we need the fast cadence so the animation appears at ~10Hz and
+/// the 1s pulse boundary is caught within 100ms. Otherwise, the idle cadence
+/// saves CPU on long-running screens with nothing to update.
+pub(crate) fn poll_cadence(animated_visible: bool, refreshing: bool) -> Duration {
+    if animated_visible || refreshing {
+        Duration::from_millis(POLL_TIMEOUT_MS)
+    } else {
+        Duration::from_millis(IDLE_POLL_TIMEOUT_MS)
+    }
+}
+
 fn run_loop(
     terminal: &mut ratatui::Terminal<ratatui::backend::CrosstermBackend<std::fs::File>>,
     app: &mut App,
@@ -2217,23 +2231,9 @@ fn run_loop(
 
         terminal.draw(|f| app.render(f))?;
 
-        // Record the tick we just rendered at (issue #281). Lets the next
-        // iteration detect whether a 1s boundary has crossed.
-        app.last_pulse_tick.set(app.pulse_tick.get());
-
-        // Poll cadence adapts to visible animation (issue #281):
-        // - 100ms when the spinner/throbber or an Idle/Input row is visible —
-        //   snappy input + 1s pulse arrive within one frame of their boundary.
-        // - 1s otherwise — idle screens don't redraw 10× per second just to
-        //   diff an unchanged buffer.
-        // `throbber_animating` and `refreshing` gate the fast cadence for
-        // non-pulse animations (full-refresh spinner) that already rely on it.
-        let fast_cadence = app.has_animated_visible_row() || app.refreshing;
-        let poll_timeout = if fast_cadence {
-            Duration::from_millis(POLL_TIMEOUT_MS)
-        } else {
-            Duration::from_secs(1)
-        };
+        // Poll cadence adapts to visible animation (issue #281); see
+        // [`poll_cadence`] for the policy and its rationale.
+        let poll_timeout = poll_cadence(app.has_animated_visible_row(), app.refreshing);
 
         if event::poll(poll_timeout)? {
             let event = event::read()?;
@@ -3313,6 +3313,48 @@ mod tests {
             DisplayGroup::Other,
         )]);
         assert!(!app.has_animated_visible_row());
+    }
+
+    // -- issue #281: adaptive poll cadence ----------------------------------
+
+    #[test]
+    fn poll_cadence_fast_when_animated_visible() {
+        assert_eq!(
+            poll_cadence(true, false),
+            Duration::from_millis(POLL_TIMEOUT_MS),
+            "animated row visible must use the fast cadence"
+        );
+    }
+
+    #[test]
+    fn poll_cadence_fast_when_refreshing() {
+        assert_eq!(
+            poll_cadence(false, true),
+            Duration::from_millis(POLL_TIMEOUT_MS),
+            "full-refresh spinner must stay on the fast cadence"
+        );
+    }
+
+    #[test]
+    fn poll_cadence_idle_when_nothing_animates() {
+        assert_eq!(
+            poll_cadence(false, false),
+            Duration::from_millis(IDLE_POLL_TIMEOUT_MS),
+            "idle screens must stretch to the idle timeout"
+        );
+    }
+
+    #[test]
+    fn idle_poll_timeout_is_user_acceptable() {
+        // Sanity guard: the idle timeout must stay below a threshold where
+        // keystroke latency becomes perceptible. 600ms is the cited threshold;
+        // we hold well below it. Tripwire for accidental bumps.
+        const {
+            assert!(
+                IDLE_POLL_TIMEOUT_MS <= 600,
+                "idle poll timeout risks perceptible input lag above 600ms"
+            );
+        }
     }
 
     #[test]

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -169,6 +169,21 @@ pub struct App {
     /// `&self`) can update the state via `StatefulWidget::render`.
     preview_scroll_state: std::cell::Cell<tui_scrollview::ScrollViewState>,
 
+    /// Pulse tick sampled at the top of each [`App::render`] call (issue #281).
+    ///
+    /// All animated glyphs in a single frame read this field rather than calling
+    /// [`crate::signal::pulse_tick`] directly — that way a render that straddles
+    /// a second boundary still produces a coherent frame.
+    pulse_tick: Cell<u8>,
+
+    /// Last pulse tick that the run loop forced a redraw on (issue #281).
+    ///
+    /// `run_loop` compares the current `pulse_tick()` against this after each
+    /// event-poll interval; when they differ AND at least one visible row is
+    /// animated, the loop forces `terminal.draw` and stores the new tick here.
+    /// When nothing animates, no forced redraw happens — idle terminals stay quiet.
+    last_pulse_tick: Cell<u8>,
+
     /// Expanded rows keyed by worktree path or standalone session name.
     ///
     /// When a key is present, the row's pane sub-rows are rendered below it.
@@ -280,6 +295,8 @@ impl App {
             preview_area: Cell::new(Rect::default()),
             last_click: None,
             preview_scroll_state: std::cell::Cell::new(tui_scrollview::ScrollViewState::default()),
+            pulse_tick: Cell::new(crate::signal::pulse_tick()),
+            last_pulse_tick: Cell::new(crate::signal::pulse_tick()),
             expanded: HashSet::new(),
             sub_cursor: SubCursor::None,
             window_expanded: HashSet::new(),
@@ -1848,6 +1865,12 @@ impl App {
     /// to the appropriate render method based on the current [`ViewState`].
     /// The preview scroll state uses `Cell` for interior mutability.
     fn render(&self, f: &mut Frame) {
+        // Pulse tick for this frame is sampled once by the run loop *before*
+        // calling `render` (see `run_loop`) and stored on `self.pulse_tick`.
+        // Every animated-row renderer reads `self.pulse_tick.get()` rather
+        // than re-sampling wall-clock time, guaranteeing frame coherence even
+        // when a render straddles a second boundary. Tests can set the field
+        // directly to force a deterministic frame (issue #281).
         match &self.view {
             ViewState::List => self.render_list(f),
             ViewState::ConfirmDelete(ds) => self.render_delete(ds, f),
@@ -1862,6 +1885,54 @@ impl App {
             }
             ViewState::Help => self.render_help(f),
         }
+    }
+
+    /// Returns `true` when any visible row has a rollup activity that animates
+    /// (`Activity::Idle` or `Activity::Input`) (issue #281).
+    ///
+    /// The run loop uses this to decide whether a pulse-tick boundary warrants
+    /// a forced redraw. When nothing animates, the 100ms event-driven repaint
+    /// carries the UI on its own — no extra CPU burned on idle terminals.
+    pub(crate) fn has_animated_visible_row(&self) -> bool {
+        use crate::signal::Activity;
+
+        let standalone_animated = self.standalone_sessions.iter().any(|ss| {
+            ss.session.claude.as_ref().is_some_and(|c| {
+                let ce = crate::orchard_state::ClaudeEnrichment {
+                    status: c.status,
+                    model: c.model.clone(),
+                    last_tool: c.last_tool.clone(),
+                    current_task: c.current_task.clone(),
+                    session_start_ts: c.session_start_ts,
+                    input_tokens: c.input_tokens,
+                    output_tokens: c.output_tokens,
+                    cache_creation_input_tokens: c.cache_creation_input_tokens,
+                    cache_read_input_tokens: c.cache_read_input_tokens,
+                    context_window_pct: c.context_window_pct,
+                    cost_usd: c.cost_usd,
+                    total_duration_ms: c.total_duration_ms,
+                    rate_limits: c.rate_limits.clone(),
+                    stop_reason: c.stop_reason.clone(),
+                    turn_count: c.turn_count,
+                    state_changed_at: c.state_changed_at,
+                };
+                matches!(
+                    crate::signal::activity_from_claude(&ce),
+                    Activity::Idle | Activity::Input
+                )
+            })
+        });
+
+        if standalone_animated {
+            return true;
+        }
+
+        self.task_rows.iter().any(|row| {
+            matches!(
+                crate::signal::rollup_activity_row(row),
+                Activity::Idle | Activity::Input
+            )
+        })
     }
 
     // -------------------------------------------------------------------
@@ -2046,6 +2117,8 @@ impl App {
             preview_area: Cell::new(Rect::default()),
             last_click: None,
             preview_scroll_state: std::cell::Cell::new(tui_scrollview::ScrollViewState::default()),
+            pulse_tick: Cell::new(crate::signal::pulse_tick()),
+            last_pulse_tick: Cell::new(crate::signal::pulse_tick()),
             expanded: HashSet::new(),
             sub_cursor: SubCursor::None,
             window_expanded: HashSet::new(),
@@ -2137,10 +2210,32 @@ fn run_loop(
         // Advance throbber animation before drawing so spinner progresses each frame.
         app.throbber_state.calc_next();
 
+        // Sample the pulse tick ONCE per frame (issue #281). All animated row
+        // renderers read `app.pulse_tick.get()` — coherent within the frame
+        // even across second boundaries.
+        app.pulse_tick.set(crate::signal::pulse_tick());
+
         terminal.draw(|f| app.render(f))?;
 
-        // Poll for events with timeout (for spinner animation).
-        if event::poll(Duration::from_millis(POLL_TIMEOUT_MS))? {
+        // Record the tick we just rendered at (issue #281). Lets the next
+        // iteration detect whether a 1s boundary has crossed.
+        app.last_pulse_tick.set(app.pulse_tick.get());
+
+        // Poll cadence adapts to visible animation (issue #281):
+        // - 100ms when the spinner/throbber or an Idle/Input row is visible —
+        //   snappy input + 1s pulse arrive within one frame of their boundary.
+        // - 1s otherwise — idle screens don't redraw 10× per second just to
+        //   diff an unchanged buffer.
+        // `throbber_animating` and `refreshing` gate the fast cadence for
+        // non-pulse animations (full-refresh spinner) that already rely on it.
+        let fast_cadence = app.has_animated_visible_row() || app.refreshing;
+        let poll_timeout = if fast_cadence {
+            Duration::from_millis(POLL_TIMEOUT_MS)
+        } else {
+            Duration::from_secs(1)
+        };
+
+        if event::poll(poll_timeout)? {
             let event = event::read()?;
             let msg = match event {
                 Event::Key(key) => app.handle_event(key),
@@ -3029,20 +3124,195 @@ mod tests {
             ..make_worktree_row("feat/waiting", DisplayGroup::NeedsAttention)
         };
         let mut app = App::new_test(vec![row]);
+        // Force tick=0 so we assert deterministic frame content. Without this
+        // the test would flake across the second boundary (both frames are
+        // valid for this row).
+        app.pulse_tick.set(0);
         let output = render_to_string(&mut app, 120, 40);
 
-        // Issue #251: NeedsInput renders as a ❓ glyph in the STATUS column
-        // (parent row's single merge-blocker glyph). Activity column A shows
-        // ⚡ because the agent is "doing something" (waiting on input).
-        let needs_input_glyph = crate::signal::PipelineStatus::NeedsInput.glyph();
+        // Issue #281: the ❓ glyph is gone from the status column. The
+        // "waiting on you" signal is carried by a rotating hourglass driven
+        // off rollup Activity::Input; column A pulses ○/? in red.
         assert!(
-            output.contains(needs_input_glyph),
-            "expected ❓ needs-input glyph in STATUS column, got:\n{output}"
+            !output.contains('\u{2753}'),
+            "❓ glyph must no longer appear after issue #281; got:\n{output}"
+        );
+        // At tick=0, column A shows ○ (open circle) and the status column
+        // shows ⏳ (sand still falling).
+        assert!(
+            output.contains('\u{25CB}'),
+            "expected ○ in column A (tick=0 Input frame); got:\n{output}"
+        );
+        assert!(
+            output.contains('\u{23F3}'),
+            "expected ⏳ hourglass in status column when rollup activity is Input; got:\n{output}"
         );
         assert!(
             output.contains("needs attention"),
             "expected NeedsAttention section header"
         );
+
+        // Swap to tick=1 — column A flips to '?' and the hourglass flips to ⌛.
+        app.pulse_tick.set(1);
+        let output = render_to_string(&mut app, 120, 40);
+        assert!(
+            output.contains('?'),
+            "expected '?' in column A (tick=1 Input frame); got:\n{output}"
+        );
+        assert!(
+            output.contains('\u{231B}'),
+            "expected ⌛ hourglass at tick=1; got:\n{output}"
+        );
+        assert!(
+            !output.contains('\u{2753}'),
+            "❓ must not appear at tick=1 either; got:\n{output}"
+        );
+    }
+
+    // -- issue #281: pulse animation / has_animated_visible_row --------------
+
+    fn make_claude_row(
+        branch: &str,
+        group: DisplayGroup,
+        state: crate::claude_state::ClaudeState,
+    ) -> WorktreeRow {
+        WorktreeRow {
+            sessions: vec![EnrichedSession {
+                tmux: TmuxSessionInfo {
+                    host: Host::Local,
+                    name: format!("sess-{}", branch.replace('/', "-")),
+                    status: SessionStatus::Running { attached: false },
+                },
+                claude: Some(ClaudeSessionInfo {
+                    status: state,
+                    model: None,
+                    last_tool: None,
+                    current_task: None,
+                    session_start_ts: None,
+                    input_tokens: None,
+                    output_tokens: None,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: None,
+                    context_window_pct: None,
+                    cost_usd: None,
+                    total_duration_ms: None,
+                    rate_limits: None,
+                    stop_reason: None,
+                    turn_count: None,
+                    state_changed_at: None,
+                }),
+                windows: vec![],
+                panes: vec![],
+                started_at: None,
+                last_activity_at: None,
+            }],
+            ..make_worktree_row(branch, group)
+        }
+    }
+
+    #[test]
+    fn snapshot_differs_between_ticks_when_row_animates() {
+        let mut app = App::new_test(vec![make_claude_row(
+            "feat/idle",
+            DisplayGroup::ClaudeWorking,
+            crate::claude_state::ClaudeState::Idle,
+        )]);
+        app.pulse_tick.set(0);
+        let at_zero = render_to_string(&mut app, 120, 40);
+        app.pulse_tick.set(1);
+        let at_one = render_to_string(&mut app, 120, 40);
+        assert_ne!(
+            at_zero, at_one,
+            "Idle-row snapshot at tick=0 must differ from tick=1"
+        );
+        assert!(at_zero.contains('\u{25CB}'), "tick=0 should contain ○"); // ○
+        assert!(at_one.contains('\u{25CF}'), "tick=1 should contain ●"); // ●
+    }
+
+    #[test]
+    fn snapshot_identical_across_ticks_when_no_row_animates() {
+        // Only Working (static ⚡) and None — nothing should animate.
+        let mut app = App::new_test(vec![
+            make_claude_row(
+                "feat/working",
+                DisplayGroup::ClaudeWorking,
+                crate::claude_state::ClaudeState::Working,
+            ),
+            make_worktree_row("feat/none", DisplayGroup::Other), // no sessions
+        ]);
+        app.pulse_tick.set(0);
+        let at_zero = render_to_string(&mut app, 120, 40);
+        app.pulse_tick.set(1);
+        let at_one = render_to_string(&mut app, 120, 40);
+        assert_eq!(
+            at_zero, at_one,
+            "Snapshot must be identical across ticks when no row animates"
+        );
+    }
+
+    #[test]
+    fn two_renders_with_same_tick_produce_identical_buffers() {
+        // Frame-coherence guard (issue #281): rendering twice with the same
+        // tick must produce identical output — the tick sampled in `render` is
+        // the *only* source of per-frame timing.
+        let mut app = App::new_test(vec![
+            make_claude_row(
+                "feat/idle",
+                DisplayGroup::ClaudeWorking,
+                crate::claude_state::ClaudeState::Idle,
+            ),
+            make_claude_row(
+                "feat/input",
+                DisplayGroup::NeedsAttention,
+                crate::claude_state::ClaudeState::Input,
+            ),
+        ]);
+        app.pulse_tick.set(0);
+        let a = render_to_string(&mut app, 120, 40);
+        let b = render_to_string(&mut app, 120, 40);
+        assert_eq!(
+            a, b,
+            "two renders with the same tick must be byte-identical"
+        );
+    }
+
+    #[test]
+    fn has_animated_visible_row_true_when_idle_row_visible() {
+        let app = App::new_test(vec![make_claude_row(
+            "feat/x",
+            DisplayGroup::ClaudeWorking,
+            crate::claude_state::ClaudeState::Idle,
+        )]);
+        assert!(app.has_animated_visible_row());
+    }
+
+    #[test]
+    fn has_animated_visible_row_true_when_input_row_visible() {
+        let app = App::new_test(vec![make_claude_row(
+            "feat/x",
+            DisplayGroup::NeedsAttention,
+            crate::claude_state::ClaudeState::Input,
+        )]);
+        assert!(app.has_animated_visible_row());
+    }
+
+    #[test]
+    fn has_animated_visible_row_false_when_only_working_visible() {
+        let app = App::new_test(vec![make_claude_row(
+            "feat/x",
+            DisplayGroup::ClaudeWorking,
+            crate::claude_state::ClaudeState::Working,
+        )]);
+        assert!(!app.has_animated_visible_row());
+    }
+
+    #[test]
+    fn has_animated_visible_row_false_when_no_claude_sessions() {
+        let app = App::new_test(vec![make_worktree_row(
+            "feat/none",
+            DisplayGroup::Other,
+        )]);
+        assert!(!app.has_animated_visible_row());
     }
 
     #[test]

--- a/crates/orchard/src/tui/theme.rs
+++ b/crates/orchard/src/tui/theme.rs
@@ -276,10 +276,7 @@ mod tests {
 
     #[test]
     fn default_claude_idle_pulse_is_orange() {
-        assert_eq!(
-            Theme::default().claude_idle_pulse,
-            Color::Rgb(255, 165, 0)
-        );
+        assert_eq!(Theme::default().claude_idle_pulse, Color::Rgb(255, 165, 0));
     }
 
     #[test]

--- a/crates/orchard/src/tui/theme.rs
+++ b/crates/orchard/src/tui/theme.rs
@@ -90,6 +90,15 @@ pub struct Theme {
     /// Color for a Claude session awaiting user input.
     pub claude_needs_input: Color,
 
+    /// Color for the Idle pulse in column A (issue #281). Orange by default so
+    /// an idle session stands apart from working (green) and input (red) rows.
+    pub claude_idle_pulse: Color,
+
+    /// Color for the Input pulse in column A (issue #281). Red by default —
+    /// shares intent with the hourglass in the status column to say "waiting
+    /// on you."
+    pub claude_input_pulse: Color,
+
     /// Base background color for popups and overlays.
     pub background: Color,
 
@@ -131,6 +140,8 @@ impl Default for Theme {
             claude_active: Color::Green,
             claude_idle: Color::DarkGray,
             claude_needs_input: Color::Red,
+            claude_idle_pulse: Color::Rgb(255, 165, 0),
+            claude_input_pulse: Color::Red,
             background: Color::Reset, // inherit terminal background
             text: Color::White,
             orchardist: Color::Magenta,
@@ -261,6 +272,19 @@ mod tests {
     #[test]
     fn default_search_highlight_is_yellow() {
         assert_eq!(Theme::default().search_highlight, Color::Yellow);
+    }
+
+    #[test]
+    fn default_claude_idle_pulse_is_orange() {
+        assert_eq!(
+            Theme::default().claude_idle_pulse,
+            Color::Rgb(255, 165, 0)
+        );
+    }
+
+    #[test]
+    fn default_claude_input_pulse_is_red() {
+        assert_eq!(Theme::default().claude_input_pulse, Color::Red);
     }
 
     #[test]

--- a/specs/features/pulse-idle-input-glyphs.feature
+++ b/specs/features/pulse-idle-input-glyphs.feature
@@ -1,0 +1,308 @@
+Feature: Pulse idle/input glyphs in column A; drop ❓ from status
+  As a user scanning the TUI for sessions that need attention
+  I want Idle and Input activity glyphs to animate in unison at 1s cadence
+  So that stuck/waiting sessions draw the eye in peripheral vision and the activity axis stays distinct from the workflow status axis
+
+  Background:
+    Given the signal module defines Activity with variants None, Idle, Working, Input, Exhausted
+    And the signal module defines PipelineStatus with variants including NeedsInput
+    And the TUI render loop polls every 100ms in crates/orchard/src/tui/mod.rs
+
+  # ===================================================================
+  # Activity glyphs — static frames (Working, Exhausted, None)
+  # ===================================================================
+
+  @unit
+  Scenario: Activity::Working renders static ⚡ regardless of tick
+    Given the Activity::Working variant
+    When glyph_at(tick) is called for tick in {0, 1}
+    Then both frames return "⚡"
+
+  @unit
+  Scenario: Activity::Exhausted renders static 💀 regardless of tick
+    Given the Activity::Exhausted variant
+    When glyph_at(tick) is called for tick in {0, 1}
+    Then both frames return "💀"
+
+  @unit
+  Scenario: Activity::None renders blank regardless of tick
+    Given the Activity::None variant
+    When glyph_at(tick) is called for tick in {0, 1}
+    Then both frames return ""
+
+  # ===================================================================
+  # Activity glyphs — animated frames (Idle, Input)
+  # ===================================================================
+
+  @unit
+  Scenario: Activity::Idle pulses between ○ and ● across ticks
+    Given the Activity::Idle variant
+    When glyph_at(0) and glyph_at(1) are called
+    Then glyph_at(0) returns "○"
+    And glyph_at(1) returns "●"
+
+  @unit
+  Scenario: Activity::Input pulses between ○ and ? across ticks
+    Given the Activity::Input variant
+    When glyph_at(0) and glyph_at(1) are called
+    Then glyph_at(0) returns "○"
+    And glyph_at(1) returns "?"
+
+  @unit
+  Scenario: glyph_at wraps every 2 ticks (symmetric 1s cadence)
+    Given any animated Activity variant (Idle or Input)
+    Then glyph_at(0) == glyph_at(2) == glyph_at(4)
+    And glyph_at(1) == glyph_at(3) == glyph_at(5)
+
+  @unit
+  Scenario: legacy Activity::glyph() remains available and returns the tick=0 frame
+    # Non-TUI callers (tests, JSON, labels) should not need to know about animation.
+    Given any Activity variant V
+    Then V.glyph() returns the same string as V.glyph_at(0)
+
+  # ===================================================================
+  # Theme additions — idle_pulse and input_pulse colors
+  # ===================================================================
+
+  @unit
+  Scenario: Theme exposes claude_idle_pulse as orange by default
+    Given the default Theme
+    Then theme.claude_idle_pulse is an orange color (e.g. Color::Rgb(255, 165, 0) or equivalent)
+
+  @unit
+  Scenario: Theme exposes claude_input_pulse as red by default
+    Given the default Theme
+    Then theme.claude_input_pulse equals theme.error (or an explicit red)
+
+  @unit
+  Scenario: activity_style uses claude_idle_pulse for Idle
+    Given the default Theme
+    When activity_style(Activity::Idle, &theme) is called
+    Then the returned Style foreground is theme.claude_idle_pulse
+
+  @unit
+  Scenario: activity_style uses claude_input_pulse for Input
+    Given the default Theme
+    When activity_style(Activity::Input, &theme) is called
+    Then the returned Style foreground is theme.claude_input_pulse
+
+  @unit
+  Scenario: activity_style leaves Working unchanged (claude_active)
+    Given the default Theme
+    When activity_style(Activity::Working, &theme) is called
+    Then the returned Style foreground is theme.claude_active
+
+  @unit
+  Scenario: activity_style leaves Exhausted unchanged (error)
+    Given the default Theme
+    When activity_style(Activity::Exhausted, &theme) is called
+    Then the returned Style foreground is theme.error
+
+  # ===================================================================
+  # Status column — drop ❓ glyph, render hourglass when activity is Input
+  # ===================================================================
+  #
+  # Decision: keep PipelineStatus::NeedsInput variant (it still drives sort
+  # severity — first match in the merge-blocker hierarchy), but blank its glyph
+  # and drop it from the legend. The visible "waiting on you" signal is carried
+  # by the animated hourglass in the status column, which is driven off rollup
+  # Activity::Input (not off PipelineStatus::NeedsInput). This decouples the
+  # activity axis from the glyph while preserving sort order.
+
+  @unit
+  Scenario: PipelineStatus::NeedsInput.glyph() returns empty string
+    # Existing signal.rs test `every_status_has_distinct_glyph` must be updated
+    # to exclude NeedsInput from the distinctness set (alongside Coding, which
+    # is already excluded).
+    Given PipelineStatus::NeedsInput
+    Then PipelineStatus::NeedsInput.glyph() returns ""
+
+  @unit
+  Scenario: Statuses other than Coding and NeedsInput each produce a unique non-empty glyph
+    Given all PipelineStatus variants except Coding and NeedsInput
+    Then each variant's glyph() is non-empty and distinct
+
+  @integration
+  Scenario: Cleanup dialog legend no longer lists NeedsInput with ❓
+    # dialogs.rs ~353 currently renders `PipelineStatus::NeedsInput.glyph()` as
+    # the first legend entry. After this feature it must be removed from the
+    # legend (because the glyph is blank) and replaced with an hourglass entry.
+    Given the cleanup dialog is rendered via TestBackend
+    Then the rendered buffer does not contain the "❓" glyph
+    And the rendered buffer contains a legend entry with "⏳" or "⌛" and "waiting on user input"
+
+  @unit
+  Scenario: status_glyph_at renders rotating hourglass when rollup activity is Input
+    Given a row with rollup Activity::Input
+    When status_glyph_at(row, tick=0) is called
+    Then it returns "⏳"
+    And status_glyph_at(row, tick=1) returns "⌛"
+
+  @unit
+  Scenario: status_glyph_at wraps every 2 ticks for Input activity
+    Given a row with rollup Activity::Input
+    Then status_glyph_at(row, 0) == status_glyph_at(row, 2)
+    And status_glyph_at(row, 1) == status_glyph_at(row, 3)
+
+  @unit
+  Scenario: status_glyph_at falls through to PipelineStatus glyph for non-Input rows
+    Given a row with rollup Activity::Working and status PipelineStatus::CiFailing
+    When status_glyph_at(row, tick=0) is called
+    Then it returns "🚫"
+
+  @unit
+  Scenario: status_glyph_at returns blank for Coding status with non-Input activity
+    Given a row with rollup Activity::Working and status PipelineStatus::Coding
+    When status_glyph_at(row, tick=0) is called
+    Then it returns ""
+
+  # ===================================================================
+  # Sort severity preserved
+  # ===================================================================
+
+  @unit
+  Scenario: Input-activity rows still sort above CiFailing rows
+    # Removing ❓ glyph must not demote Input rows in the sort order.
+    Given two worktree rows:
+      | branch | activity | status     |
+      | a      | Input    | NeedsInput |
+      | b      | Working  | CiFailing  |
+    When rows are sorted by RowSortKey
+    Then branch "a" comes before branch "b"
+
+  # ===================================================================
+  # Unison tick — single source, all rows pulse together
+  # ===================================================================
+
+  @unit
+  Scenario: Pulse tick is derived from elapsed wall-clock seconds
+    # Stateless design — no per-row or per-App counter that could drift.
+    Given the current wall-clock time
+    When pulse_tick() is called
+    Then it returns (now_secs % 2) as u8
+    And two calls within the same second return the same tick
+
+  @integration
+  Scenario: Two renders with the same tick produce identical buffers
+    # Prevents a render that straddles a second boundary from producing a mixed
+    # frame (torn frame). The tick is sampled once at the top of render and
+    # threaded through, so repeating a render with the same tick must be a
+    # fixed point.
+    Given an App with one Activity::Idle row and one Activity::Input row
+    When render is invoked with pulse tick forced to 0
+    And render is invoked a second time with pulse tick forced to 0
+    Then the two rendered buffers are byte-identical
+
+  @integration
+  Scenario: All animated rows in one frame use the same tick value
+    Given an App with three rows in Activity::Idle and two rows in Activity::Input
+    When render is invoked
+    Then every Idle row's column-A cell contains the same glyph
+    And every Input row's column-A cell contains the same glyph
+
+  # ===================================================================
+  # Render throttling — no CPU spike when animations are offscreen
+  # ===================================================================
+
+  @unit
+  Scenario: has_animated_visible_row returns true when any visible row is Idle
+    Given App.task_rows visible range contains one row with rollup Activity::Idle
+    Then has_animated_visible_row(&app) returns true
+
+  @unit
+  Scenario: has_animated_visible_row returns true when any visible row is Input
+    Given App.task_rows visible range contains one row with rollup Activity::Input
+    Then has_animated_visible_row(&app) returns true
+
+  @unit
+  Scenario: has_animated_visible_row returns false when no visible row animates
+    Given App.task_rows contain only rollup Activity::{None, Working, Exhausted}
+    Then has_animated_visible_row(&app) returns false
+
+  @integration
+  Scenario: Render loop repaints on pulse-tick boundary only when animations are visible
+    # Baseline 100ms poll stays. When the tick boundary is crossed (tick changed
+    # since App.last_pulse_tick) AND has_animated_visible_row is true, force a redraw.
+    # When nothing animates, no forced redraw happens — event-driven repaint only.
+    # Storage: App gains a `last_pulse_tick: u8` field, initialized to pulse_tick()
+    # on startup, updated after each forced pulse redraw.
+    Given the run_loop in crates/orchard/src/tui/mod.rs
+    And App has a `last_pulse_tick: u8` field
+    When one second elapses and has_animated_visible_row is true and pulse_tick() != app.last_pulse_tick
+    Then terminal.draw is invoked and app.last_pulse_tick is updated
+    When one second elapses and has_animated_visible_row is false
+    Then no forced redraw is triggered by pulse-tick alone
+
+  # ===================================================================
+  # TUI snapshot — two frames differ for animated rows
+  # ===================================================================
+
+  @integration
+  Scenario: Snapshot at tick=0 differs from tick=1 when any row animates
+    Given a test App with one Idle row and one Input row
+    When render is invoked with pulse tick forced to 0
+    And render is invoked again with pulse tick forced to 1
+    Then the rendered buffer at tick=0 differs from the buffer at tick=1
+    And the difference is isolated to column A of the animated rows and the status column of the Input row
+
+  @integration
+  Scenario: Snapshot at tick=0 equals tick=1 when no row animates
+    Given a test App with only Working/Exhausted/None rows
+    When render is invoked with pulse tick forced to 0 and then 1
+    Then the two rendered buffers are identical
+
+  # ===================================================================
+  # Regression — status column no longer shows ❓ for NeedsInput
+  # ===================================================================
+
+  @integration
+  Scenario: Rendered row with Input activity does not contain ❓ anywhere
+    Given a test App with one worktree whose rollup activity is Input
+    When render is invoked
+    Then the rendered buffer does not contain the "❓" glyph
+    And column A contains either "○" or "?"
+    And the status column contains either "⏳" or "⌛"
+
+  # ===================================================================
+  # Legend — new pulsing entries shown
+  # ===================================================================
+
+  @integration
+  Scenario: Legend lists Idle pulse and Input pulse entries
+    # The legend is rendered via ratatui; inspect the rendered buffer.
+    Given the help/legend overlay is rendered via TestBackend
+    Then the rendered buffer mentions Idle with "○" and "●" (pulsing)
+    And the rendered buffer mentions Input with "○" and "?" (pulsing)
+    And the rendered buffer mentions the hourglass as "waiting on user input"
+
+  # ===================================================================
+  # Scope: rows that animate
+  # ===================================================================
+
+  @integration
+  Scenario: Standalone sessions (orchardist, non-worktree) animate the same way
+    # Standalone session rows flow through the same activity rollup. They must
+    # pulse in unison with worktree rows.
+    Given App.standalone_sessions contains a row with rollup Activity::Idle
+    When render is invoked
+    Then the standalone row's activity cell pulses ○/● at the same tick as worktree rows
+
+  @integration
+  Scenario: Expanded pane sub-rows inherit the pulse behavior
+    # Child pane rows (expanded tmux session/window/pane tree) render per-pane
+    # activity glyphs via the same Activity enum. They pulse when Idle or Input.
+    Given an expanded worktree row with a child pane in Activity::Input
+    When render is invoked
+    Then the child pane cell pulses ○/? at the shared tick
+
+  # ===================================================================
+  # Out of scope — explicit non-goals
+  # ===================================================================
+  # - watch/diff.rs ClaudeNeedsInput events are untouched (they carry data,
+  #   not glyphs).
+  # - tmux status-bar segment: orchard does not currently write a per-row tmux
+  #   status segment that renders PipelineStatus glyphs; nothing to change.
+  # - json_output.rs does not render status glyphs (it exposes enum string /
+  #   label). NeedsInput still appears in JSON; consumers get the label.
+  # - Working/Exhausted animation, configurable blink rate, orchardist policy
+  #   on idle sessions — all explicitly out of scope per the issue.


### PR DESCRIPTION
Closes #281

## Summary

- Animates Column A for `Activity::Idle` (○↔●, orange) and `Activity::Input` (○↔?, red) at 1s cadence
- Keeps `Working` (⚡) and `Exhausted` (💀) static
- Drops the ❓ glyph from the status column and renders a rotating hourglass (⏳/⌛) when the rollup activity is `Input`
- Stateless `pulse_tick()` sampled once per render; all animated rows in a frame share the same phase
- Render loop forces a repaint on tick boundaries **only** when an animated row is visible (no CPU spike otherwise)

## Design

- `PipelineStatus::NeedsInput` variant retained for sort severity; only its glyph is blanked. The visible signal is carried by `Activity::Input` rollup → hourglass in the status column.
- Unison pulse is achieved by deriving `tick = (now_secs & 1) as u8`. No shared counter, no drift.
- Frame coherence: tick is sampled **once** at the top of `App.render` and threaded through row builders.

## Test plan

- [x] `cargo test -p orchard --lib signal::` — 57 pass (new: glyph_at pairs, pulse_tick invariants, hourglass routing, sort regression)
- [ ] TUI snapshot tests at tick=0 vs tick=1
- [ ] Render-throttling unit: `has_animated_visible_row`
- [ ] Legend/help overlay and cleanup dialog updated
- [ ] `cargo test -p orchard` (full suite green)
- [ ] Manual TUI smoke via `orchard-worktree-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #281

# Related issue

- #281

# Related issue

- #281

# Related issue

- #281

# Related issue

- #281