### PR TITLE
refactor(hosts): extract post-probe refresh pipeline (#295)

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,9 +1,0 @@
----
-active: true
-iteration: 1
-max_iterations: 0
-completion_promise: null
-started_at: "2026-04-17T06:38:21Z"
----
-
-Drive PR

--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -1,0 +1,9 @@
+---
+active: true
+iteration: 1
+max_iterations: 0
+completion_promise: null
+started_at: "2026-04-17T06:38:21Z"
+---
+
+Drive PR

--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -345,17 +345,16 @@ pub fn refresh_and_build(config: &GlobalConfig) -> OrchardState {
         .collect();
 
     // Refresh remote sources for every reachable host, once per (repo, remote) pair.
-    let mut tmux_refreshed: HashSet<String> = HashSet::new();
-    for repo in &config.repos {
-        for remote in &repo.remotes {
-            if reachable_hosts.contains(&remote.host) {
-                let _ = sources::worktrees::refresh_remote(repo, remote);
-                if tmux_refreshed.insert(remote.host.clone()) {
-                    let _ = sources::tmux::refresh_remote_adapter(repo, remote);
-                }
-            }
-        }
-    }
+    sources::hosts::refresh_remotes_for_reachable_hosts(
+        config,
+        &reachable_hosts,
+        |repo, remote| {
+            let _ = sources::worktrees::refresh_remote(repo, remote);
+        },
+        |repo, remote| {
+            let _ = sources::tmux::refresh_remote_adapter(repo, remote);
+        },
+    );
 
     build_state_with_hosts(config, &hosts)
 }

--- a/crates/orchard/src/sources/hosts.rs
+++ b/crates/orchard/src/sources/hosts.rs
@@ -9,9 +9,10 @@
 //! command for its kind. Each probe runs on its own thread so a stopped VM
 //! can't block probes for healthy hosts behind it.
 
-use crate::global_config::{GlobalConfig, RemoteConfig};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::thread;
+
+use crate::global_config::{GlobalConfig, RemoteConfig, RepoConfig};
 
 /// Returns every `RemoteConfig` configured across all repos in `config`.
 ///
@@ -58,7 +59,7 @@ where
     I: IntoIterator<Item = RemoteConfig>,
     F: Fn(&RemoteConfig) -> bool + Clone + Send + 'static,
 {
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = HashSet::new();
     let unique: Vec<RemoteConfig> = remotes
         .into_iter()
         .filter(|r| seen.insert(r.host.clone()))
@@ -86,6 +87,51 @@ where
             }
         })
         .collect()
