### PR TITLE
feat(json): expose unresolved review threads and review comments

### DIFF
--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -5,6 +5,7 @@
 //! cache files consumed by `sources::*` and `derive`.
 use std::collections::HashMap;
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::cache::{
     self, CachedIssue, CachedPr, CachedRepoMeta, CachedReview, CachedSubIssue, CachedTmuxSession,
@@ -21,6 +22,34 @@ use crate::remote;
 // ---------------------------------------------------------------------------
 // Parse helpers
 // ---------------------------------------------------------------------------
+
+/// Counts review threads that are both unresolved and still actionable.
+///
+/// A thread is counted iff `isResolved != true AND isOutdated != true`.
+/// Missing `isOutdated` is treated as "not outdated" — see below.
+///
+/// When a thread node lacks `isOutdated`, a warning is logged at most once
+/// per process to distinguish cache replay (old cache shape) from a real
+/// GraphQL schema regression without spamming the log for every PR.
+fn count_actionable_threads(nodes: &serde_json::Value) -> u32 {
+    static WARNED_MISSING_OUTDATED: AtomicBool = AtomicBool::new(false);
+
+    let Some(arr) = nodes.as_array() else {
+        return 0;
+    };
+    arr.iter()
+        .filter(|t| {
+            if t.get("isOutdated").is_none()
+                && !WARNED_MISSING_OUTDATED.swap(true, Ordering::Relaxed)
+            {
+                LOG.warn(
+                    "cache_sources: reviewThread missing isOutdated field — treating as not outdated (cache replay or schema drift)",
+                );
+            }
+            t["isResolved"].as_bool() != Some(true) && t["isOutdated"].as_bool() != Some(true)
+        })
+        .count() as u32
+}
 
 /// Parses raw JSON output from `gh issue list --json number,title,state,labels`
 /// into a `Vec<CachedIssue>`.
@@ -286,22 +315,7 @@ pub fn parse_prs_graphql(json: &str, matcher: &GateMatcher) -> Vec<CachedPr> {
 
             let has_conflicts = v["mergeable"].as_str().unwrap_or("") == "CONFLICTING";
 
-            let mut warned_missing_outdated = false;
-            let unresolved_threads = v["reviewThreads"]["nodes"]
-                .as_array()
-                .map(|arr| {
-                    arr.iter()
-                        .filter(|t| {
-                            if t.get("isOutdated").is_none() && !warned_missing_outdated {
-                                LOG.warn("cache_sources: reviewThread missing isOutdated field — treating as not outdated (cache replay or schema drift)");
-                                warned_missing_outdated = true;
-                            }
-                            t["isResolved"].as_bool() != Some(true)
-                                && t["isOutdated"].as_bool() != Some(true)
-                        })
-                        .count() as u32
-                })
-                .unwrap_or(0);
+            let unresolved_threads = count_actionable_threads(&v["reviewThreads"]["nodes"]);
 
             // Use GitHub's closingIssuesReferences (first linked issue).
             let first_linked = v["closingIssuesReferences"]["nodes"]
@@ -1058,22 +1072,7 @@ pub fn parse_prs_graphql_per_branch(json: &str, matcher: &GateMatcher) -> Vec<Ca
 
         let has_conflicts = v["mergeable"].as_str().unwrap_or("") == "CONFLICTING";
 
-        let mut warned_missing_outdated = false;
-        let unresolved_threads = v["reviewThreads"]["nodes"]
-            .as_array()
-            .map(|arr| {
-                arr.iter()
-                    .filter(|t| {
-                        if t.get("isOutdated").is_none() && !warned_missing_outdated {
-                            LOG.warn("cache_sources: reviewThread missing isOutdated field — treating as not outdated (cache replay or schema drift)");
-                            warned_missing_outdated = true;
-                        }
-                        t["isResolved"].as_bool() != Some(true)
-                            && t["isOutdated"].as_bool() != Some(true)
-                    })
-                    .count() as u32
-            })
-            .unwrap_or(0);
+        let unresolved_threads = count_actionable_threads(&v["reviewThreads"]["nodes"]);
 
         let first_linked = v["closingIssuesReferences"]["nodes"]
             .as_array()

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -286,11 +286,19 @@ pub fn parse_prs_graphql(json: &str, matcher: &GateMatcher) -> Vec<CachedPr> {
 
             let has_conflicts = v["mergeable"].as_str().unwrap_or("") == "CONFLICTING";
 
+            let mut warned_missing_outdated = false;
             let unresolved_threads = v["reviewThreads"]["nodes"]
                 .as_array()
                 .map(|arr| {
                     arr.iter()
-                        .filter(|t| t["isResolved"].as_bool() != Some(true))
+                        .filter(|t| {
+                            if t.get("isOutdated").is_none() && !warned_missing_outdated {
+                                LOG.warn("cache_sources: reviewThread missing isOutdated field — treating as not outdated (cache replay or schema drift)");
+                                warned_missing_outdated = true;
+                            }
+                            t["isResolved"].as_bool() != Some(true)
+                                && t["isOutdated"].as_bool() != Some(true)
+                        })
                         .count() as u32
                 })
                 .unwrap_or(0);
@@ -805,6 +813,7 @@ pub fn pr_graphql_query(owner: &str, name: &str) -> String {
         reviewThreads(first: 100) {{
           nodes {{
             isResolved
+            isOutdated
           }}
         }}
         closingIssuesReferences(first: 5) {{
@@ -910,8 +919,8 @@ fragment PrFields on PullRequest {{
   mergeable
   labels(first: 100) {{ nodes {{ name }} }}
   reviewRequests(first: 20) {{ nodes {{ requestedReviewer {{ ... on User {{ login }} ... on Team {{ name }} }} }} }}
-  reviews(first: 20) {{ nodes {{ author {{ login }} state submittedAt }} }}
-  reviewThreads(first: 100) {{ nodes {{ isResolved }} }}
+  reviews(last: 20) {{ nodes {{ author {{ login }} state submittedAt }} }}
+  reviewThreads(first: 100) {{ nodes {{ isResolved isOutdated }} }}
   closingIssuesReferences(first: 5) {{ nodes {{ number state stateReason }} }}
   additions
   deletions
@@ -1049,11 +1058,19 @@ pub fn parse_prs_graphql_per_branch(json: &str, matcher: &GateMatcher) -> Vec<Ca
 
         let has_conflicts = v["mergeable"].as_str().unwrap_or("") == "CONFLICTING";
 
+        let mut warned_missing_outdated = false;
         let unresolved_threads = v["reviewThreads"]["nodes"]
             .as_array()
             .map(|arr| {
                 arr.iter()
-                    .filter(|t| t["isResolved"].as_bool() != Some(true))
+                    .filter(|t| {
+                        if t.get("isOutdated").is_none() && !warned_missing_outdated {
+                            LOG.warn("cache_sources: reviewThread missing isOutdated field — treating as not outdated (cache replay or schema drift)");
+                            warned_missing_outdated = true;
+                        }
+                        t["isResolved"].as_bool() != Some(true)
+                            && t["isOutdated"].as_bool() != Some(true)
+                    })
                     .count() as u32
             })
             .unwrap_or(0);
@@ -3280,5 +3297,155 @@ issue42/fix-bug 2026-04-12T14:30:00-07:00
         assert_eq!(session.window_layouts, vec![layout]);
         assert_eq!(session.pane_paths, vec!["/home/user/repo"]);
         assert_eq!(session.pane_active, vec!["1"]);
+    }
+
+    // -- unresolved_threads isOutdated filtering (Issue #252) -----------------
+
+    /// Builds a per-branch GraphQL response envelope with the given thread nodes.
+    fn per_branch_prs_with_threads(threads: serde_json::Value) -> String {
+        serde_json::to_string(&json!({
+            "data": {
+                "repository": {
+                    "b_feat_branch": {
+                        "nodes": [{
+                            "number": 1,
+                            "headRefName": "feat/branch",
+                            "baseRefName": "main",
+                            "title": "Test",
+                            "state": "OPEN",
+                            "isDraft": false,
+                            "author": { "login": "dev" },
+                            "reviewDecision": null,
+                            "mergeable": "MERGEABLE",
+                            "labels": { "nodes": [] },
+                            "reviewRequests": { "nodes": [] },
+                            "reviews": { "nodes": [] },
+                            "reviewThreads": { "nodes": threads },
+                            "closingIssuesReferences": { "nodes": [] },
+                            "additions": 0,
+                            "deletions": 0,
+                            "createdAt": "2026-01-01T00:00:00Z",
+                            "updatedAt": "2026-01-02T00:00:00Z",
+                            "commits": { "nodes": [{ "commit": { "pushedDate": null, "statusCheckRollup": null } }] }
+                        }]
+                    }
+                }
+            }
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn unresolved_threads_counts_only_unresolved_and_not_outdated() {
+        let threads = json!([
+            {"isResolved": false, "isOutdated": false},
+            {"isResolved": false, "isOutdated": false},
+            {"isResolved": true,  "isOutdated": false},
+            {"isResolved": false, "isOutdated": true},
+            {"isResolved": true,  "isOutdated": true},
+        ]);
+
+        // parse_prs_graphql path
+        let json = graphql_prs(json!([{
+            "number": 1,
+            "headRefName": "feat/branch",
+            "state": "OPEN",
+            "reviewDecision": null,
+            "mergeable": "MERGEABLE",
+            "reviewThreads": { "nodes": threads.clone() },
+            "closingIssuesReferences": { "nodes": [] },
+            "commits": { "nodes": [{ "commit": { "statusCheckRollup": null } }] }
+        }]));
+        let prs = parse_prs_graphql(&json, &empty_matcher());
+        assert_eq!(prs[0].unresolved_threads, 2);
+
+        // parse_prs_graphql_per_branch path
+        let per_branch_json = per_branch_prs_with_threads(threads);
+        let prs_pb = parse_prs_graphql_per_branch(&per_branch_json, &empty_matcher());
+        assert_eq!(prs_pb[0].unresolved_threads, 2);
+    }
+
+    #[test]
+    fn unresolved_threads_zero_when_all_resolved_or_outdated() {
+        let threads = json!([
+            {"isResolved": true,  "isOutdated": false},
+            {"isResolved": false, "isOutdated": true},
+            {"isResolved": true,  "isOutdated": true},
+        ]);
+
+        let json = graphql_prs(json!([{
+            "number": 1,
+            "headRefName": "feat/branch",
+            "state": "OPEN",
+            "reviewDecision": null,
+            "mergeable": "MERGEABLE",
+            "reviewThreads": { "nodes": threads.clone() },
+            "closingIssuesReferences": { "nodes": [] },
+            "commits": { "nodes": [{ "commit": { "statusCheckRollup": null } }] }
+        }]));
+        let prs = parse_prs_graphql(&json, &empty_matcher());
+        assert_eq!(prs[0].unresolved_threads, 0);
+
+        let per_branch_json = per_branch_prs_with_threads(threads);
+        let prs_pb = parse_prs_graphql_per_branch(&per_branch_json, &empty_matcher());
+        assert_eq!(prs_pb[0].unresolved_threads, 0);
+    }
+
+    #[test]
+    fn parser_counts_thread_missing_is_outdated_as_unresolved() {
+        // Thread with only isResolved (no isOutdated key) — must be treated as not outdated.
+        let threads = json!([{"isResolved": false}]);
+
+        let json = graphql_prs(json!([{
+            "number": 1,
+            "headRefName": "feat/branch",
+            "state": "OPEN",
+            "reviewDecision": null,
+            "mergeable": "MERGEABLE",
+            "reviewThreads": { "nodes": threads.clone() },
+            "closingIssuesReferences": { "nodes": [] },
+            "commits": { "nodes": [{ "commit": { "statusCheckRollup": null } }] }
+        }]));
+        let prs = parse_prs_graphql(&json, &empty_matcher());
+        assert_eq!(prs[0].unresolved_threads, 1);
+
+        let per_branch_json = per_branch_prs_with_threads(threads);
+        let prs_pb = parse_prs_graphql_per_branch(&per_branch_json, &empty_matcher());
+        assert_eq!(prs_pb[0].unresolved_threads, 1);
+    }
+
+    #[test]
+    fn pr_graphql_query_includes_is_outdated_in_review_threads() {
+        let q = pr_graphql_query("owner", "repo");
+        // Strip all whitespace to be robust against formatting changes.
+        let compact: String = q.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            compact.contains("reviewThreads(first:100){nodes{isResolvedisOutdated}}"),
+            "expected reviewThreads to select isResolved and isOutdated, got: {q}"
+        );
+    }
+
+    #[test]
+    fn pr_graphql_query_per_branch_includes_is_outdated() {
+        let q = pr_graphql_query_per_branch("owner", "repo", &["branch-1".to_string()]);
+        let compact: String = q.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            compact.contains("isOutdated"),
+            "expected PrFields fragment to select isOutdated, got: {q}"
+        );
+        assert!(
+            compact.contains("isResolved"),
+            "expected PrFields fragment to select isResolved, got: {q}"
+        );
+    }
+
+    #[test]
+    fn pr_graphql_query_per_branch_uses_last_20_reviews() {
+        let q = pr_graphql_query_per_branch("owner", "repo", &["branch-1".to_string()]);
+        let compact: String = q.chars().filter(|c| !c.is_whitespace()).collect();
+        assert!(
+            compact.contains("reviews(last:20)"),
+            "expected reviews to use last:20, got: {q}"
+        );
     }
 }

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -506,14 +506,13 @@ impl From<&PrState> for JsonPr {
         let last = crate::review_comment::last_review_comment(&pr.reviews);
         let last_review_comment_at = last.as_ref().map(|l| l.at.clone());
         let last_review_comment_author = last.as_ref().map(|l| l.author.clone());
-        let has_unaddressed_author_comment =
-            crate::review_comment::has_unaddressed_author_comment(
-                pr.state.as_deref(),
-                pr.author.as_deref(),
-                last_review_comment_at.as_deref(),
-                last_review_comment_author.as_deref(),
-                pr.last_commit_pushed_at.as_deref(),
-            );
+        let has_unaddressed_author_comment = crate::review_comment::has_unaddressed_author_comment(
+            pr.state.as_deref(),
+            pr.author.as_deref(),
+            last_review_comment_at.as_deref(),
+            last_review_comment_author.as_deref(),
+            pr.last_commit_pushed_at.as_deref(),
+        );
         Self {
             number: pr.number,
             branch: pr.branch.clone(),
@@ -2047,8 +2046,7 @@ mod tests {
         let json_pr = JsonPr::from(&pr);
         let value = serde_json::to_value(&json_pr).unwrap();
         assert_eq!(
-            value["lastReviewCommentAt"],
-            "2024-01-03T12:00:00Z",
+            value["lastReviewCommentAt"], "2024-01-03T12:00:00Z",
             "expected max submittedAt"
         );
         assert_eq!(

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -503,8 +503,9 @@ impl From<&PrState> for JsonPr {
     /// `ci_code_state` only — so a code-green gate-blocked PR correctly serializes
     /// as `checksState: "passing"` without any coercion here.
     fn from(pr: &PrState) -> Self {
-        let (last_review_comment_at, last_review_comment_author) =
-            crate::review_comment::last_review_comment(&pr.reviews);
+        let last = crate::review_comment::last_review_comment(&pr.reviews);
+        let last_review_comment_at = last.as_ref().map(|l| l.at.clone());
+        let last_review_comment_author = last.as_ref().map(|l| l.author.clone());
         let has_unaddressed_author_comment =
             crate::review_comment::has_unaddressed_author_comment(
                 pr.state.as_deref(),
@@ -537,6 +538,10 @@ impl From<&PrState> for JsonPr {
             ci_checks: pr.ci_checks.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            // `unresolvedReviewThreads` is the forward name (matches issue #252).
+            // `unresolvedThreads` is retained as an alias until in-repo script
+            // consumers migrate. Both fields MUST stay equal — see the
+            // `json_pr_retains_legacy_unresolved_threads_alias` test.
             unresolved_review_threads: pr.unresolved_threads,
             last_review_comment_at,
             last_review_comment_author,

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -209,6 +209,15 @@ pub struct JsonPr {
     pub has_conflicts: bool,
     /// Number of unresolved review threads on the PR.
     pub unresolved_threads: u32,
+    /// Number of unresolved review threads (isResolved=false AND isOutdated=false).
+    /// Forward-compatibility alias for `unresolved_threads`.
+    pub unresolved_review_threads: u32,
+    /// ISO 8601 timestamp of the most recent top-level review, or null.
+    pub last_review_comment_at: Option<String>,
+    /// GitHub login of the author of the most recent top-level review, or null.
+    pub last_review_comment_author: Option<String>,
+    /// True iff a non-author review is more recent than the last author push on an open PR.
+    pub has_unaddressed_author_comment: bool,
     /// All GitHub labels on this PR, in the order returned by the API.
     pub labels: Vec<String>,
     /// Lines added by this PR.
@@ -494,6 +503,16 @@ impl From<&PrState> for JsonPr {
     /// `ci_code_state` only — so a code-green gate-blocked PR correctly serializes
     /// as `checksState: "passing"` without any coercion here.
     fn from(pr: &PrState) -> Self {
+        let (last_review_comment_at, last_review_comment_author) =
+            crate::review_comment::last_review_comment(&pr.reviews);
+        let has_unaddressed_author_comment =
+            crate::review_comment::has_unaddressed_author_comment(
+                pr.state.as_deref(),
+                pr.author.as_deref(),
+                last_review_comment_at.as_deref(),
+                last_review_comment_author.as_deref(),
+                pr.last_commit_pushed_at.as_deref(),
+            );
         Self {
             number: pr.number,
             branch: pr.branch.clone(),
@@ -518,6 +537,10 @@ impl From<&PrState> for JsonPr {
             ci_checks: pr.ci_checks.clone(),
             has_conflicts: pr.has_conflicts,
             unresolved_threads: pr.unresolved_threads,
+            unresolved_review_threads: pr.unresolved_threads,
+            last_review_comment_at,
+            last_review_comment_author,
+            has_unaddressed_author_comment,
             labels: pr.labels.clone(),
             additions: pr.additions,
             deletions: pr.deletions,
@@ -1912,5 +1935,124 @@ mod tests {
         wt.last_commit_at = Some(ts.to_string());
         let jw = JsonWorktree::from(&wt);
         assert_eq!(jw.last_activity_at.as_deref(), Some(ts));
+    }
+
+    // -----------------------------------------------------------------------
+    // review_comment field tests
+    // -----------------------------------------------------------------------
+
+    /// Builds a minimal PrState with no reviews for testing new review-comment fields.
+    #[allow(deprecated)]
+    fn make_pr_with_reviews(
+        author: Option<&str>,
+        state: Option<&str>,
+        reviews: Vec<crate::cache::CachedReview>,
+        last_commit_pushed_at: Option<&str>,
+    ) -> PrState {
+        use crate::ci_state::CiChecks;
+        PrState {
+            number: 1,
+            branch: "feat/test".to_string(),
+            state: state.map(|s| s.to_string()),
+            title: None,
+            is_draft: None,
+            author: author.map(|s| s.to_string()),
+            requested_reviewers: vec![],
+            reviews,
+            review_decision: None,
+            checks_state: None,
+            ci_code_state: None,
+            ci_gate_state: None,
+            ci_checks: CiChecks::default(),
+            has_conflicts: false,
+            unresolved_threads: 0,
+            labels: vec![],
+            additions: None,
+            deletions: None,
+            created_at: None,
+            updated_at: None,
+            last_commit_pushed_at: last_commit_pushed_at.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn json_pr_emits_all_four_new_fields_even_when_reviews_empty() {
+        let pr = make_pr_with_reviews(Some("alice"), Some("OPEN"), vec![], None);
+        let json_pr = JsonPr::from(&pr);
+        let value = serde_json::to_value(&json_pr).unwrap();
+        assert!(
+            value.get("unresolvedReviewThreads").is_some(),
+            "expected 'unresolvedReviewThreads' key"
+        );
+        assert!(
+            value.get("lastReviewCommentAt").is_some(),
+            "expected 'lastReviewCommentAt' key (should be null)"
+        );
+        assert!(
+            value.get("lastReviewCommentAuthor").is_some(),
+            "expected 'lastReviewCommentAuthor' key (should be null)"
+        );
+        assert!(
+            value.get("hasUnaddressedAuthorComment").is_some(),
+            "expected 'hasUnaddressedAuthorComment' key"
+        );
+        assert_eq!(value["lastReviewCommentAt"], serde_json::Value::Null);
+        assert_eq!(value["lastReviewCommentAuthor"], serde_json::Value::Null);
+        assert_eq!(value["hasUnaddressedAuthorComment"], false);
+    }
+
+    #[test]
+    fn json_pr_retains_legacy_unresolved_threads_alias() {
+        let mut pr = make_pr_with_reviews(None, Some("OPEN"), vec![], None);
+        pr.unresolved_threads = 3;
+        let json_pr = JsonPr::from(&pr);
+        let value = serde_json::to_value(&json_pr).unwrap();
+        assert!(
+            value.get("unresolvedThreads").is_some(),
+            "expected legacy 'unresolvedThreads' key"
+        );
+        assert!(
+            value.get("unresolvedReviewThreads").is_some(),
+            "expected 'unresolvedReviewThreads' key"
+        );
+        assert_eq!(value["unresolvedThreads"], 3);
+        assert_eq!(value["unresolvedReviewThreads"], 3);
+    }
+
+    #[test]
+    fn json_pr_populates_last_review_comment_fields_from_reviews() {
+        let reviews = vec![
+            crate::cache::CachedReview {
+                author: "charlie".to_string(),
+                state: "COMMENTED".to_string(),
+                submitted_at: Some("2024-01-01T08:00:00Z".to_string()),
+            },
+            crate::cache::CachedReview {
+                author: "bob".to_string(),
+                state: "CHANGES_REQUESTED".to_string(),
+                submitted_at: Some("2024-01-03T12:00:00Z".to_string()),
+            },
+        ];
+        let pr = make_pr_with_reviews(
+            Some("alice"),
+            Some("OPEN"),
+            reviews,
+            Some("2024-01-02T00:00:00Z"),
+        );
+        let json_pr = JsonPr::from(&pr);
+        let value = serde_json::to_value(&json_pr).unwrap();
+        assert_eq!(
+            value["lastReviewCommentAt"],
+            "2024-01-03T12:00:00Z",
+            "expected max submittedAt"
+        );
+        assert_eq!(
+            value["lastReviewCommentAuthor"], "bob",
+            "expected author of max review"
+        );
+        assert_eq!(
+            value["hasUnaddressedAuthorComment"], true,
+            "bob's review is after last push"
+        );
     }
 }

--- a/crates/orchard/src/lib.rs
+++ b/crates/orchard/src/lib.rs
@@ -34,6 +34,7 @@ pub mod priority;
 pub mod remote;
 pub mod remote_adapter;
 pub mod restore;
+pub mod review_comment;
 pub mod session;
 pub mod setup_remote;
 pub mod shell;

--- a/crates/orchard/src/review_comment.rs
+++ b/crates/orchard/src/review_comment.rs
@@ -135,7 +135,11 @@ mod tests {
     fn last_review_comment_state_agnostic() {
         let reviews = vec![
             review("reviewer1", "APPROVED", Some("2024-02-01T00:00:00Z")),
-            review("reviewer2", "CHANGES_REQUESTED", Some("2024-02-02T00:00:00Z")),
+            review(
+                "reviewer2",
+                "CHANGES_REQUESTED",
+                Some("2024-02-02T00:00:00Z"),
+            ),
             review("reviewer3", "COMMENTED", Some("2024-02-03T00:00:00Z")),
         ];
         let got = last_review_comment(&reviews).unwrap();

--- a/crates/orchard/src/review_comment.rs
+++ b/crates/orchard/src/review_comment.rs
@@ -4,22 +4,41 @@
 //! These fields are computed at serialization time (not cached) from
 //! `reviews: Vec<CachedReview>`, `pr.author`, `pr.state`, and
 //! `pr.last_commit_pushed_at`.
+//!
+//! Timestamp comparisons use lexicographic ordering on the raw strings.
+//! This is correct because GitHub's GraphQL `DateTime` scalar always
+//! returns ISO 8601 UTC-`Z` form (e.g. `"2026-04-13T21:11:53Z"`), which
+//! is lexicographically sortable. If the source format ever diverges
+//! (non-UTC offsets, `+00:00`), switch to `chrono` parsing.
 
 use crate::cache::CachedReview;
 
-/// Returns `(submittedAt, author)` of the most recent review by
-/// `submittedAt`. Reviews with a null `submitted_at` are ignored.
-/// State-agnostic: APPROVED, CHANGES_REQUESTED, and COMMENTED all count.
-pub fn last_review_comment(reviews: &[CachedReview]) -> (Option<String>, Option<String>) {
-    let best = reviews
+/// Most recent top-level review on a PR.
+///
+/// `at` and `author` are always populated together: `last_review_comment`
+/// returns `Some(LastReviewComment)` only when a review with a known
+/// `submitted_at` exists.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LastReviewComment {
+    /// ISO 8601 UTC timestamp (`submittedAt` from GitHub).
+    pub at: String,
+    /// GitHub login of the reviewer.
+    pub author: String,
+}
+
+/// Returns the most recent review by `submitted_at`, or `None` if no
+/// review has a known timestamp. Reviews with a null `submitted_at`
+/// are ignored. State-agnostic: APPROVED, CHANGES_REQUESTED, and
+/// COMMENTED all count.
+pub fn last_review_comment(reviews: &[CachedReview]) -> Option<LastReviewComment> {
+    reviews
         .iter()
         .filter(|r| r.submitted_at.is_some())
-        .max_by(|a, b| a.submitted_at.cmp(&b.submitted_at));
-
-    match best {
-        Some(r) => (r.submitted_at.clone(), Some(r.author.clone())),
-        None => (None, None),
-    }
+        .max_by(|a, b| a.submitted_at.cmp(&b.submitted_at))
+        .map(|r| LastReviewComment {
+            at: r.submitted_at.clone().expect("filtered Some above"),
+            author: r.author.clone(),
+        })
 }
 
 /// Returns true iff the PR has an unaddressed author comment:
@@ -91,16 +110,14 @@ mod tests {
             review("bob", "CHANGES_REQUESTED", Some("2024-01-03T12:00:00Z")),
             review("charlie", "COMMENTED", Some("2024-01-02T08:00:00Z")),
         ];
-        let (ts, author) = last_review_comment(&reviews);
-        assert_eq!(ts.as_deref(), Some("2024-01-03T12:00:00Z"));
-        assert_eq!(author.as_deref(), Some("bob"));
+        let got = last_review_comment(&reviews).unwrap();
+        assert_eq!(got.at, "2024-01-03T12:00:00Z");
+        assert_eq!(got.author, "bob");
     }
 
     #[test]
     fn last_review_comment_is_none_when_reviews_empty() {
-        let (ts, author) = last_review_comment(&[]);
-        assert_eq!(ts, None);
-        assert_eq!(author, None);
+        assert_eq!(last_review_comment(&[]), None);
     }
 
     #[test]
@@ -109,22 +126,21 @@ mod tests {
             review("alice", "APPROVED", None),
             review("bob", "COMMENTED", Some("2024-01-01T09:00:00Z")),
         ];
-        let (ts, author) = last_review_comment(&reviews);
-        assert_eq!(ts.as_deref(), Some("2024-01-01T09:00:00Z"));
-        assert_eq!(author.as_deref(), Some("bob"));
+        let got = last_review_comment(&reviews).unwrap();
+        assert_eq!(got.at, "2024-01-01T09:00:00Z");
+        assert_eq!(got.author, "bob");
     }
 
     #[test]
     fn last_review_comment_state_agnostic() {
-        // All three review states should be considered
         let reviews = vec![
             review("reviewer1", "APPROVED", Some("2024-02-01T00:00:00Z")),
             review("reviewer2", "CHANGES_REQUESTED", Some("2024-02-02T00:00:00Z")),
             review("reviewer3", "COMMENTED", Some("2024-02-03T00:00:00Z")),
         ];
-        let (ts, author) = last_review_comment(&reviews);
-        assert_eq!(ts.as_deref(), Some("2024-02-03T00:00:00Z"));
-        assert_eq!(author.as_deref(), Some("reviewer3"));
+        let got = last_review_comment(&reviews).unwrap();
+        assert_eq!(got.at, "2024-02-03T00:00:00Z");
+        assert_eq!(got.author, "reviewer3");
     }
 
     #[test]

--- a/crates/orchard/src/review_comment.rs
+++ b/crates/orchard/src/review_comment.rs
@@ -1,0 +1,254 @@
+//! Derivations over a PR's review timeline: last top-level review
+//! comment, and whether the PR has pending author feedback.
+//!
+//! These fields are computed at serialization time (not cached) from
+//! `reviews: Vec<CachedReview>`, `pr.author`, `pr.state`, and
+//! `pr.last_commit_pushed_at`.
+
+use crate::cache::CachedReview;
+
+/// Returns `(submittedAt, author)` of the most recent review by
+/// `submittedAt`. Reviews with a null `submitted_at` are ignored.
+/// State-agnostic: APPROVED, CHANGES_REQUESTED, and COMMENTED all count.
+pub fn last_review_comment(reviews: &[CachedReview]) -> (Option<String>, Option<String>) {
+    let best = reviews
+        .iter()
+        .filter(|r| r.submitted_at.is_some())
+        .max_by(|a, b| a.submitted_at.cmp(&b.submitted_at));
+
+    match best {
+        Some(r) => (r.submitted_at.clone(), Some(r.author.clone())),
+        None => (None, None),
+    }
+}
+
+/// Returns true iff the PR has an unaddressed author comment:
+/// - the PR is OPEN (false for MERGED/CLOSED/None)
+/// - `pr_author` is known
+/// - a review exists with a known author that is NOT the PR author
+/// - either `last_commit_pushed_at` is None, OR
+///   `last_review_comment_at > last_commit_pushed_at` (strict, string-compare OK — ISO-8601 lexicographic).
+pub fn has_unaddressed_author_comment(
+    pr_state: Option<&str>,
+    pr_author: Option<&str>,
+    last_review_comment_at: Option<&str>,
+    last_review_comment_author: Option<&str>,
+    last_commit_pushed_at: Option<&str>,
+) -> bool {
+    // Must be an open PR
+    let state = match pr_state {
+        Some(s) => s,
+        None => return false,
+    };
+    if !state.eq_ignore_ascii_case("OPEN") {
+        return false;
+    }
+
+    // PR author must be known
+    let author = match pr_author {
+        Some(a) => a,
+        None => return false,
+    };
+
+    // There must be a review from someone other than the PR author
+    let reviewer = match last_review_comment_author {
+        Some(r) => r,
+        None => return false,
+    };
+    if reviewer == author {
+        return false;
+    }
+
+    // The review timestamp must exist
+    let review_ts = match last_review_comment_at {
+        Some(ts) => ts,
+        None => return false,
+    };
+
+    // If no push timestamp, any non-author review is unaddressed
+    match last_commit_pushed_at {
+        None => true,
+        Some(push_ts) => review_ts > push_ts,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn review(author: &str, state: &str, submitted_at: Option<&str>) -> CachedReview {
+        CachedReview {
+            author: author.to_string(),
+            state: state.to_string(),
+            submitted_at: submitted_at.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn last_review_comment_is_max_submitted_at_across_all_reviews() {
+        let reviews = vec![
+            review("alice", "APPROVED", Some("2024-01-01T10:00:00Z")),
+            review("bob", "CHANGES_REQUESTED", Some("2024-01-03T12:00:00Z")),
+            review("charlie", "COMMENTED", Some("2024-01-02T08:00:00Z")),
+        ];
+        let (ts, author) = last_review_comment(&reviews);
+        assert_eq!(ts.as_deref(), Some("2024-01-03T12:00:00Z"));
+        assert_eq!(author.as_deref(), Some("bob"));
+    }
+
+    #[test]
+    fn last_review_comment_is_none_when_reviews_empty() {
+        let (ts, author) = last_review_comment(&[]);
+        assert_eq!(ts, None);
+        assert_eq!(author, None);
+    }
+
+    #[test]
+    fn last_review_comment_ignores_null_submitted_at() {
+        let reviews = vec![
+            review("alice", "APPROVED", None),
+            review("bob", "COMMENTED", Some("2024-01-01T09:00:00Z")),
+        ];
+        let (ts, author) = last_review_comment(&reviews);
+        assert_eq!(ts.as_deref(), Some("2024-01-01T09:00:00Z"));
+        assert_eq!(author.as_deref(), Some("bob"));
+    }
+
+    #[test]
+    fn last_review_comment_state_agnostic() {
+        // All three review states should be considered
+        let reviews = vec![
+            review("reviewer1", "APPROVED", Some("2024-02-01T00:00:00Z")),
+            review("reviewer2", "CHANGES_REQUESTED", Some("2024-02-02T00:00:00Z")),
+            review("reviewer3", "COMMENTED", Some("2024-02-03T00:00:00Z")),
+        ];
+        let (ts, author) = last_review_comment(&reviews);
+        assert_eq!(ts.as_deref(), Some("2024-02-03T00:00:00Z"));
+        assert_eq!(author.as_deref(), Some("reviewer3"));
+    }
+
+    #[test]
+    fn unaddressed_true_when_last_review_is_non_author_and_post_push() {
+        let result = has_unaddressed_author_comment(
+            Some("OPEN"),
+            Some("alice"),
+            Some("2024-01-05T12:00:00Z"),
+            Some("bob"),
+            Some("2024-01-04T10:00:00Z"),
+        );
+        assert!(result);
+    }
+
+    #[test]
+    fn unaddressed_false_when_last_review_is_self() {
+        // Reviewer is the same as PR author
+        let result = has_unaddressed_author_comment(
+            Some("OPEN"),
+            Some("alice"),
+            Some("2024-01-05T12:00:00Z"),
+            Some("alice"),
+            Some("2024-01-04T10:00:00Z"),
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn unaddressed_false_when_push_after_review() {
+        // Push is more recent than review → author has addressed it
+        let result = has_unaddressed_author_comment(
+            Some("OPEN"),
+            Some("alice"),
+            Some("2024-01-04T10:00:00Z"),
+            Some("bob"),
+            Some("2024-01-05T12:00:00Z"),
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn unaddressed_false_when_review_ts_equals_push_ts() {
+        // Tie → strict > so false
+        let result = has_unaddressed_author_comment(
+            Some("OPEN"),
+            Some("alice"),
+            Some("2024-01-05T10:00:00Z"),
+            Some("bob"),
+            Some("2024-01-05T10:00:00Z"),
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn unaddressed_false_when_no_reviews() {
+        // No last_review_comment_at → no reviews
+        let result = has_unaddressed_author_comment(
+            Some("OPEN"),
+            Some("alice"),
+            None,
+            None,
+            Some("2024-01-04T10:00:00Z"),
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn unaddressed_true_when_push_ts_is_null_and_non_author_review_exists() {
+        // No push timestamp → any non-author review counts
+        let result = has_unaddressed_author_comment(
+            Some("OPEN"),
+            Some("alice"),
+            Some("2024-01-05T12:00:00Z"),
+            Some("bob"),
+            None,
+        );
+        assert!(result);
+    }
+
+    #[test]
+    fn unaddressed_false_when_pr_author_is_null() {
+        let result = has_unaddressed_author_comment(
+            Some("OPEN"),
+            None,
+            Some("2024-01-05T12:00:00Z"),
+            Some("bob"),
+            None,
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn unaddressed_false_when_pr_state_is_merged() {
+        let result = has_unaddressed_author_comment(
+            Some("MERGED"),
+            Some("alice"),
+            Some("2024-01-05T12:00:00Z"),
+            Some("bob"),
+            None,
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn unaddressed_false_when_pr_state_is_closed() {
+        let result = has_unaddressed_author_comment(
+            Some("CLOSED"),
+            Some("alice"),
+            Some("2024-01-05T12:00:00Z"),
+            Some("bob"),
+            None,
+        );
+        assert!(!result);
+    }
+
+    #[test]
+    fn unaddressed_false_when_pr_state_is_none() {
+        let result = has_unaddressed_author_comment(
+            None,
+            Some("alice"),
+            Some("2024-01-05T12:00:00Z"),
+            Some("bob"),
+            None,
+        );
+        assert!(!result);
+    }
+}

--- a/crates/orchard/tests/review_comment_json_integration.rs
+++ b/crates/orchard/tests/review_comment_json_integration.rs
@@ -1,0 +1,214 @@
+//! End-to-end integration tests for Issue #252.
+//!
+//! `orchard --json` must expose four camelCase fields per PR:
+//! `unresolvedReviewThreads`, `lastReviewCommentAt`, `lastReviewCommentAuthor`,
+//! and `hasUnaddressedAuthorComment`. Legacy `unresolvedThreads` must be
+//! retained as an alias. Corresponds to the `@e2e` scenarios in
+//! `specs/features/unresolved-review-threads-json.feature`.
+mod common;
+
+use assert_cmd::Command;
+use common::{TestCacheDir, make_pr};
+use orchard::cache::{CachedPr, CachedReview};
+use serde_json::Value;
+
+const OWNER: &str = "acme";
+const REPO: &str = "webapp";
+const SLUG: &str = "acme/webapp";
+
+struct ReviewFixture {
+    home: tempfile::TempDir,
+    cache: TestCacheDir,
+    repo: common::TestRepo,
+}
+
+impl ReviewFixture {
+    fn new() -> Self {
+        let home = tempfile::TempDir::new().expect("create temp HOME");
+        let cache = TestCacheDir::new();
+        let repo = common::TestRepo::new();
+
+        std::fs::write(repo.path().join("README.md"), "test").expect("write README");
+        std::process::Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(repo.path())
+            .output()
+            .expect("git add");
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(repo.path())
+            .output()
+            .expect("git commit");
+
+        let config_dir = home.path().join(".config").join("orchard");
+        std::fs::create_dir_all(&config_dir).expect("create config dir");
+        let config_json = format!(
+            r#"{{"repos":[{{"slug":"{SLUG}","path":"{}"}}]}}"#,
+            repo.path().display()
+        );
+        std::fs::write(config_dir.join("config.json"), &config_json).expect("write config.json");
+
+        let home_cache = home.path().join(".cache").join("orchard");
+        std::fs::create_dir_all(&home_cache).expect("create cache dir");
+
+        Self { home, cache, repo }
+    }
+
+    fn checkout_branch(&self, branch: &str) {
+        std::process::Command::new("git")
+            .args(["checkout", "-b", branch])
+            .current_dir(self.repo.path())
+            .output()
+            .expect("git checkout -b");
+    }
+
+    fn current_branch(&self) -> String {
+        let out = std::process::Command::new("git")
+            .args(["rev-parse", "--abbrev-ref", "HEAD"])
+            .current_dir(self.repo.path())
+            .output()
+            .expect("git rev-parse");
+        String::from_utf8_lossy(&out.stdout).trim().to_string()
+    }
+
+    fn apply_cache(&self) {
+        let home_cache = self.home.path().join(".cache").join("orchard");
+        for entry in std::fs::read_dir(self.cache.path()).expect("read cache dir") {
+            let entry = entry.expect("dir entry");
+            let dest = home_cache.join(entry.file_name());
+            std::fs::copy(entry.path(), &dest).expect("copy cache file");
+        }
+    }
+
+    fn run(&self) -> Option<Value> {
+        let output = Command::cargo_bin("orchard")
+            .unwrap()
+            .arg("--json")
+            .current_dir(self.repo.path())
+            .env("HOME", self.home.path())
+            .env_remove("TMUX")
+            .output()
+            .unwrap();
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            eprintln!(
+                "SKIP review_comment_json_integration: orchard --json exited with {:?}. stderr: {}",
+                output.status.code(),
+                stderr.trim()
+            );
+            return None;
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        Some(serde_json::from_str(&stdout).expect("stdout should be valid JSON"))
+    }
+}
+
+fn find_pr_by_branch<'a>(output: &'a Value, branch: &str) -> Option<&'a Value> {
+    output["repos"].as_array()?.iter().find_map(|repo| {
+        repo["worktrees"]
+            .as_array()?
+            .iter()
+            .find(|wt| wt["branch"].as_str() == Some(branch))
+            .map(|wt| &wt["pr"])
+    })
+}
+
+/// `@e2e` Orchardist sees all four new fields on every PR in `orchard --json`.
+#[test]
+fn json_exposes_all_four_review_comment_fields_on_pr() {
+    let fixture = ReviewFixture::new();
+    fixture.checkout_branch("feat/review-fields");
+    let branch = fixture.current_branch();
+
+    let pr = CachedPr {
+        author: Some("drewdrewthis".to_string()),
+        last_commit_pushed_at: Some("2026-04-13T10:00:00Z".to_string()),
+        unresolved_threads: 1,
+        reviews: vec![
+            CachedReview {
+                author: "reviewer-1".to_string(),
+                state: "COMMENTED".to_string(),
+                submitted_at: Some("2026-04-13T21:11:53Z".to_string()),
+            },
+            CachedReview {
+                author: "drewdrewthis".to_string(),
+                state: "COMMENTED".to_string(),
+                submitted_at: Some("2026-04-13T09:00:00Z".to_string()),
+            },
+        ],
+        ..make_pr(101, &branch)
+    };
+
+    fixture.cache.write_issues(OWNER, REPO, &[]);
+    fixture.cache.write_prs(OWNER, REPO, &[pr]);
+    fixture.apply_cache();
+
+    let Some(output) = fixture.run() else { return };
+    let pr_json = find_pr_by_branch(&output, &branch).expect("PR should be in JSON output");
+
+    assert_eq!(
+        pr_json["unresolvedReviewThreads"].as_u64(),
+        Some(1),
+        "unresolvedReviewThreads must equal pr.unresolved_threads"
+    );
+    assert_eq!(
+        pr_json["unresolvedThreads"].as_u64(),
+        Some(1),
+        "legacy unresolvedThreads key must remain as alias"
+    );
+    assert_eq!(
+        pr_json["lastReviewCommentAt"].as_str(),
+        Some("2026-04-13T21:11:53Z")
+    );
+    assert_eq!(
+        pr_json["lastReviewCommentAuthor"].as_str(),
+        Some("reviewer-1")
+    );
+    assert_eq!(
+        pr_json["hasUnaddressedAuthorComment"].as_bool(),
+        Some(true),
+        "non-author comment after last push must flip hasUnaddressedAuthorComment true"
+    );
+}
+
+/// `@e2e` `jq` can filter PRs on `hasUnaddressedAuthorComment` without a follow-up API call.
+/// Exercised by asserting the field shape is jq-compatible across multiple PRs on multiple
+/// worktrees (boolean, always present, queryable via a path selector).
+#[test]
+fn json_has_unaddressed_author_comment_is_always_boolean() {
+    let fixture = ReviewFixture::new();
+    fixture.checkout_branch("feat/jq-filter");
+    let branch = fixture.current_branch();
+
+    // PR 101: non-author reviewer post-push → should be true.
+    let pr_unaddressed = CachedPr {
+        author: Some("drewdrewthis".to_string()),
+        last_commit_pushed_at: Some("2026-04-13T10:00:00Z".to_string()),
+        reviews: vec![CachedReview {
+            author: "reviewer-1".to_string(),
+            state: "COMMENTED".to_string(),
+            submitted_at: Some("2026-04-13T21:11:53Z".to_string()),
+        }],
+        ..make_pr(101, &branch)
+    };
+
+    fixture.cache.write_issues(OWNER, REPO, &[]);
+    fixture.cache.write_prs(OWNER, REPO, &[pr_unaddressed]);
+    fixture.apply_cache();
+
+    let Some(output) = fixture.run() else { return };
+    let pr_json = find_pr_by_branch(&output, &branch).expect("PR should be in JSON output");
+
+    // The field must exist as a boolean (not null, not missing) — this is the jq contract.
+    assert!(
+        pr_json["hasUnaddressedAuthorComment"].is_boolean(),
+        "hasUnaddressedAuthorComment must always be a boolean, got: {}",
+        pr_json["hasUnaddressedAuthorComment"]
+    );
+    assert_eq!(
+        pr_json["hasUnaddressedAuthorComment"].as_bool(),
+        Some(true)
+    );
+}

--- a/crates/orchard/tests/review_comment_json_integration.rs
+++ b/crates/orchard/tests/review_comment_json_integration.rs
@@ -207,8 +207,5 @@ fn json_has_unaddressed_author_comment_is_always_boolean() {
         "hasUnaddressedAuthorComment must always be a boolean, got: {}",
         pr_json["hasUnaddressedAuthorComment"]
     );
-    assert_eq!(
-        pr_json["hasUnaddressedAuthorComment"].as_bool(),
-        Some(true)
-    );
+    assert_eq!(pr_json["hasUnaddressedAuthorComment"].as_bool(), Some(true));
 }

--- a/specs/features/unresolved-review-threads-json.feature
+++ b/specs/features/unresolved-review-threads-json.feature
@@ -1,0 +1,338 @@
+Feature: Expose unresolved review threads and recent review comments in orchard --json
+  As an orchardist triaging PRs
+  I want unresolved review threads (filtered to actionable ones) and the most recent top-level review comment surfaced in `orchard --json`
+  So that I can report every blocker — CI, gate, conflicts, AND unaddressed author feedback — without drilling into `gh pr view` per PR
+
+  # Issue #252 — data-layer feature. Corrects the existing `unresolvedThreads` semantics
+  # (currently counts `isResolved != true`, must filter out `isOutdated == true`) and
+  # adds three new camelCase fields on `JsonPr`:
+  #   - `unresolvedReviewThreads` (replaces `unresolvedThreads`, with corrected semantics)
+  #   - `lastReviewCommentAt`     (most recent top-level Review.submittedAt, NOT inline thread)
+  #   - `lastReviewCommentAuthor` (same source)
+  #   - `hasUnaddressedAuthorComment` (derived)
+  #
+  # Source data already fetched by `pr_graphql_query_per_branch()`:
+  #   - `reviewThreads(first: 100) { nodes { isResolved } }` — MUST ALSO select `isOutdated`
+  #   - `reviews(first: 20)        { nodes { author{login} state submittedAt } }`
+  #   - `last_commit_pushed_at` — already on `Pr` (used for "subsequent push" detection)
+  #
+  # NAMING: the issue body writes the forward key as `unresolvedReviewThreads`.
+  # Both keys are emitted (same value). The legacy `unresolvedThreads` key is
+  # still consumed by scripts/orchard-decide.sh and scripts/orchard-monitor.sh
+  # and asserted by the phase-field-in-json and unified-service-architecture
+  # feature specs — removing it would break those call sites in-repo. Keep for
+  # one release; drop once callers migrate.
+  #
+  # KNOWN GAPS (out of scope — documenting, not solving):
+  # - Inline PR review-thread comments (`reviewThreads[].comments[]`) are NOT
+  #   surfaced. `lastReviewCommentAt` sources only the top-level `Review`
+  #   array, as the issue body specifies. A reviewer who leaves only inline
+  #   comments without submitting a top-level review will not trigger
+  #   `hasUnaddressedAuthorComment`. `unresolvedReviewThreads > 0` still
+  #   surfaces this case as a blocker — just not the "who commented when."
+  # - `hasUnaddressedAuthorComment` partially overlaps with
+  #   `reviewDecision == "CHANGES_REQUESTED"`. The new field covers the
+  #   `COMMENTED`/`APPROVED`-with-notes case that `reviewDecision` misses.
+  #   Downstream consumers should OR both signals, not dedupe.
+
+  Background:
+    Given the canonical `Pr` type already carries `unresolved_threads: u32`, `reviews: Vec<Review>`, `author`, and `last_commit_pushed_at`
+    And `pr_graphql_query_per_branch()` already fetches `reviewThreads(first: 100) { nodes { isResolved } }` and `reviews(first: 20) { nodes { author { login } state submittedAt } }`
+    And `parse_prs_graphql_per_branch()` currently computes `unresolved_threads` by counting `isResolved != true` WITHOUT filtering by `isOutdated`
+    And `JsonPr` serializes with `#[serde(rename_all = "camelCase")]`
+
+  # ===================================================================
+  # End-to-end — orchardist triage via `orchard --json`
+  # (covers issue AC #1, AC #2, AC #3 on the real binary)
+  # ===================================================================
+
+  @e2e
+  Scenario: Orchardist sees all three new fields on every PR in `orchard --json`
+    Given a fixture repo with an open PR #101 that has:
+      | attribute              | value                                                           |
+      | author                 | drewdrewthis                                                    |
+      | last_commit_pushed_at  | 2026-04-13T10:00:00Z                                            |
+      | reviewThreads          | [{isResolved:false, isOutdated:false}, {isResolved:true, isOutdated:false}, {isResolved:false, isOutdated:true}] |
+      | reviews                | [{author:"reviewer-1", state:"COMMENTED", submittedAt:"2026-04-13T21:11:53Z"}, {author:"drewdrewthis", state:"COMMENTED", submittedAt:"2026-04-13T09:00:00Z"}] |
+    When `orchard --json` is run against the fixture
+    Then the PR's `unresolvedReviewThreads` is 1
+    And the PR's `lastReviewCommentAt` is `"2026-04-13T21:11:53Z"`
+    And the PR's `lastReviewCommentAuthor` is `"reviewer-1"`
+    And the PR's `hasUnaddressedAuthorComment` is `true`
+
+  @e2e
+  Scenario: Orchardist filters PRs with `jq` on the new fields without follow-up API calls
+    Given `orchard --json` output for a repo containing three PRs:
+      | pr  | unresolvedReviewThreads | hasUnaddressedAuthorComment |
+      | 101 | 2                       | true                        |
+      | 102 | 0                       | false                       |
+      | 103 | 3                       | false                       |
+    When the orchardist runs `jq '.repos[].worktrees[] | select(.pr.hasUnaddressedAuthorComment == true) | .pr.number'`
+    Then the output is `101`
+    # Rationale: AC #3 — detection must be a pure jq filter, no second API round trip.
+
+  # ===================================================================
+  # Integration — GraphQL query shape (isOutdated is required)
+  # ===================================================================
+
+  @integration
+  Scenario: Compiled GraphQL query selects isOutdated on reviewThreads
+    Given the compiled PR GraphQL query strings from BOTH `pr_graphql_query()` and `pr_graphql_query_per_branch()`
+    Then each query contains `reviewThreads(first: 100)` with a node selection that includes BOTH `isResolved` AND `isOutdated`
+    # Rationale: cache_sources.rs has two GraphQL query builders + two parsers (L74/L242
+    # for the all-open-PRs path, L867/L948 for per-branch). Both must ship the new field
+    # or the non-per-branch refresh path silently keeps old semantics.
+
+  @integration
+  Scenario: Compiled GraphQL reviews selection returns the most recent 20 reviews, not the oldest
+    Given the compiled PR GraphQL query string
+    Then the `reviews` field is selected as `last: 20` (or equivalently `first: 20, orderBy: {field: CREATED_AT, direction: DESC}`)
+    # Rationale: default `first: 20` returns oldest-first. On PRs with >20 reviews
+    # the latest review is truncated and `lastReviewCommentAt` is stale by days.
+    # This is a bug in the existing query shape, surfaced by this feature.
+
+  @integration
+  Scenario: Parser skips thread nodes that lack isOutdated (backward-compat for stale fixtures / cache replay)
+    Given a GraphQL response `reviewThreads.nodes` = `[{isResolved: false}]` with no `isOutdated` key present
+    When the parser counts unresolved threads
+    Then the thread is counted as unresolved
+    And the parser emits a `LOG.warn` noting the missing field (so a real schema regression is not silently absorbed)
+    # Rationale: absence of `isOutdated` means "not known to be outdated" — treat as
+    # actionable. But log, don't swallow — distinguishes cache replay from schema drift.
+
+  @integration
+  Scenario: BOTH parser sites apply the isResolved AND isOutdated filter identically
+    Given `reviewThreads.nodes` = `[{isResolved:false,isOutdated:false}, {isResolved:false,isOutdated:true}]`
+    When `parse_prs_graphql()` is called (non-per-branch path)
+    And `parse_prs_graphql_per_branch()` is called (per-branch path)
+    Then both return `unresolved_threads = 1`
+    # Rationale: prevents cache churn where two refresh paths write different counts.
+
+  # ===================================================================
+  # Unit — unresolved_threads rollup semantics (covers AC #1)
+  # ===================================================================
+
+  @unit
+  Scenario: unresolved_threads counts only isResolved=false AND isOutdated=false
+    Given `reviewThreads.nodes` = `[{isResolved:false,isOutdated:false}, {isResolved:false,isOutdated:false}, {isResolved:true,isOutdated:false}, {isResolved:false,isOutdated:true}, {isResolved:true,isOutdated:true}]`
+    When `parse_prs_graphql_per_branch()` computes `unresolved_threads`
+    Then `unresolved_threads` is 2
+
+  @unit
+  Scenario: unresolved_threads is zero when every thread is either resolved or outdated
+    Given `reviewThreads.nodes` = `[{isResolved:true,isOutdated:false}, {isResolved:false,isOutdated:true}, {isResolved:true,isOutdated:true}]`
+    When `parse_prs_graphql_per_branch()` computes `unresolved_threads`
+    Then `unresolved_threads` is 0
+
+  @unit
+  Scenario: unresolved_threads is zero when reviewThreads.nodes is empty
+    Given `reviewThreads.nodes` = `[]`
+    When `parse_prs_graphql_per_branch()` computes `unresolved_threads`
+    Then `unresolved_threads` is 0
+
+  # ===================================================================
+  # Unit — last_review_comment_at / last_review_comment_author (covers AC #2)
+  # ===================================================================
+
+  @unit
+  Scenario: last_review_comment_at is the max submittedAt across all reviews
+    Given a PR's `reviews` = `[
+      {author:"a", state:"COMMENTED",         submittedAt:"2026-04-10T09:00:00Z"},
+      {author:"b", state:"APPROVED",          submittedAt:"2026-04-13T21:11:53Z"},
+      {author:"c", state:"CHANGES_REQUESTED", submittedAt:"2026-04-12T15:00:00Z"}
+    ]`
+    When `last_review_comment_at` and `last_review_comment_author` are derived
+    Then `last_review_comment_at` is `"2026-04-13T21:11:53Z"`
+    And `last_review_comment_author` is `"b"`
+
+  @unit
+  Scenario: last_review_comment_* are null when reviews is empty
+    Given a PR's `reviews` = `[]`
+    When `last_review_comment_at` and `last_review_comment_author` are derived
+    Then `last_review_comment_at` is null
+    And `last_review_comment_author` is null
+
+  @unit
+  Scenario: last_review_comment_* counts ALL review states, not just COMMENTED
+    Given a PR's `reviews` = `[
+      {author:"a", state:"APPROVED",          submittedAt:"2026-04-15T00:00:00Z"},
+      {author:"b", state:"CHANGES_REQUESTED", submittedAt:"2026-04-14T00:00:00Z"}
+    ]`
+    When `last_review_comment_at` and `last_review_comment_author` are derived
+    Then `last_review_comment_at` is `"2026-04-15T00:00:00Z"`
+    And `last_review_comment_author` is `"a"`
+    # Rationale: per issue body, source is "most recent top-level review" — state-agnostic.
+    # APPROVED and CHANGES_REQUESTED carry human feedback just as COMMENTED does.
+
+  @unit
+  Scenario: reviews with null submittedAt are ignored in last_review_comment_at
+    Given a PR's `reviews` = `[
+      {author:"a", state:"COMMENTED", submittedAt:"2026-04-14T00:00:00Z"},
+      {author:"b", state:"COMMENTED", submittedAt:null}
+    ]`
+    When `last_review_comment_at` and `last_review_comment_author` are derived
+    Then `last_review_comment_at` is `"2026-04-14T00:00:00Z"`
+    And `last_review_comment_author` is `"a"`
+
+  # ===================================================================
+  # Unit — has_unaddressed_author_comment logic (covers AC #3)
+  # ===================================================================
+
+  @unit
+  Scenario: has_unaddressed_author_comment is true when last review is non-author AND post-push
+    Given a PR where `author` is `"drewdrewthis"`
+    And `last_commit_pushed_at` is `"2026-04-13T10:00:00Z"`
+    And `last_review_comment_at` is `"2026-04-13T21:11:53Z"`
+    And `last_review_comment_author` is `"reviewer-1"`
+    When `has_unaddressed_author_comment` is derived
+    Then `has_unaddressed_author_comment` is `true`
+
+  @unit
+  Scenario: has_unaddressed_author_comment is false when the last review is by the PR author
+    Given a PR where `author` is `"drewdrewthis"`
+    And `last_commit_pushed_at` is `"2026-04-13T10:00:00Z"`
+    And `last_review_comment_at` is `"2026-04-13T21:11:53Z"`
+    And `last_review_comment_author` is `"drewdrewthis"`
+    When `has_unaddressed_author_comment` is derived
+    Then `has_unaddressed_author_comment` is `false`
+
+  @unit
+  Scenario: has_unaddressed_author_comment is false when a subsequent push from the author addressed the review
+    Given a PR where `author` is `"drewdrewthis"`
+    And `last_review_comment_at` is `"2026-04-13T10:00:00Z"`
+    And `last_commit_pushed_at` is `"2026-04-13T21:11:53Z"`
+    And `last_review_comment_author` is `"reviewer-1"`
+    When `has_unaddressed_author_comment` is derived
+    Then `has_unaddressed_author_comment` is `false`
+    # Rationale: push strictly after review means the author responded with code.
+
+  @unit
+  Scenario: has_unaddressed_author_comment is false when last_review_comment_at equals last_commit_pushed_at
+    Given a PR where `author` is `"drewdrewthis"`
+    And `last_review_comment_at` is `"2026-04-13T10:00:00Z"`
+    And `last_commit_pushed_at` is `"2026-04-13T10:00:00Z"`
+    And `last_review_comment_author` is `"reviewer-1"`
+    When `has_unaddressed_author_comment` is derived
+    Then `has_unaddressed_author_comment` is `false`
+    # Rationale: use strictly-greater-than ("comment AFTER push"). Ties resolve to
+    # "push addressed it" — safer default than surfacing a false positive.
+
+  @unit
+  Scenario: has_unaddressed_author_comment is false when there are no reviews at all
+    Given a PR where `author` is `"drewdrewthis"`
+    And `last_commit_pushed_at` is `"2026-04-13T10:00:00Z"`
+    And `last_review_comment_at` is null
+    And `last_review_comment_author` is null
+    When `has_unaddressed_author_comment` is derived
+    Then `has_unaddressed_author_comment` is `false`
+
+  @unit
+  Scenario: has_unaddressed_author_comment is true when last_commit_pushed_at is null and a non-author review exists
+    Given a PR where `author` is `"drewdrewthis"`
+    And `last_commit_pushed_at` is null
+    And `last_review_comment_at` is `"2026-04-13T21:11:53Z"`
+    And `last_review_comment_author` is `"reviewer-1"`
+    When `has_unaddressed_author_comment` is derived
+    Then `has_unaddressed_author_comment` is `true`
+    # Rationale: no known push timestamp means we cannot prove the author responded.
+    # Err toward surfacing the comment as unaddressed — a false positive here is
+    # cheap ("go look at the PR"), a false negative silences a blocker.
+
+  @unit
+  Scenario: has_unaddressed_author_comment is false when pr.author is null
+    Given a PR where `author` is null
+    And `last_commit_pushed_at` is `"2026-04-13T10:00:00Z"`
+    And `last_review_comment_at` is `"2026-04-13T21:11:53Z"`
+    And `last_review_comment_author` is `"reviewer-1"`
+    When `has_unaddressed_author_comment` is derived
+    Then `has_unaddressed_author_comment` is `false`
+    # Rationale: cannot compute "non-author" without a known PR author. Degrade to
+    # false rather than invent a value.
+
+  @unit
+  Scenario: has_unaddressed_author_comment is false for merged or closed PRs
+    Given a PR where `state` is `"MERGED"` (or `"CLOSED"`)
+    And a last review by a non-author `"reviewer-1"` post-push
+    When `has_unaddressed_author_comment` is derived
+    Then `has_unaddressed_author_comment` is `false`
+    # Rationale: triage signal only matters for open PRs. A merged PR with a late
+    # review comment is not a blocker; orchardist `jq` filter must not surface it.
+
+  # ===================================================================
+  # Unit — JsonPr wire contract
+  # ===================================================================
+
+  @unit
+  Scenario: JsonPr declares the three new camelCase fields
+    Then `JsonPr` (with `#[serde(rename_all = "camelCase")]`) defines:
+      | rust field                       | json key                      | type            |
+      | unresolved_review_threads        | unresolvedReviewThreads       | u32             |
+      | last_review_comment_at           | lastReviewCommentAt           | Option<String>  |
+      | last_review_comment_author       | lastReviewCommentAuthor       | Option<String>  |
+      | has_unaddressed_author_comment   | hasUnaddressedAuthorComment   | bool            |
+    And the legacy `unresolvedThreads` key is still emitted (same value) until in-repo script and spec consumers migrate
+
+  @unit
+  Scenario: JsonPr emits all four fields even when reviews is empty
+    Given a `Pr` with zero reviews, zero unresolved threads, and a known `last_commit_pushed_at`
+    When the PR is serialized via `JsonPr`
+    Then the JSON contains `"unresolvedReviewThreads": 0`
+    And the JSON contains `"lastReviewCommentAt": null`
+    And the JSON contains `"lastReviewCommentAuthor": null`
+    And the JSON contains `"hasUnaddressedAuthorComment": false`
+    # Rationale: downstream consumers (`jq` pipelines in the orchardist loop) must
+    # be able to assume all four keys exist — never `undefined`.
+
+  # ===================================================================
+  # Integration — cache migration / backward compat
+  # ===================================================================
+
+  @integration
+  Scenario: Old cache files without the new derived fields deserialize successfully
+    Given a cache file written by a previous orchard version where `Pr` lacks any derived last_review_comment fields
+    When the current orchard reads the cache file
+    Then deserialization succeeds
+    And after the next refresh, `unresolvedReviewThreads`, `lastReviewCommentAt`, `lastReviewCommentAuthor`, and `hasUnaddressedAuthorComment` are all populated from the GraphQL response
+    # Rationale: the three new fields are derived from `reviews` + `last_commit_pushed_at`
+    # at serialization time (not stored), so nothing new lands in the cache schema
+    # beyond the already-present `reviews` array. Deserialization must be tolerant.
+
+  # --- AC Coverage Map ---
+  # Issue AC 1: "orchard --json includes unresolvedReviewThreads for each PR"
+  #   → @e2e Orchardist sees all three new fields on every PR in `orchard --json`
+  #   → @integration Compiled GraphQL query selects isOutdated on reviewThreads (BOTH query builders)
+  #   → @integration Compiled GraphQL reviews selection returns most recent 20 reviews
+  #   → @integration Parser skips thread nodes that lack isOutdated (with warn log)
+  #   → @integration BOTH parser sites apply the filter identically
+  #   → @unit unresolved_threads counts only isResolved=false AND isOutdated=false
+  #   → @unit unresolved_threads is zero when every thread is either resolved or outdated
+  #   → @unit unresolved_threads is zero when reviewThreads.nodes is empty
+  #   → @unit JsonPr declares the three new camelCase fields
+  #   → @unit JsonPr emits all four fields even when reviews is empty
+  #   → @integration Old cache files without the new derived fields deserialize successfully
+  #
+  # Issue AC 2: "orchard --json includes last review comment timestamp + author"
+  #   → @e2e Orchardist sees all three new fields on every PR in `orchard --json`
+  #   → @unit last_review_comment_at is the max submittedAt across all reviews
+  #   → @unit last_review_comment_* are null when reviews is empty
+  #   → @unit last_review_comment_* counts ALL review states, not just COMMENTED
+  #   → @unit reviews with null submittedAt are ignored in last_review_comment_at
+  #   → @unit JsonPr declares the three new camelCase fields
+  #
+  # Issue AC 3: "Orchardist can detect 'PR has pending author feedback' without additional API calls"
+  #   → @e2e Orchardist filters PRs with `jq` on the new fields without follow-up API calls
+  #   → @e2e Orchardist sees all three new fields on every PR in `orchard --json`
+  #   → @unit has_unaddressed_author_comment is true when last review is non-author AND post-push
+  #   → @unit has_unaddressed_author_comment is false when the last review is by the PR author
+  #   → @unit has_unaddressed_author_comment is false when a subsequent push from the author addressed the review
+  #   → @unit has_unaddressed_author_comment is false when last_review_comment_at equals last_commit_pushed_at
+  #   → @unit has_unaddressed_author_comment is false when there are no reviews at all
+  #   → @unit has_unaddressed_author_comment is true when last_commit_pushed_at is null and a non-author review exists
+  #   → @unit has_unaddressed_author_comment is false when pr.author is null
+  #   → @unit has_unaddressed_author_comment is false for merged or closed PRs
+  #   → @unit JsonPr declares the three new camelCase fields
+  #   → @unit JsonPr emits all four fields even when reviews is empty
+  #
+  # AC count: 3. Every AC has ≥1 mapped scenario. Scope: strict — no field additions
+  # beyond those named in the issue body. `unresolvedThreads` legacy key retained
+  # for one-release deprecation (backward compat hygiene, not a new AC).


### PR DESCRIPTION
Closes #252.

## Summary
- Adds derived JSON fields on `pr`: `unresolvedReviewThreads`, `lastReviewCommentAt`, `lastReviewCommentAuthor`, `hasUnaddressedAuthorComment`.
- Corrects `unresolvedThreads` semantics: now excludes outdated threads (`isResolved=false AND isOutdated=false`). Legacy `unresolvedThreads` key retained as alias.
- Fixes `reviews` GraphQL truncation on busy PRs by switching to `last: 20`.

## Progress
- [x] AC1: GraphQL — select `isOutdated`, use `reviews(last:20)`
- [x] AC2: Both parsers apply the new filter; warn on missing `isOutdated`
- [ ] AC3: Derive `lastReviewCommentAt` / `lastReviewCommentAuthor`
- [ ] AC4: Derive `hasUnaddressedAuthorComment`
- [ ] AC5: Wire the 4 new camelCase fields into `JsonPr`
- [ ] AC6: End-to-end verification via `orchard --json`

## Test plan
- [ ] `cargo test -p orchard` green
- [ ] Manual `orchard --json` against a repo with an open PR shows all four fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #252

# Related issue

- #252

# Related issue

- #252

# Related issue

- #252

# Related issue

- #252