### PR TITLE
feat(#337): validate launch-remote + TUI Enter + federation on v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,7 +2867,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/orchard/src/events.rs
+++ b/crates/orchard/src/events.rs
@@ -30,7 +30,14 @@ pub struct Event {
 ///
 /// Used by the watch daemon tailer to know which file to tail, and by
 /// the events module internally for all writes.
+///
+/// If `ORCHARD_EVENTS_PATH` is set in the environment the value is used
+/// verbatim.  This lets unit tests redirect writes to a temp directory
+/// without touching `~/.local/state/git-orchard/events.jsonl`.
 pub fn events_path() -> PathBuf {
+    if let Ok(p) = std::env::var("ORCHARD_EVENTS_PATH") {
+        return PathBuf::from(p);
+    }
     dirs::home_dir()
         .unwrap_or_else(std::env::temp_dir)
         .join(".local")

--- a/crates/orchard/src/remote.rs
+++ b/crates/orchard/src/remote.rs
@@ -339,6 +339,12 @@ thread_local! {
     /// thread during a test run. Drain with [`take_proxy_session_calls`].
     static PROXY_SESSION_CALLS: std::cell::RefCell<Vec<ProxySessionCall>> =
         const { std::cell::RefCell::new(Vec::new()) };
+
+    /// When `Some`, the next call to [`create_remote_proxy_session`] will
+    /// drain this value and return `Err(anyhow!(msg))` instead of `Ok(local_name)`.
+    /// Consumed on first use so subsequent calls revert to the default `Ok` path.
+    static NEXT_PROXY_SESSION_RESULT: std::cell::RefCell<Option<String>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 /// Drains and returns all [`ProxySessionCall`] entries recorded in this thread.
@@ -348,6 +354,16 @@ thread_local! {
 #[cfg(test)]
 pub(crate) fn take_proxy_session_calls() -> Vec<ProxySessionCall> {
     PROXY_SESSION_CALLS.with(|calls| std::mem::take(&mut *calls.borrow_mut()))
+}
+
+/// Arms the test seam so the **next** call to [`create_remote_proxy_session`]
+/// returns `Err(anyhow!(msg))`. Consumed on first use — subsequent calls revert
+/// to the default `Ok` path.
+#[cfg(test)]
+pub(crate) fn set_next_proxy_session_error(msg: impl Into<String>) {
+    NEXT_PROXY_SESSION_RESULT.with(|slot| {
+        *slot.borrow_mut() = Some(msg.into());
+    });
 }
 
 /// Creates a local proxy tmux session that connects to the remote session via ssh or
@@ -383,6 +399,11 @@ pub fn create_remote_proxy_session(
                 proxy_name: local_name.clone(),
             });
         });
+        // If a test has armed a failure for this call, drain and return it.
+        let maybe_err = NEXT_PROXY_SESSION_RESULT.with(|slot| slot.borrow_mut().take());
+        if let Some(msg) = maybe_err {
+            return Err(anyhow::anyhow!("{}", msg));
+        }
         return Ok(local_name);
     }
 

--- a/crates/orchard/src/remote.rs
+++ b/crates/orchard/src/remote.rs
@@ -386,12 +386,23 @@ pub fn create_remote_proxy_session(
 ) -> anyhow::Result<String> {
     let local_name = proxy_session_name(name);
 
+    // mosh does not support multi-hop chains. Reject transitive (depth-2+) hosts
+    // BEFORE any SSH or test short-circuit fires, so the synchronous Err is
+    // returned regardless of build mode.
+    if shell == "mosh" && discovery_path.is_some_and(|dp| dp.len() > 2) {
+        anyhow::bail!(
+            "mosh is not supported for transitive hosts ({}); \
+             change this remote's shell to ssh",
+            discovery_path.unwrap().join(" -> ")
+        );
+    }
+
     // Under test, record the call and return immediately — no SSH or tmux.
     #[cfg(test)]
     {
-        // Suppress unused-parameter warnings: path and shell are only used
-        // in the production path below.
-        let _ = (path, shell);
+        // Suppress unused-parameter warnings: path is only used in the
+        // production path below.
+        let _ = path;
         PROXY_SESSION_CALLS.with(|calls| {
             calls.borrow_mut().push(ProxySessionCall {
                 host: host.to_string(),
@@ -413,104 +424,94 @@ pub fn create_remote_proxy_session(
     // `#[cfg_attr(test, allow(dead_code))]` to stay live in production.
     #[cfg(not(test))]
     {
-    let shell = if shell.is_empty() { "ssh" } else { shell };
+        let shell = if shell.is_empty() { "ssh" } else { shell };
 
-    // mosh does not support multi-hop chains. Reject transitive (depth-2+) hosts
-    // BEFORE any SSH is attempted to avoid a cryptic network-layer failure later.
-    if shell == "mosh" && discovery_path.is_some_and(|dp| dp.len() > 2) {
-        anyhow::bail!(
-            "mosh is not supported for transitive hosts ({}); \
-             change this remote's shell to ssh",
-            discovery_path.unwrap().join(" -> ")
-        );
-    }
+        // Create the remote session if it doesn't exist yet.
+        let has_session_cmd = format!("tmux has-session -t {}", shell_escape(name));
+        let (has_target, has_cmd) = chain_cmd(host, discovery_path, &has_session_cmd);
+        let remote_was_fresh = ssh_exec(&has_target, &has_cmd).is_err();
+        if remote_was_fresh {
+            create_remote_session(host, name, path, discovery_path)?;
+        }
 
-    // Create the remote session if it doesn't exist yet.
-    let has_session_cmd = format!("tmux has-session -t {}", shell_escape(name));
-    let (has_target, has_cmd) = chain_cmd(host, discovery_path, &has_session_cmd);
-    let remote_was_fresh = ssh_exec(&has_target, &has_cmd).is_err();
-    if remote_was_fresh {
-        create_remote_session(host, name, path, discovery_path)?;
-    }
-
-    let connect_cmd = if shell == "mosh" {
-        // Depth-0 or depth-1 mosh: direct connection is fine.
-        format!(
-            "env LC_ALL=en_US.UTF-8 mosh --predict=always {} -- tmux attach-session -t {}",
-            shell_escape(host),
-            shell_escape(name)
-        )
-    } else {
-        // Build the connect command for the local proxy pane.
-        // For depth-1: `ssh -tt host tmux attach-session -t name`
-        // For depth-2+: `ssh -tt jump_host ssh 'leaf' 'tmux attach-session -t name'`
-        let leaf_attach = format!("tmux attach-session -t {}", shell_escape(name));
-        match discovery_path {
-            Some(dp) if dp.len() > 2 => {
-                // Build inner hops using build_ssh_chain on the leaf-only portion,
-                // then add -tt on the outermost hop.
-                // hops = dp[1..] (strip "local"), jump = dp[1], rest = dp[2..]
-                let jump_host = &dp[1];
-                // Build the chain from the jump host onward (inner only).
-                // We use build_ssh_chain with a sub-path starting from the jump host.
-                let sub_path: Vec<String> = dp[1..].to_vec();
-                let inner = crate::federation::build_ssh_chain(&sub_path, &leaf_attach);
-                // inner = "ssh jump_host ssh 'leaf' 'tmux attach-session -t name'"
-                // but the outermost `ssh jump_host` needs `-tt`.
-                // Replace leading `ssh jump_host ` with `ssh -tt jump_host `.
-                let prefix = format!("ssh {} ", jump_host);
-                if inner.starts_with(&prefix) {
-                    format!("ssh -tt {} {}", jump_host, &inner[prefix.len()..])
-                } else {
-                    format!("ssh -tt {} {}", shell_escape(jump_host), inner)
-                }
-            }
-            // depth-0 or depth-1: unchanged
-            _ => format!(
-                "ssh -tt {} tmux attach-session -t {}",
+        let connect_cmd = if shell == "mosh" {
+            // Depth-0 or depth-1 mosh: direct connection is fine.
+            format!(
+                "env LC_ALL=en_US.UTF-8 mosh --predict=always {} -- tmux attach-session -t {}",
                 shell_escape(host),
                 shell_escape(name)
-            ),
-        }
-    };
+            )
+        } else {
+            // Build the connect command for the local proxy pane.
+            // For depth-1: `ssh -tt host tmux attach-session -t name`
+            // For depth-2+: `ssh -tt jump_host ssh 'leaf' 'tmux attach-session -t name'`
+            let leaf_attach = format!("tmux attach-session -t {}", shell_escape(name));
+            match discovery_path {
+                Some(dp) if dp.len() > 2 => {
+                    // Build inner hops using build_ssh_chain on the leaf-only portion,
+                    // then add -tt on the outermost hop.
+                    // hops = dp[1..] (strip "local"), jump = dp[1], rest = dp[2..]
+                    let jump_host = &dp[1];
+                    // Build the chain from the jump host onward (inner only).
+                    // We use build_ssh_chain with a sub-path starting from the jump host.
+                    let sub_path: Vec<String> = dp[1..].to_vec();
+                    let inner = crate::federation::build_ssh_chain(&sub_path, &leaf_attach);
+                    // inner = "ssh jump_host ssh 'leaf' 'tmux attach-session -t name'"
+                    // but the outermost `ssh jump_host` needs `-tt`.
+                    // Replace leading `ssh jump_host ` with `ssh -tt jump_host `.
+                    let prefix = format!("ssh {} ", jump_host);
+                    if inner.starts_with(&prefix) {
+                        format!("ssh -tt {} {}", jump_host, &inner[prefix.len()..])
+                    } else {
+                        format!("ssh -tt {} {}", shell_escape(jump_host), inner)
+                    }
+                }
+                // depth-0 or depth-1: unchanged
+                _ => format!(
+                    "ssh -tt {} tmux attach-session -t {}",
+                    shell_escape(host),
+                    shell_escape(name)
+                ),
+            }
+        };
 
-    let need_create = should_recreate_proxy(&local_name, remote_was_fresh);
-    if need_create {
-        let create_out = Command::new("tmux")
-            .args([
-                "new-session",
-                "-d",
-                "-s",
-                &local_name,
-                "--",
-                "sh",
-                "-c",
-                &connect_cmd,
-            ])
-            .output()?;
+        let need_create = should_recreate_proxy(&local_name, remote_was_fresh);
+        if need_create {
+            let create_out = Command::new("tmux")
+                .args([
+                    "new-session",
+                    "-d",
+                    "-s",
+                    &local_name,
+                    "--",
+                    "sh",
+                    "-c",
+                    &connect_cmd,
+                ])
+                .output()?;
 
-        if !create_out.status.success() {
-            let stderr = String::from_utf8_lossy(&create_out.stderr);
-            if !stderr.contains("duplicate session") {
-                return Err(anyhow!(
-                    "creating local proxy session {:?}: {}",
-                    local_name,
-                    stderr
-                ));
+            if !create_out.status.success() {
+                let stderr = String::from_utf8_lossy(&create_out.stderr);
+                if !stderr.contains("duplicate session") {
+                    return Err(anyhow!(
+                        "creating local proxy session {:?}: {}",
+                        local_name,
+                        stderr
+                    ));
+                }
             }
         }
-    }
 
-    // Keep the pane alive after the SSH/mosh process exits.
-    let _ = Command::new("tmux")
-        .args(["set-option", "-t", &local_name, "remain-on-exit", "on"])
-        .status();
+        // Keep the pane alive after the SSH/mosh process exits.
+        let _ = Command::new("tmux")
+            .args(["set-option", "-t", &local_name, "remain-on-exit", "on"])
+            .status();
 
-    LOG.info(&format!(
-        "createRemoteProxySession: {} -> {}",
-        name, local_name
-    ));
-    Ok(local_name)
+        LOG.info(&format!(
+            "createRemoteProxySession: {} -> {}",
+            name, local_name
+        ));
+        Ok(local_name)
     }
     // Test builds short-circuit above; the production block compiles but is
     // unreachable. Function must end with an expression of `Result<String>`.

--- a/crates/orchard/src/remote.rs
+++ b/crates/orchard/src/remote.rs
@@ -246,6 +246,11 @@ pub fn create_remote_session(
 /// Determines whether the local proxy session needs to be (re)created.
 /// `remote_was_fresh` indicates the remote session was just created, meaning
 /// any existing proxy is connected to a stale session.
+///
+/// In `cfg(test)` builds, [`create_remote_proxy_session`] short-circuits
+/// before calling this helper, so it appears dead. Gated to suppress the
+/// warning rather than cfg-out the helper itself.
+#[cfg_attr(test, allow(dead_code))]
 fn should_recreate_proxy(local_name: &str, remote_was_fresh: bool) -> bool {
     let proxy_exists = Command::new("tmux")
         .args(["has-session", "-t", local_name])
@@ -306,6 +311,45 @@ fn should_recreate_proxy(local_name: &str, remote_was_fresh: bool) -> bool {
     false
 }
 
+/// Returns the local proxy session name for a given remote session name.
+///
+/// The naming convention `remote_{name}` is used consistently: this function
+/// is the single source of truth for that derivation so callers and tests can
+/// verify the contract without duplicating the format string.
+pub(crate) fn proxy_session_name(name: &str) -> String {
+    format!("remote_{name}")
+}
+
+/// A single recorded invocation of [`create_remote_proxy_session`] captured
+/// during tests via the thread-local recorder.
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ProxySessionCall {
+    /// The remote host passed to `create_remote_proxy_session`.
+    pub host: String,
+    /// The source session name (the remote tmux session).
+    pub session_name: String,
+    /// The derived local proxy session name (`remote_{session_name}`).
+    pub proxy_name: String,
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Records every call to [`create_remote_proxy_session`] made in the current
+    /// thread during a test run. Drain with [`take_proxy_session_calls`].
+    static PROXY_SESSION_CALLS: std::cell::RefCell<Vec<ProxySessionCall>> =
+        const { std::cell::RefCell::new(Vec::new()) };
+}
+
+/// Drains and returns all [`ProxySessionCall`] entries recorded in this thread.
+///
+/// Call this from a test after invoking code that may call
+/// [`create_remote_proxy_session`] to assert on the recorded invocations.
+#[cfg(test)]
+pub(crate) fn take_proxy_session_calls() -> Vec<ProxySessionCall> {
+    PROXY_SESSION_CALLS.with(|calls| std::mem::take(&mut *calls.borrow_mut()))
+}
+
 /// Creates a local proxy tmux session that connects to the remote session via ssh or
 /// mosh. Does NOT switch the local tmux client to it. Returns the local session name.
 ///
@@ -324,6 +368,30 @@ pub fn create_remote_proxy_session(
     shell: &str,
     discovery_path: Option<&[String]>,
 ) -> anyhow::Result<String> {
+    let local_name = proxy_session_name(name);
+
+    // Under test, record the call and return immediately — no SSH or tmux.
+    #[cfg(test)]
+    {
+        // Suppress unused-parameter warnings: path and shell are only used
+        // in the production path below.
+        let _ = (path, shell);
+        PROXY_SESSION_CALLS.with(|calls| {
+            calls.borrow_mut().push(ProxySessionCall {
+                host: host.to_string(),
+                session_name: name.to_string(),
+                proxy_name: local_name.clone(),
+            });
+        });
+        return Ok(local_name);
+    }
+
+    // Production path: real SSH/tmux work. Gated `#[cfg(not(test))]` so the
+    // unreachable-in-test block doesn't trip the lint, and the helper
+    // `should_recreate_proxy` (only called here) is annotated with
+    // `#[cfg_attr(test, allow(dead_code))]` to stay live in production.
+    #[cfg(not(test))]
+    {
     let shell = if shell.is_empty() { "ssh" } else { shell };
 
     // mosh does not support multi-hop chains. Reject transitive (depth-2+) hosts
@@ -344,7 +412,6 @@ pub fn create_remote_proxy_session(
         create_remote_session(host, name, path, discovery_path)?;
     }
 
-    let local_name = format!("remote_{}", name);
     let connect_cmd = if shell == "mosh" {
         // Depth-0 or depth-1 mosh: direct connection is fine.
         format!(
@@ -423,6 +490,12 @@ pub fn create_remote_proxy_session(
         name, local_name
     ));
     Ok(local_name)
+    }
+    // Test builds short-circuit above; the production block compiles but is
+    // unreachable. Function must end with an expression of `Result<String>`.
+    #[cfg(test)]
+    #[allow(unreachable_code)]
+    Ok(String::new())
 }
 
 /// Captures the pane content of a remote tmux session via SSH.

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -2045,4 +2045,160 @@ mod tests {
             sessions[0].name
         );
     }
+
+    // -----------------------------------------------------------------------
+    // AC7: Mixed-config refresh — per-host command-set isolation
+    // -----------------------------------------------------------------------
+
+    /// Feature file lines 232-240: "Mixed-config refresh — proxy host uses
+    /// snapshot, non-proxy host uses legacy probe".
+    ///
+    /// Two adapters, each with its own recording SSH executor:
+    ///  - Host A (`OrchardProxy`): must issue `orchard --json` and must NOT
+    ///    issue any `tmux list-panes` or `git worktree list` commands.
+    ///  - Host B (`BoxdShared`): must issue `tmux list-panes` and must NOT
+    ///    issue `orchard --json`.
+    ///
+    /// This locks the dispatch invariant in `RemoteAdapter::from_config` and
+    /// each adapter's command vocabulary without spawning a binary or requiring
+    /// a live SSH connection.
+    #[test]
+    fn mixed_config_refresh_routes_per_remote_kind_with_no_cross_chatter() {
+        use std::sync::{Arc, Mutex};
+
+        /// Recording seam: forwards every call to an inner `FakeSshExec` and
+        /// appends the raw command string to a shared log (host-bound, so the
+        /// host argument is not needed in the log).
+        struct RecordingFakeSshExec {
+            inner: FakeSshExec,
+            calls: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl SshExec for RecordingFakeSshExec {
+            fn exec(&self, host: &str, cmd: &str) -> Result<SshOutput> {
+                self.calls.lock().unwrap().push(cmd.to_string());
+                self.inner.exec(host, cmd)
+            }
+        }
+
+        // --- Host A: OrchardProxy ---
+        let host_a = "boxd@vm-a.boxd.sh";
+        let calls_a = Arc::new(Mutex::new(Vec::<String>::new()));
+
+        let mut inner_a = FakeSshExec::new();
+        // Prime: minimal valid JsonOutput (version 6, empty repos) so
+        // list_sessions() succeeds without needing a worktree entry.
+        inner_a.insert(
+            host_a,
+            "orchard --json",
+            SshOutput {
+                stdout: r#"{"version":6,"tmuxSessions":[],"repos":[],"hosts":{}}"#.to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+        let recording_a = RecordingFakeSshExec {
+            inner: inner_a,
+            calls: calls_a.clone(),
+        };
+
+        let adapter_a = OrchardProxyAdapter {
+            host: host_a.to_string(),
+            path: "~/git-orchard-rs".to_string(),
+            ssh: Box::new(recording_a),
+            snapshot: OnceLock::new(),
+        };
+
+        // --- Host B: BoxdShared (non-proxy legacy path) ---
+        let host_b = "ubuntu@vm-b";
+        let calls_b = Arc::new(Mutex::new(Vec::<String>::new()));
+
+        let tmux_cmd = format!(
+            "tmux list-panes -a -F '{}'",
+            crate::cache_sources::TMUX_SESSION_FORMAT
+        );
+        let mut inner_b = FakeSshExec::new();
+        // Prime: one tmux pane row so list_sessions() returns a non-empty result.
+        inner_b.insert(
+            host_b,
+            &tmux_cmd,
+            SshOutput {
+                stdout: "vm-b-session\t1\t/home/ubuntu/repo\t1713000000\t1713000060\n".to_string(),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+        let recording_b = RecordingFakeSshExec {
+            inner: inner_b,
+            calls: calls_b.clone(),
+        };
+
+        let adapter_b = BoxdSharedAdapter {
+            host: host_b.to_string(),
+            path: "/home/ubuntu/repo".to_string(),
+            ssh: Box::new(recording_b),
+        };
+
+        // --- Act ---
+        let sessions_a = adapter_a
+            .list_sessions()
+            .expect("host A list_sessions must not error");
+        let sessions_b = adapter_b
+            .list_sessions()
+            .expect("host B list_sessions must not error");
+
+        // --- Assert Host A (OrchardProxy) ---
+        let recorded_a = calls_a.lock().unwrap();
+
+        // Positive: orchard --json was issued to host A.
+        assert!(
+            recorded_a.iter().any(|c| c.contains("orchard --json")),
+            "host A (OrchardProxy) must invoke `orchard --json`; recorded: {recorded_a:?}"
+        );
+
+        // Negative: no tmux list-panes on the proxy host.
+        assert!(
+            !recorded_a.iter().any(|c| c.contains("tmux list-panes")),
+            "host A (OrchardProxy) must NOT invoke `tmux list-panes`; recorded: {recorded_a:?}"
+        );
+
+        // Negative: no git worktree list on the proxy host.
+        assert!(
+            !recorded_a.iter().any(|c| c.contains("git worktree list")),
+            "host A (OrchardProxy) must NOT invoke `git worktree list`; recorded: {recorded_a:?}"
+        );
+
+        drop(recorded_a);
+
+        // --- Assert Host B (BoxdShared, legacy path) ---
+        let recorded_b = calls_b.lock().unwrap();
+
+        // Positive: tmux list-panes was issued to host B.
+        assert!(
+            recorded_b.iter().any(|c| c.contains("tmux list-panes")),
+            "host B (BoxdShared) must invoke `tmux list-panes`; recorded: {recorded_b:?}"
+        );
+
+        // Negative: no orchard --json on the legacy host.
+        assert!(
+            !recorded_b.iter().any(|c| c.contains("orchard --json")),
+            "host B (BoxdShared) must NOT invoke `orchard --json`; recorded: {recorded_b:?}"
+        );
+
+        drop(recorded_b);
+
+        // Sanity: host A snapshot was empty (no sessions), host B returned one.
+        assert!(
+            sessions_a.is_empty(),
+            "host A returned empty repos/sessions so sessions_a should be empty; got: {sessions_a:?}"
+        );
+        assert!(
+            !sessions_b.is_empty(),
+            "host B should return the one session from the canned tmux pane row; got: {sessions_b:?}"
+        );
+        assert_eq!(
+            sessions_b[0].name, "vm-b-session",
+            "host B session name must match the canned tmux pane row"
+        );
+    }
 }

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -1953,4 +1953,96 @@ mod tests {
             "session host must be '{host}'"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // AC6: Without orchard-proxy, adapter list_sessions is the source of truth
+    // -----------------------------------------------------------------------
+
+    /// AC6 scenario B: For a non-proxy remote (here `BoxdSharedAdapter`),
+    /// `list_sessions()` is sourced from a direct `tmux list-panes` SSH call —
+    /// never from `orchard --json`.
+    ///
+    /// Satisfies the contract: "no `ssh host orchard --json` call is made for
+    /// hosts that are not orchard-proxy". Verified by recording every SSH
+    /// command the adapter issues and asserting the negative.
+    #[test]
+    fn non_proxy_adapter_list_sessions_does_not_invoke_orchard_json() {
+        use std::sync::{Arc, Mutex};
+
+        /// Recording seam: forwards every call to an inner `FakeSshExec` and
+        /// appends the command string to a shared log.
+        struct RecordingFakeSshExec {
+            inner: FakeSshExec,
+            calls: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl SshExec for RecordingFakeSshExec {
+            fn exec(&self, host: &str, cmd: &str) -> Result<SshOutput> {
+                self.calls.lock().unwrap().push(cmd.to_string());
+                self.inner.exec(host, cmd)
+            }
+        }
+
+        let host = "boxd@orchard-rs.boxd.sh";
+        let session_name = "or_issue999";
+        let worktree_path = "/home/boxd/orchard/worktrees/issue999";
+
+        // Prime: shared VM returns one active-pane tmux row for or_issue999.
+        let tmux_cmd = format!(
+            "tmux list-panes -a -F '{}'",
+            crate::cache_sources::TMUX_SESSION_FORMAT
+        );
+        let mut inner = FakeSshExec::new();
+        inner.insert(
+            host,
+            &tmux_cmd,
+            SshOutput {
+                stdout: format!("{session_name}\t1\t{worktree_path}\t1713000000\t1713000060\n"),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+
+        let calls = Arc::new(Mutex::new(Vec::<String>::new()));
+        let recording = RecordingFakeSshExec {
+            inner,
+            calls: calls.clone(),
+        };
+
+        let adapter = BoxdSharedAdapter {
+            host: host.to_string(),
+            path: "/home/boxd/orchard".to_string(),
+            ssh: Box::new(recording),
+        };
+
+        // The adapter IS the source of truth for non-proxy remotes.
+        let sessions = adapter
+            .list_sessions()
+            .expect("list_sessions must not error");
+
+        let recorded = calls.lock().unwrap();
+
+        // Positive assertion: the adapter used the direct tmux probe.
+        assert!(
+            recorded.iter().any(|c| c.contains("tmux list-panes")),
+            "list_sessions for a non-proxy remote must use tmux list-panes; got: {recorded:?}"
+        );
+
+        // Negative assertion: `orchard --json` must NEVER be invoked on a non-proxy adapter.
+        assert!(
+            !recorded.iter().any(|c| c.contains("orchard --json")),
+            "list_sessions for a non-proxy remote must NOT invoke orchard --json; got: {recorded:?}"
+        );
+
+        // The adapter is the authoritative source — returned sessions are non-empty.
+        assert!(
+            !sessions.is_empty(),
+            "list_sessions must return the session from the direct tmux probe; got: {sessions:?}"
+        );
+        assert_eq!(
+            sessions[0].name, session_name,
+            "session name must be '{session_name}'; got: {}",
+            sessions[0].name
+        );
+    }
 }

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -359,9 +359,34 @@ impl BoxdSharedAdapter {
 
     /// Returns all tmux sessions from the Boxd shared VM.
     ///
-    /// Slice 2 stub — full implementation in slice 3.
+    /// Runs `tmux list-panes -a -F '...'` on the shared VM via SSH and parses
+    /// the output with `cache_sources::parse_tmux_sessions_from_panes`. Every
+    /// returned session is tagged with the shared-VM host. SSH failure returns
+    /// `Err` so the caller can preserve prior cache rather than treating an
+    /// empty result as authoritative.
     pub fn list_sessions(&self) -> Result<Vec<CachedTmuxSession>> {
-        Ok(vec![])
+        let tmux_cmd = format!(
+            "tmux list-panes -a -F '{}'",
+            crate::cache_sources::TMUX_SESSION_FORMAT
+        );
+        let stdout = match self.ssh.exec(&self.host, &tmux_cmd) {
+            Ok(output) => output.stdout,
+            Err(e) => {
+                return Err(AdapterError::FetchFailure {
+                    message: e.to_string(),
+                }
+                .into());
+            }
+        };
+
+        let sessions = crate::cache_sources::parse_tmux_sessions_from_panes(
+            &stdout,
+            Some(&self.host),
+            |_| String::new(),
+            |_| vec![],
+        );
+
+        Ok(sessions)
     }
 }
 
@@ -1458,83 +1483,12 @@ mod tests {
         );
     }
 
-    /// #337 AC5: exit 127 writes a `remote_adapter.proxy_failure` event to events.jsonl
-    /// with the host and a reason mentioning "exit 127".
-    ///
-    /// Uses `ORCHARD_EVENTS_PATH` to redirect writes to a temp directory so the
-    /// test is hermetic and does not touch `~/.local/state/git-orchard/events.jsonl`.
-    #[test]
-    fn orchard_proxy_exit_127_writes_proxy_failure_event_to_events_jsonl() {
-        use std::io::Read;
-        use tempfile::tempdir;
-
-        let dir = tempdir().expect("create temp dir");
-        let events_file = dir.path().join("events.jsonl");
-
-        // Redirect events writes to our temp file.
-        // SAFETY: setting env vars is process-global; this test uses a unique
-        // tempdir path and removes the var before parallel reads, so it cannot
-        // collide with other tests that touch `ORCHARD_EVENTS_PATH`.
-        unsafe { std::env::set_var("ORCHARD_EVENTS_PATH", events_file.as_os_str()) };
-
-        let mut fake = FakeSshExec::new();
-        fake.insert(
-            "boxd@vm.boxd.sh",
-            "orchard --json",
-            SshOutput {
-                stdout: String::new(),
-                stderr: "orchard: not found".to_string(),
-                exit_code: 127,
-            },
-        );
-
-        let adapter = OrchardProxyAdapter {
-            host: "boxd@vm.boxd.sh".to_string(),
-            path: "~/repo".to_string(),
-            ssh: Box::new(fake),
-            snapshot: OnceLock::new(),
-        };
-
-        let _result = adapter.list_worktrees();
-
-        // SAFETY: same as above — process-global mutation, but this test owns
-        // the variable lifecycle within its own scope.
-        unsafe { std::env::remove_var("ORCHARD_EVENTS_PATH") };
-
-        // Read events file.
-        let mut contents = String::new();
-        std::fs::File::open(&events_file)
-            .expect("events.jsonl must have been created")
-            .read_to_string(&mut contents)
-            .unwrap();
-
-        // Find the proxy_failure event.
-        let failure_line = contents
-            .lines()
-            .filter(|l| !l.is_empty())
-            .find(|l| l.contains("remote_adapter.proxy_failure"))
-            .expect("events.jsonl must contain a remote_adapter.proxy_failure event");
-
-        let parsed: serde_json::Map<String, serde_json::Value> =
-            serde_json::from_str(failure_line).expect("proxy_failure line must be valid JSON");
-
-        // host field must match the adapter's host.
-        assert_eq!(
-            parsed.get("host").and_then(|v| v.as_str()),
-            Some("boxd@vm.boxd.sh"),
-            "proxy_failure event must carry the host; got: {parsed:?}"
-        );
-
-        // reason field must mention exit 127.
-        let reason = parsed
-            .get("reason")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        assert!(
-            reason.contains("127"),
-            "proxy_failure reason must mention exit 127; got: '{reason}'"
-        );
-    }
+    // The "exit 127 → proxy_failure event written to events.jsonl with host
+    // and exit-127 reason" assertion is locked by the integration test
+    // `cached_snapshot_survives_proxy_failure_with_proxy_failure_event_logged`
+    // in `crates/orchard/tests/federation_wire_up.rs`. That test runs in a
+    // separate binary, sidestepping the parallel env-var race on
+    // `ORCHARD_EVENTS_PATH` that sinks unit-level attempts.
 
     /// AC6 scenario 2: malformed JSON returns ParseFailure.
     #[test]
@@ -1858,5 +1812,145 @@ mod tests {
         let reason = super::classify_proxy_failure_reason("some other error");
         assert!(reason.starts_with("fetch failure: "));
         assert!(reason.contains("some other error"));
+    }
+
+    // -----------------------------------------------------------------------
+    // AC1: BoxdForkAdapter::list_sessions — session name, host, and path
+    // -----------------------------------------------------------------------
+
+    /// AC1 scenario: `BoxdForkAdapter::list_sessions()` returns exactly one
+    /// `CachedTmuxSession` with the correct name, host, and working-directory
+    /// path for the launched issue session.
+    ///
+    /// Satisfies feature.feature:41-48.
+    #[test]
+    fn boxd_fork_adapter_list_sessions_returns_session_with_correct_name_host_and_path() {
+        let fork_host = "boxd@or-issue999.boxd.sh";
+        let fork_url = "or-issue999.boxd.sh";
+        let worktree_path = "/workspace/repo";
+        let session_name = "or_issue999";
+
+        let mut fake = FakeSshExec::new();
+
+        // Prime: golden host enumerates exactly one running fork.
+        fake.insert(
+            "boxd.sh",
+            "list --json",
+            SshOutput {
+                stdout: format!(
+                    r#"[{{"name":"{session_name}","url":"{fork_url}","status":"running","path":"{worktree_path}"}}]"#
+                ),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+
+        // Prime: fork VM returns one active-pane tmux row.
+        let tmux_cmd = format!(
+            "tmux list-panes -a -F '{}'",
+            crate::cache_sources::TMUX_SESSION_FORMAT
+        );
+        // Format: session_name\tpane_active\tpane_current_path\tsession_created\tsession_activity
+        fake.insert(
+            fork_host,
+            &tmux_cmd,
+            SshOutput {
+                stdout: format!("{session_name}\t1\t{worktree_path}\t1713000000\t1713000060\n"),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+
+        let adapter = BoxdForkAdapter {
+            golden_host: "boxd.sh".to_string(),
+            fork_repo_path: worktree_path.to_string(),
+            ssh: Box::new(fake),
+        };
+
+        let sessions = adapter
+            .list_sessions()
+            .expect("list_sessions must not error");
+
+        assert_eq!(
+            sessions.len(),
+            1,
+            "expected exactly 1 CachedTmuxSession; got: {sessions:?}"
+        );
+
+        let session = &sessions[0];
+        assert_eq!(
+            session.name, session_name,
+            "session name must be '{session_name}'"
+        );
+        assert_eq!(
+            session.host.as_deref(),
+            Some(fork_host),
+            "session host must be '{fork_host}'"
+        );
+        assert_eq!(
+            session.path, worktree_path,
+            "session working directory must be '{worktree_path}'"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC2: BoxdSharedAdapter::list_sessions — session name and host
+    // -----------------------------------------------------------------------
+
+    /// AC2 scenario: `BoxdSharedAdapter::list_sessions()` returns exactly one
+    /// `CachedTmuxSession` with the correct name and host for an issue session
+    /// on the shared VM.
+    ///
+    /// Satisfies feature.feature:69-75.
+    #[test]
+    fn boxd_shared_adapter_list_sessions_returns_session_with_correct_name_and_host() {
+        let host = "boxd@orchard-rs.boxd.sh";
+        let worktree_path = "/home/boxd/orchard/worktrees/issue999";
+        let session_name = "or_issue999";
+
+        let mut fake = FakeSshExec::new();
+
+        // Prime: shared VM returns one active-pane tmux row.
+        let tmux_cmd = format!(
+            "tmux list-panes -a -F '{}'",
+            crate::cache_sources::TMUX_SESSION_FORMAT
+        );
+        // Format: session_name\tpane_active\tpane_current_path\tsession_created\tsession_activity
+        fake.insert(
+            host,
+            &tmux_cmd,
+            SshOutput {
+                stdout: format!("{session_name}\t1\t{worktree_path}\t1713000000\t1713000060\n"),
+                stderr: String::new(),
+                exit_code: 0,
+            },
+        );
+
+        let adapter = BoxdSharedAdapter {
+            host: host.to_string(),
+            path: "/home/boxd/orchard".to_string(),
+            ssh: Box::new(fake),
+        };
+
+        let sessions = adapter
+            .list_sessions()
+            .expect("list_sessions must not error");
+
+        assert_eq!(
+            sessions.len(),
+            1,
+            "expected exactly 1 CachedTmuxSession; got: {sessions:?}"
+        );
+
+        let session = &sessions[0];
+        assert_eq!(
+            session.name, session_name,
+            "session name must be '{session_name}'"
+        );
+        assert_eq!(
+            session.host.as_deref(),
+            Some(host),
+            "session host must be '{host}'"
+        );
     }
 }

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -1387,8 +1387,10 @@ mod tests {
     // AC6: Proxy failures surface as events; no silent fallback
     // -----------------------------------------------------------------------
 
-    /// AC6 scenario 1: exit code 127 returns FetchFailure and does NOT attempt
-    /// any legacy `git worktree list --porcelain` invocation.
+    /// AC6 scenario 1 / #337 AC5: exit code 127 returns FetchFailure and does NOT attempt
+    /// any legacy `git worktree list --porcelain` or `tmux list-sessions` invocations.
+    ///
+    /// Scenario contract: "Proxy failure does NOT trigger any legacy shell-discovery on that host"
     #[test]
     fn orchard_proxy_exit_127_surfaces_proxy_failure_event() {
         use std::sync::{Arc, Mutex};
@@ -1435,11 +1437,102 @@ mod tests {
             "exit 127 must surface as Err (FetchFailure), not Ok; got: {result:?}"
         );
 
-        // The recorded command list must only contain `orchard --json` — no git worktree list.
         let recorded = calls.lock().unwrap();
+
+        // AC5: the positive assertion — `orchard --json` must have been attempted.
+        assert!(
+            recorded.iter().any(|c| c.contains("orchard --json")),
+            "orchard --json must be in the recorded commands; got: {recorded:?}"
+        );
+
+        // AC5: legacy git discovery must NOT be triggered on failure.
         assert!(
             !recorded.iter().any(|c| c.contains("git worktree list")),
             "git worktree list --porcelain must NOT be invoked on failure path; got: {recorded:?}"
+        );
+
+        // AC5: legacy tmux discovery must NOT be triggered on failure.
+        assert!(
+            !recorded.iter().any(|c| c.contains("tmux list-sessions")),
+            "tmux list-sessions must NOT be invoked on failure path; got: {recorded:?}"
+        );
+    }
+
+    /// #337 AC5: exit 127 writes a `remote_adapter.proxy_failure` event to events.jsonl
+    /// with the host and a reason mentioning "exit 127".
+    ///
+    /// Uses `ORCHARD_EVENTS_PATH` to redirect writes to a temp directory so the
+    /// test is hermetic and does not touch `~/.local/state/git-orchard/events.jsonl`.
+    #[test]
+    fn orchard_proxy_exit_127_writes_proxy_failure_event_to_events_jsonl() {
+        use std::io::Read;
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("create temp dir");
+        let events_file = dir.path().join("events.jsonl");
+
+        // Redirect events writes to our temp file.
+        // SAFETY: setting env vars is process-global; this test uses a unique
+        // tempdir path and removes the var before parallel reads, so it cannot
+        // collide with other tests that touch `ORCHARD_EVENTS_PATH`.
+        unsafe { std::env::set_var("ORCHARD_EVENTS_PATH", events_file.as_os_str()) };
+
+        let mut fake = FakeSshExec::new();
+        fake.insert(
+            "boxd@vm.boxd.sh",
+            "orchard --json",
+            SshOutput {
+                stdout: String::new(),
+                stderr: "orchard: not found".to_string(),
+                exit_code: 127,
+            },
+        );
+
+        let adapter = OrchardProxyAdapter {
+            host: "boxd@vm.boxd.sh".to_string(),
+            path: "~/repo".to_string(),
+            ssh: Box::new(fake),
+            snapshot: OnceLock::new(),
+        };
+
+        let _result = adapter.list_worktrees();
+
+        // SAFETY: same as above — process-global mutation, but this test owns
+        // the variable lifecycle within its own scope.
+        unsafe { std::env::remove_var("ORCHARD_EVENTS_PATH") };
+
+        // Read events file.
+        let mut contents = String::new();
+        std::fs::File::open(&events_file)
+            .expect("events.jsonl must have been created")
+            .read_to_string(&mut contents)
+            .unwrap();
+
+        // Find the proxy_failure event.
+        let failure_line = contents
+            .lines()
+            .filter(|l| !l.is_empty())
+            .find(|l| l.contains("remote_adapter.proxy_failure"))
+            .expect("events.jsonl must contain a remote_adapter.proxy_failure event");
+
+        let parsed: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(failure_line).expect("proxy_failure line must be valid JSON");
+
+        // host field must match the adapter's host.
+        assert_eq!(
+            parsed.get("host").and_then(|v| v.as_str()),
+            Some("boxd@vm.boxd.sh"),
+            "proxy_failure event must carry the host; got: {parsed:?}"
+        );
+
+        // reason field must mention exit 127.
+        let reason = parsed
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(
+            reason.contains("127"),
+            "proxy_failure reason must mention exit 127; got: '{reason}'"
         );
     }
 

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -4346,6 +4346,49 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // AC4 unit lock — TaskEnterAction builder for remote worktree with no sessions
+    // Feature: launch-remote-tui-enter-federation-validation.feature lines 107-114
+    // -----------------------------------------------------------------------
+
+    /// When a worktree row has a remote host and **no** existing sessions, the Enter
+    /// action builder must choose `CreateSession`, not `JoinSession`.
+    ///
+    /// The boxd-fork routing is preserved: the host on the action equals the
+    /// worktree's host field (`boxd@vm.boxd.sh`).
+    ///
+    /// Note: `host_reachable` is checked by `block_if_host_unreachable` at the App
+    /// level, not inside the builder — so it is irrelevant to this unit test.
+    #[test]
+    fn enter_action_builder_selects_create_session_for_remote_worktree_with_no_sessions() {
+        let host = "boxd@vm.boxd.sh";
+
+        // A worktree row on a remote host with no sessions.
+        let row = WorktreeRow {
+            worktree_host: Some(host.to_string()),
+            sessions: vec![],
+            ..make_task_row(337, DisplayGroup::ClaudeWorking)
+        };
+
+        let action = build_worktree_enter_action(&row);
+
+        match action {
+            TaskEnterAction::CreateSession { ref host, .. } => {
+                assert_eq!(
+                    host.as_deref(),
+                    Some("boxd@vm.boxd.sh"),
+                    "host must be Some(\"boxd@vm.boxd.sh\"), got {host:?}"
+                );
+            }
+            TaskEnterAction::JoinSession { .. } => {
+                panic!("expected CreateSession but got JoinSession — builder chose wrong variant for no-session remote row");
+            }
+            TaskEnterAction::JoinStandalone { .. } => {
+                panic!("expected CreateSession but got JoinStandalone");
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // AC3 regression lock — join_or_create_session dispatch
     // Feature: launch-remote-tui-enter-federation-validation.feature lines 92-99
     // -----------------------------------------------------------------------

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -4498,4 +4498,74 @@ mod tests {
             "proxy_name in recorder must equal proxy_session_name(session_name)"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // AC4 regression lock — CreateSession dispatch
+    // Feature: launch-remote-tui-enter-federation-validation.feature lines 124-130
+    // -----------------------------------------------------------------------
+
+    /// Regression lock for AC4 (CreateSession path):
+    /// When `join_or_create_session` is called with `remote_host=Some(...)` —
+    /// as it is from the `TaskEnterAction::CreateSession` arm in
+    /// `handle_enter_action` — it must call
+    /// `remote::create_remote_proxy_session` exactly once with the correct host.
+    ///
+    /// Note: the "create_remote_session is called first" sub-claim in the
+    /// scenario refers to an implementation detail *inside*
+    /// `create_remote_proxy_session`'s production block (`#[cfg(not(test))]`
+    /// at remote.rs:336-337). That internal two-step is not observable through
+    /// this seam in test builds; it is covered by the `#[ignore]`-gated live
+    /// e2e harness (Task #22). What we lock here is that the CreateSession
+    /// arm dispatches through the same `create_remote_proxy_session` gateway
+    /// as the JoinSession arm — same contract, different caller.
+    #[test]
+    fn join_or_create_session_for_create_session_dispatches_create_remote_proxy_session() {
+        use crate::remote;
+
+        let host = "boxd@vm.boxd.sh";
+        let session_name = "issue999_workflow";
+        let worktree_path = "/path/to/worktree";
+
+        // Drain any stale recorder state from a prior test in this thread.
+        let _ = remote::take_proxy_session_calls();
+
+        let mut app = App::new_test(vec![]);
+        // This is the same call shape the CreateSession arm of handle_enter_action
+        // produces after deriving session_name via tmux::derive_session_name.
+        app.join_or_create_session(
+            session_name,
+            worktree_path,
+            Some("issue999/branch"),
+            Some(host),
+            None,
+        );
+
+        let calls = remote::take_proxy_session_calls();
+
+        assert_eq!(
+            calls.len(),
+            1,
+            "expected exactly one create_remote_proxy_session call from CreateSession path, got {}: {calls:?}",
+            calls.len()
+        );
+
+        let call = &calls[0];
+
+        assert_eq!(
+            call.host, host,
+            "recorded host must be {host:?}, got {:?}",
+            call.host
+        );
+        assert_eq!(
+            call.session_name, session_name,
+            "recorded source session must be {session_name:?}, got {:?}",
+            call.session_name
+        );
+        assert_eq!(
+            call.proxy_name,
+            remote::proxy_session_name(session_name),
+            "proxy_name must equal proxy_session_name(session_name), got {:?}",
+            call.proxy_name
+        );
+    }
 }

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -4380,7 +4380,9 @@ mod tests {
                 );
             }
             TaskEnterAction::JoinSession { .. } => {
-                panic!("expected CreateSession but got JoinSession — builder chose wrong variant for no-session remote row");
+                panic!(
+                    "expected CreateSession but got JoinSession — builder chose wrong variant for no-session remote row"
+                );
             }
             TaskEnterAction::JoinStandalone { .. } => {
                 panic!("expected CreateSession but got JoinStandalone");
@@ -4460,6 +4462,7 @@ mod tests {
             Some("issue3201/fix"),
             Some(host),
             None,
+            None,
         );
 
         let calls = remote::take_proxy_session_calls();
@@ -4538,6 +4541,7 @@ mod tests {
             Some("issue999/branch"),
             Some(host),
             None,
+            None,
         );
 
         let calls = remote::take_proxy_session_calls();
@@ -4602,10 +4606,14 @@ mod tests {
             Some("issue999/x"),
             Some(host),
             None,
+            None,
         );
 
         // Returns false on the failure path.
-        assert!(!result, "join_or_create_session must return false on proxy error");
+        assert!(
+            !result,
+            "join_or_create_session must return false on proxy error"
+        );
 
         // No premature tmux switch.
         assert!(

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -4389,6 +4389,46 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // AC4 regression lock — Unknown host does not block Enter (#285)
+    // Feature: launch-remote-tui-enter-federation-validation.feature lines 116-122
+    // -----------------------------------------------------------------------
+
+    /// Regression lock for #285:
+    /// When a host has no entry in `host_reachable` (probe never ran, timed out,
+    /// or returned Unknown), `block_if_host_unreachable` must return `false` so
+    /// that Enter is NOT short-circuited.  A missing entry means Unknown, and
+    /// Unknown is treated as "proceed optimistically" — only a confirmed
+    /// `Reachability::Unreachable` blocks.
+    ///
+    /// This test also asserts that no spurious warning is written for the Unknown
+    /// state, since a warning would confuse the user into thinking the host was
+    /// checked and found unreachable.
+    #[test]
+    fn block_if_host_unreachable_returns_false_for_unknown_host() {
+        let host = "boxd@unknown-host.boxd.sh";
+
+        let mut app = App::new_test(vec![]);
+
+        // Intentionally do NOT insert the host — this is the Unknown state.
+        assert!(
+            !app.host_reachable.contains_key(host),
+            "pre-condition: host must be absent from host_reachable (Unknown state)"
+        );
+
+        let blocked = app.block_if_host_unreachable(host);
+
+        assert!(
+            !blocked,
+            "block_if_host_unreachable must return false for Unknown (missing) host, got true"
+        );
+        assert!(
+            app.warning.is_none(),
+            "no warning must be written for Unknown host; got {:?}",
+            app.warning.as_ref().map(|(s, _)| s.as_str())
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // AC3 regression lock — join_or_create_session dispatch
     // Feature: launch-remote-tui-enter-federation-validation.feature lines 92-99
     // -----------------------------------------------------------------------

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -4344,4 +4344,75 @@ mod tests {
             }
         }
     }
+
+    // -----------------------------------------------------------------------
+    // AC3 regression lock — join_or_create_session dispatch
+    // Feature: launch-remote-tui-enter-federation-validation.feature lines 92-99
+    // -----------------------------------------------------------------------
+
+    /// Regression lock for AC3:
+    /// When `join_or_create_session` receives a `JoinSession` action for a
+    /// remote host, it must call `remote::create_remote_proxy_session` exactly
+    /// once with the correct host and source session name, and the derived
+    /// proxy session name must equal `"remote_{source}"`.
+    ///
+    /// Validated manually 2026-04-22 06:14 (createRemoteProxySession:
+    /// claude -> remote_claude; hostname=issue3201). This test locks the
+    /// call-site dispatch contract.
+    #[test]
+    fn join_or_create_session_calls_create_remote_proxy_session_for_remote_join() {
+        use crate::remote;
+
+        let host = "boxd@issue3201.boxd.sh";
+        let session_name = "claude";
+        let worktree_path = "/workspace/issue3201";
+
+        // Drain any stale recorder state from a prior test in this thread.
+        let _ = remote::take_proxy_session_calls();
+
+        let mut app = App::new_test(vec![]);
+        app.join_or_create_session(
+            session_name,
+            worktree_path,
+            Some("issue3201/fix"),
+            Some(host),
+            None,
+        );
+
+        let calls = remote::take_proxy_session_calls();
+
+        assert_eq!(
+            calls.len(),
+            1,
+            "expected exactly one create_remote_proxy_session call, got {}: {calls:?}",
+            calls.len()
+        );
+
+        let call = &calls[0];
+
+        assert_eq!(
+            call.host, host,
+            "recorded host must be {host:?}, got {:?}",
+            call.host
+        );
+        assert_eq!(
+            call.session_name, session_name,
+            "recorded source session must be {session_name:?}, got {:?}",
+            call.session_name
+        );
+
+        // The proxy session name is the central naming-convention contract.
+        assert_eq!(
+            call.proxy_name, "remote_claude",
+            "proxy session name must be \"remote_claude\", got {:?}",
+            call.proxy_name
+        );
+
+        // Cross-check via the pure helper — both paths derive the same name.
+        assert_eq!(
+            call.proxy_name,
+            remote::proxy_session_name(session_name),
+            "proxy_name in recorder must equal proxy_session_name(session_name)"
+        );
+    }
 }

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -4568,4 +4568,65 @@ mod tests {
             call.proxy_name
         );
     }
+
+    // -----------------------------------------------------------------------
+    // AC4 regression lock — CreateSession failure surfaces warning
+    // Feature: launch-remote-tui-enter-federation-validation.feature lines 132-138
+    // -----------------------------------------------------------------------
+
+    /// When `create_remote_proxy_session` fails, `join_or_create_session` must:
+    ///   - return `false` (failure path),
+    ///   - leave `switch_target` as `None` (no premature switch),
+    ///   - set `app.warning` with a message containing the error description.
+    ///
+    /// This locks the "failure surfaces warning, not silent swallow" contract
+    /// from the scenario at feature file lines 132-138.
+    #[test]
+    fn join_or_create_session_failure_surfaces_warning_in_app() {
+        use crate::remote;
+
+        let host = "boxd@vm.boxd.sh";
+        let session_name = "issue999";
+        let worktree_path = "/path";
+
+        // Drain any stale recorder state from a prior test in this thread.
+        let _ = remote::take_proxy_session_calls();
+
+        // Arm the failure — next call returns Err("simulated SSH failure").
+        remote::set_next_proxy_session_error("simulated SSH failure");
+
+        let mut app = App::new_test(vec![]);
+        let result = app.join_or_create_session(
+            session_name,
+            worktree_path,
+            Some("issue999/x"),
+            Some(host),
+            None,
+        );
+
+        // Returns false on the failure path.
+        assert!(!result, "join_or_create_session must return false on proxy error");
+
+        // No premature tmux switch.
+        assert!(
+            app.switch_target.is_none(),
+            "switch_target must be None when proxy call fails, got {:?}",
+            app.switch_target
+        );
+
+        // Warning must be set and contain the error context.
+        let (msg, _) = app
+            .warning
+            .as_ref()
+            .expect("app.warning must be Some after a remote proxy session failure");
+
+        assert!(
+            msg.contains("remote session error"),
+            "warning must contain \"remote session error\", got {msg:?}"
+        );
+        assert!(
+            msg.contains("simulated SSH failure"),
+            "warning must contain the original error message \"simulated SSH failure\", got {msg:?}"
+        );
+    }
 }

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -51,7 +51,7 @@ pub(crate) const ID_W: usize = 17;
 
 /// Describes what action the Enter key should take in the task view.
 /// Used to avoid holding a borrow on `task_rows` while calling `&mut self` methods.
-enum TaskEnterAction {
+pub(crate) enum TaskEnterAction {
     JoinSession {
         session_name: String,
         worktree_path: String,
@@ -79,6 +79,36 @@ enum TaskEnterAction {
         /// When `Some`, select this pane after switching (tmux target "window.pane").
         pane_target: Option<String>,
     },
+}
+
+/// Builds the [`TaskEnterAction`] for a worktree row.
+///
+/// Returns `JoinSession` when the row has at least one existing session, or
+/// `CreateSession` when there are no sessions. The `pane_target` field is
+/// always `None`; callers that need pane routing (e.g. `handle_enter_action`)
+/// patch it in after calling this function.
+pub(crate) fn build_worktree_enter_action(row: &WorktreeRow) -> TaskEnterAction {
+    if let Some(session) = row.sessions.first() {
+        let host = match &session.tmux.host {
+            crate::session::Host::Local => None,
+            crate::session::Host::Remote(h) => Some(h.clone()),
+        };
+        TaskEnterAction::JoinSession {
+            session_name: session.tmux.name.clone(),
+            worktree_path: row.worktree_path.clone(),
+            branch: Some(row.branch.clone()),
+            host,
+            pane_target: None,
+            discovery_path: row.discovery_path.clone(),
+        }
+    } else {
+        TaskEnterAction::CreateSession {
+            worktree_path: row.worktree_path.clone(),
+            branch: Some(row.branch.clone()),
+            host: row.worktree_host.clone(),
+            discovery_path: row.discovery_path.clone(),
+        }
+    }
 }
 
 /// Returns whether the cursor is currently on a standalone session row.
@@ -535,28 +565,17 @@ impl App {
             let tasks =
                 visible_tasks_filtered(&self.task_rows, &self.filter_text, self.active_repo_slug());
             let action = tasks.get(worktree_cursor).map(|vt| {
-                if let Some(session) = vt.row.sessions.first() {
-                    let host = match &session.tmux.host {
-                        crate::session::Host::Local => None,
-                        crate::session::Host::Remote(h) => Some(h.clone()),
-                    };
-                    let pane_target = resolve_pane_target_from_sub_cursor(&sub_cursor, session);
-                    TaskEnterAction::JoinSession {
-                        session_name: session.tmux.name.clone(),
-                        worktree_path: vt.row.worktree_path.clone(),
-                        branch: Some(vt.row.branch.clone()),
-                        host,
-                        pane_target,
-                        discovery_path: vt.row.discovery_path.clone(),
-                    }
-                } else {
-                    TaskEnterAction::CreateSession {
-                        worktree_path: vt.row.worktree_path.clone(),
-                        branch: Some(vt.row.branch.clone()),
-                        host: vt.row.worktree_host.clone(),
-                        discovery_path: vt.row.discovery_path.clone(),
-                    }
+                // Build the base action (no pane_target) then patch in pane routing.
+                let mut action = build_worktree_enter_action(vt.row);
+                if let TaskEnterAction::JoinSession {
+                    ref mut pane_target,
+                    ..
+                } = action
+                    && let Some(session) = vt.row.sessions.first()
+                {
+                    *pane_target = resolve_pane_target_from_sub_cursor(&sub_cursor, session);
                 }
+                action
             });
             drop(tasks);
             action
@@ -4264,5 +4283,65 @@ mod tests {
             "unexpected '[b]' in badge text: {:?}",
             text
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC3 regression lock — TaskEnterAction builder: JoinSession vs CreateSession
+    // Feature: launch-remote-tui-enter-federation-validation.feature lines 84-90
+    // -----------------------------------------------------------------------
+
+    /// Regression lock for AC3:
+    /// When a worktree row has a remote host and an existing session, the Enter
+    /// action builder must choose `JoinSession`, not `CreateSession`.
+    ///
+    /// Validated manually 2026-04-22 06:14 (createRemoteProxySession:
+    /// claude -> remote_claude; hostname=issue3201). This test locks that behaviour.
+    #[test]
+    fn enter_action_builder_selects_join_session_for_remote_worktree_with_existing_session() {
+        let host = "boxd@issue3201.boxd.sh";
+
+        // A worktree row on a remote host with exactly one existing session named "claude".
+        let row = WorktreeRow {
+            worktree_host: Some(host.to_string()),
+            sessions: vec![EnrichedSession {
+                tmux: TmuxSessionInfo {
+                    host: Host::Remote(host.to_string()),
+                    name: "claude".to_string(),
+                    status: SessionStatus::Running { attached: false },
+                },
+                claude: None,
+                windows: vec![],
+                panes: vec![],
+                started_at: None,
+                last_activity_at: None,
+            }],
+            ..make_task_row(3201, DisplayGroup::ClaudeWorking)
+        };
+
+        let action = build_worktree_enter_action(&row);
+
+        match action {
+            TaskEnterAction::JoinSession {
+                ref session_name,
+                ref host,
+                ..
+            } => {
+                assert_eq!(
+                    session_name, "claude",
+                    "session_name must be 'claude', got '{session_name}'"
+                );
+                assert_eq!(
+                    host.as_deref(),
+                    Some("boxd@issue3201.boxd.sh"),
+                    "host must be Some(\"boxd@issue3201.boxd.sh\"), got {host:?}"
+                );
+            }
+            TaskEnterAction::CreateSession { .. } => {
+                panic!("expected JoinSession but got CreateSession — builder chose wrong variant");
+            }
+            TaskEnterAction::JoinStandalone { .. } => {
+                panic!("expected JoinSession but got JoinStandalone");
+            }
+        }
     }
 }

--- a/crates/orchard/tests/e2e_launch_remote.rs
+++ b/crates/orchard/tests/e2e_launch_remote.rs
@@ -165,9 +165,9 @@ fn session_row_visible(json_stdout: &str, repo_slug: &str, needle: &str) -> bool
     // fails, fall back to the substring gate (which is already permissive).
     if let Ok(json) = serde_json::from_str::<serde_json::Value>(json_stdout)
         && let Some(repos) = json.get("repos").and_then(|v| v.as_array())
-        && let Some(repo) = repos.iter().find(|r| {
-            r.get("slug").and_then(|s| s.as_str()) == Some(repo_slug)
-        })
+        && let Some(repo) = repos
+            .iter()
+            .find(|r| r.get("slug").and_then(|s| s.as_str()) == Some(repo_slug))
         && let Some(worktrees) = repo.get("worktrees").and_then(|v| v.as_array())
     {
         for wt in worktrees {

--- a/crates/orchard/tests/e2e_launch_remote.rs
+++ b/crates/orchard/tests/e2e_launch_remote.rs
@@ -1,0 +1,201 @@
+//! End-to-end harness for `/launch-remote` visibility (AC1 + AC2 of #337).
+//!
+//! These tests are gated behind `#[ignore]` because they require:
+//! - A real boxd VM (or shared VM) reachable from the test runner
+//! - The user's `~/.config/orchard/config.json` configured for that remote
+//! - Real GitHub credentials available to `gh`
+//! - A real test issue number on the target repo
+//!
+//! CI does not run them. Run on demand with:
+//!
+//! ```bash
+//! ORCHARD_E2E_TEST_ISSUE=999 cargo test -p orchard --test e2e_launch_remote -- --ignored
+//! ```
+//!
+//! Each test:
+//! 1. Records `t0`
+//! 2. Invokes the production launch flow against a configured remote
+//! 3. Polls `orchard refresh && orchard --json` for the new session row
+//! 4. Records `t1` when the session appears
+//! 5. Asserts visibility under the AC's budget (30s) and prints elapsed time
+//!
+//! The polling interleaves an explicit `orchard refresh` per the Plan: the
+//! follow-up issue for `orchard refresh --remote <host>` (Phase 7) is what
+//! eventually closes the AC1 30s budget honestly. Until then this harness
+//! documents the refresh-on-launch gap empirically — run it 5–10 times to
+//! capture a baseline distribution.
+//!
+//! ## Why no automatic CI run
+//!
+//! - Real boxd cycles cost money and require credentials.
+//! - The launch flow is a markdown skill (not the orchard binary), so we can
+//!   only invoke its constituent pieces here, not the user-facing entry point.
+//! - The contract being verified is "after `/launch-remote` completes, the
+//!   session appears in `orchard --json` within 30s". The harness measures
+//!   the second half (refresh + --json visibility) given a session that
+//!   already exists on the remote — the first half (skill execution) is out
+//!   of scope for an in-tree test.
+
+use std::time::{Duration, Instant};
+
+use assert_cmd::Command;
+
+const VISIBILITY_BUDGET: Duration = Duration::from_secs(30);
+const POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+/// AC1: After a session appears on a boxd-fork host (e.g., the LangWatch
+/// fleet's per-issue forks), `orchard refresh && orchard --json` surfaces
+/// it locally within `VISIBILITY_BUDGET`.
+///
+/// Setup before running:
+/// 1. Have a boxd-fork remote configured in `~/.config/orchard/config.json`
+///    for `langwatch/langwatch` (or any repo with `type: boxd-fork`).
+/// 2. Manually create a tmux session on a real boxd fork (or run
+///    `/launch-remote langwatch/langwatch#$ORCHARD_E2E_TEST_ISSUE` in
+///    your shell beforehand).
+/// 3. Set `ORCHARD_E2E_TEST_ISSUE` to the issue number used.
+/// 4. Optionally set `ORCHARD_E2E_REPO_SLUG` (default: `langwatch/langwatch`).
+///
+/// On success, prints the elapsed seconds to stdout — capture this in the PR
+/// description as the AC1 baseline measurement.
+#[test]
+#[ignore = "requires real boxd-fork remote + GitHub credentials; run on demand with --ignored"]
+fn launch_remote_boxd_fork_visibility_within_30s() {
+    let issue = std::env::var("ORCHARD_E2E_TEST_ISSUE")
+        .expect("set ORCHARD_E2E_TEST_ISSUE to the issue number with a live session on the boxd-fork remote");
+    let repo = std::env::var("ORCHARD_E2E_REPO_SLUG")
+        .unwrap_or_else(|_| "langwatch/langwatch".to_string());
+
+    let elapsed = poll_for_session_visibility(&repo, &issue);
+    print_baseline("AC1 boxd-fork", &repo, &issue, elapsed);
+    assert!(
+        elapsed < VISIBILITY_BUDGET,
+        "AC1 budget exceeded: {elapsed:?} > {VISIBILITY_BUDGET:?}"
+    );
+}
+
+/// AC2: After a session appears on a boxd-shared remote (e.g.,
+/// `boxd@orchard-rs.boxd.sh`), `orchard refresh && orchard --json` surfaces
+/// it locally within `VISIBILITY_BUDGET`.
+///
+/// Setup before running:
+/// 1. Have a boxd-shared (or remmy-typed boxd) remote configured for
+///    `drewdrewthis/git-orchard-rs`.
+/// 2. Manually create a tmux session on the shared VM with a name that
+///    references the issue (e.g., `git-orchard-rs_issue<N>`).
+/// 3. Set `ORCHARD_E2E_TEST_ISSUE` to the issue number used.
+/// 4. Optionally set `ORCHARD_E2E_REPO_SLUG`
+///    (default: `drewdrewthis/git-orchard-rs`).
+#[test]
+#[ignore = "requires real boxd-shared remote + GitHub credentials; run on demand with --ignored"]
+fn launch_remote_boxd_shared_visibility_within_30s() {
+    let issue = std::env::var("ORCHARD_E2E_TEST_ISSUE")
+        .expect("set ORCHARD_E2E_TEST_ISSUE to the issue number with a live session on the boxd-shared remote");
+    let repo = std::env::var("ORCHARD_E2E_REPO_SLUG")
+        .unwrap_or_else(|_| "drewdrewthis/git-orchard-rs".to_string());
+
+    let elapsed = poll_for_session_visibility(&repo, &issue);
+    print_baseline("AC2 boxd-shared", &repo, &issue, elapsed);
+    assert!(
+        elapsed < VISIBILITY_BUDGET,
+        "AC2 budget exceeded: {elapsed:?} > {VISIBILITY_BUDGET:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Polls `orchard refresh && orchard --json` until the output contains a
+/// session row whose name references the issue number (substring match on
+/// `issue<N>`), or until `VISIBILITY_BUDGET` elapses. Returns the elapsed
+/// `Duration` on success; panics on timeout.
+fn poll_for_session_visibility(repo_slug: &str, issue_number: &str) -> Duration {
+    let needle = format!("issue{issue_number}");
+    let started = Instant::now();
+
+    loop {
+        // Run the same two-step the user runs: refresh, then read.
+        let _ = Command::cargo_bin("orchard")
+            .unwrap()
+            .arg("refresh")
+            .timeout(Duration::from_secs(15))
+            .output()
+            .expect("orchard refresh must run");
+
+        let output = Command::cargo_bin("orchard")
+            .unwrap()
+            .arg("--json")
+            .timeout(Duration::from_secs(10))
+            .output()
+            .expect("orchard --json must run");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if session_row_visible(&stdout, repo_slug, &needle) {
+            return started.elapsed();
+        }
+
+        if started.elapsed() >= VISIBILITY_BUDGET {
+            panic!(
+                "session referencing '{needle}' on repo '{repo_slug}' did not appear within \
+                 {VISIBILITY_BUDGET:?}; last orchard --json stdout begins with:\n{}",
+                stdout.lines().take(20).collect::<Vec<_>>().join("\n")
+            );
+        }
+
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Returns true when the JSON payload contains a worktree on the given repo
+/// slug whose `sessions` array contains a session whose name includes
+/// `needle`.
+///
+/// Uses substring search rather than full JSON parsing for two reasons:
+/// 1. Robust against minor schema drift (we want this harness to keep
+///    working through small JsonOutput version bumps).
+/// 2. The assertion the user cares about is "the session appeared in some
+///    form" — an exact-shape match would be brittle.
+fn session_row_visible(json_stdout: &str, repo_slug: &str, needle: &str) -> bool {
+    // Quick gate: both the slug and the needle must appear at all.
+    if !json_stdout.contains(repo_slug) || !json_stdout.contains(needle) {
+        return false;
+    }
+    // Belt-and-suspenders: parse and check the structure if we can. If parse
+    // fails, fall back to the substring gate (which is already permissive).
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(json_stdout)
+        && let Some(repos) = json.get("repos").and_then(|v| v.as_array())
+        && let Some(repo) = repos.iter().find(|r| {
+            r.get("slug").and_then(|s| s.as_str()) == Some(repo_slug)
+        })
+        && let Some(worktrees) = repo.get("worktrees").and_then(|v| v.as_array())
+    {
+        for wt in worktrees {
+            if let Some(sessions) = wt.get("sessions").and_then(|v| v.as_array()) {
+                for s in sessions {
+                    if let Some(name) = s.get("name").and_then(|v| v.as_str())
+                        && name.contains(needle)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+    // Fallback: substring already matched both gate strings.
+    true
+}
+
+/// Prints the AC baseline measurement to stdout in a parseable form.
+///
+/// Format: `[AC?-baseline] strategy=... repo=... issue=... elapsed_s=...`
+///
+/// Capture this in PR descriptions or follow-up issues to ground the
+/// "30s budget" claim empirically.
+fn print_baseline(label: &str, repo: &str, issue: &str, elapsed: Duration) {
+    println!(
+        "[{label}-baseline] repo={repo} issue={issue} elapsed_s={:.3}",
+        elapsed.as_secs_f64()
+    );
+}

--- a/crates/orchard/tests/federation_wire_up.rs
+++ b/crates/orchard/tests/federation_wire_up.rs
@@ -13,14 +13,15 @@
 //! pr/issue fields).
 
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
 use orchard::global_config::{GlobalConfig, RemoteConfig, RepoConfig};
 use orchard::json_output::{
     CiChecks as JsonCiChecks, JsonIssue, JsonOutput, JsonPr, JsonRepo, JsonWorktree,
 };
 use orchard::merge_remote::build_state_with_cached_snapshots_from;
-use orchard::orchard_snapshot::write_snapshot_to;
-use orchard::remote_adapter::RemoteKind;
+use orchard::orchard_snapshot::{orchard_snapshot_path_in, write_snapshot_to};
+use orchard::remote_adapter::{FakeSshExec, OrchardProxyAdapter, RemoteKind, SshOutput};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
@@ -338,4 +339,168 @@ fn host_reachability_persists_to_cache_and_is_read_on_build() {
     // write_host_reachability is production-only (writes to real cache dir);
     // smoke-test it without asserting on the real filesystem path.
     let _ = write_host_reachability(&hosts);
+}
+
+// ---------------------------------------------------------------------------
+// Test: cached snapshot survives proxy failure — no phantom data, no data loss
+// ---------------------------------------------------------------------------
+
+/// Builds a `JsonOutput` containing 2 worktrees for "owner/repo" under the
+/// given `host`, for use in the proxy-failure survival test.
+fn make_json_output_with_two_worktrees() -> JsonOutput {
+    fn bare_worktree(path: &str, branch: &str) -> JsonWorktree {
+        JsonWorktree {
+            path: path.to_string(),
+            branch: branch.to_string(),
+            host: None,
+            layout: "bare".to_string(),
+            ahead_behind: None,
+            last_commit_at: None,
+            issue: None,
+            pr: None,
+            sessions: vec![],
+            display_group: "other".to_string(),
+            status: "ready".to_string(),
+            status_glyph: "\u{1f7e2}".to_string(),
+            is_main_worktree: false,
+            last_activity_at: None,
+        }
+    }
+
+    JsonOutput {
+        version: 6,
+        tmux_sessions: vec![],
+        repos: vec![JsonRepo {
+            slug: "owner/repo".to_string(),
+            default_branch: None,
+            main_ci_state: None,
+            worktrees: vec![
+                bare_worktree("/remote/wt1", "issue1/foo"),
+                bare_worktree("/remote/wt2", "issue2/bar"),
+            ],
+        }],
+        hosts: HashMap::new(),
+    }
+}
+
+/// #337 Scenario: "Last-known snapshot stays visible after a proxy failure
+/// (no phantom data, but no data loss)"
+///
+/// Proves that when `OrchardProxyAdapter::fetch_snapshot` fails with exit 127:
+/// 1. The cached snapshot file is NOT deleted.
+/// 2. `build_state_with_cached_snapshots_from` still surfaces the 2 worktrees
+///    from the prior snapshot in the merged `OrchardState`.
+/// 3. A `remote_adapter.proxy_failure` event is written to `events.jsonl`.
+#[test]
+fn cached_snapshot_survives_proxy_failure_with_proxy_failure_event_logged() {
+    use std::io::Read as _;
+
+    let cache_dir = TempDir::new().expect("create temp cache dir");
+    let events_dir = TempDir::new().expect("create temp events dir");
+    let events_file = events_dir.path().join("events.jsonl");
+
+    let host = "boxd@orchard-rs.boxd.sh";
+
+    // Step 1–3: write a prior snapshot with 2 worktrees.
+    let snapshot = make_json_output_with_two_worktrees();
+    write_snapshot_to(host, &snapshot, cache_dir.path()).expect("write snapshot");
+
+    // Step 4: derive the expected snapshot path (@ and . → _).
+    let snapshot_path = orchard_snapshot_path_in(host, cache_dir.path());
+    assert!(snapshot_path.exists(), "snapshot must exist before the adapter call");
+
+    // Step 5: redirect events.jsonl to tempdir.
+    // SAFETY: process-global mutation; isolated per-test via unique tempdir path.
+    unsafe { std::env::set_var("ORCHARD_EVENTS_PATH", events_file.as_os_str()) };
+
+    // Step 6: build an OrchardProxyAdapter primed to fail with exit 127.
+    let mut fake = FakeSshExec::new();
+    fake.insert(
+        host,
+        "orchard --json",
+        SshOutput {
+            stdout: String::new(),
+            stderr: "orchard: not found".to_string(),
+            exit_code: 127,
+        },
+    );
+
+    let adapter = OrchardProxyAdapter {
+        host: host.to_string(),
+        path: "~/repo".to_string(),
+        ssh: Box::new(fake),
+        snapshot: OnceLock::new(),
+    };
+
+    // Step 7: the call must return Err — no silent fallback.
+    let result = adapter.list_worktrees();
+    assert!(
+        result.is_err(),
+        "exit 127 must surface as Err, not Ok; got: {result:?}"
+    );
+
+    // Step 8: remove env var before touching the filesystem.
+    unsafe { std::env::remove_var("ORCHARD_EVENTS_PATH") };
+
+    // Step 9: snapshot file must still exist — the adapter must not delete it on failure.
+    assert!(
+        snapshot_path.exists(),
+        "snapshot file must NOT be deleted on proxy failure; path: {snapshot_path:?}"
+    );
+
+    // Step 10–11: build OrchardState from the cached snapshot (cold-start path).
+    let config = make_config_with_proxy(host);
+    let state = build_state_with_cached_snapshots_from(&config, &HashMap::new(), cache_dir.path());
+
+    // Step 12–13: the 2 worktrees must still appear in the merged state.
+    let repo = state
+        .repos
+        .iter()
+        .find(|r| r.slug == "owner/repo")
+        .expect("owner/repo must be present after snapshot merge");
+
+    let remote_worktrees: Vec<_> = repo
+        .worktrees
+        .iter()
+        .filter(|w| w.host.as_deref() == Some(host))
+        .collect();
+
+    assert_eq!(
+        remote_worktrees.len(),
+        2,
+        "exactly 2 worktrees from the cached snapshot must survive the proxy failure; \
+         got: {remote_worktrees:?}"
+    );
+
+    let branches: Vec<&str> = remote_worktrees.iter().map(|w| w.branch.as_str()).collect();
+    assert!(
+        branches.contains(&"issue1/foo"),
+        "branch 'issue1/foo' must appear in merged state; got: {branches:?}"
+    );
+    assert!(
+        branches.contains(&"issue2/bar"),
+        "branch 'issue2/bar' must appear in merged state; got: {branches:?}"
+    );
+
+    // Step 14: events.jsonl must contain a remote_adapter.proxy_failure event.
+    let mut contents = String::new();
+    std::fs::File::open(&events_file)
+        .expect("events.jsonl must have been created by the adapter call")
+        .read_to_string(&mut contents)
+        .unwrap();
+
+    let failure_line = contents
+        .lines()
+        .filter(|l| !l.is_empty())
+        .find(|l| l.contains("remote_adapter.proxy_failure"))
+        .expect("events.jsonl must contain a remote_adapter.proxy_failure event");
+
+    let parsed: serde_json::Map<String, serde_json::Value> =
+        serde_json::from_str(failure_line).expect("proxy_failure line must be valid JSON");
+
+    assert_eq!(
+        parsed.get("host").and_then(|v| v.as_str()),
+        Some(host),
+        "proxy_failure event must carry the correct host; got: {parsed:?}"
+    );
 }

--- a/crates/orchard/tests/federation_wire_up.rs
+++ b/crates/orchard/tests/federation_wire_up.rs
@@ -19,8 +19,9 @@ use orchard::global_config::{GlobalConfig, RemoteConfig, RepoConfig};
 use orchard::json_output::{
     CiChecks as JsonCiChecks, JsonIssue, JsonOutput, JsonPr, JsonRepo, JsonWorktree,
 };
-use orchard::merge_remote::build_state_with_cached_snapshots_from;
+use orchard::merge_remote::{build_state_with_cached_snapshots_from, merge_remote_snapshot};
 use orchard::orchard_snapshot::{orchard_snapshot_path_in, write_snapshot_to};
+use orchard::orchard_state::{OrchardState, RepoState, WorktreeState};
 use orchard::remote_adapter::{FakeSshExec, OrchardProxyAdapter, RemoteKind, SshOutput};
 use tempfile::TempDir;
 
@@ -502,5 +503,318 @@ fn cached_snapshot_survives_proxy_failure_with_proxy_failure_event_logged() {
         parsed.get("host").and_then(|v| v.as_str()),
         Some(host),
         "proxy_failure event must carry the correct host; got: {parsed:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test: multi-snapshot merge dedupes by (host, path)
+// ---------------------------------------------------------------------------
+
+/// #337 Scenario A — `(host, path)` deduplication collapses duplicate entries
+/// within a single snapshot.
+///
+/// A `JsonOutput` that contains two `JsonWorktree` entries with the same path
+/// (and therefore the same `(host, path)` tuple after tagging with the snapshot
+/// host) must produce exactly **one** `WorktreeState` in the merged
+/// `OrchardState`. The second entry overwrites the first — snapshot-wins
+/// semantics per `merge_remote.rs`.
+///
+/// Cross-host case: two different hosts each contributing a worktree at the
+/// same *path string* produce **two** `WorktreeState` entries — they are
+/// distinct `(host, path)` tuples.
+#[test]
+fn multi_snapshot_merge_dedupes_by_host_path_tuple() {
+    // ---- Part 1: same host, same path → one WorktreeState ------------------
+    let host = "boxd@vm.boxd.sh";
+
+    // Two entries with identical path under the same snapshot host.
+    let snapshot_with_dupes = JsonOutput {
+        version: 6,
+        tmux_sessions: vec![],
+        repos: vec![JsonRepo {
+            slug: "owner/repo".to_string(),
+            default_branch: None,
+            main_ci_state: None,
+            worktrees: vec![
+                // First entry at /remote/repo — will be overwritten by second.
+                JsonWorktree {
+                    path: "/remote/repo".to_string(),
+                    branch: "issue1/first".to_string(),
+                    host: None,
+                    layout: "bare".to_string(),
+                    ahead_behind: None,
+                    last_commit_at: None,
+                    issue: None,
+                    pr: None,
+                    sessions: vec![],
+                    display_group: "other".to_string(),
+                    status: "ready".to_string(),
+                    status_glyph: "\u{1f7e2}".to_string(),
+                    is_main_worktree: false,
+                    last_activity_at: None,
+                },
+                // Second entry at same /remote/repo — snapshot-wins dedup.
+                JsonWorktree {
+                    path: "/remote/repo".to_string(),
+                    branch: "issue2/second".to_string(),
+                    host: None,
+                    layout: "bare".to_string(),
+                    ahead_behind: None,
+                    last_commit_at: None,
+                    issue: None,
+                    pr: None,
+                    sessions: vec![],
+                    display_group: "other".to_string(),
+                    status: "ready".to_string(),
+                    status_glyph: "\u{1f7e2}".to_string(),
+                    is_main_worktree: false,
+                    last_activity_at: None,
+                },
+            ],
+        }],
+        hosts: HashMap::new(),
+    };
+
+    let mut state = OrchardState::new();
+    merge_remote_snapshot(&mut state, snapshot_with_dupes, host.to_string());
+
+    let repo = state
+        .repos
+        .iter()
+        .find(|r| r.slug == "owner/repo")
+        .expect("owner/repo must be present after merge");
+
+    // The dedup key is (host, path). Both entries share the same effective host
+    // (snapshot host "boxd@vm.boxd.sh") and path "/remote/repo", so they must
+    // collapse to a single WorktreeState. The second entry wins.
+    let same_path_entries: Vec<_> = repo
+        .worktrees
+        .iter()
+        .filter(|w| w.path == "/remote/repo" && w.host.as_deref() == Some(host))
+        .collect();
+
+    assert_eq!(
+        same_path_entries.len(),
+        1,
+        "two entries with the same (host, path) must collapse to one; got: {same_path_entries:?}"
+    );
+
+    // The surviving entry is the last-written one (second entry wins).
+    assert_eq!(
+        same_path_entries[0].branch,
+        "issue2/second",
+        "the second (later) entry must win the dedup; got branch: {}",
+        same_path_entries[0].branch
+    );
+
+    // ---- Part 2: different hosts, same path string → two WorktreeStates ----
+    // (host, path) tuples are distinct because the hosts differ.
+    let host_a = "boxd@vm1.boxd.sh";
+    let host_b = "boxd@vm2.boxd.sh";
+
+    let snapshot_a = JsonOutput {
+        version: 6,
+        tmux_sessions: vec![],
+        repos: vec![JsonRepo {
+            slug: "owner/repo".to_string(),
+            default_branch: None,
+            main_ci_state: None,
+            worktrees: vec![JsonWorktree {
+                path: "/remote/repo".to_string(),
+                branch: "main".to_string(),
+                host: None,
+                layout: "bare".to_string(),
+                ahead_behind: None,
+                last_commit_at: None,
+                issue: None,
+                pr: None,
+                sessions: vec![],
+                display_group: "other".to_string(),
+                status: "ready".to_string(),
+                status_glyph: "\u{1f7e2}".to_string(),
+                is_main_worktree: false,
+                last_activity_at: None,
+            }],
+        }],
+        hosts: HashMap::new(),
+    };
+
+    let snapshot_b = JsonOutput {
+        version: 6,
+        tmux_sessions: vec![],
+        repos: vec![JsonRepo {
+            slug: "owner/repo".to_string(),
+            default_branch: None,
+            main_ci_state: None,
+            worktrees: vec![JsonWorktree {
+                path: "/remote/repo".to_string(),
+                branch: "main".to_string(),
+                host: None,
+                layout: "bare".to_string(),
+                ahead_behind: None,
+                last_commit_at: None,
+                issue: None,
+                pr: None,
+                sessions: vec![],
+                display_group: "other".to_string(),
+                status: "ready".to_string(),
+                status_glyph: "\u{1f7e2}".to_string(),
+                is_main_worktree: false,
+                last_activity_at: None,
+            }],
+        }],
+        hosts: HashMap::new(),
+    };
+
+    let mut cross_state = OrchardState::new();
+    merge_remote_snapshot(&mut cross_state, snapshot_a, host_a.to_string());
+    merge_remote_snapshot(&mut cross_state, snapshot_b, host_b.to_string());
+
+    let cross_repo = cross_state
+        .repos
+        .iter()
+        .find(|r| r.slug == "owner/repo")
+        .expect("owner/repo must be present");
+
+    // Different hosts → different (host, path) tuples → must NOT collapse.
+    assert_eq!(
+        cross_repo.worktrees.len(),
+        2,
+        "same path on different hosts must yield 2 WorktreeStates (distinct (host, path) tuples); \
+         got: {cross_repo:?}"
+    );
+
+    let has_vm1 = cross_repo
+        .worktrees
+        .iter()
+        .any(|w| w.host.as_deref() == Some(host_a));
+    let has_vm2 = cross_repo
+        .worktrees
+        .iter()
+        .any(|w| w.host.as_deref() == Some(host_b));
+    assert!(has_vm1, "worktree for {host_a} must be present");
+    assert!(has_vm2, "worktree for {host_b} must be present");
+}
+
+// ---------------------------------------------------------------------------
+// Test: local and remote worktrees for the same slug stay separate by host
+// ---------------------------------------------------------------------------
+
+/// #337 Scenario B — Local (`host=None`) and remote (`host=Some(...)`) worktrees
+/// for the same repo slug do NOT collapse, because they are distinct `(host, path)`.
+///
+/// Manually construct an `OrchardState` with a local `WorktreeState` (host=None,
+/// path="/local/repo"), then merge a remote snapshot carrying a worktree at a
+/// different path on the remote. Assert both rows survive and host attribution
+/// is preserved exactly.
+#[test]
+fn local_and_remote_worktrees_for_same_slug_stay_separate_by_host() {
+    let remote_host = "boxd@orchard-rs.boxd.sh";
+
+    // Seed the OrchardState with a local worktree (host = None).
+    let local_wt = WorktreeState {
+        path: "/local/git-orchard-rs".to_string(),
+        branch: "main".to_string(),
+        is_bare: false,
+        host: None,
+        issue: None,
+        pr: None,
+        sessions: vec![],
+        display_group: orchard::derive::DisplayGroup::RepoMain,
+        is_main_worktree: true,
+        ahead_behind: None,
+        last_commit_at: None,
+        layout: orchard::cache::WorktreeLayout::Bare,
+    };
+
+    let mut state = OrchardState {
+        repos: vec![RepoState {
+            slug: "drewdrewthis/git-orchard-rs".to_string(),
+            worktrees: vec![local_wt],
+            default_branch: Some("main".to_string()),
+            main_ci_state: None,
+        }],
+        standalone_sessions: vec![],
+        hosts: HashMap::new(),
+    };
+
+    // Remote snapshot: same slug, different path, remote machine's worktree.
+    let remote_snapshot = JsonOutput {
+        version: 6,
+        tmux_sessions: vec![],
+        repos: vec![JsonRepo {
+            slug: "drewdrewthis/git-orchard-rs".to_string(),
+            default_branch: Some("main".to_string()),
+            main_ci_state: None,
+            worktrees: vec![JsonWorktree {
+                path: "/remote/git-orchard-rs".to_string(),
+                branch: "issue337/validate-launch-remote-and-federation".to_string(),
+                host: None,
+                layout: "bare".to_string(),
+                ahead_behind: None,
+                last_commit_at: None,
+                issue: None,
+                pr: None,
+                sessions: vec![],
+                display_group: "other".to_string(),
+                status: "ready".to_string(),
+                status_glyph: "\u{1f7e2}".to_string(),
+                is_main_worktree: false,
+                last_activity_at: None,
+            }],
+        }],
+        hosts: HashMap::new(),
+    };
+
+    merge_remote_snapshot(&mut state, remote_snapshot, remote_host.to_string());
+
+    let repo = state
+        .repos
+        .iter()
+        .find(|r| r.slug == "drewdrewthis/git-orchard-rs")
+        .expect("drewdrewthis/git-orchard-rs must be present after merge");
+
+    // Both the local and remote worktrees must coexist.
+    assert_eq!(
+        repo.worktrees.len(),
+        2,
+        "local (host=None) and remote (host=Some) worktrees must both survive; \
+         got: {repo:?}"
+    );
+
+    // The local row must keep host = None.
+    let local_row = repo
+        .worktrees
+        .iter()
+        .find(|w| w.path == "/local/git-orchard-rs")
+        .expect("local worktree at /local/git-orchard-rs must still be present");
+
+    assert!(
+        local_row.host.is_none(),
+        "local worktree host must stay None; got: {:?}",
+        local_row.host
+    );
+
+    // The remote row must have host = Some(remote_host).
+    let remote_row = repo
+        .worktrees
+        .iter()
+        .find(|w| w.path == "/remote/git-orchard-rs")
+        .expect("remote worktree at /remote/git-orchard-rs must be present after merge");
+
+    assert_eq!(
+        remote_row.host.as_deref(),
+        Some(remote_host),
+        "remote worktree host must equal {remote_host}; got: {:?}",
+        remote_row.host
+    );
+
+    // Confirm the two rows are on separate (host, path) tuples — they must not
+    // have collapsed into a single entry.
+    let local_tuple = (local_row.host.as_deref(), local_row.path.as_str());
+    let remote_tuple = (remote_row.host.as_deref(), remote_row.path.as_str());
+    assert_ne!(
+        local_tuple, remote_tuple,
+        "local and remote rows must have distinct (host, path) tuples"
     );
 }

--- a/crates/orchard/tests/federation_wire_up.rs
+++ b/crates/orchard/tests/federation_wire_up.rs
@@ -17,7 +17,7 @@ use std::sync::OnceLock;
 
 use orchard::global_config::{GlobalConfig, RemoteConfig, RepoConfig};
 use orchard::json_output::{
-    CiChecks as JsonCiChecks, JsonIssue, JsonOutput, JsonPr, JsonRepo, JsonWorktree,
+    CiChecks as JsonCiChecks, JsonIssue, JsonOutput, JsonPr, JsonRepo, JsonSession, JsonWorktree,
 };
 use orchard::merge_remote::{build_state_with_cached_snapshots_from, merge_remote_snapshot};
 use orchard::orchard_snapshot::{orchard_snapshot_path_in, write_snapshot_to};
@@ -817,4 +817,112 @@ fn local_and_remote_worktrees_for_same_slug_stay_separate_by_host() {
         local_tuple, remote_tuple,
         "local and remote rows must have distinct (host, path) tuples"
     );
+}
+
+// ---------------------------------------------------------------------------
+// AC6 unit: Scenario A — cached snapshot exposes sessions for orchard-proxy host
+// ---------------------------------------------------------------------------
+
+/// AC6 scenario A: With orchard-proxy enabled, `load_cached_snapshots_from`
+/// returns the cached snapshot including its worktree sessions.
+///
+/// A precheck-style consumer can read `load_cached_snapshots_from` and inspect
+/// the returned sessions to determine whether a tmux session already exists for
+/// a given issue — without any new SSH call.
+///
+/// No real SSH is involved — we write the snapshot directly to a TempDir and
+/// pass that directory to `load_cached_snapshots_from`.
+#[test]
+fn load_cached_snapshots_exposes_session_for_orchard_proxy_host() {
+    let cache_dir = TempDir::new().expect("create temp cache dir");
+    let host = "boxd@orchard-rs.boxd.sh";
+
+    // Build a snapshot containing a worktree with an active tmux session.
+    let snapshot = JsonOutput {
+        version: 6,
+        tmux_sessions: vec![],
+        repos: vec![JsonRepo {
+            slug: "owner/repo".to_string(),
+            default_branch: None,
+            main_ci_state: None,
+            worktrees: vec![JsonWorktree {
+                path: "/remote/worktree".to_string(),
+                branch: "issue999/foo".to_string(),
+                // host is None on the wire — the merge step tags it with the
+                // snapshot host at merge time (not at snapshot-read time).
+                host: None,
+                layout: "bare".to_string(),
+                ahead_behind: None,
+                last_commit_at: None,
+                issue: None,
+                pr: None,
+                sessions: vec![JsonSession {
+                    name: "or_issue999".to_string(),
+                    host: "local".to_string(),
+                    status: "running".to_string(),
+                    started_at: None,
+                    last_activity_at: None,
+                    claude: None,
+                    windows: vec![],
+                }],
+                display_group: "other".to_string(),
+                status: "ready".to_string(),
+                status_glyph: "\u{1f7e2}".to_string(),
+                is_main_worktree: false,
+                last_activity_at: None,
+            }],
+        }],
+        hosts: HashMap::new(),
+    };
+
+    // Write the snapshot as if OrchardProxyAdapter had just fetched and persisted it.
+    write_snapshot_to(host, &snapshot, cache_dir.path()).expect("write snapshot");
+
+    // Build config with OrchardProxy remote pointing at the same host.
+    let config = make_config_with_proxy(host);
+
+    // Call the production cache-reader — this is the data layer a precheck
+    // would call to determine whether a session already exists.
+    // No SSH is involved here: load_cached_snapshots_from reads from disk only.
+    let snapshots =
+        orchard::orchard_snapshot::load_cached_snapshots_from(&config, cache_dir.path());
+
+    // Must return exactly one entry for our host.
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "expected one snapshot for {host}; got: {:?}",
+        snapshots.iter().map(|(h, _)| h).collect::<Vec<_>>()
+    );
+
+    let (returned_host, loaded_snapshot) = &snapshots[0];
+    assert_eq!(
+        returned_host, host,
+        "snapshot must be keyed by the remote host string"
+    );
+
+    // Locate the worktree in the loaded snapshot.
+    let repo = loaded_snapshot
+        .repos
+        .iter()
+        .find(|r| r.slug == "owner/repo")
+        .expect("owner/repo must be present in loaded snapshot");
+
+    let wt = repo
+        .worktrees
+        .iter()
+        .find(|w| w.branch == "issue999/foo")
+        .expect("worktree branch issue999/foo must be present in loaded snapshot");
+
+    // The session data is intact — a precheck can read session names from here
+    // without making any new SSH call.
+    let session_names: Vec<&str> = wt.sessions.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        session_names.contains(&"or_issue999"),
+        "session 'or_issue999' must be present in the loaded snapshot's worktree sessions; \
+         got: {session_names:?}"
+    );
+    // SSH-free assertion is structural: load_cached_snapshots_from reads the
+    // {safe_host}_orchard_snapshot.json file from disk — no SshExec is
+    // involved and no network call is made.
 }

--- a/crates/orchard/tests/federation_wire_up.rs
+++ b/crates/orchard/tests/federation_wire_up.rs
@@ -365,6 +365,7 @@ fn make_json_output_with_two_worktrees() -> JsonOutput {
             status_glyph: "\u{1f7e2}".to_string(),
             is_main_worktree: false,
             last_activity_at: None,
+            discovery_path: None,
         }
     }
 
@@ -381,6 +382,7 @@ fn make_json_output_with_two_worktrees() -> JsonOutput {
             ],
         }],
         hosts: HashMap::new(),
+        errors: vec![],
     }
 }
 

--- a/crates/orchard/tests/federation_wire_up.rs
+++ b/crates/orchard/tests/federation_wire_up.rs
@@ -410,7 +410,10 @@ fn cached_snapshot_survives_proxy_failure_with_proxy_failure_event_logged() {
 
     // Step 4: derive the expected snapshot path (@ and . → _).
     let snapshot_path = orchard_snapshot_path_in(host, cache_dir.path());
-    assert!(snapshot_path.exists(), "snapshot must exist before the adapter call");
+    assert!(
+        snapshot_path.exists(),
+        "snapshot must exist before the adapter call"
+    );
 
     // Step 5: redirect events.jsonl to tempdir.
     // SAFETY: process-global mutation; isolated per-test via unique tempdir path.
@@ -554,6 +557,7 @@ fn multi_snapshot_merge_dedupes_by_host_path_tuple() {
                     status_glyph: "\u{1f7e2}".to_string(),
                     is_main_worktree: false,
                     last_activity_at: None,
+                    discovery_path: None,
                 },
                 // Second entry at same /remote/repo — snapshot-wins dedup.
                 JsonWorktree {
@@ -571,10 +575,12 @@ fn multi_snapshot_merge_dedupes_by_host_path_tuple() {
                     status_glyph: "\u{1f7e2}".to_string(),
                     is_main_worktree: false,
                     last_activity_at: None,
+                    discovery_path: None,
                 },
             ],
         }],
         hosts: HashMap::new(),
+        errors: vec![],
     };
 
     let mut state = OrchardState::new();
@@ -603,8 +609,7 @@ fn multi_snapshot_merge_dedupes_by_host_path_tuple() {
 
     // The surviving entry is the last-written one (second entry wins).
     assert_eq!(
-        same_path_entries[0].branch,
-        "issue2/second",
+        same_path_entries[0].branch, "issue2/second",
         "the second (later) entry must win the dedup; got branch: {}",
         same_path_entries[0].branch
     );
@@ -636,9 +641,11 @@ fn multi_snapshot_merge_dedupes_by_host_path_tuple() {
                 status_glyph: "\u{1f7e2}".to_string(),
                 is_main_worktree: false,
                 last_activity_at: None,
+                discovery_path: None,
             }],
         }],
         hosts: HashMap::new(),
+        errors: vec![],
     };
 
     let snapshot_b = JsonOutput {
@@ -663,9 +670,11 @@ fn multi_snapshot_merge_dedupes_by_host_path_tuple() {
                 status_glyph: "\u{1f7e2}".to_string(),
                 is_main_worktree: false,
                 last_activity_at: None,
+                discovery_path: None,
             }],
         }],
         hosts: HashMap::new(),
+        errors: vec![],
     };
 
     let mut cross_state = OrchardState::new();
@@ -727,6 +736,7 @@ fn local_and_remote_worktrees_for_same_slug_stay_separate_by_host() {
         ahead_behind: None,
         last_commit_at: None,
         layout: orchard::cache::WorktreeLayout::Bare,
+        discovery_path: None,
     };
 
     let mut state = OrchardState {
@@ -738,6 +748,7 @@ fn local_and_remote_worktrees_for_same_slug_stay_separate_by_host() {
         }],
         standalone_sessions: vec![],
         hosts: HashMap::new(),
+        transitive_errors: vec![],
     };
 
     // Remote snapshot: same slug, different path, remote machine's worktree.
@@ -763,9 +774,11 @@ fn local_and_remote_worktrees_for_same_slug_stay_separate_by_host() {
                 status_glyph: "\u{1f7e2}".to_string(),
                 is_main_worktree: false,
                 last_activity_at: None,
+                discovery_path: None,
             }],
         }],
         hosts: HashMap::new(),
+        errors: vec![],
     };
 
     merge_remote_snapshot(&mut state, remote_snapshot, remote_host.to_string());
@@ -866,15 +879,18 @@ fn load_cached_snapshots_exposes_session_for_orchard_proxy_host() {
                     last_activity_at: None,
                     claude: None,
                     windows: vec![],
+                    discovery_path: None,
                 }],
                 display_group: "other".to_string(),
                 status: "ready".to_string(),
                 status_glyph: "\u{1f7e2}".to_string(),
                 is_main_worktree: false,
                 last_activity_at: None,
+                discovery_path: None,
             }],
         }],
         hosts: HashMap::new(),
+        errors: vec![],
     };
 
     // Write the snapshot as if OrchardProxyAdapter had just fetched and persisted it.

--- a/specs/features/launch-remote-tui-enter-federation-validation.feature
+++ b/specs/features/launch-remote-tui-enter-federation-validation.feature
@@ -1,0 +1,272 @@
+Feature: Validate launch-remote + TUI Enter + federation end-to-end on v0.9.0
+  As an orchardist using both local and remote (boxd-fork, boxd-shared, orchard-proxy) workflows
+  I want /launch-remote, TUI Enter on remote rows, and federated discovery to all work
+    coherently against v0.9.0
+  So that I can trust that launching a remote session is immediately visible,
+    attaching to a remote session lands me in a shell on the VM,
+    and a host configured `"type": "orchard-proxy"` reflects the remote's own snapshot
+    (PRs, CI, tmux) rather than re-derived shell-discovery.
+
+  # Scope: this issue is a VALIDATION + REGRESSION-LOCK pass on v0.9.0 (per Plan).
+  # Implementation gaps (refresh-on-launch, proxy-failure UI surface,
+  # `orchard launch-precheck`, worktree-gone UX) are filed as follow-up issues.
+  # Tests in this feature file MUST NOT depend on those follow-ups landing.
+
+  Background:
+    Given local orchard is built at v0.9.0 or later
+    And `~/.config/orchard/config.json` contains the user's remotes
+    And the per-host cache directory is "~/.cache/orchard/"
+    And `events.jsonl` is at "~/.local/state/git-orchard/events.jsonl"
+    And the `JsonOutput.version` supported list is `[6]` for this branch
+
+  # =======================================================================
+  # AC1 — Fresh launch (boxd-fork): /launch-remote on a langwatch issue
+  # creates the fork, launches Claude, and within 30s the session appears
+  # under the remote's `sessions` in `orchard --json` locally.
+  # =======================================================================
+
+  @e2e
+  Scenario: /launch-remote against a langwatch issue surfaces the new boxd-fork session locally
+    Given the user has a configured boxd-fork remote for "langwatch/langwatch"
+    And no existing fork or tmux session exists for issue #<N>
+    When the user runs `/launch-remote langwatch/langwatch#<N>`
+    And the user runs `orchard refresh` after the launch completes
+    And the user runs `orchard --json` locally
+    Then within 30 seconds (after the explicit refresh) the output contains a worktree
+        for the new fork host
+    And that worktree's `sessions` array contains a session whose name references issue <N>
+    And the session's host equals the boxd-fork host
+    And evidence (the matching `--json` excerpt + elapsed seconds) is captured in the PR
+
+  @integration
+  Scenario: boxd-fork adapter routing emits a session row matching the launched session
+    Given a fake SSH exec runner configured for a boxd-fork host
+    And the runner is primed to return a tmux session named "or_issue<N>" at the fork's worktree path
+    When `BoxdForkAdapter::list_sessions()` runs against that host
+    Then exactly one CachedTmuxSession is returned with name "or_issue<N>"
+    And its host equals the boxd-fork host
+    And its working directory equals the worktree path
+
+  # =======================================================================
+  # AC2 — Fresh launch (boxd-shared): /launch-remote on a git-orchard-rs
+  # issue uses the shared VM adapter, creates the session, and it appears
+  # locally.
+  # =======================================================================
+
+  @e2e
+  Scenario: /launch-remote against a git-orchard-rs issue surfaces the new boxd-shared session locally
+    Given the user has a configured boxd-shared remote for "drewdrewthis/git-orchard-rs"
+        (host "boxd@orchard-rs.boxd.sh")
+    And no existing tmux session exists for issue #<N> on that VM
+    When the user runs `/launch-remote drewdrewthis/git-orchard-rs#<N>`
+    And the user runs `orchard refresh` after the launch completes
+    And the user runs `orchard --json` locally
+    Then within 30 seconds (after the explicit refresh) the output contains a worktree
+        on host "boxd@orchard-rs.boxd.sh" for the issue branch
+    And that worktree's `sessions` array contains a session whose name references issue <N>
+    And evidence (the matching `--json` excerpt + elapsed seconds) is captured in the PR
+
+  @integration
+  Scenario: boxd-shared adapter discovers the new session on the shared VM
+    Given a fake SSH exec runner configured for "boxd@orchard-rs.boxd.sh"
+    And the runner is primed to return a tmux session "or_issue<N>" at the shared-VM worktree path
+    When `BoxdSharedAdapter::list_sessions()` runs against that host
+    Then exactly one CachedTmuxSession is returned with name "or_issue<N>"
+    And its host equals "boxd@orchard-rs.boxd.sh"
+
+  # =======================================================================
+  # AC3 — TUI Enter on an existing remote session creates the local proxy,
+  # SSH-attaches, and the user lands in a shell on the VM.
+  # Already validated 2026-04-22 06:14 (log: createRemoteProxySession:
+  # claude -> remote_claude; hostname=issue3201). Lock with a regression test.
+  # =======================================================================
+
+  @unit
+  Scenario: TaskEnterAction builder selects JoinSession for a remote worktree with an existing session
+    Given a worktree row with `host == Some("boxd@issue3201.boxd.sh")`
+    And `sessions` contains exactly one entry named "claude"
+    When `handle_enter_action` builds a TaskEnterAction from that row
+    Then the action equals `JoinSession { host: Some("boxd@issue3201.boxd.sh"), session: "claude", .. }`
+    And the action does NOT equal `CreateSession`
+
+  @integration
+  Scenario: join_or_create_session on a JoinSession with a remote host calls create_remote_proxy_session
+    Given a TaskEnterAction::JoinSession with `host == Some("boxd@issue3201.boxd.sh")` and session "claude"
+    And a fake remote-session executor that records every call it receives
+    When `join_or_create_session` runs that action
+    Then the executor records exactly one `create_remote_proxy_session` call
+        with host "boxd@issue3201.boxd.sh" and source session "claude"
+    And the proxy session name on the recorded call equals "remote_claude"
+
+  # =======================================================================
+  # AC4 — TUI Enter on a remote worktree with no tmux session creates the
+  # remote session then attaches; the probe-unknown fix (#285) does not
+  # block Enter; boxd-fork adapter routing (#288) is still honored.
+  # =======================================================================
+
+  @unit
+  Scenario: TaskEnterAction builder selects CreateSession for a remote worktree with no sessions
+    Given a worktree row with `host == Some("boxd@vm.boxd.sh")`
+    And `sessions` is empty
+    And `host_reachable == Some(true)`
+    When `handle_enter_action` builds a TaskEnterAction from that row
+    Then the action equals `CreateSession { host: Some("boxd@vm.boxd.sh"), .. }`
+    And the chosen host equals the worktree's host (boxd-fork routing preserved)
+
+  @unit
+  Scenario: Enter is NOT blocked when host_reachable is Unknown (regression for #285)
+    Given a remote worktree row with `host_reachable == None` (probe never ran or returned Unknown)
+    And `sessions` is empty
+    When `handle_enter_action` builds a TaskEnterAction from that row
+    Then the action is built (Enter is not short-circuited / blocked)
+    And the action targets the worktree's remote host
+
+  @integration
+  Scenario: CreateSession on a reachable remote host calls create_remote_session then attaches
+    Given a TaskEnterAction::CreateSession with `host == Some("boxd@vm.boxd.sh")`
+    And a fake remote executor that succeeds
+    When `join_or_create_session` runs that action
+    Then the executor records a `create_remote_session` call for that host
+    And then a `create_remote_proxy_session` (or attach) call is made for the new session
+
+  @integration
+  Scenario: CreateSession failure on a reachable remote surfaces a warning in the app
+    Given a TaskEnterAction::CreateSession with `host == Some(...)` and `host_reachable == Some(true)`
+    And a fake remote executor that returns an error from create_remote_session
+    When `join_or_create_session` runs that action
+    Then the app records a warning describing the remote-session failure
+    And the warning is visible to the user (not silently swallowed)
+
+  # =======================================================================
+  # AC5 — Federation wiring: a remote flipped to `"type": "orchard-proxy"`
+  # surfaces its worktrees/sessions/PRs from its own snapshot in local
+  # `orchard --json`. No silent fallback: missing remote orchard yields a
+  # stale warning, not phantom data.
+  #
+  # The "no silent fallback" sub-clause in this issue is split per the Plan:
+  # the WIRE invariant (no legacy git/tmux call attempted on proxy failure +
+  # `remote_adapter.proxy_failure` event written + last-known snapshot stays)
+  # is validated here. The TUI surfacing of `(proxy stale)` is a follow-up.
+  # =======================================================================
+
+  @e2e
+  Scenario: Single host flipped to orchard-proxy shows remote-sourced data in local --json
+    Given the host "boxd@orchard-rs.boxd.sh" has `orchard --version` returning >= "0.9.0"
+    And `~/.config/orchard/config.json` for that remote is updated to `"type": "orchard-proxy"`
+    When the user runs `orchard refresh`
+    Then a file matching `~/.cache/orchard/*orchard-rs*orchard_snapshot.json` is written
+    And `orchard --json` includes worktrees attributed to that host
+    And those worktrees carry `pr` / `issue` / `check_state` enrichment fields
+        sourced from the remote snapshot
+
+  @unit
+  Scenario: Proxy failure does NOT trigger any legacy shell-discovery on that host
+    Given an OrchardProxyAdapter wired to a fake SSH runner that records every command
+    And the runner returns exit 127 ("orchard: command not found") for `orchard --json`
+    When `OrchardProxyAdapter::list_worktrees()` runs
+    Then the recorded commands include `orchard --json`
+    And the recorded commands do NOT include `git worktree list --porcelain`
+    And the recorded commands do NOT include `tmux list-sessions`
+    And `events.jsonl` contains a `remote_adapter.proxy_failure` event with the host
+        and a reason mentioning exit 127
+
+  @unit
+  Scenario: Last-known snapshot stays visible after a proxy failure (no phantom data, but no data loss)
+    Given a prior `~/.cache/orchard/{safe_host}_orchard_snapshot.json` exists with 2 worktrees
+        for host "boxd@orchard-rs.boxd.sh"
+    And the next `OrchardProxyAdapter::fetch_snapshot` for that host returns exit 127
+    When `build_state_with_cached_snapshots` constructs OrchardState
+    Then the 2 worktrees from the cached snapshot remain in the merged state
+    And the cached snapshot file is NOT deleted
+    And a `remote_adapter.proxy_failure` event is present in `events.jsonl`
+
+  @integration
+  Scenario: Multi-snapshot merge dedupes by (host, path) across two orchard-proxy remotes
+    Given two `OrchardProxy` remotes both configured against orchard-installed VMs
+    And both snapshots include a worktree row with the same `(host, path)` tuple
+    When `merge_remote_snapshot` runs
+    Then exactly one WorktreeState is emitted for that tuple
+    And the dedupe key `(host, path)` is honored
+
+  @integration
+  Scenario: Same-slug repo from local cache and remote snapshot is host-attributed correctly
+    Given a local cache contains a worktree on slug "drewdrewthis/git-orchard-rs"
+        with `host == None`
+    And a remote snapshot from "boxd@orchard-rs.boxd.sh" contains a worktree on the same slug
+        with `host == Some("boxd@orchard-rs.boxd.sh")`
+    When the merged OrchardState is built
+    Then the local row's host stays None
+    And the remote row's host equals "boxd@orchard-rs.boxd.sh"
+    And the two rows do not collapse into one (different `(host, path)` tuples)
+
+  # =======================================================================
+  # AC6 — /launch-remote uses federation when available: when targeting a
+  # host with `orchard-proxy` enabled, decide whether a session already
+  # exists from the remote orchard's view (avoid double-launch). When not
+  # enabled, fall back to the adapter-based tmux probe (current behavior).
+  #
+  # NOTE: per the Plan's "Suggested follow-ups", AC6 is destined for a
+  # follow-up `orchard launch-precheck <host> <session>` Rust subcommand.
+  # For #337, validate the BEHAVIORAL CONTRACT at the data layer:
+  # the federated snapshot is a sufficient input for a precheck, and
+  # absent a federated snapshot the adapter-based tmux probe is what
+  # /launch-remote sees.
+  # =======================================================================
+
+  @unit
+  Scenario: With orchard-proxy enabled, the cached snapshot lists existing sessions for a host
+    Given a `{safe_host}_orchard_snapshot.json` exists for host "boxd@orchard-rs.boxd.sh"
+    And the snapshot contains a tmux session "or_issue<N>" attached to a worktree on that host
+    When a precheck-style consumer reads `load_cached_snapshots()` for that host
+    Then the loaded data exposes the session named "or_issue<N>"
+    And a duplicate-launch check could be performed without any new SSH call
+
+  @unit
+  Scenario: Without orchard-proxy, /launch-remote falls back to the adapter-based tmux probe
+    Given a remote configured as `"type": "remmy"` (or "boxd-fork" / "boxd-shared")
+    And no `{safe_host}_orchard_snapshot.json` exists for that host
+    When the system needs to determine whether a tmux session already exists for the target issue
+    Then the per-kind adapter's `list_sessions` is the source of truth for that decision
+    And no `ssh host orchard --json` call is made for hosts that are not orchard-proxy
+
+  @integration
+  Scenario: Mixed-config refresh — proxy host uses snapshot, non-proxy host uses legacy probe
+    Given two remotes: host A is `"type": "orchard-proxy"`, host B is `"type": "remmy"`
+    And both hosts are reachable
+    When `orchard refresh` runs
+    Then host A's session list is sourced from `ssh A orchard --json`
+    And host B's session list is sourced from `ssh B tmux list-sessions ...` (legacy)
+    And host A does NOT trigger any legacy `tmux list-sessions` call
+    And host B does NOT trigger any `ssh B orchard --json` call
+
+  # =======================================================================
+  # AC Coverage Map
+  # =======================================================================
+
+  # --- AC Coverage Map ---
+  # AC1 "Fresh launch — boxd-fork: session visible in local `orchard --json` after launch"
+  #   -> "/launch-remote against a langwatch issue surfaces the new boxd-fork session locally" (@e2e)
+  #   -> "boxd-fork adapter routing emits a session row matching the launched session" (@integration)
+  # AC2 "Fresh launch — boxd-shared: session visible in local `orchard --json` after launch"
+  #   -> "/launch-remote against a git-orchard-rs issue surfaces the new boxd-shared session locally" (@e2e)
+  #   -> "boxd-shared adapter discovers the new session on the shared VM" (@integration)
+  # AC3 "TUI Enter — existing remote session: creates local proxy, SSH-attaches, lands in shell on VM"
+  #   -> "TaskEnterAction builder selects JoinSession for a remote worktree with an existing session" (@unit)
+  #   -> "join_or_create_session on a JoinSession with a remote host calls create_remote_proxy_session" (@integration)
+  # AC4 "TUI Enter — no-session remote worktree: creates remote session then attaches; #285 + #288 still honored"
+  #   -> "TaskEnterAction builder selects CreateSession for a remote worktree with no sessions" (@unit)
+  #   -> "Enter is NOT blocked when host_reachable is Unknown (regression for #285)" (@unit)
+  #   -> "CreateSession on a reachable remote host calls create_remote_session then attaches" (@integration)
+  #   -> "CreateSession failure on a reachable remote surfaces a warning in the app" (@integration)
+  # AC5 "Federation wiring: orchard-proxy remote surfaces its own snapshot data; no silent fallback"
+  #   -> "Single host flipped to orchard-proxy shows remote-sourced data in local --json" (@e2e)
+  #   -> "Proxy failure does NOT trigger any legacy shell-discovery on that host" (@unit)
+  #   -> "Last-known snapshot stays visible after a proxy failure (no phantom data, but no data loss)" (@unit)
+  #   -> "Multi-snapshot merge dedupes by (host, path) across two orchard-proxy remotes" (@integration)
+  #   -> "Same-slug repo from local cache and remote snapshot is host-attributed correctly" (@integration)
+  #   -> NOTE: TUI surfacing of `(proxy stale)` is split out as a follow-up issue per Plan Phase 7
+  # AC6 "/launch-remote uses federation when available; falls back to adapter-based tmux probe otherwise"
+  #   -> "With orchard-proxy enabled, the cached snapshot lists existing sessions for a host" (@unit)
+  #   -> "Without orchard-proxy, /launch-remote falls back to the adapter-based tmux probe" (@unit)
+  #   -> "Mixed-config refresh — proxy host uses snapshot, non-proxy host uses legacy probe" (@integration)
+  #   -> NOTE: `orchard launch-precheck <host> <session>` Rust subcommand is a follow-up per Plan Phase 7


### PR DESCRIPTION
## Why

Closes #337.

v0.9.0 shipped federated discovery (`"type": "orchard-proxy"`, `ssh host orchard --json`, ADR-008) but the end-to-end story across `/launch-remote`, TUI Enter on remote rows, and federation has never been validated coherently. The issue surfaced six ACs spanning three remote backends (boxd-fork, boxd-shared, orchard-proxy). `/investigate` + `/challenge` revealed that **four of six ACs require implementation, not just verification** — so per the Plan, this PR shrinks #337 to a validation+regression-lock pass and files the implementation gaps as sharp follow-ups.

## What changed

This PR is the foundation of the validation pass. It currently contains:

- **A complete BDD feature file** (`specs/features/launch-remote-tui-enter-federation-validation.feature`) — 18 scenarios mapped to all 6 ACs via an explicit AC Coverage Map. 4 `@e2e`, 9 `@unit`, 5 `@integration`. Notes inline where AC sub-clauses are deferred to follow-ups (proxy-failure UI, `orchard launch-precheck` Rust subcommand).
- **AC3 regression test** locking the empirically-validated `TaskEnterAction::JoinSession` path. Extracted the inline builder closure from `handle_enter_action` into `pub(crate) build_worktree_enter_action` so it's directly testable. Behavior is preserved; pane_target patching still happens after the builder runs.

More commits will follow as `/deliver-work` iterates through the remaining 17 scenarios. The PR will move to ready when all AC convergence + Phase 7 follow-up issues are filed.

## Test plan

- [x] `cargo test -p orchard --lib enter_action_builder_selects_join_session_for_remote_worktree_with_existing_session` — passes
- [x] `cargo test -p orchard --lib` — full suite green (1326 tests)
- [x] `cargo clippy -p orchard --lib --tests` — clean
- [ ] (in progress) Remaining 17 scenarios from the feature file
- [ ] (in progress) Live federation flip on `boxd@orchard-rs.boxd.sh` — evidence to be captured in this PR description before ready
- [ ] (in progress) Phase 7 follow-up issues filed (refresh-on-launch, proxy-failure UI, `launch-precheck`, worktree-gone UX)

## Anything surprising?

**Scope shrink** is the load-bearing decision. Per `/challenge`'s findings (full report in the issue body's Investigation section):

- AC5's "no silent fallback → user sees stale warning" is **materially false against current code** — `(stale)` only fires on `Reachability::Unreachable`. `OrchardProxyAdapter` parse/version/127 failures emit only an `events.jsonl` line that nobody reads. UI surfacing is a follow-up; this PR validates the data-layer wire invariant (no legacy shell-discovery on proxy failure, last-known snapshot survives).
- AC1's 30s budget is unachievable with `full_poll_secs = 60` and no refresh-on-launch hook. The e2e harness (Task #22) inserts an explicit `orchard refresh` between launch and the `--json` check; the production fix is a follow-up.
- AC6's "uses federation when available" should be a Rust subcommand (`orchard launch-precheck`), not the markdown skill parsing the snapshot path scheme directly. Filed as follow-up.

If reviewer prefers full-scope (build the four implementation gaps inline), see the **Alternative** section at the bottom of the Plan in the issue body. Recommend against — single-PR regression surface across four unrelated subsystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #337

# Related issue

- #337

# Related issue

- #337