### PR TITLE
feat(monitor): include draft/phase in PR reports, flag ready-but-DRAFT

### DIFF
--- a/scripts/orchard-monitor.sh
+++ b/scripts/orchard-monitor.sh
@@ -42,13 +42,15 @@ try:
             pr_checks = pr.get('checksState', '')
             pr_conflicts = pr.get('hasConflicts', False)
             pr_threads = pr.get('unresolvedThreads', 0)
+            pr_draft = str(pr.get('isDraft', False)).lower()
+            pr_phase = pr.get('phase') or 'none'
             session_info = []
             for s in wt.get('sessions', []):
                 claude = s.get('claude') or {}
                 cs = claude.get('status', 'no-claude') if claude else 'no-claude'
                 session_info.append(f'{s[\"name\"]}={cs}')
             sessions_str = ','.join(session_info) if session_info else 'no-session'
-            lines.append(f'#{issue_num}|{sessions_str}|pr:{pr_state}|ci:{pr_checks}|conflicts:{pr_conflicts}|threads:{pr_threads}')
+            lines.append(f'#{issue_num}|{sessions_str}|pr:{pr_state}|ci:{pr_checks}|conflicts:{pr_conflicts}|threads:{pr_threads}|draft:{pr_draft}|phase:{pr_phase}')
     print('\n'.join(sorted(lines)))
 except:
     pass
@@ -64,8 +66,11 @@ lines = sys.stdin.read().strip().split('\n')
 removed = [l[2:] for l in lines if l.startswith('< ')]
 added = [l[2:] for l in lines if l.startswith('> ')]
 changes = []
+actions = []
 rm_by_issue = {l.split('|')[0]: l for l in removed}
 add_by_issue = {l.split('|')[0]: l for l in added}
+# Context fields: always shown as snapshot (k=v), never as diff (k:old→new)
+CONTEXT_KEYS = {'draft', 'phase'}
 for issue in set(list(rm_by_issue.keys()) + list(add_by_issue.keys())):
     old = rm_by_issue.get(issue, '')
     new = add_by_issue.get(issue, '')
@@ -73,17 +78,28 @@ for issue in set(list(rm_by_issue.keys()) + list(add_by_issue.keys())):
         old_parts = dict(p.split(':',1) if ':' in p else (p,'') for p in old.split('|')[1:])
         new_parts = dict(p.split(':',1) if ':' in p else (p,'') for p in new.split('|')[1:])
         diffs = []
-        for k in set(list(old_parts.keys()) + list(new_parts.keys())):
+        for k in set(list(old_parts.keys()) + list(new_parts.keys())) - CONTEXT_KEYS:
             if old_parts.get(k) != new_parts.get(k):
                 diffs.append(f'{k}:{old_parts.get(k,\"?\")}→{new_parts.get(k,\"?\")}')
-        if diffs:
-            changes.append(f'{issue} {\" \".join(diffs)}')
+        ctx = [f'{k}={new_parts.get(k,\"?\")}' for k in ('draft','phase') if k in new_parts]
+        if diffs or any(old_parts.get(k) != new_parts.get(k) for k in CONTEXT_KEYS):
+            parts = diffs + ctx
+            changes.append(f'{issue} {\" \".join(parts)}')
+            # AC3: flag PRs that are ready (ci passing, no threads) but still draft
+            if (new_parts.get('ci') == 'passing' and new_parts.get('threads') == '0'
+                    and new_parts.get('draft') == 'true'):
+                actions.append(f'[action] {issue}: ready but still DRAFT')
     elif new:
         changes.append(f'{issue} NEW')
     elif old:
         changes.append(f'{issue} REMOVED')
+out = []
 if changes:
-    print('[orchard-monitor] ' + '; '.join(changes[:5]))
+    out.append('[orchard-monitor] ' + '; '.join(changes[:5]))
+if actions:
+    out.extend(actions)
+if out:
+    print('\n'.join(out))
 " 2>/dev/null)
 
       # Filter to only report watched issues
@@ -220,6 +236,7 @@ for issue_num in watched:
     parts = dict(p.split(':',1) if ':' in p else (p,'') for p in state.split('|')[1:])
     ci = parts.get('ci', '')
     threads = parts.get('threads', '0')
+    draft = parts.get('draft', 'false')
     sessions = state.split('|')[1] if '|' in state else ''
 
     # Calculate how long in current state
@@ -237,7 +254,9 @@ for issue_num in watched:
     elif 'idle' in sessions or 'input' in sessions:
         problems.append('session idle/waiting')
 
-    if not problems and ci == 'passing' and threads == '0':
+    if ci == 'passing' and threads == '0' and draft == 'true':
+        alerts.append(f'[action] {key}: ready but still DRAFT ({dur})')
+    elif not problems and ci == 'passing' and threads == '0':
         alerts.append(f'{key}: GREEN \u2713')
     elif problems:
         alerts.append(f'{key}: {\" | \".join(problems)} ({dur})')