+}
+
+/// Runs per-reachable-host refresh work across all repos and their remotes.
+///
+/// For each `(repo, remote)` pair whose host appears in `reachable`, calls
+/// `refresh_worktree(repo, remote)`. The first time each unique host is
+/// encountered, also calls `refresh_tmux(repo, remote)`. Tmux is deduped per
+/// host across all repos so it runs exactly once regardless of how many repos
+/// share that host. The `(repo, remote)` pair handed to `refresh_tmux` is the
+/// first one that introduced the host, which is what adapter-routed tmux
+/// refresh needs to pick the right per-host cache file.
+///
+/// Callers supply the refresh strategy via closures, allowing both the
+/// `--json` path (direct `sources::*` calls) and the TUI SWR path
+/// (`cache_sources::*` calls) to share this loop without duplication.
+///
+/// # Arguments
+///
+/// * `config` - Global config supplying the repo × remote matrix to iterate.
+/// * `reachable` - Set of host strings confirmed reachable by a prior
+///   [`probe_reachability_all_for_remotes`] call.
+/// * `refresh_worktree` - Called once per `(repo, remote)` pair whose host is
+///   reachable.
+/// * `refresh_tmux` - Called once per unique reachable host (deduplicated),
+///   with the first `(repo, remote)` pair that introduced the host.
+pub fn refresh_remotes_for_reachable_hosts<W, T>(
+    config: &GlobalConfig,
+    reachable: &HashSet<String>,
+    mut refresh_worktree: W,
+    mut refresh_tmux: T,
+) where
+    W: FnMut(&RepoConfig, &RemoteConfig),
+    T: FnMut(&RepoConfig, &RemoteConfig),
+{
+    let mut tmux_refreshed: HashSet<String> = HashSet::new();
+    for repo in &config.repos {
+        for remote in &repo.remotes {
+            if reachable.contains(&remote.host) {
+                refresh_worktree(repo, remote);
+                if tmux_refreshed.insert(remote.host.clone()) {
+                    refresh_tmux(repo, remote);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -241,6 +287,110 @@ mod tests {
             "live probe must dispatch within 100ms of the earliest probe \
              (serial would delay it ~500ms), gap was {:?}",
             dispatch_gap
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // refresh_remotes_for_reachable_hosts tests
+    // -----------------------------------------------------------------------
+
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    fn config(repos: Vec<RepoConfig>) -> GlobalConfig {
+        GlobalConfig {
+            repos,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn refresh_worktree_called_once_per_reachable_repo_remote_pair() {
+        let cfg = config(vec![
+            repo("owner/a", &["host1"]),
+            repo("owner/b", &["host1", "host2"]),
+        ]);
+        let reachable: HashSet<String> = ["host1".to_string(), "host2".to_string()]
+            .into_iter()
+            .collect();
+
+        let wt_calls: Rc<RefCell<Vec<(String, String)>>> = Rc::new(RefCell::new(Vec::new()));
+        let wt_calls_ref = wt_calls.clone();
+
+        refresh_remotes_for_reachable_hosts(
+            &cfg,
+            &reachable,
+            |repo, remote| {
+                wt_calls_ref
+                    .borrow_mut()
+                    .push((repo.slug.clone(), remote.host.clone()));
+            },
+            |_repo, _remote| {},
+        );
+
+        let calls = wt_calls.borrow();
+        // 3 (repo, remote) pairs total: (a, host1), (b, host1), (b, host2)
+        assert_eq!(calls.len(), 3);
+        assert!(calls.contains(&("owner/a".to_string(), "host1".to_string())));
+        assert!(calls.contains(&("owner/b".to_string(), "host1".to_string())));
+        assert!(calls.contains(&("owner/b".to_string(), "host2".to_string())));
+    }
+
+    #[test]
+    fn refresh_tmux_called_once_per_unique_reachable_host() {
+        // host1 appears in two repos — tmux should only refresh it once.
+        let cfg = config(vec![
+            repo("owner/a", &["host1"]),
+            repo("owner/b", &["host1", "host2"]),
+        ]);
+        let reachable: HashSet<String> = ["host1".to_string(), "host2".to_string()]
+            .into_iter()
+            .collect();
+
+        let tmux_calls: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let tmux_calls_ref = tmux_calls.clone();
+
+        refresh_remotes_for_reachable_hosts(
+            &cfg,
+            &reachable,
+            |_repo, _remote| {},
+            |_repo, remote| {
+                tmux_calls_ref.borrow_mut().push(remote.host.clone());
+            },
+        );
+
+        let mut calls = tmux_calls.borrow().clone();
+        calls.sort();
+        assert_eq!(calls, vec!["host1".to_string(), "host2".to_string()]);
+    }
+
+    #[test]
+    fn unreachable_hosts_skipped_entirely() {
+        let cfg = config(vec![repo("owner/a", &["dead-host"])]);
+        // Empty reachable set — nothing is reachable.
+        let reachable: HashSet<String> = HashSet::new();
+
+        let wt_calls: Rc<RefCell<u32>> = Rc::new(RefCell::new(0));
+        let tmux_calls: Rc<RefCell<u32>> = Rc::new(RefCell::new(0));
+        let wt_ref = wt_calls.clone();
+        let tmux_ref = tmux_calls.clone();
+
+        refresh_remotes_for_reachable_hosts(
+            &cfg,
+            &reachable,
+            |_repo, _remote| *wt_ref.borrow_mut() += 1,
+            |_repo, _remote| *tmux_ref.borrow_mut() += 1,
+        );
+
+        assert_eq!(
+            *wt_calls.borrow(),
+            0,
+            "refresh_worktree must not be called for unreachable hosts"
+        );
+        assert_eq!(
+            *tmux_calls.borrow(),
+            0,
+            "refresh_tmux must not be called for unreachable hosts"
         );
     }
 }

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -692,26 +692,20 @@ impl App {
                 let _ = cache_sources::refresh_issues(repo);
                 let _ = cache_sources::refresh_prs(repo);
                 let _ = cache_sources::refresh_worktrees(repo);
-                for remote in &repo.remotes {
-                    if reachable_hosts.contains(&remote.host) {
-                        let _ = cache_sources::refresh_remote_worktrees(repo, remote);
-                    }
-                }
             }
             // Refresh tmux sessions (local).
             let _ = cache_sources::refresh_tmux_sessions(None);
-            // Refresh remote tmux sessions for reachable hosts only.
-            let mut tmux_hosts_refreshed: std::collections::HashSet<String> =
-                std::collections::HashSet::new();
-            for repo in &config.repos {
-                for remote in &repo.remotes {
-                    if reachable_hosts.contains(&remote.host)
-                        && tmux_hosts_refreshed.insert(remote.host.clone())
-                    {
-                        let _ = cache_sources::refresh_remote_tmux_sessions(repo, remote);
-                    }
-                }
-            }
+            // Refresh remote worktrees and remote tmux sessions for reachable hosts.
+            crate::sources::hosts::refresh_remotes_for_reachable_hosts(
+                &config,
+                &reachable_hosts,
+                |repo, remote| {
+                    let _ = cache_sources::refresh_remote_worktrees(repo, remote);
+                },
+                |repo, remote| {
+                    let _ = cache_sources::refresh_remote_tmux_sessions(repo, remote);
+                },
+            );
             // Ensure a main tmux session exists for each configured repo.
             ensure_main_sessions(&config);
             // Signal that caches are updated.


### PR DESCRIPTION
## Summary

- Extract the post-probe pipeline duplicated between `build_state::refresh_and_build` and `tui::start_full_refresh` into a single `sources::hosts::refresh_remotes_for_reachable_hosts` helper.
- Helper is parameterised by closures, so `--json` keeps using fresh `sources::*` and the TUI keeps using SWR `cache_sources::*`. `AppMsg::HostReachability` emission stays in the TUI shell.
- Adds 3 unit tests for the helper's invariants (worktree-per-pair, tmux-dedup-per-host, unreachable-skipped).

Closes #295.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib` — 1129 passed (baseline 1126 + 3 new)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Grep `tmux_refreshed` — only appears once, inside the new helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #295

# Related issue

- #295

# Related issue

- #295

# Related issue

- #295