### PR TITLE
fix(heal): use live active-pane cwd instead of frozen session_path

### DIFF
--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -194,8 +194,12 @@ fn check_sessions(
     let worktree_paths: Vec<&str> = worktrees.iter().map(|w| w.path.as_str()).collect();
 
     for session in sessions {
-        let path_exists = Path::new(&session.path).exists();
-        let path_has_worktree = worktree_paths.contains(&session.path.as_str());
+        // Prefer the live active-pane cwd over the frozen session path. Users
+        // `cd` inside sessions, so the active pane reflects where they actually
+        // are — the frozen path may be stale but the session is still healthy.
+        let effective_path = session.active_pane_cwd.as_deref().unwrap_or(&session.path);
+        let path_exists = Path::new(effective_path).exists();
+        let path_has_worktree = worktree_paths.contains(&effective_path);
 
         if !path_exists {
             findings.push(HealFinding {
@@ -203,7 +207,7 @@ fn check_sessions(
                 severity: Severity::Error,
                 message: format!(
                     "Session \"{}\" points to non-existent path \"{}\"",
-                    session.name, session.path
+                    session.name, effective_path
                 ),
                 action: HealAction::KillSession(session.name.clone()),
             });
@@ -213,7 +217,7 @@ fn check_sessions(
                 severity: Severity::Warning,
                 message: format!(
                     "Session \"{}\" has no matching worktree (path: {})",
-                    session.name, session.path
+                    session.name, effective_path
                 ),
                 action: HealAction::KillSession(session.name.clone()),
             });
@@ -322,8 +326,9 @@ fn check_session_naming(
     findings: &mut Vec<HealFinding>,
 ) {
     for session in sessions {
-        // Find the worktree this session is associated with (by path).
-        let Some(wt) = worktrees.iter().find(|w| w.path == session.path) else {
+        // Match by live active-pane cwd first; fall back to frozen session path.
+        let effective_path = session.active_pane_cwd.as_deref().unwrap_or(&session.path);
+        let Some(wt) = worktrees.iter().find(|w| w.path == effective_path) else {
             continue;
         };
         let Some(expected) = &wt.expected_session_name else {
@@ -352,7 +357,14 @@ fn check_multiple_sessions_per_worktree(
     findings: &mut Vec<HealFinding>,
 ) {
     for wt in worktrees {
-        let matching: Vec<&TmuxSession> = sessions.iter().filter(|s| s.path == wt.path).collect();
+        // Match by live active-pane cwd when available; fall back to frozen path.
+        let matching: Vec<&TmuxSession> = sessions
+            .iter()
+            .filter(|s| {
+                let effective = s.active_pane_cwd.as_deref().unwrap_or(&s.path);
+                effective == wt.path
+            })
+            .collect();
 
         if matching.len() > 1 {
             let names: Vec<&str> = matching.iter().map(|s| s.name.as_str()).collect();

--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -645,6 +645,7 @@ mod tests {
             path: path.to_string(),
             attached: false,
             pane_title: None,
+            active_pane_cwd: None,
         }
     }
 
@@ -1031,6 +1032,58 @@ mod tests {
     fn extract_repo_slug_returns_none_for_too_few_parts() {
         let slug = extract_repo_slug_from_cache_filename("something.json");
         assert!(slug.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Live active-pane cwd rescues session with stale frozen path (issue #297)
+    // -----------------------------------------------------------------------
+
+    /// Regression test: a session whose frozen `session.path` does not exist on
+    /// disk but whose live active-pane cwd IS a known worktree path must be
+    /// classified as healthy — not DeadSessionDirectory or OrphanedSession.
+    ///
+    /// This test MUST FAIL until `check_sessions` (or `TmuxSession`) is updated
+    /// to consult `active_pane_cwd` before `path` when classifying sessions.
+    #[test]
+    fn live_active_pane_cwd_rescues_session_with_stale_frozen_path() {
+        let worktree_path = std::env::temp_dir()
+            .join("orchard-test-worktree-297")
+            .to_string_lossy()
+            .to_string();
+        // Ensure the directory actually exists so path_exists check passes.
+        std::fs::create_dir_all(&worktree_path).unwrap();
+
+        // Frozen session.path is stale/non-existent.
+        let stale_path = "/tmp/orchard-nonexistent-stale-session-path-xyz".to_string();
+        assert!(
+            !std::path::Path::new(&stale_path).exists(),
+            "stale path must not exist for this test to be valid"
+        );
+
+        let session = TmuxSession {
+            name: "myrepo_issue297".to_string(),
+            path: stale_path,
+            attached: false,
+            pane_title: None,
+            // The live active-pane cwd points to the real worktree.
+            active_pane_cwd: Some(worktree_path.clone()),
+        };
+
+        let worktrees = vec![make_worktree(&worktree_path, "issue297/fix")];
+        let report = diagnose(&[session], &worktrees, &[], &[], &[]);
+
+        let bad = report.findings.iter().find(|f| {
+            matches!(
+                f.category,
+                HealCategory::DeadSessionDirectory | HealCategory::OrphanedSession
+            )
+        });
+        assert!(
+            bad.is_none(),
+            "session with live active-pane cwd matching a worktree must be healthy, \
+             but got finding: {:?}",
+            bad
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -161,8 +161,37 @@ fn handle_upgrade() {
 /// When `fix` is true, applies all actionable fixes. When `json` is true,
 /// outputs machine-readable JSON instead of the formatted report.
 fn handle_heal(fix: bool, json: bool) {
+    use orchard::cache::{CachedTmuxSession, read_cache, tmux_cache_path};
+    use orchard::cache_sources;
+    use orchard::session::active_pane_cwd;
+    use orchard::types::TmuxSession;
+
     let config = global_config::load_global_config();
-    let sessions = orchard::tmux::list_tmux_sessions();
+
+    // Refresh the local tmux cache so active_pane_cwd reflects current state.
+    // Best-effort: a failure here means we fall back to whatever is on disk.
+    if let Err(e) = cache_sources::refresh_tmux_sessions(None) {
+        eprintln!("heal: tmux cache refresh failed (using cached data): {e}");
+    }
+
+    // Build TmuxSession list from the cache, enriching each entry with the
+    // live active-pane cwd derived from pane_paths + pane_active.
+    let sessions: Vec<TmuxSession> = read_cache::<CachedTmuxSession>(&tmux_cache_path(None))
+        .entries
+        .into_iter()
+        .map(|s| {
+            let pane_title = s.pane_titles.first().cloned();
+            let cwd = active_pane_cwd(&s);
+            TmuxSession {
+                name: s.name,
+                path: s.path,
+                attached: false,
+                pane_title,
+                active_pane_cwd: cwd,
+            }
+        })
+        .collect();
+
     let claude_states = heal::gather_claude_states();
     let cache_files = heal::gather_cache_files();
     let known_slugs: Vec<String> = config.repos.iter().map(|r| r.slug.clone()).collect();

--- a/crates/orchard/src/remote.rs
+++ b/crates/orchard/src/remote.rs
@@ -202,6 +202,7 @@ fn parse_tmux_output(out: &str) -> Vec<TmuxSession> {
             path: parts[1].to_string(),
             attached: parts[2] == "1",
             pane_title: None,
+            active_pane_cwd: None,
         });
     }
     sessions

--- a/crates/orchard/src/session.rs
+++ b/crates/orchard/src/session.rs
@@ -227,6 +227,21 @@ pub struct PaneColumns<'a> {
     pub window_layouts: &'a [String],
 }
 
+/// Returns the working directory of the active pane in a cached tmux session.
+///
+/// Scans `pane_active` for the first entry equal to `"1"` and returns the
+/// corresponding path from `pane_paths`. Empty paths are treated as absent.
+/// Returns `None` when no active pane is found or the path is empty.
+pub fn active_pane_cwd(s: &crate::cache::CachedTmuxSession) -> Option<String> {
+    s.pane_active
+        .iter()
+        .enumerate()
+        .find(|(_, flag)| flag.as_str() == "1")
+        .and_then(|(i, _)| s.pane_paths.get(i))
+        .filter(|p| !p.is_empty())
+        .cloned()
+}
+
 impl<'a> PaneColumns<'a> {
     /// Constructs a `PaneColumns` view over a `CachedTmuxSession`'s parallel
     /// vecs. The cache struct is the primary on-disk source for every field

--- a/crates/orchard/src/tmux.rs
+++ b/crates/orchard/src/tmux.rs
@@ -41,6 +41,7 @@ pub fn list_tmux_sessions() -> Vec<TmuxSession> {
             path: parts[1].to_string(),
             attached: parts[2] == "1",
             pane_title: None,
+            active_pane_cwd: None,
         });
     }
 
@@ -400,18 +401,21 @@ mod tests {
                 path: "/other/path".into(),
                 attached: false,
                 pane_title: None,
+                active_pane_cwd: None,
             },
             TmuxSession {
                 name: "myrepo_feature-x".into(),
                 path: "/home/user/myrepo-feature-x".into(),
                 attached: false,
                 pane_title: None,
+                active_pane_cwd: None,
             },
             TmuxSession {
                 name: "orchard".into(),
                 path: "/home/user/orchard".into(),
                 attached: true,
                 pane_title: None,
+                active_pane_cwd: None,
             },
         ]
     }

--- a/crates/orchard/src/types.rs
+++ b/crates/orchard/src/types.rs
@@ -259,12 +259,18 @@ pub enum IssueState {
 pub struct TmuxSession {
     /// The tmux session name.
     pub name: String,
-    /// The working directory of the session's first window.
+    /// The working directory of the session's first window (frozen at session creation).
     pub path: String,
     /// Whether a client is currently attached to this session.
     pub attached: bool,
     /// Title of the active pane, if available.
     pub pane_title: Option<String>,
+    /// The live cwd of the active pane, if available.
+    ///
+    /// Users `cd` inside sessions, so this reflects where the user actually is
+    /// right now — which may differ from the frozen `path`. When `Some`, heal
+    /// classification should prefer this over `path`.
+    pub active_pane_cwd: Option<String>,
 }
 
 /// Connection details for a remote machine that hosts worktrees.

--- a/crates/orchard/tests/heal_test.rs
+++ b/crates/orchard/tests/heal_test.rs
@@ -17,6 +17,7 @@ fn session(name: &str, path: &str) -> TmuxSession {
         path: path.to_string(),
         attached: false,
         pane_title: None,
+        active_pane_cwd: None,
     }
 }
 


### PR DESCRIPTION
## Why

Closes #297

`orchard heal --fix` could kill healthy sessions. Classification
relied on the tmux `#{session_path}` — the directory where the
session was created. Users `cd` around inside sessions, so a session
whose active pane is sitting in a valid worktree could be flagged as
`DeadSessionDirectory` or `OrphanedSession` and then killed, even
though it was alive and doing real work. This follows the same
direction as #275 / #292, which are fixing the sister bug in the TUI.

## What changed

Heal now classifies sessions by the **live active-pane cwd** instead
of the frozen creation path. When the active pane has `cd`'d into a
valid worktree, the session is healthy; the stale `session_path` no
longer matters.

- New `session::active_pane_cwd(CachedTmuxSession) -> Option<String>`:
  derives the live cwd from the `pane_paths` entry where
  `pane_active == "1"`.
- `TmuxSession` gains an `active_pane_cwd: Option<String>` field.
  Populated only on the heal CLI path; every other constructor sets
  `None`.
- `heal::check_sessions`, `check_session_naming`, and
  `check_multiple_sessions_per_worktree` now use
  `active_pane_cwd.unwrap_or(&session.path)` as the effective path.
- `handle_heal` in `main.rs` refreshes the local tmux cache and
  builds the session list from `CachedTmuxSession` entries
  (de-dupes the fetch per Option 2 in the issue). On cache-refresh
  failure it logs and falls back to whatever is on disk — heal still
  runs.

## How it works

`cache_sources::refresh_tmux_sessions(None)` already records
`#{pane_current_path}` and `#{pane_active}` per pane in the cache.
The helper walks that parallel array, picks the index where the
active-pane flag is `"1"`, and returns the corresponding path
(filtering empty strings). `heal::check_sessions` then prefers that
value over the frozen path for both the "directory exists" and
"matches a worktree" checks.

TUI / other callers keep using `tmux::list_tmux_sessions()`
unchanged. Their fix ships in #292.

## Test plan

Regression test added:
`heal::tests::live_active_pane_cwd_rescues_session_with_stale_frozen_path`.
Given a `TmuxSession` with a non-existent `path` but an
`active_pane_cwd` pointing at a real worktree, `diagnose` must
return no `DeadSessionDirectory` / `OrphanedSession` finding.

- Without the fix: test fails with
  `"Session points to non-existent path /tmp/..."` → kill action.
- With the fix: test passes.

Also verified:

- `cargo test -p orchard` — 1127 lib tests + 70 integration tests
  pass, 2 pre-existing ignored.
- `cargo clippy -p orchard --all-targets -- -D warnings` clean.
- `cargo fmt -p orchard --check` clean.

## Anything surprising?

- `TmuxSession` is only used in-memory; no cache/wire format impact.
- Out of scope (per the issue): deleting the dead
  `parse_tmux_output` in `cache_sources.rs` and the dead
  `find_session_for_worktree` in `tmux.rs`. Bundle with a broader
  hygiene sweep.
- Sister fix for TUI classification (same bug class) tracked in
  #292 / #275. This PR is intentionally standalone so it can merge
  independently.


# Related issue

- #297