--- a/scripts/orchard-monitor.sh
+++ b/scripts/orchard-monitor.sh
@@ -81,14 +81,16 @@ for issue in set(list(rm_by_issue.keys()) + list(add_by_issue.keys())):
         for k in set(list(old_parts.keys()) + list(new_parts.keys())) - CONTEXT_KEYS:
             if old_parts.get(k) != new_parts.get(k):
                 diffs.append(f'{k}:{old_parts.get(k,\"?\")}→{new_parts.get(k,\"?\")}')
-        ctx = [f'{k}={new_parts.get(k,\"?\")}' for k in ('draft','phase') if k in new_parts]
-        if diffs or any(old_parts.get(k) != new_parts.get(k) for k in CONTEXT_KEYS):
+        ctx = [f'{k}={new_parts.get(k,\"?\")}' for k in sorted(CONTEXT_KEYS) if k in new_parts]
+        ctx_changed = any(old_parts.get(k) != new_parts.get(k) for k in CONTEXT_KEYS)
+        if diffs or ctx_changed:
             parts = diffs + ctx
             changes.append(f'{issue} {\" \".join(parts)}')
-            # AC3: flag PRs that are ready (ci passing, no threads) but still draft
+            # Shared predicate (also in watchlist block): ready-but-DRAFT = ci passing + 0 threads + draft
             if (new_parts.get('ci') == 'passing' and new_parts.get('threads') == '0'
                     and new_parts.get('draft') == 'true'):
-                actions.append(f'[action] {issue}: ready but still DRAFT')
+                phase = new_parts.get('phase', 'none')
+                actions.append(f'[action] {issue}: ready but still DRAFT (phase={phase})')
     elif new:
         changes.append(f'{issue} NEW')
     elif old:
@@ -107,17 +109,27 @@ if out:
         WATCHED_NUMS=$(grep -v '^#' "$WATCH_FILE" | tr '\n' '|' | sed 's/|$//')
         if [ -n "$WATCHED_NUMS" ]; then
           MSG=$(echo "$MSG" | python3 -c "
-import sys, re
-line = sys.stdin.read().strip()
+import sys
+lines = sys.stdin.read().split('\n')
 watched = set(['#$w' for w in '''$WATCHED_NUMS'''.split('|')])
-# Parse changes from the message
 prefix = '[orchard-monitor] '
-if line.startswith(prefix):
-    body = line[len(prefix):]
-    parts = [p.strip() for p in body.split(';')]
-    filtered = [p for p in parts if any(p.startswith(w) for w in watched)]
-    if filtered:
-        print(prefix + '; '.join(filtered))
+out = []
+for line in lines:
+    line = line.strip()
+    if not line:
+        continue
+    if line.startswith(prefix):
+        # Filter change segments to watched issues
+        body = line[len(prefix):]
+        parts = [p.strip() for p in body.split(';')]
+        filtered = [p for p in parts if any(p.startswith(w) for w in watched)]
+        if filtered:
+            out.append(prefix + '; '.join(filtered))
+    else:
+        # [action] lines and any other non-prefixed lines pass through unfiltered
+        out.append(line)
+if out:
+    print('\n'.join(out))
 " 2>/dev/null)
         fi
       fi
@@ -237,6 +249,7 @@ for issue_num in watched:
     ci = parts.get('ci', '')
     threads = parts.get('threads', '0')
     draft = parts.get('draft', 'false')
+    phase = parts.get('phase', 'none')
     sessions = state.split('|')[1] if '|' in state else ''
 
     # Calculate how long in current state
@@ -254,8 +267,9 @@ for issue_num in watched:
     elif 'idle' in sessions or 'input' in sessions:
         problems.append('session idle/waiting')
 
+    # Shared predicate (also in transition block): ready-but-DRAFT = ci passing + 0 threads + draft
     if ci == 'passing' and threads == '0' and draft == 'true':
-        alerts.append(f'[action] {key}: ready but still DRAFT ({dur})')
+        alerts.append(f'[action] {key}: ready but still DRAFT (phase={phase}, {dur})')
     elif not problems and ci == 'passing' and threads == '0':
         alerts.append(f'{key}: GREEN \u2713')
     elif problems:


### PR DESCRIPTION
## Summary

- Monitor state tuple now includes `isDraft` and `phase` for every PR
- Every transition message shows `draft=X phase=Y` as context fields (snapshot, not diff)
- Flags PRs matching `ci:passing + threads:0 + draft:true` with `[action] #N: ready but still DRAFT` in both the transition block and the periodic watchlist sweep

Closes #245

## Acceptance Criteria

- [x] Monitor includes `isDraft` and `phase` label in every PR state report
- [x] Example format: `#3111 ci:pending→passing threads:1→0 draft=true phase=none`
- [x] Flag PRs where CI passes + 0 threads + isDraft=true: `[action] #N: ready but still DRAFT`

## Test plan

- [x] Fixture replay of old→new state produces `draft=true phase=in-progress` context fields
- [x] Fixture replay emits `[action] #N: ready but still DRAFT` when ci=passing, threads=0, draft=true
- [x] Fixture confirms watchlist sweep also fires DRAFT alert on periodic poll
- [x] `bash -n` syntax check passes
- [ ] Live monitor run against `orchard --json` (manual)

# Related issue

- #245

# Related issue

- #245