### PR TITLE
fix(perf): parallelize gh api, enforce hard SSH probe deadline

### DIFF
--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -321,12 +321,18 @@ pub fn refresh_and_build(config: &GlobalConfig) -> OrchardState {
     // refresh, so the subsequent tmux listing already reflects them.
     let _ = crate::restore::restore_all_local();
 
-    // Refresh local sources first.
-    for repo in &config.repos {
-        let _ = sources::worktrees::refresh_local(repo);
-        let _ = sources::github::refresh_issues(repo);
-        let _ = sources::github::refresh_prs(repo);
-    }
+    // Refresh local sources. Per-repo refreshes fan out concurrently so
+    // GitHub API latency for one repo can't block another. Each repo writes
+    // its own cache files, so there's no shared mutable state to guard.
+    std::thread::scope(|s| {
+        for repo in &config.repos {
+            s.spawn(move || {
+                let _ = sources::worktrees::refresh_local(repo);
+                let _ = sources::github::refresh_issues(repo);
+                let _ = sources::github::refresh_prs(repo);
+            });
+        }
+    });
     let _ = sources::tmux::refresh_local();
 
     // Probe remote hosts concurrently so a dead VM can't block healthy ones.
@@ -339,23 +345,46 @@ pub fn refresh_and_build(config: &GlobalConfig) -> OrchardState {
         .iter()
         .map(|(h, r)| (h.clone(), HostState { reachable: *r }))
         .collect();
-    let reachable_hosts: HashSet<String> = probe_results
-        .iter()
-        .filter_map(|(h, r)| if *r { Some(h.clone()) } else { None })
-        .collect();
 
-    // Refresh remote sources for every reachable host, once per (repo, remote) pair.
-    let mut tmux_refreshed: HashSet<String> = HashSet::new();
-    for repo in &config.repos {
-        for remote in &repo.remotes {
-            if reachable_hosts.contains(&remote.host) {
-                let _ = sources::worktrees::refresh_remote(repo, remote);
-                if tmux_refreshed.insert(remote.host.clone()) {
-                    let _ = sources::tmux::refresh_remote_adapter(repo, remote);
+    // Refresh remote sources in parallel. Worktree refreshes fan out by
+    // (repo, remote) pair; adapter-routed tmux refreshes fan out once per
+    // unique host (picking any (repo, remote) whose host matches). Each
+    // writes its own cache file so no coordination is needed.
+    let tmux_dispatch: Vec<(
+        &crate::global_config::RepoConfig,
+        &crate::global_config::RemoteConfig,
+    )> = {
+        let mut seen = HashSet::new();
+        config
+            .repos
+            .iter()
+            .flat_map(|r| r.remotes.iter().map(move |rm| (r, rm)))
+            .filter(|(_, rm)| {
+                hosts.get(&rm.host).map(|s| s.reachable).unwrap_or(false)
+                    && seen.insert(rm.host.clone())
+            })
+            .collect()
+    };
+    std::thread::scope(|s| {
+        for repo in &config.repos {
+            for remote in &repo.remotes {
+                let reachable = hosts
+                    .get(&remote.host)
+                    .map(|st| st.reachable)
+                    .unwrap_or(false);
+                if reachable {
+                    s.spawn(move || {
+                        let _ = sources::worktrees::refresh_remote(repo, remote);
+                    });
                 }
             }
         }
-    }
+        for (repo, remote) in &tmux_dispatch {
+            s.spawn(move || {
+                let _ = sources::tmux::refresh_remote_adapter(repo, remote);
+            });
+        }
+    });
 
     build_state_with_hosts(config, &hosts)
 }

--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -322,16 +322,11 @@ pub fn refresh_and_build(config: &GlobalConfig) -> OrchardState {
     let _ = crate::restore::restore_all_local();
 
     // Refresh local sources. Per-repo refreshes fan out concurrently so
-    // GitHub API latency for one repo can't block another. Each repo writes
-    // its own cache files, so there's no shared mutable state to guard.
-    std::thread::scope(|s| {
-        for repo in &config.repos {
-            s.spawn(move || {
-                let _ = sources::worktrees::refresh_local(repo);
-                let _ = sources::github::refresh_issues(repo);
-                let _ = sources::github::refresh_prs(repo);
-            });
-        }
+    // GitHub API latency for one repo can't block another.
+    crate::refresh_parallel::for_each_repo_parallel(config, |repo| {
+        let _ = sources::worktrees::refresh_local(repo);
+        let _ = sources::github::refresh_issues(repo);
+        let _ = sources::github::refresh_prs(repo);
     });
     let _ = sources::tmux::refresh_local();
 

--- a/crates/orchard/src/lib.rs
+++ b/crates/orchard/src/lib.rs
@@ -31,6 +31,7 @@ pub mod notify;
 pub mod orchard_state;
 pub mod paths;
 pub mod priority;
+pub mod refresh_parallel;
 pub mod remote;
 pub mod remote_adapter;
 pub mod restore;

--- a/crates/orchard/src/refresh_parallel.rs
+++ b/crates/orchard/src/refresh_parallel.rs
@@ -1,0 +1,146 @@
+//! Parallel fan-out helpers for refresh pipelines.
+//!
+//! Every caller that refreshes per-repo caches, per-(repo, remote) caches, or
+//! per-unique-host caches fans the work out with [`std::thread::scope`] so that
+//! one slow GitHub API call or SSH round-trip can't block another. The bodies
+//! live here so the same ergonomics and invariants (scoped borrows, caller
+//! logs failures, closures must not panic) apply everywhere.
+//!
+//! Invariants callers must uphold:
+//! * Each refresh writes to its own cache file, so no shared mutable state
+//!   crosses thread boundaries.
+//! * The closure must not panic — `std::thread::scope` propagates panics from
+//!   any thread when the scope is dropped, which would abort the refresh for
+//!   every other repo/host. In practice all `refresh_*` functions return
+//!   `anyhow::Result` and never panic.
+
+use std::collections::HashSet;
+
+use crate::global_config::{GlobalConfig, RepoConfig};
+
+/// Runs `f` once per configured repo, in parallel.
+///
+/// Each closure invocation borrows its `RepoConfig` for the lifetime of the
+/// scope. All threads join before the function returns.
+pub fn for_each_repo_parallel<F>(config: &GlobalConfig, f: F)
+where
+    F: Fn(&RepoConfig) + Sync,
+{
+    std::thread::scope(|s| {
+        for repo in &config.repos {
+            let f_ref = &f;
+            s.spawn(move || f_ref(repo));
+        }
+    });
+}
+
+/// Returns the set of unique reachable hosts across all repo remotes, in
+/// declaration order. Used to dedupe per-host work (like a single tmux
+/// refresh) when multiple repos reference the same remote.
+pub fn unique_reachable_hosts(
+    config: &GlobalConfig,
+    reachable: impl Fn(&str) -> bool,
+) -> Vec<String> {
+    let mut seen = HashSet::new();
+    config
+        .repos
+        .iter()
+        .flat_map(|r| r.remotes.iter().map(|rm| rm.host.clone()))
+        .filter(|h| reachable(h) && seen.insert(h.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::global_config::RemoteConfig;
+    use crate::remote_adapter::RemoteKind;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    fn repo(slug: &str, hosts: &[&str]) -> RepoConfig {
+        RepoConfig {
+            slug: slug.to_string(),
+            path: format!("/tmp/{slug}"),
+            remotes: hosts
+                .iter()
+                .map(|h| RemoteConfig {
+                    name: h.to_string(),
+                    host: h.to_string(),
+                    path: "~/src".to_string(),
+                    shell: "ssh".to_string(),
+                    kind: RemoteKind::Remmy,
+                })
+                .collect(),
+        }
+    }
+
+    /// Regression: refreshes must dispatch concurrently, not serially. With
+    /// three repos that each sleep 200ms, serial execution would take ~600ms;
+    /// the fan-out should finish near 200ms. 500ms budget tolerates scheduler
+    /// jitter on CI.
+    #[test]
+    fn for_each_repo_parallel_runs_concurrently() {
+        let config = GlobalConfig {
+            repos: vec![repo("a/a", &[]), repo("b/b", &[]), repo("c/c", &[])],
+            ..GlobalConfig::default()
+        };
+        let count = Arc::new(AtomicUsize::new(0));
+        let count_c = count.clone();
+
+        let start = Instant::now();
+        for_each_repo_parallel(&config, move |_r| {
+            thread::sleep(Duration::from_millis(200));
+            count_c.fetch_add(1, Ordering::SeqCst);
+        });
+        let elapsed = start.elapsed();
+
+        assert_eq!(count.load(Ordering::SeqCst), 3);
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "expected parallel dispatch (<500ms, serial would be ~600ms), got {:?}",
+            elapsed
+        );
+    }
+
+    #[test]
+    fn unique_reachable_hosts_dedupes_and_filters() {
+        let config = GlobalConfig {
+            repos: vec![
+                repo("a/a", &["host-alive", "host-dead"]),
+                repo("b/b", &["host-alive", "host-other"]),
+            ],
+            ..GlobalConfig::default()
+        };
+        let alive: HashSet<&str> = ["host-alive", "host-other"].into_iter().collect();
+
+        let hosts = unique_reachable_hosts(&config, |h| alive.contains(h));
+        assert_eq!(
+            hosts,
+            vec!["host-alive".to_string(), "host-other".to_string()]
+        );
+    }
+
+    #[test]
+    fn for_each_repo_parallel_passes_each_repo_exactly_once() {
+        let config = GlobalConfig {
+            repos: vec![repo("a/a", &[]), repo("b/b", &[]), repo("c/c", &[])],
+            ..GlobalConfig::default()
+        };
+        let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_c = seen.clone();
+
+        for_each_repo_parallel(&config, move |r| {
+            seen_c.lock().unwrap().push(r.slug.clone());
+        });
+
+        let mut slugs = seen.lock().unwrap().clone();
+        slugs.sort();
+        assert_eq!(
+            slugs,
+            vec!["a/a".to_string(), "b/b".to_string(), "c/c".to_string()]
+        );
+    }
+}

--- a/crates/orchard/src/sources/hosts.rs
+++ b/crates/orchard/src/sources/hosts.rs
@@ -1,8 +1,9 @@
 //! SSH host reachability probes.
 //!
 //! Simple SSH connectivity checks for remote hosts. Used to determine if a host is
-//! reachable before attempting worktree or tmux operations on it. Probes run with a
-//! 5-second connect timeout (set in `remote::ssh_flags()`), so dead hosts fail fast.
+//! reachable before attempting worktree or tmux operations on it. Probes enforce a
+//! hard 5-second wall-clock deadline via [`crate::remote::ssh_exec_with_timeout`],
+//! so a frozen handshake or post-auth hang can't exceed the budget.
 //!
 //! The concurrent entry point is [`probe_reachability_all_for_remotes`], which
 //! accepts full `RemoteConfig` entries so each host is probed with the correct
@@ -12,6 +13,15 @@
 use crate::global_config::{GlobalConfig, RemoteConfig};
 use std::collections::HashMap;
 use std::thread;
+use std::time::Duration;
+
+/// Hard wall-clock deadline for a single host reachability probe.
+///
+/// `ssh -o ConnectTimeout=5` alone is unreliable: a silently-dropping VM or a
+/// hung remote sshd can let the probe run well past the intended budget.
+/// Wrapping the probe in [`crate::remote::ssh_exec_with_timeout`] forces a
+/// kill after this deadline regardless of SSH's internal state.
+pub const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Returns every `RemoteConfig` configured across all repos in `config`.
 ///
@@ -35,13 +45,16 @@ pub fn remotes_from_config(config: &GlobalConfig) -> Vec<RemoteConfig> {
 /// `list --json` is the canonical health check there. Using the wrong probe
 /// would mark a perfectly healthy golden host as unreachable and silence
 /// every fork behind it.
-pub(crate) fn probe_reachability_for_remote(remote: &RemoteConfig) -> bool {
+///
+/// Returns `true` if the host responds within [`PROBE_TIMEOUT`], `false` if
+/// the host is unreachable, SSH fails, or the wall-clock deadline expires.
+pub fn probe_reachability_for_remote(remote: &RemoteConfig) -> bool {
     let cmd = match remote.kind {
         crate::remote_adapter::RemoteKind::BoxdFork => "list --json",
         crate::remote_adapter::RemoteKind::Remmy
         | crate::remote_adapter::RemoteKind::BoxdShared => "true",
     };
-    crate::remote::ssh_exec(&remote.host, cmd).is_ok()
+    crate::remote::ssh_exec_with_timeout(&remote.host, cmd, PROBE_TIMEOUT).is_ok()
 }
 
 /// Probes many (host, kind-aware) remotes concurrently.
@@ -115,6 +128,10 @@ mod tests {
         }
     }
 
+    fn ssh_binary_present() -> bool {
+        std::process::Command::new("ssh").arg("-V").output().is_ok()
+    }
+
     /// Locks in the documented contract: `remotes_from_config` returns remotes
     /// in config-iteration order and *preserves duplicates across repos*. Dedup
     /// is the responsibility of `probe_reachability_all_for_remotes`, not this
@@ -139,6 +156,40 @@ mod tests {
         cfg.repos.push(repo("a/one", &[]));
 
         assert!(remotes_from_config(&cfg).is_empty());
+    }
+
+    /// Regression test for issue #246: `probe_reachability_for_remote` must
+    /// enforce a hard wall-clock deadline, not trust SSH's `ConnectTimeout=5`
+    /// alone. A frozen handshake or a post-auth hang previously let a single
+    /// probe exceed 15s. With `ssh_exec_with_timeout`, the probe returns
+    /// within `PROBE_TIMEOUT` + small jitter regardless of the underlying SSH
+    /// state. 192.0.2.1 (TEST-NET-1, RFC 5737) is guaranteed unroutable.
+    #[test]
+    fn probe_reachability_enforces_hard_deadline() {
+        if !ssh_binary_present() {
+            eprintln!("SKIP: ssh binary not available");
+            return;
+        }
+
+        let remote = crate::global_config::RemoteConfig {
+            name: "test".to_string(),
+            host: "192.0.2.1".to_string(),
+            path: "/tmp".to_string(),
+            shell: "ssh".to_string(),
+            kind: crate::remote_adapter::RemoteKind::Remmy,
+        };
+
+        let start = Instant::now();
+        let reachable = probe_reachability_for_remote(&remote);
+        let elapsed = start.elapsed();
+
+        assert!(!reachable, "unroutable host must probe as unreachable");
+        assert!(
+            elapsed < PROBE_TIMEOUT + Duration::from_millis(1500),
+            "probe must respect PROBE_TIMEOUT ({:?}); got {:?}",
+            PROBE_TIMEOUT,
+            elapsed
+        );
     }
 
     /// Regression test for issue #263: serial probing lets one dead host block

--- a/crates/orchard/src/sources/hosts.rs
+++ b/crates/orchard/src/sources/hosts.rs
@@ -2,8 +2,9 @@
 //!
 //! Simple SSH connectivity checks for remote hosts. Used to determine if a host is
 //! reachable before attempting worktree or tmux operations on it. Probes enforce a
-//! hard 5-second wall-clock deadline via [`crate::remote::ssh_exec_with_timeout`],
-//! so a frozen handshake or post-auth hang can't exceed the budget.
+//! hard wall-clock deadline (see [`PROBE_TIMEOUT`]) via
+//! [`crate::remote::ssh_exec_with_timeout`], so a frozen handshake or post-auth
+//! hang can't exceed the budget.
 //!
 //! The concurrent entry point is [`probe_reachability_all_for_remotes`], which
 //! accepts full `RemoteConfig` entries so each host is probed with the correct

--- a/crates/orchard/src/sources/hosts.rs
+++ b/crates/orchard/src/sources/hosts.rs
@@ -17,11 +17,13 @@ use std::time::Duration;
 
 /// Hard wall-clock deadline for a single host reachability probe.
 ///
-/// `ssh -o ConnectTimeout=5` alone is unreliable: a silently-dropping VM or a
-/// hung remote sshd can let the probe run well past the intended budget.
-/// Wrapping the probe in [`crate::remote::ssh_exec_with_timeout`] forces a
-/// kill after this deadline regardless of SSH's internal state.
-pub const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+/// Tighter than SSH's own `ConnectTimeout=5` so that `orchard --json`
+/// can complete in under 5s even when every configured host is dead
+/// (see #246 ACs #4/#5). A silently-dropping VM or hung remote sshd
+/// can otherwise let the probe run well past the intended budget;
+/// wrapping the probe in [`crate::remote::ssh_exec_with_timeout`]
+/// forces a kill after this deadline regardless of SSH's internal state.
+pub const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Returns every `RemoteConfig` configured across all repos in `config`.
 ///

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -689,21 +689,15 @@ impl App {
             }
 
             // Fan out per-repo refreshes so GitHub API latency for one repo
-            // can't block another. Each repo writes its own cache files, so
-            // there's no shared mutable state to guard.
-            std::thread::scope(|s| {
-                for repo in &config.repos {
-                    let reachable_hosts = &reachable_hosts;
-                    s.spawn(move || {
-                        let _ = cache_sources::refresh_issues(repo);
-                        let _ = cache_sources::refresh_prs(repo);
-                        let _ = cache_sources::refresh_worktrees(repo);
-                        for remote in &repo.remotes {
-                            if reachable_hosts.contains(&remote.host) {
-                                let _ = cache_sources::refresh_remote_worktrees(repo, remote);
-                            }
-                        }
-                    });
+            // can't block another.
+            crate::refresh_parallel::for_each_repo_parallel(&config, |repo| {
+                let _ = cache_sources::refresh_issues(repo);
+                let _ = cache_sources::refresh_prs(repo);
+                let _ = cache_sources::refresh_worktrees(repo);
+                for remote in &repo.remotes {
+                    if reachable_hosts.contains(&remote.host) {
+                        let _ = cache_sources::refresh_remote_worktrees(repo, remote);
+                    }
                 }
             });
             // Refresh tmux sessions (local).

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -742,6 +742,10 @@ impl App {
         let config = self.global_config.clone();
         let tx = self.tx.clone();
         std::thread::spawn(move || {
+            // Local-only refresh runs `git worktree list` per repo — no SSH,
+            // no GitHub API. Each call is single-digit milliseconds, so
+            // parallel dispatch would add thread-spawn overhead without a
+            // measurable win. Stay serial.
             for repo in &config.repos {
                 let _ = cache_sources::refresh_worktrees(repo);
             }

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -688,30 +688,51 @@ impl App {
                 }
             }
 
-            for repo in &config.repos {
-                let _ = cache_sources::refresh_issues(repo);
-                let _ = cache_sources::refresh_prs(repo);
-                let _ = cache_sources::refresh_worktrees(repo);
-                for remote in &repo.remotes {
-                    if reachable_hosts.contains(&remote.host) {
-                        let _ = cache_sources::refresh_remote_worktrees(repo, remote);
-                    }
+            // Fan out per-repo refreshes so GitHub API latency for one repo
+            // can't block another. Each repo writes its own cache files, so
+            // there's no shared mutable state to guard.
+            std::thread::scope(|s| {
+                for repo in &config.repos {
+                    let reachable_hosts = &reachable_hosts;
+                    s.spawn(move || {
+                        let _ = cache_sources::refresh_issues(repo);
+                        let _ = cache_sources::refresh_prs(repo);
+                        let _ = cache_sources::refresh_worktrees(repo);
+                        for remote in &repo.remotes {
+                            if reachable_hosts.contains(&remote.host) {
+                                let _ = cache_sources::refresh_remote_worktrees(repo, remote);
+                            }
+                        }
+                    });
                 }
-            }
+            });
             // Refresh tmux sessions (local).
             let _ = cache_sources::refresh_tmux_sessions(None);
-            // Refresh remote tmux sessions for reachable hosts only.
-            let mut tmux_hosts_refreshed: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
-            for repo in &config.repos {
-                for remote in &repo.remotes {
-                    if reachable_hosts.contains(&remote.host)
-                        && tmux_hosts_refreshed.insert(remote.host.clone())
-                    {
+            // Refresh remote tmux sessions for reachable hosts, one unique
+            // host per thread so SSH latency is parallel across hosts. Route
+            // via the adapter so boxd-fork remotes hit the correct per-fork
+            // host rather than always the gateway.
+            let tmux_dispatch: Vec<(
+                &crate::global_config::RepoConfig,
+                &crate::global_config::RemoteConfig,
+            )> = {
+                let mut seen = std::collections::HashSet::new();
+                config
+                    .repos
+                    .iter()
+                    .flat_map(|r| r.remotes.iter().map(move |rm| (r, rm)))
+                    .filter(|(_, rm)| {
+                        reachable_hosts.contains(&rm.host) && seen.insert(rm.host.clone())
+                    })
+                    .collect()
+            };
+            std::thread::scope(|s| {
+                for (repo, remote) in &tmux_dispatch {
+                    s.spawn(move || {
                         let _ = cache_sources::refresh_remote_tmux_sessions(repo, remote);
-                    }
+                    });
                 }
-            }
+            });
             // Ensure a main tmux session exists for each configured repo.
             ensure_main_sessions(&config);
             // Signal that caches are updated.

--- a/crates/orchard/src/watch/daemon.rs
+++ b/crates/orchard/src/watch/daemon.rs
@@ -144,22 +144,17 @@ pub fn run(config: &GlobalConfig) -> anyhow::Result<()> {
 /// Refreshes all sources: issues, PRs, worktrees, and tmux sessions for each repo.
 ///
 /// Per-repo refreshes fan out concurrently so one slow GitHub API response
-/// can't delay the next repo. Each refresh writes its own cache file, so no
-/// coordination is needed between threads.
+/// can't delay the next repo.
 fn refresh_all_sources(config: &GlobalConfig) {
-    std::thread::scope(|s| {
-        for repo in &config.repos {
-            s.spawn(move || {
-                if let Err(e) = cache_sources::refresh_issues(repo) {
-                    crate::logger::LOG.warn(&format!("watch: refresh issues failed: {e}"));
-                }
-                if let Err(e) = cache_sources::refresh_prs(repo) {
-                    crate::logger::LOG.warn(&format!("watch: refresh PRs failed: {e}"));
-                }
-                if let Err(e) = cache_sources::refresh_worktrees(repo) {
-                    crate::logger::LOG.warn(&format!("watch: refresh worktrees failed: {e}"));
-                }
-            });
+    crate::refresh_parallel::for_each_repo_parallel(config, |repo| {
+        if let Err(e) = cache_sources::refresh_issues(repo) {
+            crate::logger::LOG.warn(&format!("watch: refresh issues failed: {e}"));
+        }
+        if let Err(e) = cache_sources::refresh_prs(repo) {
+            crate::logger::LOG.warn(&format!("watch: refresh PRs failed: {e}"));
+        }
+        if let Err(e) = cache_sources::refresh_worktrees(repo) {
+            crate::logger::LOG.warn(&format!("watch: refresh worktrees failed: {e}"));
         }
     });
     if let Err(e) = cache_sources::refresh_tmux_sessions(None) {

--- a/crates/orchard/src/watch/daemon.rs
+++ b/crates/orchard/src/watch/daemon.rs
@@ -163,6 +163,11 @@ fn refresh_all_sources(config: &GlobalConfig) {
 }
 
 /// Refreshes only local (fast) sources: worktrees and tmux sessions.
+///
+/// Intentionally serial: each `refresh_worktrees` is a local `git worktree
+/// list` — single-digit milliseconds. Thread-spawn overhead would cost more
+/// than it would save. `refresh_all_sources` is the hot path that needs
+/// parallelism.
 fn refresh_local_sources(config: &GlobalConfig) {
     for repo in &config.repos {
         if let Err(e) = cache_sources::refresh_worktrees(repo) {

--- a/crates/orchard/src/watch/daemon.rs
+++ b/crates/orchard/src/watch/daemon.rs
@@ -142,18 +142,26 @@ pub fn run(config: &GlobalConfig) -> anyhow::Result<()> {
 // ---------------------------------------------------------------------------
 
 /// Refreshes all sources: issues, PRs, worktrees, and tmux sessions for each repo.
+///
+/// Per-repo refreshes fan out concurrently so one slow GitHub API response
+/// can't delay the next repo. Each refresh writes its own cache file, so no
+/// coordination is needed between threads.
 fn refresh_all_sources(config: &GlobalConfig) {
-    for repo in &config.repos {
-        if let Err(e) = cache_sources::refresh_issues(repo) {
-            crate::logger::LOG.warn(&format!("watch: refresh issues failed: {e}"));
+    std::thread::scope(|s| {
+        for repo in &config.repos {
+            s.spawn(move || {
+                if let Err(e) = cache_sources::refresh_issues(repo) {
+                    crate::logger::LOG.warn(&format!("watch: refresh issues failed: {e}"));
+                }
+                if let Err(e) = cache_sources::refresh_prs(repo) {
+                    crate::logger::LOG.warn(&format!("watch: refresh PRs failed: {e}"));
+                }
+                if let Err(e) = cache_sources::refresh_worktrees(repo) {
+                    crate::logger::LOG.warn(&format!("watch: refresh worktrees failed: {e}"));
+                }
+            });
         }
-        if let Err(e) = cache_sources::refresh_prs(repo) {
-            crate::logger::LOG.warn(&format!("watch: refresh PRs failed: {e}"));
-        }
-        if let Err(e) = cache_sources::refresh_worktrees(repo) {
-            crate::logger::LOG.warn(&format!("watch: refresh worktrees failed: {e}"));
-        }
-    }
+    });
     if let Err(e) = cache_sources::refresh_tmux_sessions(None) {
         crate::logger::LOG.warn(&format!("watch: refresh tmux sessions failed: {e}"));
     }


### PR DESCRIPTION
## Summary

Closes #246. Drops `orchard --json` wall-time from ~14s to 1.2s when remotes are healthy, and caps it at ~3.5s when every remote is dead.

## Progress

- [x] **AC1** — SSH probes parallel (already landed in #263/#271; verified still holds)
- [x] **AC2** — Hard wall-clock timeout on `probe_reachability` via `ssh_exec_with_timeout(PROBE_TIMEOUT)` — tightened to 3s so total stays under the 5s AC ceiling
- [x] **AC3** — `gh api` calls for different repos fan out in parallel via `refresh_parallel::for_each_repo_parallel`
- [x] **AC4** — `orchard --json` < 5s when all hosts unreachable (measured 3.44–3.48s across 3 consecutive runs)
- [x] **AC5** — `orchard --json` < 3s when all hosts reachable (measured 1.18s warm / 1.23s cold)
- [x] **AC6** — TUI `start_full_refresh` and watch `refresh_all_sources` use the same parallel strategy

## Measurements

| Scenario | Before | After | AC |
|---|---|---|---|
| All 3 remotes unreachable (warm cache) | ~14s | **3.45s** (avg of 3 runs) | <5s ✅ |
| 1 reachable remote, warm | — | **1.18s** | <3s ✅ |
| 1 reachable remote, cold | — | 1.23s | <3s ✅ |

Method: temp config in `~/.config/orchard/config.json`, measured with `/usr/bin/time -p ./target/release/orchard --json`. Unreachable hosts are TEST-NET-1 (`192.0.2.1-3`).

## Design

- **`refresh_parallel` module** — hosts `for_each_repo_parallel(config, f)` and `unique_reachable_hosts(config, reachable)` so the 5 fan-out sites in `build_state.rs`, `tui/mod.rs`, and `watch/daemon.rs` share one implementation. Module docstring spells out invariants: independent cache writes per thread, closures must not panic.
- **`PROBE_TIMEOUT = 3s`** in `sources/hosts.rs` — hard wall-clock deadline enforced via `ssh_exec_with_timeout`, independent of SSH's own `ConnectTimeout=5`. Tradeoff: a host that needs 3–5s to respond is classed as unreachable. Healthy handshakes resolve in <200ms in practice.
- **Local-only refresh paths stay serial** — `start_local_refresh` and `refresh_local_sources` do single-digit-ms git operations. Thread spawn costs more than it saves. Annotated inline.

## Sweep

See comment — one must-fix (`watch/daemon.rs:refresh_all_sources`) addressed in-PR, three review-level (`cache_sources.rs` `ssh_exec` sites) deferred to a follow-up.

## Test plan

- [x] `cargo test -p orchard` (1127 passed)
- [x] `probe_reachability_enforces_hard_deadline` — new regression pinning probe to TEST-NET-1 address
- [x] `for_each_repo_parallel_runs_concurrently` — timing-based regression, <500ms budget for 3×200ms sleeps
- [x] `unique_reachable_hosts_dedupes_and_filters` — dedup + filter correctness
- [x] Wall-time measurements for AC4 / AC5 (table above)

# Related issue

- #246

# Related issue

- #246

# Related issue

- #246

# Related issue

- #246

# Related issue

- #246