### PR TITLE
feat(federation): transitive remote discovery (#363)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,7 +2867,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/orchard/schema.json
+++ b/crates/orchard/schema.json
@@ -10,6 +10,13 @@
     "version"
   ],
   "properties": {
+    "errors": {
+      "description": "Transitive-federation walk errors from the most recent refresh.\n\nEmpty when no transitive federation is configured or all hops succeeded.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/JsonTransitiveError"
+      }
+    },
     "hosts": {
       "description": "Reachability state keyed by SSH host name.",
       "type": "object",
@@ -661,6 +668,16 @@
             }
           ]
         },
+        "discoveryPath": {
+          "description": "Full discovery path from `\"local\"` to the host that owns this session.\n\nAbsent for local sessions and direct (depth-1) remotes when not set.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "host": {
           "description": "Host as a string: \"local\" or the SSH target.",
           "type": "string"
@@ -717,6 +734,42 @@
         },
         "title": {
           "description": "Sub-issue title.",
+          "type": "string"
+        }
+      }
+    },
+    "JsonTransitiveError": {
+      "description": "A transitive-federation walk error surfaced in JSON output.\n\nOne entry per node that failed during the transitive walk. The walk continues after each failure (non-fatal). Empty when no transitive federation is configured or all hops succeeded.",
+      "type": "object",
+      "required": [
+        "dedupKey",
+        "discoveryPath",
+        "phase",
+        "reason",
+        "root"
+      ],
+      "properties": {
+        "dedupKey": {
+          "description": "`host_dedup_key()` of the failing host.",
+          "type": "string"
+        },
+        "discoveryPath": {
+          "description": "Full discovery path from `\"local\"` to the failing node.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "phase": {
+          "description": "Which call failed: `\"list-remotes\"` or `\"fetch\"`.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Short, stable reason label (e.g. `\"timeout (10s)\"`, `\"exit 255\"`).",
+          "type": "string"
+        },
+        "root": {
+          "description": "The first element after `\"local\"` — the directly-configured root.",
           "type": "string"
         }
       }
@@ -787,6 +840,16 @@
         "branch": {
           "description": "Git branch checked out in this worktree.",
           "type": "string"
+        },
+        "discoveryPath": {
+          "description": "Full discovery path from `\"local\"` to the host that owns this worktree.\n\nAbsent for local worktrees and direct (depth-1) remotes when not set. Example: `[\"local\", \"boxd\", \"scenario-voice-agents.boxd.sh\"]`",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         },
         "displayGroup": {
           "description": "Display group as a snake_case string.",

--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -407,7 +407,9 @@ pub fn refresh_and_build_with_walker_config(
     let mut state = build_state_with_hosts(config, &hosts);
 
     // --- Transitive federation walk ------------------------------------------
-    // Collect OrchardProxy roots that have allow_transitive=true.
+    // Collect only OrchardProxy roots with allow_transitive=true.  Roots with
+    // allow_transitive=false need no child discovery; their snapshots are
+    // already fetched by the OrchardProxyAdapter phase above.
     let transitive_roots: Vec<(&str, bool)> = {
         let mut seen = HashSet::new();
         config
@@ -416,6 +418,7 @@ pub fn refresh_and_build_with_walker_config(
             .flat_map(|r| r.remotes.iter())
             .filter(|rm| {
                 rm.kind == crate::remote_adapter::RemoteKind::OrchardProxy
+                    && rm.allow_transitive
                     && seen.insert(rm.host.clone())
             })
             .map(|rm| (rm.host.as_str(), rm.allow_transitive))
@@ -424,7 +427,10 @@ pub fn refresh_and_build_with_walker_config(
 
     if !transitive_roots.is_empty() {
         let ssh = Arc::new(ProcessSshExec) as Arc<dyn crate::remote_adapter::SshExec>;
-        let mut walker_cfg = WalkerConfig::new(ssh);
+        let mut walker_cfg = WalkerConfig::new(ssh)
+            // Depth-1 snapshots were already fetched by OrchardProxyAdapter above;
+            // the walker only needs list-remotes for depth-1 roots to find children.
+            .with_skip_depth1_snapshot();
         if let Some(d) = max_depth {
             walker_cfg = walker_cfg.with_max_depth(d);
         }

--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -309,6 +309,7 @@ pub fn build_state_with_hosts(
         repos,
         standalone_sessions,
         hosts: hosts.clone(),
+        transitive_errors: Vec::new(),
     }
 }
 
@@ -316,7 +317,28 @@ pub fn build_state_with_hosts(
 ///
 /// Intended for `--json` mode where the caller wants fresh data before output.
 /// Probes host reachability before attempting remote refreshes.
+///
+/// Uses default walker settings ([`crate::transitive_walker::DEFAULT_MAX_DEPTH`] and
+/// [`crate::transitive_walker::DEFAULT_PER_HOP_TIMEOUT`]).
 pub fn refresh_and_build(config: &GlobalConfig) -> OrchardState {
+    refresh_and_build_with_walker_config(config, None, None)
+}
+
+/// Like [`refresh_and_build`] but allows overriding transitive-federation walker settings.
+///
+/// - `max_depth`: override [`crate::transitive_walker::DEFAULT_MAX_DEPTH`]
+///   (e.g. from `--max-depth` CLI flag).
+/// - `per_hop_timeout_secs`: override [`crate::transitive_walker::DEFAULT_PER_HOP_TIMEOUT`]
+///   (e.g. from `--per-hop-timeout` CLI flag).
+pub fn refresh_and_build_with_walker_config(
+    config: &GlobalConfig,
+    max_depth: Option<u32>,
+    per_hop_timeout_secs: Option<u64>,
+) -> OrchardState {
+    use crate::remote_adapter::ProcessSshExec;
+    use crate::transitive_walker::{WalkerConfig, walk};
+    use std::sync::Arc;
+
     // Best-effort restore of dead tmux sessions from cache before the first
     // refresh, so the subsequent tmux listing already reflects them.
     let _ = crate::restore::restore_all_local();
@@ -381,7 +403,90 @@ pub fn refresh_and_build(config: &GlobalConfig) -> OrchardState {
         }
     });
 
-    build_state_with_hosts(config, &hosts)
+    // Build base state from local caches and one-hop remotes.
+    let mut state = build_state_with_hosts(config, &hosts);
+
+    // --- Transitive federation walk ------------------------------------------
+    // Collect OrchardProxy roots that have allow_transitive=true.
+    let transitive_roots: Vec<(&str, bool)> = {
+        let mut seen = HashSet::new();
+        config
+            .repos
+            .iter()
+            .flat_map(|r| r.remotes.iter())
+            .filter(|rm| {
+                rm.kind == crate::remote_adapter::RemoteKind::OrchardProxy
+                    && seen.insert(rm.host.clone())
+            })
+            .map(|rm| (rm.host.as_str(), rm.allow_transitive))
+            .collect()
+    };
+
+    if !transitive_roots.is_empty() {
+        let ssh = Arc::new(ProcessSshExec) as Arc<dyn crate::remote_adapter::SshExec>;
+        let mut walker_cfg = WalkerConfig::new(ssh);
+        if let Some(d) = max_depth {
+            walker_cfg = walker_cfg.with_max_depth(d);
+        }
+        if let Some(t) = per_hop_timeout_secs {
+            walker_cfg = walker_cfg.with_per_hop_timeout(std::time::Duration::from_secs(t));
+        }
+
+        let walker_result = walk(&transitive_roots, &walker_cfg);
+
+        // Write per-host snapshots and build topology entries.
+        let mut topology_entries: Vec<(Vec<String>, String)> = Vec::new();
+        for (discovery_path, snapshot) in &walker_result.snapshots {
+            let host = discovery_path.last().cloned().unwrap_or_default();
+            let dedup_key =
+                crate::federation::host_dedup_key(&host).unwrap_or_else(|_| host.clone());
+
+            // Only write and merge if depth > 1 (depth-1 already handled above).
+            if discovery_path.len() > 2 {
+                // Write snapshot cache file for this transitive host.
+                let _ = crate::orchard_snapshot::write_snapshot(&host, snapshot);
+
+                // Merge into state with discovery_path.
+                crate::merge_remote::merge_remote_snapshot_with_path(
+                    &mut state,
+                    (**snapshot).clone(),
+                    host.clone(),
+                    Some(discovery_path.clone()),
+                );
+
+                topology_entries.push((discovery_path.clone(), dedup_key));
+            } else {
+                // Depth-1: update discovery_path on already-merged worktrees.
+                // The one-hop merge above didn't set discovery_path — set it now.
+                let dedup = dedup_key.clone();
+                for repo in &mut state.repos {
+                    for wt in &mut repo.worktrees {
+                        if wt.host.as_deref() == Some(&dedup) || wt.host.as_deref() == Some(&host) {
+                            wt.discovery_path = Some(discovery_path.clone());
+                            for sess in &mut wt.sessions {
+                                sess.discovery_path = Some(discovery_path.clone());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Persist topology.
+        if !topology_entries.is_empty() {
+            let topology = crate::federation_topology::build_topology(&topology_entries);
+            let _ = crate::federation_topology::write_topology(&topology);
+
+            // GC orphan snapshots.
+            let topology_read = crate::federation_topology::read_topology();
+            crate::federation_topology::gc_orphan_snapshots(topology_read.as_ref(), config);
+        }
+
+        // Surface transitive errors onto the state.
+        state.transitive_errors = walker_result.errors;
+    }
+
+    state
 }
 
 #[cfg(test)]

--- a/crates/orchard/src/cache_sources.rs
+++ b/crates/orchard/src/cache_sources.rs
@@ -4140,6 +4140,7 @@ issue42/fix-bug 2026-04-12T14:30:00-07:00
             path: "/workspace".to_string(),
             shell: "ssh".to_string(),
             kind: RemoteKind::Remmy,
+            allow_transitive: false,
         };
 
         let result = snapshot_fork_hosts_for_remote(&config, &remote);
@@ -4188,6 +4189,7 @@ issue42/fix-bug 2026-04-12T14:30:00-07:00
             path: "/workspace".to_string(),
             shell: "ssh".to_string(),
             kind: RemoteKind::BoxdFork,
+            allow_transitive: false,
         };
 
         // Write a remote_worktrees cache containing a mix of:

--- a/crates/orchard/src/derive.rs
+++ b/crates/orchard/src/derive.rs
@@ -254,6 +254,16 @@ pub struct WorktreeRow {
     /// Physical layout of this worktree (`Bare` bare-repo+worktrees, or
     /// `Flat` single-clone-per-VM). Propagated from `CachedWorktree.layout`.
     pub layout: crate::cache::WorktreeLayout,
+    /// Full discovery path from `"local"` to the host that owns this worktree.
+    ///
+    /// `None` for local worktrees and depth-1 Remmy-type remotes. Set for
+    /// transitively-federated (OrchardProxy) worktrees when the row is
+    /// populated from an `OrchardState` that has been through the transitive
+    /// walker merge. The write-path uses this to build a nested SSH chain via
+    /// [`crate::federation::build_ssh_chain`].
+    ///
+    /// Example: `Some(["local", "boxd", "scenario-voice-agents.boxd.sh"])`
+    pub discovery_path: Option<Vec<String>>,
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/orchard/src/federation.rs
+++ b/crates/orchard/src/federation.rs
@@ -1,0 +1,662 @@
+//! Federation foundations for transitive-discovery (issue #363, Phase 1).
+//!
+//! Provides:
+//!
+//! - [`host_dedup_key`] — best-effort SSH target normalisation for seen-set
+//!   deduplication across the transitive walk. Strips the default port (22),
+//!   case-folds the hostname (not the user), trims a trailing DNS dot, and
+//!   brackets IPv6 addresses consistently.  Rejects malformed inputs (paths,
+//!   whitespace, backslashes) with an explicit error.
+//!
+//! - [`JsonRemoteConfig`] / [`ListRemotesOutput`] — the wire types for the
+//!   `orchard list-remotes --json` subcommand.  Version-controlled independently
+//!   of `JsonOutput` with a **lower-bound** check (`version >= LIST_REMOTES_MIN_VERSION`)
+//!   so additive-only fields on newer remotes do not break older callers.
+//!
+//! - [`emit_federation_discovered_host`] — append a `federation.discovered_host`
+//!   event to `events.jsonl` the first time a dedup key is encountered within a
+//!   single refresh pass.  Callers maintain the `seen` set; this function only
+//!   writes the event.
+//!
+//! # Design notes
+//!
+//! `host_dedup_key` is NOT a full SSH canonicalisation (no DNS resolution, no
+//! `~/.ssh/config` alias expansion, no ProxyJump flattening).  Its purpose is
+//! purely *best-effort deduplication*: catching the most common textual variants
+//! of the same host so a diamond topology does not fire two SSH round-trips for
+//! what is clearly the same machine.  Collisions (two aliases that resolve to
+//! the same IP but have different text) are surfaced via the
+//! `federation.discovered_host` event so an operator can investigate.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::events::log_event;
+use crate::global_config::RemoteConfig;
+
+// ---------------------------------------------------------------------------
+// Wire types: `orchard list-remotes --json`
+// ---------------------------------------------------------------------------
+
+/// Minimum version accepted when parsing a remote `orchard list-remotes --json`
+/// response.
+///
+/// The check is a **lower bound** (`version >= LIST_REMOTES_MIN_VERSION`), NOT an
+/// exact whitelist.  A future remote that emits `version: 2` is accepted — any
+/// unknown fields are ignored by serde.  This is the lesson learned from
+/// `JsonOutput`'s exact-whitelist design which caused version-skew failures on
+/// mixed fleets.
+///
+/// Bump this only when a **breaking** (non-additive) change is made to the
+/// wire format.
+pub const LIST_REMOTES_MIN_VERSION: u32 = 1;
+
+/// Wire representation of a single remote as emitted by `orchard list-remotes
+/// --json`.
+///
+/// All fields mirror the corresponding fields in [`RemoteConfig`] with the
+/// exception that `kind` is serialized as a human-readable string (kebab-case)
+/// matching the existing [`RemoteKind`] serialization.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JsonRemoteConfig {
+    /// Logical name for this remote (e.g. `"boxd"`, `"gpu-box"`).
+    pub name: String,
+    /// SSH target, e.g. `"user@host"` or `"host"`.
+    pub host: String,
+    /// Adapter kind (e.g. `"orchard-proxy"`, `"remmy"`).
+    pub kind: String,
+    /// Absolute path on the remote host.
+    pub path: String,
+    /// Whether the transitive walker should follow this remote's own
+    /// `orchard list-remotes` output to discover grandchild nodes.
+    pub allow_transitive: bool,
+}
+
+/// Top-level output of `orchard list-remotes --json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListRemotesOutput {
+    /// Schema version for the list-remotes wire format.
+    ///
+    /// Callers check `version >= LIST_REMOTES_MIN_VERSION` (lower bound).
+    pub version: u32,
+    /// All configured remotes for the local orchard installation.
+    pub remotes: Vec<JsonRemoteConfig>,
+}
+
+/// Validates that the given `version` from a remote `orchard list-remotes --json`
+/// response is acceptable (i.e. `>= LIST_REMOTES_MIN_VERSION`).
+///
+/// Returns `Ok(())` when the version is acceptable, `Err(String)` with a
+/// human-readable reason when it is too old.
+///
+/// # Examples
+///
+/// ```
+/// use orchard::federation::{check_list_remotes_version, LIST_REMOTES_MIN_VERSION};
+///
+/// assert!(check_list_remotes_version(LIST_REMOTES_MIN_VERSION).is_ok());
+/// assert!(check_list_remotes_version(LIST_REMOTES_MIN_VERSION + 1).is_ok());
+/// assert!(check_list_remotes_version(0).is_err());
+/// ```
+pub fn check_list_remotes_version(version: u32) -> Result<(), String> {
+    if version >= LIST_REMOTES_MIN_VERSION {
+        Ok(())
+    } else {
+        Err(format!(
+            "list-remotes version {version} is below minimum supported version \
+             {LIST_REMOTES_MIN_VERSION}"
+        ))
+    }
+}
+
+/// Builds a [`ListRemotesOutput`] from the local `GlobalConfig`.
+///
+/// Collects all configured remotes across all repos, deduplicates by host
+/// (keeping the first occurrence), and returns a versioned JSON-ready struct.
+pub fn build_list_remotes_output(config: &crate::global_config::GlobalConfig) -> ListRemotesOutput {
+    let mut seen_hosts = std::collections::HashSet::new();
+    let mut remotes = Vec::new();
+
+    for repo in &config.repos {
+        for r in &repo.remotes {
+            if seen_hosts.insert(r.host.clone()) {
+                remotes.push(remote_config_to_json(r));
+            }
+        }
+    }
+
+    ListRemotesOutput {
+        version: LIST_REMOTES_MIN_VERSION,
+        remotes,
+    }
+}
+
+fn remote_config_to_json(r: &RemoteConfig) -> JsonRemoteConfig {
+    // RemoteKind serializes to kebab-case; re-use serde for consistency.
+    let kind = serde_json::to_value(r.kind)
+        .ok()
+        .and_then(|v| v.as_str().map(String::from))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    JsonRemoteConfig {
+        name: r.name.clone(),
+        host: r.host.clone(),
+        kind,
+        path: r.path.clone(),
+        allow_transitive: r.allow_transitive,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// host_dedup_key
+// ---------------------------------------------------------------------------
+
+/// Error returned by [`host_dedup_key`] when the input is structurally invalid.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidSshTarget(pub String);
+
+impl std::fmt::Display for InvalidSshTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid SSH target: {}", self.0)
+    }
+}
+
+impl std::error::Error for InvalidSshTarget {}
+
+/// Computes a best-effort deduplication key for an SSH target string.
+///
+/// The key is suitable for cycle detection and adapter dedup across the
+/// transitive federation walk.  It is NOT a full canonicalization:
+///
+/// - The **hostname** portion is case-folded to ASCII lowercase.
+/// - The **user** portion (before `@`) is preserved as-is (SSH treats users
+///   as distinct identities; `alice@host` and `bob@host` are different keys).
+/// - The default SSH port (22) is treated as implicit — `host:22` and `host`
+///   produce the same key.
+/// - A trailing DNS dot on the hostname is stripped (`host.` → `host`).
+/// - IPv6 addresses in brackets are accepted; the bracket syntax is preserved
+///   and the inner address is case-folded.
+///
+/// # Errors
+///
+/// Returns [`InvalidSshTarget`] if the input contains path separators (`/`),
+/// whitespace, or backslashes — these are never valid in an SSH host position
+/// and most likely indicate a misconfiguration or injection attempt.
+///
+/// # Examples
+///
+/// ```
+/// use orchard::federation::host_dedup_key;
+///
+/// // Case-fold hostname only (user preserved):
+/// assert_eq!(host_dedup_key("boxd@VM.Boxd.Sh").unwrap(), "boxd@vm.boxd.sh");
+///
+/// // Default port stripped:
+/// assert_eq!(host_dedup_key("boxd@vm.boxd.sh:22").unwrap(), "boxd@vm.boxd.sh");
+///
+/// // Non-default port preserved:
+/// assert!(host_dedup_key("boxd@vm.boxd.sh:2222").unwrap() != host_dedup_key("boxd@vm.boxd.sh").unwrap());
+///
+/// // Trailing dot stripped:
+/// assert_eq!(host_dedup_key("boxd@vm.boxd.sh.").unwrap(), "boxd@vm.boxd.sh");
+///
+/// // IPv6 default port stripped:
+/// assert_eq!(host_dedup_key("boxd@[2001:db8::1]:22").unwrap(), host_dedup_key("boxd@[2001:db8::1]").unwrap());
+///
+/// // Distinct users differ:
+/// assert!(host_dedup_key("alice@host").unwrap() != host_dedup_key("bob@host").unwrap());
+///
+/// // Malformed input rejected:
+/// assert!(host_dedup_key("boxd@host/evil").is_err());
+/// ```
+pub fn host_dedup_key(target: &str) -> Result<String, InvalidSshTarget> {
+    // Reject inputs containing characters that are never valid in an SSH target.
+    if target.contains('/') || target.contains('\\') || target.chars().any(|c| c.is_whitespace()) {
+        return Err(InvalidSshTarget(target.to_string()));
+    }
+
+    // Split optional user prefix from the host part.
+    let (user_prefix, host_and_port) = if let Some(at) = target.find('@') {
+        let user = &target[..at];
+        let rest = &target[at + 1..];
+        (Some(user), rest)
+    } else {
+        (None, target)
+    };
+
+    // Normalise the host-and-optional-port portion.
+    let normalised_host_port = normalise_host_port(host_and_port)?;
+
+    let key = if let Some(user) = user_prefix {
+        format!("{user}@{normalised_host_port}")
+    } else {
+        normalised_host_port
+    };
+
+    Ok(key)
+}
+
+/// Normalises `host` or `host:port` or `[ipv6]:port`.
+fn normalise_host_port(s: &str) -> Result<String, InvalidSshTarget> {
+    if s.starts_with('[') {
+        // IPv6 bracketed address: `[addr]` or `[addr]:port`.
+        let close = s.find(']').ok_or_else(|| InvalidSshTarget(s.to_string()))?;
+        let inner = &s[1..close]; // address without brackets
+        let after_bracket = &s[close + 1..]; // empty, or ":port"
+
+        let port = parse_after_bracket(after_bracket, s)?;
+
+        let normalised_addr = inner.to_ascii_lowercase();
+        if port == 22 {
+            // Default port — omit from key.
+            Ok(format!("[{normalised_addr}]"))
+        } else if port == 0 {
+            // No port specified.
+            Ok(format!("[{normalised_addr}]"))
+        } else {
+            Ok(format!("[{normalised_addr}]:{port}"))
+        }
+    } else {
+        // Plain hostname or IPv4 address, possibly with `:port`.
+        let (host, port) = split_host_port(s)?;
+        // Strip trailing DNS dot.
+        let host = host.trim_end_matches('.');
+        let normalised = host.to_ascii_lowercase();
+        if port == 22 || port == 0 {
+            Ok(normalised)
+        } else {
+            Ok(format!("{normalised}:{port}"))
+        }
+    }
+}
+
+/// Parses the part after `]` in an IPv6 target.  Must be empty or `:port`.
+/// Returns the port number (0 = absent).
+fn parse_after_bracket(after: &str, original: &str) -> Result<u32, InvalidSshTarget> {
+    if after.is_empty() {
+        return Ok(0);
+    }
+    if let Some(port_str) = after.strip_prefix(':') {
+        port_str
+            .parse::<u32>()
+            .map_err(|_| InvalidSshTarget(original.to_string()))
+    } else {
+        Err(InvalidSshTarget(original.to_string()))
+    }
+}
+
+/// Splits `host` or `host:port` (non-IPv6) into `(host, port)`.
+/// Returns `port = 0` when absent.
+fn split_host_port(s: &str) -> Result<(String, u32), InvalidSshTarget> {
+    // Count colons: more than one means it's a bare IPv6 address (no brackets).
+    // In that case return as-is with port=0.
+    let colon_count = s.chars().filter(|&c| c == ':').count();
+    if colon_count > 1 {
+        // Bare IPv6 without brackets — accept but normalise without port.
+        return Ok((s.to_string(), 0));
+    }
+
+    if let Some(colon) = s.rfind(':') {
+        let host = &s[..colon];
+        let port_str = &s[colon + 1..];
+        let port = port_str
+            .parse::<u32>()
+            .map_err(|_| InvalidSshTarget(s.to_string()))?;
+        Ok((host.to_string(), port))
+    } else {
+        Ok((s.to_string(), 0))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// federation.discovered_host event
+// ---------------------------------------------------------------------------
+
+/// Appends a `federation.discovered_host` event to `events.jsonl`.
+///
+/// This should be called once per refresh pass for each *new* dedup key
+/// encountered by the walker.  The `seen` set is maintained by the caller;
+/// this function only writes the event.
+///
+/// Fields emitted:
+/// - `raw_target` — the original string passed to [`host_dedup_key`]
+/// - `dedup_key`  — the computed normalised key
+///
+/// The event allows an operator to detect silent collision cases where two
+/// different textual targets normalise to the same key (e.g. `HOST.example.com`
+/// and `host.example.com` both → `host.example.com`).
+pub fn emit_federation_discovered_host(raw_target: &str, dedup_key: &str) {
+    log_event(
+        "federation.discovered_host",
+        &[
+            ("raw_target", Value::String(raw_target.to_string())),
+            ("dedup_key", Value::String(dedup_key.to_string())),
+        ],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::remote_adapter::RemoteKind;
+
+    // -----------------------------------------------------------------------
+    // AC4: host_dedup_key — exhaustive scenario matrix
+    // -----------------------------------------------------------------------
+
+    /// Case-folds the host portion but preserves user case.
+    /// feature:99 — "host_dedup_key case-folds the host portion but preserves user case"
+    #[test]
+    fn host_dedup_key_case_folds_host_preserves_user() {
+        let a = host_dedup_key("boxd@VM.Boxd.Sh").expect("should be valid");
+        let b = host_dedup_key("boxd@vm.boxd.sh").expect("should be valid");
+        assert_eq!(a, b, "case variants of hostname must produce equal keys");
+        assert_eq!(a, "boxd@vm.boxd.sh", "key must be lowercase");
+    }
+
+    /// Default SSH port (22) is treated as implicit — same key as no port.
+    /// feature:105 — "host_dedup_key treats default SSH port as implicit"
+    #[test]
+    fn host_dedup_key_default_port_implicit() {
+        let no_port = host_dedup_key("boxd@vm.boxd.sh").expect("valid");
+        let port_22 = host_dedup_key("boxd@vm.boxd.sh:22").expect("valid");
+        let port_2222 = host_dedup_key("boxd@vm.boxd.sh:2222").expect("valid");
+
+        assert_eq!(no_port, port_22, "no-port and :22 must produce equal keys");
+        assert_ne!(
+            no_port, port_2222,
+            ":2222 must produce a DIFFERENT key from :22 / no-port"
+        );
+    }
+
+    /// Trailing dot on hostname is stripped.
+    /// feature:113 — "host_dedup_key strips a trailing dot on the hostname"
+    #[test]
+    fn host_dedup_key_strips_trailing_dot() {
+        let with_dot = host_dedup_key("boxd@vm.boxd.sh.").expect("valid");
+        let without = host_dedup_key("boxd@vm.boxd.sh").expect("valid");
+        assert_eq!(with_dot, without, "trailing dot must be stripped");
+    }
+
+    /// IPv6 bracketed address: default port implicit, non-default preserved.
+    /// feature:119 — "host_dedup_key normalizes IPv6 brackets consistently"
+    #[test]
+    fn host_dedup_key_ipv6_default_port_implicit() {
+        let bare = host_dedup_key("boxd@[2001:db8::1]").expect("valid");
+        let port_22 = host_dedup_key("boxd@[2001:db8::1]:22").expect("valid");
+        let port_2222 = host_dedup_key("boxd@[2001:db8::1]:2222").expect("valid");
+
+        assert_eq!(bare, port_22, "IPv6 bare and :22 must produce equal keys");
+        assert_ne!(bare, port_2222, "IPv6 :2222 must differ from bare / :22");
+    }
+
+    /// Distinct users on same host produce different keys.
+    /// feature:125 — "host_dedup_key preserves distinct users on the same host"
+    #[test]
+    fn host_dedup_key_distinct_users_differ() {
+        let alice = host_dedup_key("alice@vm.boxd.sh").expect("valid");
+        let bob = host_dedup_key("bob@vm.boxd.sh").expect("valid");
+        assert_ne!(alice, bob, "different users must produce different keys");
+        assert_eq!(alice, "alice@vm.boxd.sh");
+        assert_eq!(bob, "bob@vm.boxd.sh");
+    }
+
+    /// Malformed targets are rejected (paths, whitespace, backslashes).
+    /// feature:131 — "host_dedup_key rejects malformed strings"
+    #[test]
+    fn host_dedup_key_rejects_path() {
+        let result = host_dedup_key("boxd@vm.boxd.sh/evil");
+        assert!(result.is_err(), "path separator must be rejected");
+    }
+
+    #[test]
+    fn host_dedup_key_rejects_whitespace() {
+        let result = host_dedup_key("boxd@vm.boxd.sh extra");
+        assert!(result.is_err(), "whitespace must be rejected");
+    }
+
+    #[test]
+    fn host_dedup_key_rejects_backslash() {
+        let result = host_dedup_key("boxd@vm.boxd.sh\\evil");
+        assert!(result.is_err(), "backslash must be rejected");
+    }
+
+    // -----------------------------------------------------------------------
+    // host_dedup_key — additional correctness checks
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn host_dedup_key_no_user_prefix_works() {
+        let key = host_dedup_key("vm.boxd.sh").expect("valid");
+        assert_eq!(key, "vm.boxd.sh");
+    }
+
+    #[test]
+    fn host_dedup_key_no_user_with_port() {
+        let k22 = host_dedup_key("vm.boxd.sh:22").expect("valid");
+        let k_none = host_dedup_key("vm.boxd.sh").expect("valid");
+        assert_eq!(k22, k_none);
+    }
+
+    #[test]
+    fn host_dedup_key_mixed_case_ipv6() {
+        let upper = host_dedup_key("boxd@[2001:DB8::1]").expect("valid");
+        let lower = host_dedup_key("boxd@[2001:db8::1]").expect("valid");
+        assert_eq!(upper, lower, "IPv6 case must be folded");
+    }
+
+    // -----------------------------------------------------------------------
+    // list-remotes version check
+    // -----------------------------------------------------------------------
+
+    /// Lower-bound check: min version passes, version below min fails.
+    /// feature:387 — "list-remotes version check is lower-bound, not exact-whitelist"
+    #[test]
+    fn check_list_remotes_version_lower_bound() {
+        assert!(
+            check_list_remotes_version(LIST_REMOTES_MIN_VERSION).is_ok(),
+            "min version must be accepted"
+        );
+        assert!(
+            check_list_remotes_version(LIST_REMOTES_MIN_VERSION + 1).is_ok(),
+            "version above min must be accepted (additive-only)"
+        );
+        assert!(
+            check_list_remotes_version(LIST_REMOTES_MIN_VERSION + 100).is_ok(),
+            "future versions must be accepted by lower-bound check"
+        );
+    }
+
+    #[test]
+    fn check_list_remotes_version_rejects_below_min() {
+        // Only fails if LIST_REMOTES_MIN_VERSION > 0.
+        if LIST_REMOTES_MIN_VERSION > 0 {
+            assert!(
+                check_list_remotes_version(0).is_err(),
+                "version 0 must be rejected when min > 0"
+            );
+        }
+    }
+
+    /// list-remotes version constant is independent of JsonOutput's version.
+    /// feature:379 — "emits its own independent version field"
+    #[test]
+    fn list_remotes_version_is_independent_of_json_output_version() {
+        // JsonOutput always emits version 6. LIST_REMOTES_MIN_VERSION is a
+        // separate constant — its value must not be required to match.
+        // We simply assert they are separate constants (different addresses).
+        // The meaningful semantic: list-remotes version check must not use
+        // SUPPORTED_JSON_OUTPUT_VERSIONS.
+        use crate::json_output::SUPPORTED_JSON_OUTPUT_VERSIONS;
+        // This compiles only if the two constants are defined separately.
+        let _ = SUPPORTED_JSON_OUTPUT_VERSIONS;
+        let _ = LIST_REMOTES_MIN_VERSION;
+        // The test passes as long as it compiles — we can't compare function
+        // pointers, but the point is both are accessible and separate.
+    }
+
+    // -----------------------------------------------------------------------
+    // JsonRemoteConfig + build_list_remotes_output
+    // -----------------------------------------------------------------------
+
+    /// feature:379 — JsonRemoteConfig has {name, host, kind, path, allow_transitive}
+    #[test]
+    fn json_remote_config_has_required_fields() {
+        use crate::global_config::{GlobalConfig, RepoConfig};
+
+        let config = GlobalConfig {
+            repos: vec![RepoConfig {
+                slug: "owner/repo".to_string(),
+                path: "/local".to_string(),
+                remotes: vec![RemoteConfig {
+                    name: "vm".to_string(),
+                    host: "boxd@vm.boxd.sh".to_string(),
+                    path: "/remote".to_string(),
+                    shell: "ssh".to_string(),
+                    kind: RemoteKind::OrchardProxy,
+                    allow_transitive: true,
+                }],
+            }],
+            ..GlobalConfig::default()
+        };
+
+        let output = build_list_remotes_output(&config);
+        assert_eq!(output.version, LIST_REMOTES_MIN_VERSION);
+        assert_eq!(output.remotes.len(), 1);
+
+        let r = &output.remotes[0];
+        assert_eq!(r.name, "vm");
+        assert_eq!(r.host, "boxd@vm.boxd.sh");
+        assert_eq!(r.kind, "orchard-proxy");
+        assert_eq!(r.path, "/remote");
+        assert!(r.allow_transitive);
+    }
+
+    /// JSON serialization of ListRemotesOutput includes version and remotes.
+    #[test]
+    fn list_remotes_output_serializes_correctly() {
+        use crate::global_config::{GlobalConfig, RepoConfig};
+
+        let config = GlobalConfig {
+            repos: vec![RepoConfig {
+                slug: "owner/repo".to_string(),
+                path: "/local".to_string(),
+                remotes: vec![RemoteConfig {
+                    name: "boxd".to_string(),
+                    host: "boxd@vm.boxd.sh".to_string(),
+                    path: "/home/boxd".to_string(),
+                    shell: "ssh".to_string(),
+                    kind: RemoteKind::OrchardProxy,
+                    allow_transitive: false,
+                }],
+            }],
+            ..GlobalConfig::default()
+        };
+
+        let output = build_list_remotes_output(&config);
+        let json = serde_json::to_value(&output).expect("serialization must succeed");
+
+        assert!(json.get("version").is_some(), "must have 'version'");
+        assert!(json.get("remotes").is_some(), "must have 'remotes'");
+
+        let remotes = json["remotes"].as_array().expect("remotes must be array");
+        assert_eq!(remotes.len(), 1);
+
+        let r = &remotes[0];
+        assert!(r.get("name").is_some());
+        assert!(r.get("host").is_some());
+        assert!(r.get("kind").is_some());
+        assert!(r.get("path").is_some());
+        assert!(r.get("allowTransitive").is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // RemoteConfig.allow_transitive backward compatibility
+    // -----------------------------------------------------------------------
+
+    /// feature (Background, line 26) — allow_transitive defaults to false when
+    /// absent from JSON (backward-compatible deserialization).
+    #[test]
+    fn remote_config_allow_transitive_defaults_to_false() {
+        let json = r#"{
+            "name": "vm",
+            "host": "boxd@vm.boxd.sh",
+            "path": "/remote",
+            "shell": "ssh",
+            "type": "orchard-proxy"
+        }"#;
+
+        let remote: RemoteConfig = serde_json::from_str(json).expect("must parse");
+        assert!(
+            !remote.allow_transitive,
+            "allow_transitive must default to false for legacy configs"
+        );
+    }
+
+    #[test]
+    fn remote_config_allow_transitive_true_round_trips() {
+        let json = r#"{
+            "name": "vm",
+            "host": "boxd@vm.boxd.sh",
+            "path": "/remote",
+            "shell": "ssh",
+            "type": "orchard-proxy",
+            "allow_transitive": true
+        }"#;
+
+        let remote: RemoteConfig = serde_json::from_str(json).expect("must parse");
+        assert!(remote.allow_transitive, "allow_transitive: true must parse");
+    }
+
+    // -----------------------------------------------------------------------
+    // federation.discovered_host event
+    // -----------------------------------------------------------------------
+
+    /// feature:138 — first-seen host emits federation.discovered_host event;
+    /// second sighting (same key) does NOT emit (caller dedup responsibility).
+    ///
+    /// We test only that the function writes a correctly-shaped event line;
+    /// the seen-set dedup logic is the walker's responsibility, exercised via
+    /// the walker tests in Phase 2.
+    #[test]
+    fn emit_federation_discovered_host_writes_event() {
+        use tempfile::TempDir;
+
+        // Redirect HOME so the event goes to a temp directory.
+        let home = TempDir::new().expect("temp dir");
+        unsafe {
+            std::env::set_var("HOME", home.path());
+        }
+
+        emit_federation_discovered_host("Boxd@VM.Boxd.Sh", "boxd@vm.boxd.sh");
+
+        let events_path = home
+            .path()
+            .join(".local")
+            .join("state")
+            .join("git-orchard")
+            .join("events.jsonl");
+
+        let contents = std::fs::read_to_string(&events_path).expect("events.jsonl must exist");
+        let line = contents
+            .lines()
+            .next()
+            .expect("must have at least one line");
+
+        let parsed: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(line).expect("must be valid JSON");
+
+        assert_eq!(
+            parsed["event"].as_str().unwrap(),
+            "federation.discovered_host"
+        );
+        assert_eq!(parsed["raw_target"].as_str().unwrap(), "Boxd@VM.Boxd.Sh");
+        assert_eq!(parsed["dedup_key"].as_str().unwrap(), "boxd@vm.boxd.sh");
+    }
+}

--- a/crates/orchard/src/federation.rs
+++ b/crates/orchard/src/federation.rs
@@ -338,6 +338,113 @@ pub fn emit_federation_discovered_host(raw_target: &str, dedup_key: &str) {
 }
 
 // ---------------------------------------------------------------------------
+// build_ssh_chain — write-path chaining for transitive nodes (AC5)
+// ---------------------------------------------------------------------------
+
+/// Shell-quote a string for use in a POSIX single-quoted context.
+///
+/// Single-quotes in the string are escaped as `'\''` (end-single-quote,
+/// escaped-single-quote, start-single-quote).  The result is wrapped in
+/// outer single quotes.
+///
+/// # Examples
+///
+/// ```
+/// use orchard::federation::shell_quote;
+///
+/// assert_eq!(shell_quote("hello"), "'hello'");
+/// assert_eq!(shell_quote("it's"), "'it'\\''s'");
+/// assert_eq!(shell_quote("$VAR"), "'$VAR'");
+/// ```
+pub fn shell_quote(s: &str) -> String {
+    // Replace each `'` with `'\''` and wrap in single quotes.
+    let escaped = s.replace('\'', "'\\''");
+    format!("'{escaped}'")
+}
+
+/// Builds an SSH command string that executes `cmd` on the leaf host in
+/// `discovery_path` by chaining through each intermediate hop.
+///
+/// `discovery_path` is the same slice carried on `WorktreeState.discovery_path`
+/// and `SessionState.discovery_path` — it starts with `"local"` and ends with
+/// the target host.  The `"local"` sentinel is always stripped before building
+/// the chain.
+///
+/// # Behaviour
+///
+/// | path length | result |
+/// |---|---|
+/// | 0 or 1 (`["local"]` or empty) | `cmd` unchanged (already on local machine) |
+/// | 2 (`["local", "boxd"]`) | `ssh boxd <cmd>` |
+/// | 3 (`["local", "boxd", "child"]`) | `ssh boxd ssh 'child' <shell-quoted-cmd>` |
+/// | N | recursively nested: each intermediate hop wraps the inner command |
+///
+/// Shell metacharacters in `cmd` and in host names are quoted at each nesting
+/// level so the payload arrives at the leaf byte-identical.
+///
+/// # Examples
+///
+/// ```
+/// use orchard::federation::build_ssh_chain;
+///
+/// // depth-1: single hop — no nesting
+/// let chain = build_ssh_chain(&["local".into(), "boxd".into()], "tmux ls");
+/// assert_eq!(chain, "ssh boxd tmux ls");
+///
+/// // depth-2: nested SSH
+/// let chain = build_ssh_chain(
+///     &["local".into(), "boxd".into(), "child.example.com".into()],
+///     "tmux ls",
+/// );
+/// assert_eq!(chain, "ssh boxd ssh 'child.example.com' 'tmux ls'");
+///
+/// // empty / local-only path → unchanged cmd
+/// let chain = build_ssh_chain(&["local".into()], "echo hi");
+/// assert_eq!(chain, "echo hi");
+/// ```
+pub fn build_ssh_chain(discovery_path: &[String], cmd: &str) -> String {
+    // Strip the leading "local" sentinel if present.
+    let hops: &[String] = if discovery_path.first().map(String::as_str) == Some("local") {
+        &discovery_path[1..]
+    } else {
+        discovery_path
+    };
+
+    if hops.is_empty() {
+        // Already local — run cmd directly.
+        return cmd.to_string();
+    }
+
+    // Build the command inside-out: start from the innermost (leaf) command
+    // and wrap it in each hop's ssh call from right to left.
+    //
+    // For hops = ["boxd", "child"] and cmd = "tmux ls":
+    //   inner = "tmux ls"
+    //   wrap with "child" → "ssh 'child' 'tmux ls'"
+    //   wrap with "boxd"  → "ssh boxd ssh 'child' 'tmux ls'"
+    //
+    // The leaf hop uses the raw cmd; each outer hop quotes the inner string.
+
+    let mut inner = cmd.to_string();
+
+    // Walk hops from right-to-left, but we want the *leftmost* hop to be
+    // outermost (not quoted).  Strategy:
+    //   - all hops except the first: build the inner chain with quoting
+    //   - first (outermost) hop: `ssh <host> <inner>` without host quoting
+    //     (the immediate SSH target doesn't need shell-quoting — it's an arg
+    //     to ssh, not a sub-shell string)
+
+    // Wrap from the rightmost hop inward, quoting cmd at each step.
+    // After this loop, `inner` holds the fully-nested quoted command.
+    for hop in hops[1..].iter().rev() {
+        inner = format!("ssh {} {}", shell_quote(hop), shell_quote(&inner));
+    }
+
+    // The outermost hop is not shell-quoted (it's a direct ssh argument).
+    format!("ssh {} {}", hops[0], inner)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -658,5 +765,96 @@ mod tests {
         );
         assert_eq!(parsed["raw_target"].as_str().unwrap(), "Boxd@VM.Boxd.Sh");
         assert_eq!(parsed["dedup_key"].as_str().unwrap(), "boxd@vm.boxd.sh");
+    }
+
+    // -----------------------------------------------------------------------
+    // build_ssh_chain / shell_quote — AC5
+    // -----------------------------------------------------------------------
+
+    /// AC5: depth-1 direct remote produces `ssh host cmd` (no nesting).
+    #[test]
+    fn build_ssh_chain_depth1_no_nesting() {
+        let path = vec!["local".to_string(), "boxd".to_string()];
+        let result = build_ssh_chain(&path, "tmux ls");
+        assert_eq!(result, "ssh boxd tmux ls");
+    }
+
+    /// AC5: depth-2 target produces `ssh parent ssh 'child' 'cmd'`.
+    #[test]
+    fn build_ssh_chain_depth2_nested_ssh() {
+        let path = vec![
+            "local".to_string(),
+            "boxd".to_string(),
+            "scenario-voice-agents.boxd.sh".to_string(),
+        ];
+        let result = build_ssh_chain(&path, "tmux ls");
+        assert_eq!(
+            result,
+            "ssh boxd ssh 'scenario-voice-agents.boxd.sh' 'tmux ls'"
+        );
+    }
+
+    /// AC5: empty path or local-only returns cmd unchanged.
+    #[test]
+    fn build_ssh_chain_local_only_returns_cmd_unchanged() {
+        let path_empty: Vec<String> = vec![];
+        assert_eq!(build_ssh_chain(&path_empty, "echo hi"), "echo hi");
+
+        let path_local = vec!["local".to_string()];
+        assert_eq!(build_ssh_chain(&path_local, "echo hi"), "echo hi");
+    }
+
+    /// AC5: shell metacharacters in cmd are escaped at inner nesting level.
+    #[test]
+    fn build_ssh_chain_shell_metacharacters_escaped() {
+        let path = vec!["local".to_string(), "boxd".to_string(), "child".to_string()];
+        // cmd with $, backtick, double-quote, backslash — starts with $ to make
+        // assertion unambiguous regardless of surrounding context.
+        let cmd = "$VAR `cmd` \"q\" \\n echo done";
+        let result = build_ssh_chain(&path, cmd);
+
+        // The resulting string must contain the outer ssh invocation.
+        assert!(result.starts_with("ssh boxd "), "outer ssh must be first");
+        // The inner cmd must be single-quoted at the inner layer so $ is not interpolated.
+        // shell_quote wraps in single quotes: result contains "'$VAR"
+        assert!(
+            result.contains("'$VAR"),
+            "$ must be within single quotes to prevent interpolation; got: {result}"
+        );
+    }
+
+    /// AC5: depth-3 chain produces three-level nesting.
+    #[test]
+    fn build_ssh_chain_depth3_three_level_nesting() {
+        let path = vec![
+            "local".to_string(),
+            "hop1".to_string(),
+            "hop2".to_string(),
+            "leaf".to_string(),
+        ];
+        let result = build_ssh_chain(&path, "echo done");
+        // Outermost: ssh hop1 <inner>
+        assert!(
+            result.starts_with("ssh hop1 "),
+            "outermost hop must be hop1"
+        );
+        // Should contain hop2 and leaf quoted
+        assert!(result.contains("'hop2'"), "hop2 must be quoted");
+        assert!(result.contains("'leaf'"), "leaf must be quoted");
+    }
+
+    /// shell_quote wraps in single quotes and escapes embedded single quotes.
+    #[test]
+    fn shell_quote_basic() {
+        assert_eq!(shell_quote("hello"), "'hello'");
+        assert_eq!(shell_quote("it's"), "'it'\\''s'");
+        assert_eq!(shell_quote("$VAR"), "'$VAR'");
+        assert_eq!(shell_quote("back`tick"), "'back`tick'");
+    }
+
+    /// shell_quote: empty string produces two single quotes.
+    #[test]
+    fn shell_quote_empty_string() {
+        assert_eq!(shell_quote(""), "''");
     }
 }

--- a/crates/orchard/src/federation_topology.rs
+++ b/crates/orchard/src/federation_topology.rs
@@ -245,22 +245,23 @@ pub fn gc_orphan_snapshots_in(
 
             // Soft TTL: log stale entries but keep them.
             if let Ok(age_days) = age_days_from_iso8601(&entry.last_seen_at, now)
-                && age_days > TOPOLOGY_SOFT_TTL_DAYS {
-                    log_event(
-                        "remote_snapshot.stale",
-                        &[
-                            (
-                                "dedup_key",
-                                serde_json::Value::String(entry.dedup_key.clone()),
-                            ),
-                            (
-                                "last_seen_at",
-                                serde_json::Value::String(entry.last_seen_at.clone()),
-                            ),
-                            ("age_days", serde_json::Value::Number(age_days.into())),
-                        ],
-                    );
-                }
+                && age_days > TOPOLOGY_SOFT_TTL_DAYS
+            {
+                log_event(
+                    "remote_snapshot.stale",
+                    &[
+                        (
+                            "dedup_key",
+                            serde_json::Value::String(entry.dedup_key.clone()),
+                        ),
+                        (
+                            "last_seen_at",
+                            serde_json::Value::String(entry.last_seen_at.clone()),
+                        ),
+                        ("age_days", serde_json::Value::Number(age_days.into())),
+                    ],
+                );
+            }
         }
     }
 
@@ -304,17 +305,16 @@ pub fn gc_orphan_snapshots_in(
                 .is_some_and(|n| n == entry.file_name())
         });
 
-        if !is_known
-            && std::fs::remove_file(&path).is_ok() {
-                log_event(
-                    "remote_snapshot.gc_deleted",
-                    &[(
-                        "path",
-                        serde_json::Value::String(path.display().to_string()),
-                    )],
-                );
-                deleted.push(path);
-            }
+        if !is_known && std::fs::remove_file(&path).is_ok() {
+            log_event(
+                "remote_snapshot.gc_deleted",
+                &[(
+                    "path",
+                    serde_json::Value::String(path.display().to_string()),
+                )],
+            );
+            deleted.push(path);
+        }
     }
 
     deleted

--- a/crates/orchard/src/federation_topology.rs
+++ b/crates/orchard/src/federation_topology.rs
@@ -244,8 +244,8 @@ pub fn gc_orphan_snapshots_in(
             known_keys.insert(entry.dedup_key.clone());
 
             // Soft TTL: log stale entries but keep them.
-            if let Ok(age_days) = age_days_from_iso8601(&entry.last_seen_at, now) {
-                if age_days > TOPOLOGY_SOFT_TTL_DAYS {
+            if let Ok(age_days) = age_days_from_iso8601(&entry.last_seen_at, now)
+                && age_days > TOPOLOGY_SOFT_TTL_DAYS {
                     log_event(
                         "remote_snapshot.stale",
                         &[
@@ -261,7 +261,6 @@ pub fn gc_orphan_snapshots_in(
                         ],
                     );
                 }
-            }
         }
     }
 
@@ -305,8 +304,8 @@ pub fn gc_orphan_snapshots_in(
                 .is_some_and(|n| n == entry.file_name())
         });
 
-        if !is_known {
-            if std::fs::remove_file(&path).is_ok() {
+        if !is_known
+            && std::fs::remove_file(&path).is_ok() {
                 log_event(
                     "remote_snapshot.gc_deleted",
                     &[(
@@ -316,7 +315,6 @@ pub fn gc_orphan_snapshots_in(
                 );
                 deleted.push(path);
             }
-        }
     }
 
     deleted

--- a/crates/orchard/src/federation_topology.rs
+++ b/crates/orchard/src/federation_topology.rs
@@ -1,0 +1,676 @@
+//! Topology persistence for transitive-federation discovery (issue #363, Phase 3).
+//!
+//! After each successful walker run, the discovered topology is persisted at
+//! `~/.cache/orchard/federation_topology.json`.  On cold start,
+//! [`load_cached_snapshots_from`](crate::orchard_snapshot::load_cached_snapshots_from)
+//! reads this file so transitively-discovered hosts are available before any SSH
+//! occurs.
+//!
+//! # File schema
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "written_at": "2026-01-02T03:04:05Z",
+//!   "entries": [
+//!     {
+//!       "dedup_key": "boxd@vm.boxd.sh",
+//!       "discovery_path": ["local", "boxd", "scenario-voice-agents.boxd.sh"],
+//!       "root": "boxd",
+//!       "last_seen_at": "2026-01-02T03:04:05Z"
+//!     }
+//!   ]
+//! }
+//! ```
+//!
+//! The `version` field is versioned **independently** of `JsonOutput`. The check
+//! is a lower-bound (`version >= TOPOLOGY_MIN_VERSION`), not an exact whitelist.
+//!
+//! # GC
+//!
+//! [`gc_orphan_snapshots`] deletes `{safe_host}_orchard_snapshot.json` files
+//! whose `dedup_key` is not present in the current topology AND is not a
+//! directly-configured remote (per `GlobalConfig`). It is called at the end of
+//! each `orchard refresh` run.
+//!
+//! # Soft 7-day TTL
+//!
+//! Entries older than 7 days are logged via `remote_snapshot.stale` but kept
+//! on disk. They are deleted on the next GC pass if they have become orphans
+//! (the host is no longer discovered at all).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::cache::cache_dir;
+use crate::events::log_event;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Minimum acceptable version in a `federation_topology.json` file.
+///
+/// Lower-bound check (`version >= TOPOLOGY_MIN_VERSION`) — not exact-whitelist.
+pub const TOPOLOGY_MIN_VERSION: u32 = 1;
+
+/// Current version written by this build.
+pub const TOPOLOGY_CURRENT_VERSION: u32 = 1;
+
+/// Soft TTL for topology entries: 7 days.
+pub const TOPOLOGY_SOFT_TTL_DAYS: u64 = 7;
+
+// ---------------------------------------------------------------------------
+// Schema types
+// ---------------------------------------------------------------------------
+
+/// A single entry in the topology file — one per transitively-discovered host.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TopologyEntry {
+    /// `host_dedup_key()` of the discovered host.
+    pub dedup_key: String,
+    /// Full discovery path from `"local"` to this host.
+    ///
+    /// Example: `["local", "boxd", "scenario-voice-agents.boxd.sh"]`
+    pub discovery_path: Vec<String>,
+    /// The first element after `"local"` — the directly-configured root from
+    /// which this host was reached.
+    pub root: String,
+    /// ISO 8601 UTC timestamp of the last time this host was seen during a
+    /// successful walk.
+    pub last_seen_at: String,
+}
+
+/// Top-level structure of `federation_topology.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FederationTopology {
+    /// Schema version. Lower-bound check on read.
+    pub version: u32,
+    /// ISO 8601 UTC timestamp when this file was written.
+    pub written_at: String,
+    /// All transitively-discovered topology entries.
+    pub entries: Vec<TopologyEntry>,
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/// Path to `federation_topology.json` under the default cache dir.
+pub fn topology_path() -> PathBuf {
+    topology_path_in(&cache_dir())
+}
+
+/// Path to `federation_topology.json` under `dir` (testing variant).
+pub fn topology_path_in(dir: &Path) -> PathBuf {
+    dir.join("federation_topology.json")
+}
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
+
+/// Writes `topology` atomically to `~/.cache/orchard/federation_topology.json`.
+///
+/// Uses write-to-tmp-then-rename for crash safety.
+pub fn write_topology(topology: &FederationTopology) -> anyhow::Result<()> {
+    write_topology_to(topology, &cache_dir())
+}
+
+/// Like [`write_topology`] but writes under `dir` (testing variant).
+pub fn write_topology_to(topology: &FederationTopology, dir: &Path) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+
+    let path = topology_path_in(dir);
+    let parent = path.parent().context("topology path has no parent")?;
+    std::fs::create_dir_all(parent).context("create topology cache directory")?;
+
+    let json = serde_json::to_string_pretty(topology).context("serialize topology")?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &json).context("write topology .tmp file")?;
+    std::fs::rename(&tmp, &path).context("rename topology .tmp to final")?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+/// Reads `federation_topology.json` from the default cache dir.
+///
+/// Returns `None` if the file is missing or the version is below
+/// [`TOPOLOGY_MIN_VERSION`].
+pub fn read_topology() -> Option<FederationTopology> {
+    read_topology_from(&cache_dir())
+}
+
+/// Like [`read_topology`] but reads from `dir` (testing variant).
+pub fn read_topology_from(dir: &Path) -> Option<FederationTopology> {
+    let path = topology_path_in(dir);
+    let contents = std::fs::read_to_string(&path).ok()?;
+    let topo: FederationTopology = serde_json::from_str(&contents).ok()?;
+
+    if topo.version < TOPOLOGY_MIN_VERSION {
+        log_event(
+            "federation_topology.version_skew",
+            &[
+                ("version", serde_json::Value::Number(topo.version.into())),
+                (
+                    "min_version",
+                    serde_json::Value::Number(TOPOLOGY_MIN_VERSION.into()),
+                ),
+            ],
+        );
+        return None;
+    }
+
+    Some(topo)
+}
+
+// ---------------------------------------------------------------------------
+// Build topology from walker results
+// ---------------------------------------------------------------------------
+
+/// Constructs a [`FederationTopology`] from a slice of
+/// `(discovery_path, dedup_key)` pairs produced by the walker.
+///
+/// Each pair maps to a [`TopologyEntry`] with `last_seen_at` set to now.
+pub fn build_topology(entries: &[(Vec<String>, String)]) -> FederationTopology {
+    let now = now_iso8601();
+
+    let topology_entries: Vec<TopologyEntry> = entries
+        .iter()
+        .map(|(path, key)| {
+            let root = path.get(1).cloned().unwrap_or_default();
+            TopologyEntry {
+                dedup_key: key.clone(),
+                discovery_path: path.clone(),
+                root,
+                last_seen_at: now.clone(),
+            }
+        })
+        .collect();
+
+    FederationTopology {
+        version: TOPOLOGY_CURRENT_VERSION,
+        written_at: now,
+        entries: topology_entries,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GC
+// ---------------------------------------------------------------------------
+
+/// Deletes orphan snapshot files: those whose `dedup_key` is not in `topology`
+/// AND whose host is not a directly-configured remote in `config`.
+///
+/// A file is considered an orphan when the host it represents is no longer
+/// discovered by the walker and is not a directly-configured remote — it was
+/// likely from a VM that has since been destroyed.
+///
+/// Entries that are in the topology but have a `last_seen_at` older than
+/// [`TOPOLOGY_SOFT_TTL_DAYS`] days emit a `remote_snapshot.stale` event
+/// (logged but not deleted — they remain available for observability).
+///
+/// Returns the list of deleted file paths.
+pub fn gc_orphan_snapshots(
+    topology: Option<&FederationTopology>,
+    config: &crate::global_config::GlobalConfig,
+) -> Vec<PathBuf> {
+    gc_orphan_snapshots_in(topology, config, &cache_dir())
+}
+
+/// Like [`gc_orphan_snapshots`] but operates under `dir` (testing variant).
+pub fn gc_orphan_snapshots_in(
+    topology: Option<&FederationTopology>,
+    config: &crate::global_config::GlobalConfig,
+    dir: &Path,
+) -> Vec<PathBuf> {
+    use crate::orchard_snapshot::orchard_snapshot_path_in;
+    use crate::remote_adapter::RemoteKind;
+
+    // Build the set of "known" dedup keys: topology entries + config remotes.
+    let mut known_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    // Add all dedup keys from the topology.
+    if let Some(topo) = topology {
+        let now = now_unix_secs();
+        for entry in &topo.entries {
+            known_keys.insert(entry.dedup_key.clone());
+
+            // Soft TTL: log stale entries but keep them.
+            if let Ok(age_days) = age_days_from_iso8601(&entry.last_seen_at, now) {
+                if age_days > TOPOLOGY_SOFT_TTL_DAYS {
+                    log_event(
+                        "remote_snapshot.stale",
+                        &[
+                            (
+                                "dedup_key",
+                                serde_json::Value::String(entry.dedup_key.clone()),
+                            ),
+                            (
+                                "last_seen_at",
+                                serde_json::Value::String(entry.last_seen_at.clone()),
+                            ),
+                            ("age_days", serde_json::Value::Number(age_days.into())),
+                        ],
+                    );
+                }
+            }
+        }
+    }
+
+    // Add dedup keys for directly-configured OrchardProxy remotes.
+    for repo in &config.repos {
+        for remote in &repo.remotes {
+            if remote.kind == RemoteKind::OrchardProxy {
+                if let Ok(key) = crate::federation::host_dedup_key(&remote.host) {
+                    known_keys.insert(key);
+                }
+                // Also add the raw host in case host_dedup_key fails.
+                known_keys.insert(remote.host.clone());
+            }
+        }
+    }
+
+    // Scan the cache dir for _orchard_snapshot.json files and delete orphans.
+    let mut deleted: Vec<PathBuf> = Vec::new();
+
+    let read_dir = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return deleted,
+    };
+
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        // Only consider files matching the snapshot filename pattern.
+        if !name.ends_with("_orchard_snapshot.json") {
+            continue;
+        }
+
+        // Reverse-map the filename back to a dedup key to check if known.
+        // We scan all known keys: for each key, check if it would produce this filename.
+        let is_known = known_keys.iter().any(|key| {
+            orchard_snapshot_path_in(key, dir)
+                .file_name()
+                .is_some_and(|n| n == entry.file_name())
+        });
+
+        if !is_known {
+            if std::fs::remove_file(&path).is_ok() {
+                log_event(
+                    "remote_snapshot.gc_deleted",
+                    &[(
+                        "path",
+                        serde_json::Value::String(path.display().to_string()),
+                    )],
+                );
+                deleted.push(path);
+            }
+        }
+    }
+
+    deleted
+}
+
+// ---------------------------------------------------------------------------
+// Host list extraction (for cold-start loader)
+// ---------------------------------------------------------------------------
+
+/// Returns the list of unique hosts from a topology that are not already in
+/// the direct-config host set.
+///
+/// These are the transitively-discovered hosts whose snapshots should be loaded
+/// at cold start (in addition to the directly-configured OrchardProxy hosts
+/// already loaded by [`crate::orchard_snapshot::load_cached_snapshots_from`]).
+pub fn transitive_hosts_from_topology(topology: &FederationTopology) -> Vec<String> {
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut hosts: Vec<String> = Vec::new();
+
+    for entry in &topology.entries {
+        if seen.insert(entry.dedup_key.clone()) {
+            hosts.push(entry.dedup_key.clone());
+        }
+    }
+
+    hosts
+}
+
+// ---------------------------------------------------------------------------
+// Time helpers
+// ---------------------------------------------------------------------------
+
+fn now_iso8601() -> String {
+    use std::time::SystemTime;
+    let secs = SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    unix_secs_to_iso8601(secs)
+}
+
+fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn unix_secs_to_iso8601(secs: u64) -> String {
+    // Produce a simple ISO 8601 UTC string without external crate dependencies.
+    // Using chrono is fine since it's already in the dependency tree.
+    use chrono::{DateTime, Utc};
+    let dt = DateTime::<Utc>::from_timestamp(secs as i64, 0)
+        .unwrap_or_else(|| DateTime::<Utc>::from_timestamp(0, 0).unwrap());
+    dt.to_rfc3339()
+}
+
+fn age_days_from_iso8601(iso: &str, now_secs: u64) -> Result<u64, ()> {
+    let ts = chrono::DateTime::parse_from_rfc3339(iso).map_err(|_| ())?;
+    let ts_secs = ts.timestamp() as u64;
+    let age_secs = now_secs.saturating_sub(ts_secs);
+    Ok(age_secs / 86400)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_entry(key: &str, path: &[&str], root: &str) -> TopologyEntry {
+        TopologyEntry {
+            dedup_key: key.to_string(),
+            discovery_path: path.iter().map(|s| s.to_string()).collect(),
+            root: root.to_string(),
+            last_seen_at: "2026-01-01T00:00:00+00:00".to_string(),
+        }
+    }
+
+    fn make_topology(entries: Vec<TopologyEntry>) -> FederationTopology {
+        FederationTopology {
+            version: TOPOLOGY_CURRENT_VERSION,
+            written_at: "2026-01-01T00:00:00+00:00".to_string(),
+            entries,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 343: topology round-trip
+    // -----------------------------------------------------------------------
+
+    /// feature:343 — topology file round-trip (write then read back)
+    #[test]
+    fn topology_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let topo = make_topology(vec![
+            make_entry(
+                "boxd@vm.boxd.sh",
+                &["local", "boxd", "scenario-voice-agents.boxd.sh"],
+                "boxd",
+            ),
+            make_entry(
+                "evals-v3-debug",
+                &["local", "boxd", "evals-v3-debug"],
+                "boxd",
+            ),
+        ]);
+
+        write_topology_to(&topo, dir.path()).unwrap();
+
+        let loaded = read_topology_from(dir.path()).expect("must load back");
+        assert_eq!(loaded.version, TOPOLOGY_CURRENT_VERSION);
+        assert_eq!(loaded.entries.len(), 2);
+        assert_eq!(loaded.entries[0].dedup_key, "boxd@vm.boxd.sh");
+        assert_eq!(loaded.entries[0].root, "boxd");
+    }
+
+    #[test]
+    fn topology_write_is_atomic_no_tmp_left() {
+        let dir = TempDir::new().unwrap();
+        let topo = make_topology(vec![]);
+
+        write_topology_to(&topo, dir.path()).unwrap();
+
+        let tmp = topology_path_in(dir.path()).with_extension("json.tmp");
+        assert!(!tmp.exists(), ".tmp must be renamed away");
+    }
+
+    #[test]
+    fn topology_missing_file_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let result = read_topology_from(dir.path());
+        assert!(result.is_none(), "missing file must return None");
+    }
+
+    #[test]
+    fn topology_version_below_min_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let bad_json = r#"{"version":0,"writtenAt":"2026-01-01T00:00:00Z","entries":[]}"#;
+        std::fs::write(topology_path_in(dir.path()), bad_json).unwrap();
+
+        let result = read_topology_from(dir.path());
+        // version 0 < TOPOLOGY_MIN_VERSION (1) → None
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn topology_future_version_accepted() {
+        let dir = TempDir::new().unwrap();
+        // version 99 > TOPOLOGY_MIN_VERSION → accepted (lower-bound check)
+        let json = r#"{"version":99,"writtenAt":"2026-01-01T00:00:00Z","entries":[]}"#;
+        std::fs::write(topology_path_in(dir.path()), json).unwrap();
+
+        let result = read_topology_from(dir.path());
+        assert!(
+            result.is_some(),
+            "future version must be accepted by lower-bound check"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 351: load_cached_snapshots returns union of config + topology
+    // -----------------------------------------------------------------------
+
+    /// feature:351 — transitive_hosts_from_topology returns unique dedup keys
+    #[test]
+    fn transitive_hosts_returns_unique_keys() {
+        let topo = make_topology(vec![
+            make_entry(
+                "scenario-voice-agents",
+                &["local", "boxd", "scenario-voice-agents"],
+                "boxd",
+            ),
+            make_entry("evals", &["local", "boxd", "evals"], "boxd"),
+            // Duplicate key — must be deduped.
+            make_entry(
+                "scenario-voice-agents",
+                &["local", "other", "scenario-voice-agents"],
+                "other",
+            ),
+        ]);
+
+        let hosts = transitive_hosts_from_topology(&topo);
+        assert_eq!(hosts.len(), 2, "duplicates must be collapsed");
+        assert!(hosts.contains(&"scenario-voice-agents".to_string()));
+        assert!(hosts.contains(&"evals".to_string()));
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 360: orphan snapshot GC
+    // -----------------------------------------------------------------------
+
+    /// feature:360 — orphan snapshots are deleted; known snapshots are kept
+    #[test]
+    fn gc_orphan_snapshots_deletes_orphans_keeps_known() {
+        use crate::global_config::{GlobalConfig, RemoteConfig, RepoConfig};
+        use crate::json_output::JsonOutput;
+        use crate::orchard_snapshot::write_snapshot_to;
+        use std::collections::HashMap;
+
+        let dir = TempDir::new().unwrap();
+
+        let snapshot = JsonOutput {
+            version: 6,
+            tmux_sessions: vec![],
+            repos: vec![],
+            hosts: HashMap::new(),
+        };
+
+        // Write a known snapshot (in config).
+        write_snapshot_to("known-host", &snapshot, dir.path()).unwrap();
+        // Write an orphan snapshot (not in config, not in topology).
+        write_snapshot_to("abandoned-host", &snapshot, dir.path()).unwrap();
+
+        let config = GlobalConfig {
+            repos: vec![RepoConfig {
+                slug: "owner/repo".to_string(),
+                path: "/local".to_string(),
+                remotes: vec![RemoteConfig {
+                    name: "known".to_string(),
+                    host: "known-host".to_string(),
+                    path: "/remote".to_string(),
+                    shell: "ssh".to_string(),
+                    kind: crate::remote_adapter::RemoteKind::OrchardProxy,
+                    allow_transitive: false,
+                }],
+            }],
+            ..GlobalConfig::default()
+        };
+
+        let topo = make_topology(vec![]); // empty topology — no transitive hosts
+
+        let deleted = gc_orphan_snapshots_in(Some(&topo), &config, dir.path());
+
+        // abandoned-host should be deleted, known-host should be kept.
+        assert_eq!(deleted.len(), 1, "exactly one file should be deleted");
+        assert!(
+            deleted[0].to_string_lossy().contains("abandoned"),
+            "deleted path must contain 'abandoned'"
+        );
+
+        // known-host snapshot must still exist.
+        use crate::orchard_snapshot::orchard_snapshot_path_in;
+        assert!(orchard_snapshot_path_in("known-host", dir.path()).exists());
+    }
+
+    /// feature:360 — GC keeps topology-listed hosts (not direct config)
+    #[test]
+    fn gc_keeps_topology_listed_transitive_hosts() {
+        use crate::global_config::GlobalConfig;
+        use crate::json_output::JsonOutput;
+        use crate::orchard_snapshot::write_snapshot_to;
+        use std::collections::HashMap;
+
+        let dir = TempDir::new().unwrap();
+
+        let snapshot = JsonOutput {
+            version: 6,
+            tmux_sessions: vec![],
+            repos: vec![],
+            hosts: HashMap::new(),
+        };
+
+        // A transitive host — not in config but in topology.
+        write_snapshot_to("transitive-child", &snapshot, dir.path()).unwrap();
+
+        let config = GlobalConfig::default(); // no remotes
+
+        let topo = make_topology(vec![make_entry(
+            "transitive-child",
+            &["local", "root", "transitive-child"],
+            "root",
+        )]);
+
+        let deleted = gc_orphan_snapshots_in(Some(&topo), &config, dir.path());
+
+        assert!(
+            deleted.is_empty(),
+            "topology-listed host must NOT be deleted by GC"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 368: 7-day TTL log event
+    // -----------------------------------------------------------------------
+
+    /// feature:368 — stale topology entry emits remote_snapshot.stale event (smoke test)
+    ///
+    /// We can't easily assert on the live events file, but we verify the code runs
+    /// without panicking.  The TTL is checked against `last_seen_at`.
+    #[test]
+    fn gc_stale_entry_does_not_delete_but_logs() {
+        use crate::global_config::GlobalConfig;
+        use crate::json_output::JsonOutput;
+        use crate::orchard_snapshot::write_snapshot_to;
+        use std::collections::HashMap;
+
+        let dir = TempDir::new().unwrap();
+
+        let snapshot = JsonOutput {
+            version: 6,
+            tmux_sessions: vec![],
+            repos: vec![],
+            hosts: HashMap::new(),
+        };
+
+        // A very old topology entry.
+        write_snapshot_to("old-host", &snapshot, dir.path()).unwrap();
+
+        let config = GlobalConfig::default();
+
+        // Entry with an ancient last_seen_at (more than 7 days ago).
+        let old_entry = TopologyEntry {
+            dedup_key: "old-host".to_string(),
+            discovery_path: vec![
+                "local".to_string(),
+                "root".to_string(),
+                "old-host".to_string(),
+            ],
+            root: "root".to_string(),
+            last_seen_at: "2020-01-01T00:00:00+00:00".to_string(), // way old
+        };
+        let topo = make_topology(vec![old_entry]);
+
+        // Must not panic; GC should keep the file (it's in topology).
+        let deleted = gc_orphan_snapshots_in(Some(&topo), &config, dir.path());
+
+        assert!(
+            deleted.is_empty(),
+            "stale but topology-listed file must NOT be deleted"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // build_topology helper
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_topology_sets_correct_fields() {
+        let entries = vec![(
+            vec!["local".to_string(), "boxd".to_string(), "child".to_string()],
+            "child-key".to_string(),
+        )];
+        let topo = build_topology(&entries);
+        assert_eq!(topo.version, TOPOLOGY_CURRENT_VERSION);
+        assert_eq!(topo.entries.len(), 1);
+        assert_eq!(topo.entries[0].dedup_key, "child-key");
+        assert_eq!(topo.entries[0].root, "boxd");
+        assert_eq!(
+            topo.entries[0].discovery_path,
+            vec!["local", "boxd", "child"]
+        );
+    }
+}

--- a/crates/orchard/src/federation_topology.rs
+++ b/crates/orchard/src/federation_topology.rs
@@ -527,6 +527,7 @@ mod tests {
             tmux_sessions: vec![],
             repos: vec![],
             hosts: HashMap::new(),
+            errors: vec![],
         };
 
         // Write a known snapshot (in config).
@@ -581,6 +582,7 @@ mod tests {
             tmux_sessions: vec![],
             repos: vec![],
             hosts: HashMap::new(),
+            errors: vec![],
         };
 
         // A transitive host — not in config but in topology.
@@ -624,6 +626,7 @@ mod tests {
             tmux_sessions: vec![],
             repos: vec![],
             hosts: HashMap::new(),
+            errors: vec![],
         };
 
         // A very old topology entry.

--- a/crates/orchard/src/federation_topology.rs
+++ b/crates/orchard/src/federation_topology.rs
@@ -66,6 +66,11 @@ pub const TOPOLOGY_SOFT_TTL_DAYS: u64 = 7;
 // ---------------------------------------------------------------------------
 
 /// A single entry in the topology file — one per transitively-discovered host.
+///
+/// Serde silently ignores unknown fields (no `deny_unknown_fields`), so
+/// existing `federation_topology.json` files that contain a `"root"` field
+/// will still deserialize correctly after the field was removed from this
+/// struct.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TopologyEntry {
@@ -75,12 +80,19 @@ pub struct TopologyEntry {
     ///
     /// Example: `["local", "boxd", "scenario-voice-agents.boxd.sh"]`
     pub discovery_path: Vec<String>,
-    /// The first element after `"local"` — the directly-configured root from
-    /// which this host was reached.
-    pub root: String,
     /// ISO 8601 UTC timestamp of the last time this host was seen during a
     /// successful walk.
     pub last_seen_at: String,
+}
+
+impl TopologyEntry {
+    /// Returns the directly-configured root host from which this node was
+    /// reached: `discovery_path[1]` (the first element after `"local"`).
+    ///
+    /// Returns `None` when `discovery_path` has fewer than 2 elements.
+    pub fn root(&self) -> Option<&str> {
+        self.discovery_path.get(1).map(String::as_str)
+    }
 }
 
 /// Top-level structure of `federation_topology.json`.
@@ -184,14 +196,10 @@ pub fn build_topology(entries: &[(Vec<String>, String)]) -> FederationTopology {
 
     let topology_entries: Vec<TopologyEntry> = entries
         .iter()
-        .map(|(path, key)| {
-            let root = path.get(1).cloned().unwrap_or_default();
-            TopologyEntry {
-                dedup_key: key.clone(),
-                discovery_path: path.clone(),
-                root,
-                last_seen_at: now.clone(),
-            }
+        .map(|(path, key)| TopologyEntry {
+            dedup_key: key.clone(),
+            discovery_path: path.clone(),
+            last_seen_at: now.clone(),
         })
         .collect();
 
@@ -388,11 +396,11 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn make_entry(key: &str, path: &[&str], root: &str) -> TopologyEntry {
+    fn make_entry(key: &str, path: &[&str], _root: &str) -> TopologyEntry {
+        // `root` is no longer stored as a field; it is derived from discovery_path[1].
         TopologyEntry {
             dedup_key: key.to_string(),
             discovery_path: path.iter().map(|s| s.to_string()).collect(),
-            root: root.to_string(),
             last_seen_at: "2026-01-01T00:00:00+00:00".to_string(),
         }
     }
@@ -432,7 +440,7 @@ mod tests {
         assert_eq!(loaded.version, TOPOLOGY_CURRENT_VERSION);
         assert_eq!(loaded.entries.len(), 2);
         assert_eq!(loaded.entries[0].dedup_key, "boxd@vm.boxd.sh");
-        assert_eq!(loaded.entries[0].root, "boxd");
+        assert_eq!(loaded.entries[0].root(), Some("boxd"));
     }
 
     #[test]
@@ -640,7 +648,6 @@ mod tests {
                 "root".to_string(),
                 "old-host".to_string(),
             ],
-            root: "root".to_string(),
             last_seen_at: "2020-01-01T00:00:00+00:00".to_string(), // way old
         };
         let topo = make_topology(vec![old_entry]);
@@ -668,7 +675,7 @@ mod tests {
         assert_eq!(topo.version, TOPOLOGY_CURRENT_VERSION);
         assert_eq!(topo.entries.len(), 1);
         assert_eq!(topo.entries[0].dedup_key, "child-key");
-        assert_eq!(topo.entries[0].root, "boxd");
+        assert_eq!(topo.entries[0].root(), Some("boxd"));
         assert_eq!(
             topo.entries[0].discovery_path,
             vec!["local", "boxd", "child"]

--- a/crates/orchard/src/global_config.rs
+++ b/crates/orchard/src/global_config.rs
@@ -37,6 +37,13 @@ pub struct RemoteConfig {
     /// field are rejected at parse time, preventing silent misclassification.
     #[serde(rename = "type")]
     pub kind: RemoteKind,
+    /// When `true`, the transitive-federation walker will follow this remote's
+    /// own `orchard list-remotes` output to discover grandchild nodes.
+    ///
+    /// Defaults to `false` — opt-in per root so existing single-hop configs
+    /// are unaffected by deserialization of configs that predate this field.
+    #[serde(default)]
+    pub allow_transitive: bool,
 }
 
 fn default_remote_name() -> String {
@@ -437,6 +444,8 @@ fn load_from_path(path: &PathBuf) -> GlobalConfig {
         shell: String,
         #[serde(rename = "type", default)]
         kind: Option<RemoteKind>,
+        #[serde(default)]
+        allow_transitive: bool,
         // Note: existing configs may carry a `fallback_kind` field; serde
         // silently ignores unknown fields, so no explicit field is needed.
     }
@@ -502,6 +511,7 @@ fn load_from_path(path: &PathBuf) -> GlobalConfig {
                     // Legacy configs predate the `type` field; default to Remmy
                     // for backward compatibility when loading from disk.
                     kind: r.kind.unwrap_or(RemoteKind::Remmy),
+                    allow_transitive: r.allow_transitive,
                 })
                 .collect();
 
@@ -516,6 +526,7 @@ fn load_from_path(path: &PathBuf) -> GlobalConfig {
                     path: r.path.or(r.repo_path).unwrap_or_default(),
                     shell: r.shell,
                     kind: r.kind.unwrap_or(RemoteKind::Remmy),
+                    allow_transitive: r.allow_transitive,
                 });
             }
 
@@ -637,6 +648,8 @@ fn load_orchard_json_remotes(repo_root: &PathBuf) -> Vec<RemoteConfig> {
         shell: Option<String>,
         #[serde(rename = "type", default)]
         kind: Option<RemoteKind>,
+        #[serde(default)]
+        allow_transitive: bool,
     }
 
     #[derive(Deserialize)]
@@ -665,6 +678,7 @@ fn load_orchard_json_remotes(repo_root: &PathBuf) -> Vec<RemoteConfig> {
                     path,
                     shell: r.shell.unwrap_or_else(|| "ssh".to_string()),
                     kind: r.kind.unwrap_or(RemoteKind::Remmy),
+                    allow_transitive: r.allow_transitive,
                 });
             }
         }
@@ -682,6 +696,7 @@ fn load_orchard_json_remotes(repo_root: &PathBuf) -> Vec<RemoteConfig> {
             path,
             shell: r.shell.unwrap_or_else(|| "ssh".to_string()),
             kind: r.kind.unwrap_or(RemoteKind::Remmy),
+            allow_transitive: r.allow_transitive,
         });
     }
 
@@ -845,6 +860,7 @@ mod tests {
                     path: "/home/ubuntu/repo".to_string(),
                     shell: "mosh".to_string(),
                     kind: RemoteKind::Remmy,
+                    allow_transitive: false,
                 },
                 RemoteConfig {
                     name: "cpu".to_string(),
@@ -852,6 +868,7 @@ mod tests {
                     path: "/home/ubuntu/repo".to_string(),
                     shell: "ssh".to_string(),
                     kind: RemoteKind::Remmy,
+                    allow_transitive: false,
                 },
             ],
         };
@@ -883,6 +900,7 @@ mod tests {
                     path: "/home/ubuntu/repo".to_string(),
                     shell: "mosh".to_string(),
                     kind: RemoteKind::Remmy,
+                    allow_transitive: false,
                 },
                 RemoteConfig {
                     name: "cpu".to_string(),
@@ -890,6 +908,7 @@ mod tests {
                     path: "/home/ubuntu/repo".to_string(),
                     shell: "ssh".to_string(),
                     kind: RemoteKind::Remmy,
+                    allow_transitive: false,
                 },
             ],
         };

--- a/crates/orchard/src/join.rs
+++ b/crates/orchard/src/join.rs
@@ -124,6 +124,9 @@ pub fn derive_worktree_rows(
             display_group,
             is_main_worktree,
             layout: wt.layout,
+            // CachedWorktree has no discovery_path; set for transitive rows via
+            // OrchardState enrichment after the derive pass.
+            discovery_path: None,
         });
 
         is_first_non_bare = false;

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -421,7 +421,8 @@ impl From<&OrchardState> for JsonOutput {
             .map(|e| JsonTransitiveError {
                 dedup_key: e.dedup_key.clone(),
                 discovery_path: e.discovery_path.clone(),
-                root: e.root.clone(),
+                // root is derived from discovery_path[1] rather than a stored field.
+                root: e.root().unwrap_or_default().to_string(),
                 reason: e.reason.clone(),
                 phase: e.phase.clone(),
             })

--- a/crates/orchard/src/json_output.rs
+++ b/crates/orchard/src/json_output.rs
@@ -296,6 +296,7 @@ impl From<&SessionState> for JsonSession {
             last_activity_at: unix_to_iso8601(s.last_activity_at),
             claude,
             windows: s.windows.iter().map(Into::into).collect(),
+            discovery_path: s.discovery_path.clone(),
         }
     }
 }
@@ -330,6 +331,7 @@ impl From<&WorktreeState> for JsonWorktree {
                 .as_ref()
                 .and_then(|pr| pr.last_commit_pushed_at.clone())
                 .or_else(|| ws.last_commit_at.clone()),
+            discovery_path: ws.discovery_path.clone(),
         }
     }
 }
@@ -389,6 +391,7 @@ impl From<&StandaloneSessionRow> for JsonSession {
             last_activity_at: unix_to_iso8601(row.session.last_activity_at),
             claude,
             windows,
+            discovery_path: None, // standalone sessions don't carry discovery_path
         }
     }
 }
@@ -412,11 +415,24 @@ impl From<&OrchardState> for JsonOutput {
             })
             .collect();
 
+        let errors: Vec<JsonTransitiveError> = state
+            .transitive_errors
+            .iter()
+            .map(|e| JsonTransitiveError {
+                dedup_key: e.dedup_key.clone(),
+                discovery_path: e.discovery_path.clone(),
+                root: e.root.clone(),
+                reason: e.reason.clone(),
+                phase: e.phase.clone(),
+            })
+            .collect();
+
         Self {
             version: 6,
             tmux_sessions: state.standalone_sessions.iter().map(Into::into).collect(),
             repos: state.repos.iter().map(Into::into).collect(),
             hosts,
+            errors,
         }
     }
 }
@@ -487,6 +503,7 @@ mod tests {
             ahead_behind: None,
             last_commit_at: None,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         }
     }
 
@@ -556,6 +573,7 @@ mod tests {
             }],
             standalone_sessions: vec![],
             hosts: HashMap::new(),
+            transitive_errors: vec![],
         };
         let output = JsonOutput::from(&state);
         let value = serde_json::to_value(&output).unwrap();
@@ -578,6 +596,7 @@ mod tests {
             }],
             standalone_sessions: vec![],
             hosts: HashMap::new(),
+            transitive_errors: vec![],
         };
         let output = JsonOutput::from(&state);
         let value = serde_json::to_value(&output).unwrap();
@@ -618,6 +637,7 @@ mod tests {
             windows: vec![],
             started_at: None,
             last_activity_at: None,
+            discovery_path: None,
         };
         let js = JsonSession::from(&session);
         assert_eq!(js.host, "local");
@@ -635,6 +655,7 @@ mod tests {
             windows: vec![],
             started_at: None,
             last_activity_at: None,
+            discovery_path: None,
         };
         let js = JsonSession::from(&session);
         assert!(js.claude.is_none());
@@ -651,6 +672,7 @@ mod tests {
             claude: None,
             started_at: None,
             last_activity_at: None,
+            discovery_path: None,
             windows: vec![
                 WindowState {
                     index: 0,
@@ -743,6 +765,7 @@ mod tests {
             claude: None,
             started_at: None,
             last_activity_at: None,
+            discovery_path: None,
             windows: vec![WindowState {
                 index: 0,
                 name: "main".to_string(),
@@ -907,6 +930,7 @@ mod tests {
             windows: vec![],
             started_at: None,
             last_activity_at: None,
+            discovery_path: None,
         }
     }
 
@@ -1126,6 +1150,7 @@ mod tests {
             windows: vec![],
             started_at: None,
             last_activity_at: None,
+            discovery_path: None,
         };
         let value = serde_json::to_value(JsonSession::from(&session)).unwrap();
         assert!(
@@ -1638,6 +1663,7 @@ mod tests {
             }],
             standalone_sessions: vec![],
             hosts: HashMap::new(),
+            transitive_errors: vec![],
         };
         let original = JsonOutput::from(&state);
 
@@ -1691,6 +1717,7 @@ mod tests {
             claude: None,
             started_at: None,
             last_activity_at: None,
+            discovery_path: None,
             windows: vec![WindowState {
                 index: 0,
                 name: "main".to_string(),
@@ -1959,6 +1986,7 @@ mod tests {
             ahead_behind: None,
             last_commit_at: None,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         }
     }
 

--- a/crates/orchard/src/json_output_types.rs
+++ b/crates/orchard/src/json_output_types.rs
@@ -23,7 +23,7 @@
 // ---------------------------------------------------------------------------
 
 /// A single CI check with its normalized state (wire-format mirror for schema gen).
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CheckInfo {
     /// Name of the check.
     pub name: String,
@@ -35,7 +35,7 @@ pub struct CheckInfo {
 }
 
 /// Two-bucket classification of all CI checks on a PR (wire-format mirror for schema gen).
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CiChecks {
     /// Checks classified as code CI.
     pub code: Vec<CheckInfo>,
@@ -69,8 +69,28 @@ pub enum WorkflowPhase {
 // JSON output types (versioned, camelCase) — mirrors of json_output.rs
 // ---------------------------------------------------------------------------
 
+/// A transitive-federation walk error surfaced in JSON output.
+///
+/// One entry per node that failed during the transitive walk. The walk
+/// continues after each failure (non-fatal). Empty when no transitive
+/// federation is configured or all hops succeeded.
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct JsonTransitiveError {
+    /// `host_dedup_key()` of the failing host.
+    pub dedup_key: String,
+    /// Full discovery path from `"local"` to the failing node.
+    pub discovery_path: Vec<String>,
+    /// The first element after `"local"` — the directly-configured root.
+    pub root: String,
+    /// Short, stable reason label (e.g. `"timeout (10s)"`, `"exit 255"`).
+    pub reason: String,
+    /// Which call failed: `"list-remotes"` or `"fetch"`.
+    pub phase: String,
+}
+
 /// Top-level versioned JSON output for `orchard --json`.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonOutput {
     /// Schema version number for forward compatibility.
@@ -81,10 +101,15 @@ pub struct JsonOutput {
     pub repos: Vec<JsonRepo>,
     /// Reachability state keyed by SSH host name.
     pub hosts: HashMap<String, JsonHostState>,
+    /// Transitive-federation walk errors from the most recent refresh.
+    ///
+    /// Empty when no transitive federation is configured or all hops succeeded.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub errors: Vec<JsonTransitiveError>,
 }
 
 /// A single repository in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonRepo {
     /// Repository slug in `owner/repo` format.
@@ -100,7 +125,7 @@ pub struct JsonRepo {
 }
 
 /// Commit distance from the upstream branch.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonAheadBehind {
     /// Commits ahead of upstream.
@@ -110,7 +135,7 @@ pub struct JsonAheadBehind {
 }
 
 /// A single worktree in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonWorktree {
     /// Absolute path to the worktree on disk.
@@ -147,10 +172,16 @@ pub struct JsonWorktree {
     /// ISO 8601 timestamp of the most recent activity.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_activity_at: Option<String>,
+    /// Full discovery path from `"local"` to the host that owns this worktree.
+    ///
+    /// Absent for local worktrees and direct (depth-1) remotes when not set.
+    /// Example: `["local", "boxd", "scenario-voice-agents.boxd.sh"]`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discovery_path: Option<Vec<String>>,
 }
 
 /// A child issue nested under a parent in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonSubIssue {
     /// GitHub issue number.
@@ -162,7 +193,7 @@ pub struct JsonSubIssue {
 }
 
 /// Issue information in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonIssue {
     /// GitHub issue number.
@@ -190,7 +221,7 @@ pub struct JsonIssue {
 }
 
 /// A single review on a pull request in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonReview {
     /// GitHub login of the reviewer.
@@ -203,7 +234,7 @@ pub struct JsonReview {
 }
 
 /// Pull request information in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonPr {
     /// GitHub PR number.
@@ -269,7 +300,7 @@ pub struct JsonPr {
 }
 
 /// Session information in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonSession {
     /// tmux session name.
@@ -288,10 +319,15 @@ pub struct JsonSession {
     pub claude: Option<JsonClaudeInfo>,
     /// Window hierarchy for this session.
     pub windows: Vec<JsonWindow>,
+    /// Full discovery path from `"local"` to the host that owns this session.
+    ///
+    /// Absent for local sessions and direct (depth-1) remotes when not set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discovery_path: Option<Vec<String>>,
 }
 
 /// Window within a session in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonWindow {
     /// Tmux's stable window index.
@@ -307,7 +343,7 @@ pub struct JsonWindow {
 }
 
 /// Individual pane within a window in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonPane {
     /// Zero-based sequential index in the flat pane list.
@@ -327,7 +363,7 @@ pub struct JsonPane {
 }
 
 /// Claude enrichment data in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonClaudeInfo {
     /// Claude state as a string: "working", "idle", "input", or "none".
@@ -377,7 +413,7 @@ pub struct JsonClaudeInfo {
 }
 
 /// Host reachability information in JSON output.
-#[derive(Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
 pub struct JsonHostState {
     /// True when the SSH host responded to the last reachability check.
     pub reachable: bool,

--- a/crates/orchard/src/lib.rs
+++ b/crates/orchard/src/lib.rs
@@ -46,6 +46,7 @@ pub mod signal;
 pub mod sources;
 pub mod swr;
 pub mod tmux;
+pub mod transitive_walker;
 pub mod tui;
 pub mod types;
 pub mod watch;

--- a/crates/orchard/src/lib.rs
+++ b/crates/orchard/src/lib.rs
@@ -16,6 +16,7 @@ pub mod claude_state;
 pub mod config;
 pub mod derive;
 pub mod events;
+pub mod federation;
 pub mod git;
 pub mod git_parse;
 pub mod github;

--- a/crates/orchard/src/lib.rs
+++ b/crates/orchard/src/lib.rs
@@ -17,6 +17,7 @@ pub mod config;
 pub mod derive;
 pub mod events;
 pub mod federation;
+pub mod federation_topology;
 pub mod git;
 pub mod git_parse;
 pub mod github;

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
         "heal" => handle_heal(fix_flag, json_flag),
         "chat" => handle_chat(chat_target.as_deref(), chat_message.as_deref()),
         "watch" => handle_watch(&args),
-        "refresh" => handle_refresh(),
+        "refresh" => handle_refresh(&args),
         "hook-enrich" => handle_hook_enrich(transcript_path.as_deref()),
         "webhook-serve" => handle_webhook_serve(&args),
         "list-remotes" => handle_list_remotes(json_flag),
@@ -362,10 +362,37 @@ fn handle_json() {
 /// fresh data to disk. `orchard --json` and the TUI cold-start both read
 /// the caches written here. `orchard watch` calls `refresh_and_build`
 /// internally on its own schedule.
-fn handle_refresh() {
+///
+/// Flags:
+/// - `--max-depth <n>`: override the maximum transitive federation depth
+/// - `--per-hop-timeout <secs>`: override the per-hop SSH timeout in seconds
+fn handle_refresh(args: &[String]) {
     use std::collections::HashSet;
+
+    let mut max_depth: Option<u32> = None;
+    let mut per_hop_timeout: Option<u64> = None;
+    let mut skip_next = false;
+    for (i, arg) in args.iter().enumerate() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        match arg.as_str() {
+            "--max-depth" => {
+                max_depth = args.get(i + 1).and_then(|v| v.parse().ok());
+                skip_next = true;
+            }
+            "--per-hop-timeout" => {
+                per_hop_timeout = args.get(i + 1).and_then(|v| v.parse().ok());
+                skip_next = true;
+            }
+            _ => {}
+        }
+    }
+
     let config = global_config::load_global_config();
-    let state = build_state::refresh_and_build(&config);
+    let state =
+        build_state::refresh_and_build_with_walker_config(&config, max_depth, per_hop_timeout);
 
     // Persist host reachability so subsequent cache-only reads
     // (--json, TUI cold start, watch daemon) can populate OrchardState.hosts.

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -13,6 +13,7 @@ use crossterm::{
 use orchard::build_state;
 use orchard::cache;
 use orchard::chat;
+use orchard::federation;
 use orchard::global_config;
 use orchard::heal;
 use orchard::hook_enrich;
@@ -104,6 +105,7 @@ fn main() {
         "refresh" => handle_refresh(),
         "hook-enrich" => handle_hook_enrich(transcript_path.as_deref()),
         "webhook-serve" => handle_webhook_serve(&args),
+        "list-remotes" => handle_list_remotes(json_flag),
         _ => {
             if json_flag {
                 handle_json();
@@ -148,6 +150,48 @@ fn handle_upgrade() {
     eprintln!(
         "Download the latest from: https://github.com/drewdrewthis/git-orchard-rs/releases/latest"
     );
+}
+
+/// Outputs the list of configured remotes in JSON format.
+///
+/// When `--json` is present, serialises a [`federation::ListRemotesOutput`]
+/// to stdout.  Without `--json`, prints a human-readable summary.
+///
+/// The JSON wire format is versioned with its OWN independent version constant
+/// ([`federation::LIST_REMOTES_MIN_VERSION`]) — callers check `version >=
+/// LIST_REMOTES_MIN_VERSION` (lower bound, NOT an exact whitelist).  This
+/// avoids the version-skew trap in `JsonOutput`'s exact-whitelist design.
+fn handle_list_remotes(json: bool) {
+    let config = global_config::load_global_config();
+
+    if json {
+        let output = federation::build_list_remotes_output(&config);
+        match serde_json::to_string_pretty(&output) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("list-remotes: failed to serialize output: {e}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        let all_remotes: Vec<_> = config.repos.iter().flat_map(|r| r.remotes.iter()).collect();
+        if all_remotes.is_empty() {
+            println!("No remotes configured.");
+        } else {
+            for r in &all_remotes {
+                println!(
+                    "{} ({}) — {}",
+                    r.name,
+                    r.host,
+                    if r.allow_transitive {
+                        "transitive"
+                    } else {
+                        "direct"
+                    }
+                );
+            }
+        }
+    }
 }
 
 /// Runs the heal command in CLI mode (non-TUI).

--- a/crates/orchard/src/merge_remote.rs
+++ b/crates/orchard/src/merge_remote.rs
@@ -46,7 +46,25 @@ use crate::session::{
 /// Standalone sessions (top-level `tmux_sessions` in `JsonOutput`) are merged
 /// into `state.standalone_sessions`. Same `(name, host)` pair → one row. Same
 /// name on different hosts → both rows are kept.
+///
+/// `discovery_path` is the full path from `"local"` to `host`. When `Some`,
+/// it is stamped onto every `WorktreeState` and `SessionState` sourced from
+/// this snapshot. Pass `None` for direct (depth-1) remotes when the caller
+/// does not track federation topology.
 pub fn merge_remote_snapshot(state: &mut OrchardState, snapshot: JsonOutput, host: String) {
+    merge_remote_snapshot_with_path(state, snapshot, host, None);
+}
+
+/// Like [`merge_remote_snapshot`] but also stamps `discovery_path` onto every
+/// `WorktreeState` and `SessionState` sourced from the snapshot.
+///
+/// Called by the transitive-federation merge path.
+pub fn merge_remote_snapshot_with_path(
+    state: &mut OrchardState,
+    snapshot: JsonOutput,
+    host: String,
+    discovery_path: Option<Vec<String>>,
+) {
     // --- Repos and worktrees --------------------------------------------------
     for json_repo in snapshot.repos {
         // Find or create the matching RepoState.
@@ -76,7 +94,17 @@ pub fn merge_remote_snapshot(state: &mut OrchardState, snapshot: JsonOutput, hos
                 !(w_host == wt_host && w.path == path)
             });
 
-            let wt_state = worktree_state_from_json(json_wt, wt_host);
+            let mut wt_state = worktree_state_from_json(json_wt, wt_host);
+            // Stamp discovery_path if provided by the transitive walk.
+            if wt_state.discovery_path.is_none() {
+                wt_state.discovery_path = discovery_path.clone();
+            }
+            // Also stamp discovery_path onto all sessions in this worktree.
+            for sess in &mut wt_state.sessions {
+                if sess.discovery_path.is_none() {
+                    sess.discovery_path = discovery_path.clone();
+                }
+            }
             state.repos[repo_idx].worktrees.push(wt_state);
         }
     }
@@ -189,6 +217,7 @@ fn worktree_state_from_json(json_wt: JsonWorktree, host: String) -> WorktreeStat
         ahead_behind,
         last_commit_at: json_wt.last_commit_at,
         layout,
+        discovery_path: None,
     }
 }
 
@@ -327,6 +356,7 @@ fn session_state_from_json(
         windows,
         started_at: None,
         last_activity_at: None,
+        discovery_path: None,
     }
 }
 
@@ -497,6 +527,7 @@ mod tests {
                 worktrees: vec![wt],
             }],
             hosts: HashMap::new(),
+            errors: vec![],
         }
     }
 
@@ -516,6 +547,7 @@ mod tests {
             status_glyph: "\u{1f7e2}".to_string(),
             is_main_worktree: false,
             last_activity_at: None,
+            discovery_path: None,
         }
     }
 
@@ -657,6 +689,7 @@ mod tests {
                 state_elapsed_sec: None,
             }),
             windows: vec![],
+            discovery_path: None,
         }];
         let mut pr = make_empty_pr(335, "issue329/federated", "open");
         pr.ci_code_state = Some("passing".to_string());
@@ -762,9 +795,11 @@ mod tests {
                 last_activity_at: None,
                 claude: None,
                 windows: vec![],
+                discovery_path: None,
             }],
             repos: vec![],
             hosts: HashMap::new(),
+            errors: vec![],
         };
 
         let mut state = make_empty_state();
@@ -819,9 +854,11 @@ mod tests {
                 last_activity_at: None,
                 claude: None,
                 windows: vec![],
+                discovery_path: None,
             }],
             repos: vec![],
             hosts: HashMap::new(),
+            errors: vec![],
         };
 
         let mut state = make_empty_state();
@@ -876,6 +913,7 @@ mod tests {
             ahead_behind: None,
             last_commit_at: None,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         };
         let local_wt2 = WorktreeState {
             path: "/local/repo-feat".to_string(),
@@ -890,6 +928,7 @@ mod tests {
             ahead_behind: None,
             last_commit_at: None,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         };
 
         let mut state = OrchardState {
@@ -901,6 +940,7 @@ mod tests {
             }],
             standalone_sessions: vec![],
             hosts: HashMap::new(),
+            transitive_errors: vec![],
         };
 
         let snapshot = JsonOutput {
@@ -917,6 +957,7 @@ mod tests {
                 ],
             }],
             hosts: HashMap::new(),
+            errors: vec![],
         };
 
         merge_remote_snapshot(&mut state, snapshot, "vm.boxd.sh".to_string());
@@ -950,6 +991,7 @@ mod tests {
             ahead_behind: None,
             last_commit_at: None,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         };
 
         let mut state = OrchardState {
@@ -961,6 +1003,7 @@ mod tests {
             }],
             standalone_sessions: vec![],
             hosts: HashMap::new(),
+            transitive_errors: vec![],
         };
 
         // Snapshot entry for the same (host, path) but with enriched PR data.
@@ -982,6 +1025,7 @@ mod tests {
                 worktrees: vec![remote_wt],
             }],
             hosts: HashMap::new(),
+            errors: vec![],
         };
 
         merge_remote_snapshot(&mut state, snapshot, "vm.boxd.sh".to_string());
@@ -1042,9 +1086,11 @@ mod tests {
                 last_activity_at: None,
                 claude: None,
                 windows: vec![],
+                discovery_path: None,
             }],
             repos: vec![],
             hosts: HashMap::new(),
+            errors: vec![],
         };
 
         merge_remote_snapshot(&mut state, snapshot, "remote-host".to_string());
@@ -1106,6 +1152,7 @@ mod tests {
                 worktrees: vec![make_minimal_worktree("/remote/main", "main")],
             }],
             hosts: HashMap::new(),
+            errors: vec![],
         };
 
         let state = build_state_with_snapshots(

--- a/crates/orchard/src/merge_remote.rs
+++ b/crates/orchard/src/merge_remote.rs
@@ -217,7 +217,11 @@ fn worktree_state_from_json(json_wt: JsonWorktree, host: String) -> WorktreeStat
         ahead_behind,
         last_commit_at: json_wt.last_commit_at,
         layout,
-        discovery_path: None,
+        // Preserve the discovery_path serialised into the on-disk snapshot so
+        // that a TUI restart or cache-only `orchard --json` round-trip does not
+        // lose the transitive hop chain.  `merge_remote_snapshot_with_path` will
+        // overwrite with `None`-check semantics, so this is safe to populate here.
+        discovery_path: json_wt.discovery_path,
     }
 }
 
@@ -356,7 +360,10 @@ fn session_state_from_json(
         windows,
         started_at: None,
         last_activity_at: None,
-        discovery_path: None,
+        // Preserve the discovery_path from the on-disk snapshot so that
+        // cache-reload restores the full hop chain.  The caller may overwrite
+        // this with a caller-supplied path (None-check semantics above).
+        discovery_path: json_session.discovery_path.clone(),
     }
 }
 
@@ -1230,5 +1237,114 @@ mod tests {
         assert_eq!(ci.gate.len(), 1);
         assert_eq!(ci.gate[0].name, "license-check");
         assert_eq!(ci.gate[0].state, "failing");
+    }
+
+    // ---- Fix 1: cache-reload preserves discovery_path -----------------------
+
+    /// Regression test: worktree `discovery_path` survives a cache round-trip.
+    ///
+    /// When a depth-2 snapshot is written to disk with `discovery_path` set and
+    /// then loaded via `build_state_with_cached_snapshots_from`, the resulting
+    /// `WorktreeState` must have the correct `discovery_path`.
+    ///
+    /// Without the fix, `worktree_state_from_json` hardcoded `None` and the hop
+    /// chain was silently dropped, causing write-path operations (delete/launch/
+    /// kill) to SSH directly to the leaf host instead of routing through the jump.
+    #[test]
+    fn fix1_cache_reload_preserves_discovery_path() {
+        use crate::global_config::{GlobalConfig, RemoteConfig, RepoConfig};
+        use crate::orchard_snapshot::write_snapshot_to;
+        use crate::remote_adapter::RemoteKind;
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+
+        // Build a snapshot whose worktree already has discovery_path set
+        // (as written by orchard refresh after a transitive walk).
+        let dp = vec!["local".to_string(), "B".to_string(), "C".to_string()];
+        let snapshot = JsonOutput {
+            version: 6,
+            tmux_sessions: vec![],
+            repos: vec![JsonRepo {
+                slug: "owner/repo".to_string(),
+                default_branch: None,
+                main_ci_state: None,
+                worktrees: vec![JsonWorktree {
+                    path: "/remote/wt".to_string(),
+                    branch: "issue99/branch".to_string(),
+                    host: None,
+                    layout: "bare".to_string(),
+                    ahead_behind: None,
+                    last_commit_at: None,
+                    issue: None,
+                    pr: None,
+                    sessions: vec![JsonSession {
+                        name: "sess1".to_string(),
+                        host: "local".to_string(),
+                        status: "running".to_string(),
+                        started_at: None,
+                        last_activity_at: None,
+                        claude: None,
+                        windows: vec![],
+                        discovery_path: Some(dp.clone()),
+                    }],
+                    display_group: "other".to_string(),
+                    status: "ready".to_string(),
+                    status_glyph: "\u{1f7e2}".to_string(),
+                    is_main_worktree: false,
+                    last_activity_at: None,
+                    discovery_path: Some(dp.clone()),
+                }],
+            }],
+            hosts: HashMap::new(),
+            errors: vec![],
+        };
+
+        // Write to cache as the "C" host (the transitive leaf).
+        write_snapshot_to("C", &snapshot, dir.path()).unwrap();
+
+        // Config: "B" is a directly-configured OrchardProxy.  "C" is not in
+        // config — it is discovered transitively and loaded via topology.
+        // For this test, we bypass topology and just manually add "C" to config
+        // so load_cached_snapshots_from finds it.  The important thing is that
+        // the discovery_path field on the JsonWorktree is preserved.
+        let config = GlobalConfig {
+            repos: vec![RepoConfig {
+                slug: "owner/repo".to_string(),
+                path: "/local".to_string(),
+                remotes: vec![RemoteConfig {
+                    name: "C".to_string(),
+                    host: "C".to_string(),
+                    path: "/remote".to_string(),
+                    shell: "ssh".to_string(),
+                    kind: RemoteKind::OrchardProxy,
+                    allow_transitive: false,
+                }],
+            }],
+            ..GlobalConfig::default()
+        };
+
+        let state = build_state_with_cached_snapshots_from(&config, &HashMap::new(), dir.path());
+
+        let wt = state
+            .repos
+            .iter()
+            .flat_map(|r| r.worktrees.iter())
+            .find(|w| w.branch == "issue99/branch")
+            .expect("worktree must be present after cache-reload");
+
+        assert_eq!(
+            wt.discovery_path.as_deref(),
+            Some(dp.as_slice()),
+            "discovery_path must survive cache round-trip (fix1 regression)"
+        );
+
+        // Session discovery_path must also be preserved.
+        let sess = wt.sessions.first().expect("session must be present");
+        assert_eq!(
+            sess.discovery_path.as_deref(),
+            Some(dp.as_slice()),
+            "session discovery_path must survive cache round-trip (fix1 regression)"
+        );
     }
 }

--- a/crates/orchard/src/orchard_snapshot.rs
+++ b/crates/orchard/src/orchard_snapshot.rs
@@ -197,11 +197,10 @@ pub fn load_cached_snapshots_from(
         let transitive_hosts =
             crate::federation_topology::transitive_hosts_from_topology(&topology);
         for host in transitive_hosts {
-            if seen_hosts.insert(host.clone()) {
-                if let Some(snapshot) = read_snapshot_from(&host, cache_dir) {
+            if seen_hosts.insert(host.clone())
+                && let Some(snapshot) = read_snapshot_from(&host, cache_dir) {
                     results.push((host, snapshot));
                 }
-            }
         }
     }
 

--- a/crates/orchard/src/orchard_snapshot.rs
+++ b/crates/orchard/src/orchard_snapshot.rs
@@ -648,7 +648,6 @@ mod tests {
                     "direct-host".to_string(),
                     "transitive-child".to_string(),
                 ],
-                root: "direct-host".to_string(),
                 last_seen_at: "2026-01-01T00:00:00+00:00".to_string(),
             }],
         };

--- a/crates/orchard/src/orchard_snapshot.rs
+++ b/crates/orchard/src/orchard_snapshot.rs
@@ -226,6 +226,7 @@ mod tests {
             tmux_sessions: vec![],
             repos: vec![],
             hosts: HashMap::new(),
+            errors: vec![],
         }
     }
 
@@ -245,6 +246,7 @@ mod tests {
                     ahead_behind: None,
                     last_commit_at: None,
                     issue: None,
+                    discovery_path: None,
                     pr: None,
                     sessions: vec![],
                     display_group: "other".to_string(),
@@ -255,6 +257,7 @@ mod tests {
                 }],
             }],
             hosts: HashMap::new(),
+            errors: vec![],
         }
     }
 
@@ -424,6 +427,7 @@ mod tests {
                         status_glyph: "\u{1f7e2}".to_string(),
                         is_main_worktree: false,
                         last_activity_at: None,
+                        discovery_path: None,
                     },
                     JsonWorktree {
                         path: "/remote/wt2".to_string(),
@@ -440,10 +444,12 @@ mod tests {
                         status_glyph: "\u{1f7e2}".to_string(),
                         is_main_worktree: false,
                         last_activity_at: None,
+                        discovery_path: None,
                     },
                 ],
             }],
             hosts: HashMap::new(),
+            errors: vec![],
         };
         write_snapshot_to("vm.boxd.sh", &second, dir.path()).unwrap();
 

--- a/crates/orchard/src/orchard_snapshot.rs
+++ b/crates/orchard/src/orchard_snapshot.rs
@@ -198,9 +198,10 @@ pub fn load_cached_snapshots_from(
             crate::federation_topology::transitive_hosts_from_topology(&topology);
         for host in transitive_hosts {
             if seen_hosts.insert(host.clone())
-                && let Some(snapshot) = read_snapshot_from(&host, cache_dir) {
-                    results.push((host, snapshot));
-                }
+                && let Some(snapshot) = read_snapshot_from(&host, cache_dir)
+            {
+                results.push((host, snapshot));
+            }
         }
     }
 

--- a/crates/orchard/src/orchard_snapshot.rs
+++ b/crates/orchard/src/orchard_snapshot.rs
@@ -462,6 +462,7 @@ mod tests {
                     path: "/remote/repo".to_string(),
                     shell: "ssh".to_string(),
                     kind: RemoteKind::OrchardProxy,
+                    allow_transitive: false,
                 }],
             }],
             ..GlobalConfig::default()
@@ -495,6 +496,7 @@ mod tests {
                     path: "/remote/repo".to_string(),
                     shell: "ssh".to_string(),
                     kind: RemoteKind::Remmy,
+                    allow_transitive: false,
                 }],
             }],
             ..GlobalConfig::default()
@@ -529,6 +531,7 @@ mod tests {
                         path: "/remote/repo1".to_string(),
                         shell: "ssh".to_string(),
                         kind: RemoteKind::OrchardProxy,
+                        allow_transitive: false,
                     }],
                 },
                 RepoConfig {
@@ -540,6 +543,7 @@ mod tests {
                         path: "/remote/repo2".to_string(),
                         shell: "ssh".to_string(),
                         kind: RemoteKind::OrchardProxy,
+                        allow_transitive: false,
                     }],
                 },
             ],

--- a/crates/orchard/src/orchard_snapshot.rs
+++ b/crates/orchard/src/orchard_snapshot.rs
@@ -190,6 +190,21 @@ pub fn load_cached_snapshots_from(
         }
     }
 
+    // Also load snapshots for transitively-discovered hosts from topology.
+    // These hosts are not in config.repos.remotes but were discovered on a
+    // prior successful walk and persisted in federation_topology.json.
+    if let Some(topology) = crate::federation_topology::read_topology_from(cache_dir) {
+        let transitive_hosts =
+            crate::federation_topology::transitive_hosts_from_topology(&topology);
+        for host in transitive_hosts {
+            if seen_hosts.insert(host.clone()) {
+                if let Some(snapshot) = read_snapshot_from(&host, cache_dir) {
+                    results.push((host, snapshot));
+                }
+            }
+        }
+    }
+
     results
 }
 
@@ -573,5 +588,86 @@ mod tests {
     fn orchard_snapshot_path_in_no_special_chars() {
         let p = orchard_snapshot_path_in("myhost", Path::new("/tmp/cache"));
         assert_eq!(p, Path::new("/tmp/cache/myhost_orchard_snapshot.json"));
+    }
+
+    // ---- load_cached_snapshots: topology extension (Phase 3 / feature:351) ---
+
+    /// feature:351 — load_cached_snapshots consults federation_topology.json
+    ///
+    /// When the topology lists a transitive host that is not in config.repos.remotes
+    /// but has a snapshot file on disk, that snapshot must be loaded.
+    #[test]
+    fn load_cached_snapshots_includes_transitive_hosts_from_topology() {
+        use crate::federation_topology::{
+            FederationTopology, TOPOLOGY_CURRENT_VERSION, TopologyEntry, write_topology_to,
+        };
+        use crate::global_config::{GlobalConfig, RemoteConfig, RepoConfig};
+
+        let dir = TempDir::new().unwrap();
+
+        // Write a snapshot for a directly-configured host.
+        let direct_snap = json_output_with_worktree(6, "/remote/direct", "direct-branch");
+        write_snapshot_to("direct-host", &direct_snap, dir.path()).unwrap();
+
+        // Write a snapshot for a transitively-discovered host.
+        let transitive_snap =
+            json_output_with_worktree(6, "/remote/transitive", "transitive-branch");
+        write_snapshot_to("transitive-child", &transitive_snap, dir.path()).unwrap();
+
+        // Config only knows about direct-host.
+        let config = GlobalConfig {
+            repos: vec![RepoConfig {
+                slug: "owner/repo".to_string(),
+                path: "/local".to_string(),
+                remotes: vec![RemoteConfig {
+                    name: "direct".to_string(),
+                    host: "direct-host".to_string(),
+                    path: "/remote".to_string(),
+                    shell: "ssh".to_string(),
+                    kind: RemoteKind::OrchardProxy,
+                    allow_transitive: false,
+                }],
+            }],
+            ..GlobalConfig::default()
+        };
+
+        // Write a topology that lists transitive-child.
+        let topo = FederationTopology {
+            version: TOPOLOGY_CURRENT_VERSION,
+            written_at: "2026-01-01T00:00:00+00:00".to_string(),
+            entries: vec![TopologyEntry {
+                dedup_key: "transitive-child".to_string(),
+                discovery_path: vec![
+                    "local".to_string(),
+                    "direct-host".to_string(),
+                    "transitive-child".to_string(),
+                ],
+                root: "direct-host".to_string(),
+                last_seen_at: "2026-01-01T00:00:00+00:00".to_string(),
+            }],
+        };
+        write_topology_to(&topo, dir.path()).unwrap();
+
+        let snapshots = load_cached_snapshots_from(&config, dir.path());
+
+        assert_eq!(
+            snapshots.len(),
+            2,
+            "both direct and transitive must be loaded"
+        );
+        assert!(
+            snapshots.iter().any(|(h, _)| h == "direct-host"),
+            "direct host must be present"
+        );
+        assert!(
+            snapshots.iter().any(|(h, _)| h == "transitive-child"),
+            "transitive host must be present"
+        );
+        // Verify the transitive snapshot's content is intact.
+        let trans = snapshots
+            .iter()
+            .find(|(h, _)| h == "transitive-child")
+            .unwrap();
+        assert_eq!(trans.1.repos[0].worktrees[0].branch, "transitive-branch");
     }
 }

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -54,7 +54,6 @@ impl OrchardState {
 
         all
     }
-
 }
 
 impl Default for OrchardState {

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -54,6 +54,36 @@ impl OrchardState {
 
         all
     }
+
+    /// Returns the `discovery_path` for any worktree on the given `host`.
+    ///
+    /// Scans all repos' worktrees and returns the first non-`None`
+    /// `discovery_path` whose final element matches `host`. All worktrees on
+    /// the same host share the same discovery path by construction (the
+    /// transitive walker records a single path per host), so returning the
+    /// first match is correct.
+    ///
+    /// Returns `None` when:
+    /// - the host has no worktrees in state, or
+    /// - all worktrees for that host have `discovery_path = None` (local /
+    ///   direct depth-1 remotes that pre-date federation or don't need chaining).
+    ///
+    /// Used by write-path callers to look up the SSH hop chain before
+    /// dispatching a remote command.
+    pub fn discovery_path_for_host<'a>(&'a self, host: &str) -> Option<&'a [String]> {
+        self.repos
+            .iter()
+            .flat_map(|r| r.worktrees.iter())
+            .find_map(|wt| {
+                let dp = wt.discovery_path.as_deref()?;
+                // The last element of discovery_path is the leaf host.
+                if dp.last().map(String::as_str) == Some(host) {
+                    Some(dp)
+                } else {
+                    None
+                }
+            })
+    }
 }
 
 impl Default for OrchardState {
@@ -474,7 +504,7 @@ impl From<&crate::derive::WorktreeRow> for WorktreeState {
             ahead_behind,
             last_commit_at: row.worktree_last_commit_at.clone(),
             layout: row.layout,
-            discovery_path: None,
+            discovery_path: row.discovery_path.clone(),
         }
     }
 }
@@ -515,6 +545,7 @@ mod tests {
             worktree_behind: None,
             worktree_last_commit_at: None,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         }
     }
 

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -24,6 +24,12 @@ pub struct OrchardState {
     pub standalone_sessions: Vec<StandaloneSessionRow>,
     /// Reachability state keyed by SSH host name.
     pub hosts: HashMap<String, HostState>,
+    /// Transitive-federation walk errors from the most recent refresh.
+    ///
+    /// One entry per node that failed during the walk. The walk continues
+    /// after each failure (non-fatal). Empty when no transitive federation
+    /// is configured or all hops succeeded.
+    pub transitive_errors: Vec<crate::transitive_walker::TransitiveError>,
 }
 
 impl OrchardState {
@@ -33,6 +39,7 @@ impl OrchardState {
             repos: Vec::new(),
             standalone_sessions: Vec::new(),
             hosts: HashMap::new(),
+            transitive_errors: Vec::new(),
         }
     }
 
@@ -100,6 +107,13 @@ pub struct WorktreeState {
     /// Physical layout of this worktree — `Bare` (bare repo + linked
     /// worktrees) or `Flat` (single non-bare clone per BoxdFork VM).
     pub layout: crate::cache::WorktreeLayout,
+    /// Full discovery path from `"local"` to the host that owns this worktree.
+    ///
+    /// `None` for local worktrees and direct (depth-1) remotes when not set
+    /// by the merge path. Set during transitive federation merge.
+    ///
+    /// Example: `Some(["local", "boxd", "scenario-voice-agents.boxd.sh"])`
+    pub discovery_path: Option<Vec<String>>,
 }
 
 impl WorktreeState {
@@ -230,6 +244,11 @@ pub struct SessionState {
     pub started_at: Option<u64>,
     /// Unix timestamp of the last activity in this session.
     pub last_activity_at: Option<u64>,
+    /// Full discovery path from `"local"` to the host that owns this session.
+    ///
+    /// Set during transitive federation merge; `None` for local sessions and
+    /// direct (depth-1) remotes when the path is not propagated.
+    pub discovery_path: Option<Vec<String>>,
 }
 
 /// Window within a session, with nested panes.
@@ -412,6 +431,7 @@ impl From<&EnrichedSession> for SessionState {
             windows,
             started_at: s.started_at,
             last_activity_at: s.last_activity_at,
+            discovery_path: None,
         }
     }
 }
@@ -454,6 +474,7 @@ impl From<&crate::derive::WorktreeRow> for WorktreeState {
             ahead_behind,
             last_commit_at: row.worktree_last_commit_at.clone(),
             layout: row.layout,
+            discovery_path: None,
         }
     }
 }
@@ -519,6 +540,7 @@ mod tests {
             repos,
             standalone_sessions: Vec::new(),
             hosts: std::collections::HashMap::new(),
+            transitive_errors: Vec::new(),
         }
     }
 

--- a/crates/orchard/src/orchard_state.rs
+++ b/crates/orchard/src/orchard_state.rs
@@ -55,35 +55,6 @@ impl OrchardState {
         all
     }
 
-    /// Returns the `discovery_path` for any worktree on the given `host`.
-    ///
-    /// Scans all repos' worktrees and returns the first non-`None`
-    /// `discovery_path` whose final element matches `host`. All worktrees on
-    /// the same host share the same discovery path by construction (the
-    /// transitive walker records a single path per host), so returning the
-    /// first match is correct.
-    ///
-    /// Returns `None` when:
-    /// - the host has no worktrees in state, or
-    /// - all worktrees for that host have `discovery_path = None` (local /
-    ///   direct depth-1 remotes that pre-date federation or don't need chaining).
-    ///
-    /// Used by write-path callers to look up the SSH hop chain before
-    /// dispatching a remote command.
-    pub fn discovery_path_for_host<'a>(&'a self, host: &str) -> Option<&'a [String]> {
-        self.repos
-            .iter()
-            .flat_map(|r| r.worktrees.iter())
-            .find_map(|wt| {
-                let dp = wt.discovery_path.as_deref()?;
-                // The last element of discovery_path is the leaf host.
-                if dp.last().map(String::as_str) == Some(host) {
-                    Some(dp)
-                } else {
-                    None
-                }
-            })
-    }
 }
 
 impl Default for OrchardState {

--- a/crates/orchard/src/refresh_parallel.rs
+++ b/crates/orchard/src/refresh_parallel.rs
@@ -72,6 +72,7 @@ mod tests {
                     path: "~/src".to_string(),
                     shell: "ssh".to_string(),
                     kind: RemoteKind::Remmy,
+                    allow_transitive: false,
                 })
                 .collect(),
         }

--- a/crates/orchard/src/remote.rs
+++ b/crates/orchard/src/remote.rs
@@ -416,17 +416,24 @@ pub fn create_remote_proxy_session(
 }
 
 /// Captures the pane content of a remote tmux session via SSH.
+///
+/// `discovery_path` is the full hop chain from `"local"` to `host`.  Pass
+/// `None` for direct (depth-1) remotes; the behaviour is unchanged.  For
+/// transitive (depth-2+) remotes the call is routed through the jump host
+/// via `chain_cmd`, matching the pattern used by the other write-path helpers.
 pub fn capture_remote_pane_content(
     host: &str,
     session: &str,
     lines: u32,
+    discovery_path: Option<&[String]>,
 ) -> anyhow::Result<String> {
     let cmd = format!(
         "tmux capture-pane -t {} -p -J -S -{}",
         shell_escape(session),
         lines
     );
-    let out = ssh_exec(host, &cmd)?;
+    let (ssh_target, chained_cmd) = chain_cmd(host, discovery_path, &cmd);
+    let out = ssh_exec(&ssh_target, &chained_cmd)?;
     Ok(out.trim_end_matches('\n').to_string())
 }
 

--- a/crates/orchard/src/remote.rs
+++ b/crates/orchard/src/remote.rs
@@ -334,9 +334,19 @@ pub fn create_remote_proxy_session(
         create_remote_session(host, name, path, discovery_path)?;
     }
 
+    // mosh does not support multi-hop chains. Reject transitive (depth-2+) hosts
+    // early to avoid a cryptic network-layer failure later.
+    if shell == "mosh" && discovery_path.map_or(false, |dp| dp.len() > 2) {
+        anyhow::bail!(
+            "mosh is not supported for transitive hosts ({}); \
+             change this remote's shell to ssh",
+            discovery_path.unwrap().join(" -> ")
+        );
+    }
+
     let local_name = format!("remote_{}", name);
     let connect_cmd = if shell == "mosh" {
-        // mosh doesn't support transitive hops — use direct host.
+        // Depth-0 or depth-1 mosh: direct connection is fine.
         format!(
             "env LC_ALL=en_US.UTF-8 mosh --predict=always {} -- tmux attach-session -t {}",
             shell_escape(host),
@@ -601,5 +611,54 @@ mod tests {
     fn sanitize_remote_payload_caps_at_256_chars() {
         let long = "x".repeat(1000);
         assert_eq!(sanitize_remote_payload(&long).len(), 256);
+    }
+
+    // Fix 8 — mosh+transitive guard
+    //
+    // `create_remote_proxy_session` must reject mosh when the discovery path
+    // has more than 2 segments (i.e. the host is not directly reachable from
+    // localhost).  The check must fire *before* any SSH call so it is
+    // synchronous and returns a plain `Err`.
+
+    /// Calling `create_remote_proxy_session` with `shell="mosh"` and a
+    /// 3-segment discovery path (local → jump → leaf) returns an error
+    /// whose message calls out "mosh is not supported for transitive hosts".
+    #[test]
+    fn mosh_transitive_host_returns_error() {
+        let dp: Vec<String> = vec![
+            "local".to_string(),
+            "jump".to_string(),
+            "leaf".to_string(),
+        ];
+        let result = create_remote_proxy_session("leaf", "my-session", "/work", "mosh", Some(&dp));
+        assert!(result.is_err(), "mosh + transitive must return Err");
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            msg.contains("mosh is not supported for transitive hosts"),
+            "error message must mention mosh unsupported for transitive; got: {msg}"
+        );
+    }
+
+    /// Depth-1 mosh (discovery_path has exactly 2 segments) must NOT be
+    /// rejected by the guard — the guard must remain a no-op in that case.
+    /// (The function may still fail for other reasons in a test environment;
+    /// that is acceptable — we assert only that the *mosh guard* did not
+    /// fire.)
+    #[test]
+    fn mosh_depth1_host_does_not_hit_transitive_guard() {
+        let dp: Vec<String> = vec!["local".to_string(), "jump".to_string()];
+        let result =
+            create_remote_proxy_session("jump", "my-session", "/work", "mosh", Some(&dp));
+        // In a unit-test environment there is no real SSH or tmux, so the
+        // function will fail — but NOT with the mosh-transitive message.
+        if let Err(e) = result {
+            let msg = format!("{e:#}");
+            assert!(
+                !msg.contains("mosh is not supported for transitive hosts"),
+                "depth-1 mosh must not hit the transitive guard; got: {msg}"
+            );
+        }
+        // If it somehow succeeds (e.g. a tmux session named "my-session" already
+        // exists on the CI host), that's also fine.
     }
 }

--- a/crates/orchard/src/remote.rs
+++ b/crates/orchard/src/remote.rs
@@ -138,25 +138,71 @@ pub fn ssh_exec_with_timeout(
     }
 }
 
+/// Returns the first hop SSH target and the fully-chained command string for a
+/// remote write operation.
+///
+/// When `discovery_path` is `Some` and has length ≥ 3 (i.e., at least one
+/// intermediate hop between local and the leaf), the leaf command is wrapped in
+/// nested SSH calls via [`crate::federation::build_ssh_chain`] and the first
+/// hop host is returned as the SSH target.
+///
+/// For depth-1 direct remotes (`discovery_path` is `None`, empty, or
+/// `["local", host]`) the command and host are returned unchanged — behaviour
+/// is bit-identical to before federation was introduced.
+///
+/// Exposed for testing so callers can verify the SSH chain without performing a
+/// real SSH round-trip.
+pub fn chain_cmd(host: &str, discovery_path: Option<&[String]>, cmd: &str) -> (String, String) {
+    match discovery_path {
+        Some(path) if path.len() > 2 => {
+            // Transitive: build nested SSH chain and target the first hop.
+            let chained = crate::federation::build_ssh_chain(path, cmd);
+            // The first element is "local"; the second is the jump host.
+            let jump_host = path[1].clone();
+            (jump_host, chained)
+        }
+        // Depth-1 or no path — pass through unchanged.
+        _ => (host.to_string(), cmd.to_string()),
+    }
+}
+
 /// Kills the named tmux session on the remote host.
-pub fn kill_remote_tmux_session(host: &str, name: &str) -> anyhow::Result<()> {
-    ssh_exec(
-        host,
-        &format!("tmux kill-session -t {}", shell_escape(name)),
-    )?;
+///
+/// `discovery_path` is the full hop chain from `"local"` to `host`
+/// (e.g. `["local", "boxd", "child.example.com"]`).  Pass `None` for
+/// direct (depth-1) remotes; the behaviour is unchanged from before
+/// transitive federation was introduced.
+pub fn kill_remote_tmux_session(
+    host: &str,
+    name: &str,
+    discovery_path: Option<&[String]>,
+) -> anyhow::Result<()> {
+    let inner_cmd = format!("tmux kill-session -t {}", shell_escape(name));
+    let (ssh_target, cmd) = chain_cmd(host, discovery_path, &inner_cmd);
+    ssh_exec(&ssh_target, &cmd)?;
     LOG.info(&format!("remote: killed tmux session {}", name));
     Ok(())
 }
 
 /// Removes a worktree on the remote host.
+///
 /// First tries `git worktree remove --force`; falls back to `git worktree prune && rm -rf`.
-pub fn remove_remote_worktree(host: &str, repo_path: &str, wt_path: &str) -> anyhow::Result<()> {
+///
+/// `discovery_path` is the full hop chain from `"local"` to `host`.  Pass
+/// `None` for direct (depth-1) remotes; the behaviour is unchanged.
+pub fn remove_remote_worktree(
+    host: &str,
+    repo_path: &str,
+    wt_path: &str,
+    discovery_path: Option<&[String]>,
+) -> anyhow::Result<()> {
     let cmd = format!(
         "cd {} && git worktree remove --force {}",
         shell_escape(repo_path),
         shell_escape(wt_path)
     );
-    if ssh_exec(host, &cmd).is_ok() {
+    let (ssh_target, chained_cmd) = chain_cmd(host, discovery_path, &cmd);
+    if ssh_exec(&ssh_target, &chained_cmd).is_ok() {
         return Ok(());
     }
 
@@ -165,19 +211,30 @@ pub fn remove_remote_worktree(host: &str, repo_path: &str, wt_path: &str) -> any
         shell_escape(repo_path),
         shell_escape(wt_path)
     );
-    ssh_exec(host, &fallback)?;
+    let (ssh_target2, chained_fallback) = chain_cmd(host, discovery_path, &fallback);
+    ssh_exec(&ssh_target2, &chained_fallback)?;
     Ok(())
 }
 
 /// Creates a new detached tmux session on the remote host.
+///
 /// If the session already exists the error is silently ignored.
-pub fn create_remote_session(host: &str, name: &str, path: &str) -> anyhow::Result<()> {
+///
+/// `discovery_path` is the full hop chain from `"local"` to `host`.  Pass
+/// `None` for direct (depth-1) remotes; the behaviour is unchanged.
+pub fn create_remote_session(
+    host: &str,
+    name: &str,
+    path: &str,
+    discovery_path: Option<&[String]>,
+) -> anyhow::Result<()> {
     let cmd = format!(
         "tmux new-session -d -s {} -c {}",
         shell_escape(name),
         shell_escape(path)
     );
-    match ssh_exec(host, &cmd) {
+    let (ssh_target, chained_cmd) = chain_cmd(host, discovery_path, &cmd);
+    match ssh_exec(&ssh_target, &chained_cmd) {
         Ok(_) => Ok(()),
         Err(e) if e.to_string().contains("duplicate session") => Ok(()),
         Err(e) => Err(e),
@@ -254,34 +311,69 @@ fn should_recreate_proxy(local_name: &str, remote_was_fresh: bool) -> bool {
 ///
 /// This is the popup-mode entry point: the caller gets the local session name back
 /// and prints it to stdout for the wrapper script to call `tmux switch-client`.
+///
+/// `discovery_path` is the full hop chain from `"local"` to `host`.  Pass
+/// `None` for direct (depth-1) remotes; the behaviour is unchanged.  For
+/// transitive (depth-2+) remotes the `has-session` probe, `create_remote_session`
+/// call, and the local proxy's inner `ssh ... tmux attach-session` command all
+/// route through the nested SSH chain.
 pub fn create_remote_proxy_session(
     host: &str,
     name: &str,
     path: &str,
     shell: &str,
+    discovery_path: Option<&[String]>,
 ) -> anyhow::Result<String> {
     let shell = if shell.is_empty() { "ssh" } else { shell };
 
     // Create the remote session if it doesn't exist yet.
-    let remote_was_fresh =
-        ssh_exec(host, &format!("tmux has-session -t {}", shell_escape(name))).is_err();
+    let has_session_cmd = format!("tmux has-session -t {}", shell_escape(name));
+    let (has_target, has_cmd) = chain_cmd(host, discovery_path, &has_session_cmd);
+    let remote_was_fresh = ssh_exec(&has_target, &has_cmd).is_err();
     if remote_was_fresh {
-        create_remote_session(host, name, path)?;
+        create_remote_session(host, name, path, discovery_path)?;
     }
 
     let local_name = format!("remote_{}", name);
     let connect_cmd = if shell == "mosh" {
+        // mosh doesn't support transitive hops — use direct host.
         format!(
             "env LC_ALL=en_US.UTF-8 mosh --predict=always {} -- tmux attach-session -t {}",
             shell_escape(host),
             shell_escape(name)
         )
     } else {
-        format!(
-            "ssh -tt {} tmux attach-session -t {}",
-            shell_escape(host),
-            shell_escape(name)
-        )
+        // Build the connect command for the local proxy pane.
+        // For depth-1: `ssh -tt host tmux attach-session -t name`
+        // For depth-2+: `ssh -tt jump_host ssh 'leaf' 'tmux attach-session -t name'`
+        let leaf_attach = format!("tmux attach-session -t {}", shell_escape(name));
+        match discovery_path {
+            Some(dp) if dp.len() > 2 => {
+                // Build inner hops using build_ssh_chain on the leaf-only portion,
+                // then add -tt on the outermost hop.
+                // hops = dp[1..] (strip "local"), jump = dp[1], rest = dp[2..]
+                let jump_host = &dp[1];
+                // Build the chain from the jump host onward (inner only).
+                // We use build_ssh_chain with a sub-path starting from the jump host.
+                let sub_path: Vec<String> = dp[1..].to_vec();
+                let inner = crate::federation::build_ssh_chain(&sub_path, &leaf_attach);
+                // inner = "ssh jump_host ssh 'leaf' 'tmux attach-session -t name'"
+                // but the outermost `ssh jump_host` needs `-tt`.
+                // Replace leading `ssh jump_host ` with `ssh -tt jump_host `.
+                let prefix = format!("ssh {} ", jump_host);
+                if inner.starts_with(&prefix) {
+                    format!("ssh -tt {} {}", jump_host, &inner[prefix.len()..])
+                } else {
+                    format!("ssh -tt {} {}", shell_escape(jump_host), inner)
+                }
+            }
+            // depth-0 or depth-1: unchanged
+            _ => format!(
+                "ssh -tt {} tmux attach-session -t {}",
+                shell_escape(host),
+                shell_escape(name)
+            ),
+        }
     };
 
     let need_create = should_recreate_proxy(&local_name, remote_was_fresh);
@@ -340,11 +432,17 @@ pub fn capture_remote_pane_content(
 
 /// Removes the remmy session registry file for the given session name on the
 /// remote host.
-pub fn remove_remote_registry_entry(host: &str, name: &str) -> anyhow::Result<()> {
-    ssh_exec(
-        host,
-        &format!("rm -f ~/.remmy/sessions/{}.json", shell_escape(name)),
-    )?;
+///
+/// `discovery_path` is the full hop chain from `"local"` to `host`.  Pass
+/// `None` for direct (depth-1) remotes; the behaviour is unchanged.
+pub fn remove_remote_registry_entry(
+    host: &str,
+    name: &str,
+    discovery_path: Option<&[String]>,
+) -> anyhow::Result<()> {
+    let cmd = format!("rm -f ~/.remmy/sessions/{}.json", shell_escape(name));
+    let (ssh_target, chained_cmd) = chain_cmd(host, discovery_path, &cmd);
+    ssh_exec(&ssh_target, &chained_cmd)?;
     Ok(())
 }
 

--- a/crates/orchard/src/remote.rs
+++ b/crates/orchard/src/remote.rs
@@ -326,22 +326,22 @@ pub fn create_remote_proxy_session(
 ) -> anyhow::Result<String> {
     let shell = if shell.is_empty() { "ssh" } else { shell };
 
+    // mosh does not support multi-hop chains. Reject transitive (depth-2+) hosts
+    // BEFORE any SSH is attempted to avoid a cryptic network-layer failure later.
+    if shell == "mosh" && discovery_path.is_some_and(|dp| dp.len() > 2) {
+        anyhow::bail!(
+            "mosh is not supported for transitive hosts ({}); \
+             change this remote's shell to ssh",
+            discovery_path.unwrap().join(" -> ")
+        );
+    }
+
     // Create the remote session if it doesn't exist yet.
     let has_session_cmd = format!("tmux has-session -t {}", shell_escape(name));
     let (has_target, has_cmd) = chain_cmd(host, discovery_path, &has_session_cmd);
     let remote_was_fresh = ssh_exec(&has_target, &has_cmd).is_err();
     if remote_was_fresh {
         create_remote_session(host, name, path, discovery_path)?;
-    }
-
-    // mosh does not support multi-hop chains. Reject transitive (depth-2+) hosts
-    // early to avoid a cryptic network-layer failure later.
-    if shell == "mosh" && discovery_path.map_or(false, |dp| dp.len() > 2) {
-        anyhow::bail!(
-            "mosh is not supported for transitive hosts ({}); \
-             change this remote's shell to ssh",
-            discovery_path.unwrap().join(" -> ")
-        );
     }
 
     let local_name = format!("remote_{}", name);
@@ -625,11 +625,7 @@ mod tests {
     /// whose message calls out "mosh is not supported for transitive hosts".
     #[test]
     fn mosh_transitive_host_returns_error() {
-        let dp: Vec<String> = vec![
-            "local".to_string(),
-            "jump".to_string(),
-            "leaf".to_string(),
-        ];
+        let dp: Vec<String> = vec!["local".to_string(), "jump".to_string(), "leaf".to_string()];
         let result = create_remote_proxy_session("leaf", "my-session", "/work", "mosh", Some(&dp));
         assert!(result.is_err(), "mosh + transitive must return Err");
         let msg = format!("{:#}", result.unwrap_err());
@@ -647,8 +643,7 @@ mod tests {
     #[test]
     fn mosh_depth1_host_does_not_hit_transitive_guard() {
         let dp: Vec<String> = vec!["local".to_string(), "jump".to_string()];
-        let result =
-            create_remote_proxy_session("jump", "my-session", "/work", "mosh", Some(&dp));
+        let result = create_remote_proxy_session("jump", "my-session", "/work", "mosh", Some(&dp));
         // In a unit-test environment there is no real SSH or tmux, so the
         // function will fail — but NOT with the mosh-transitive message.
         if let Err(e) = result {

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -1586,6 +1586,7 @@ mod tests {
                         ahead_behind: None,
                         last_commit_at: None,
                         last_activity_at: None,
+                        discovery_path: None,
                     },
                     JsonWorktree {
                         path: "/remote/wt2".to_string(),
@@ -1602,10 +1603,12 @@ mod tests {
                         ahead_behind: None,
                         last_commit_at: None,
                         last_activity_at: None,
+                        discovery_path: None,
                     },
                 ],
             }],
             hosts: HashMap::new(),
+            errors: vec![],
         };
 
         write_snapshot_to(host, &snapshot, cache_dir.path()).expect("write snapshot");

--- a/crates/orchard/src/remote_adapter.rs
+++ b/crates/orchard/src/remote_adapter.rs
@@ -1082,6 +1082,7 @@ mod tests {
             path: "~/git-orchard-rs".to_string(),
             shell: "ssh".to_string(),
             kind: RemoteKind::OrchardProxy,
+            allow_transitive: false,
         };
         let adapter = RemoteAdapter::from_config(&cfg, Box::new(FakeSshExec::new()));
         match adapter {
@@ -1646,6 +1647,7 @@ mod tests {
                     path: "/remote/repo".to_string(),
                     shell: "ssh".to_string(),
                     kind: RemoteKind::OrchardProxy,
+                    allow_transitive: false,
                 }],
             }],
             ..GlobalConfig::default()

--- a/crates/orchard/src/setup_remote.rs
+++ b/crates/orchard/src/setup_remote.rs
@@ -360,6 +360,7 @@ mod tests {
                     path: path.to_string(),
                     shell: "ssh".to_string(),
                     kind: RemoteKind::Remmy,
+                    allow_transitive: false,
                 }],
             }],
             terminal_app: "com.apple.Terminal".to_string(),

--- a/crates/orchard/src/signal.rs
+++ b/crates/orchard/src/signal.rs
@@ -915,6 +915,7 @@ mod tests {
             windows: vec![],
             started_at: None,
             last_activity_at: None,
+            discovery_path: None,
         }
     }
 

--- a/crates/orchard/src/signal.rs
+++ b/crates/orchard/src/signal.rs
@@ -854,6 +854,7 @@ mod tests {
             display_group: DisplayGroup::Other,
             is_main_worktree: false,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         })
     }
 

--- a/crates/orchard/src/sources/hosts.rs
+++ b/crates/orchard/src/sources/hosts.rs
@@ -158,6 +158,7 @@ mod tests {
             path: "/tmp/repo".to_string(),
             shell: "ssh".to_string(),
             kind: RemoteKind::Remmy,
+            allow_transitive: false,
         }
     }
 
@@ -218,6 +219,7 @@ mod tests {
             path: "/tmp".to_string(),
             shell: "ssh".to_string(),
             kind: crate::remote_adapter::RemoteKind::Remmy,
+            allow_transitive: false,
         };
 
         let start = Instant::now();
@@ -334,6 +336,7 @@ mod tests {
             path: "/tmp".to_string(),
             shell: "ssh".to_string(),
             kind: RemoteKind::OrchardProxy,
+            allow_transitive: false,
         };
 
         let start = Instant::now();
@@ -374,6 +377,7 @@ mod tests {
                 path: "/tmp".to_string(),
                 shell: "ssh".to_string(),
                 kind: RemoteKind::OrchardProxy,
+                allow_transitive: false,
             })
             .collect();
 
@@ -478,6 +482,7 @@ mod tests {
             path: "/tmp/repo".to_string(),
             shell: "ssh".to_string(),
             kind: RemoteKind::OrchardProxy,
+            allow_transitive: false,
         };
 
         let reachable = probe_reachability_for_remote(&remote);
@@ -537,6 +542,7 @@ mod tests {
             path: "/tmp/repo".to_string(),
             shell: "ssh".to_string(),
             kind: RemoteKind::Remmy,
+            allow_transitive: false,
         };
 
         let reachable = probe_reachability_for_remote(&remote);

--- a/crates/orchard/src/transitive_walker.rs
+++ b/crates/orchard/src/transitive_walker.rs
@@ -126,14 +126,23 @@ pub struct TransitiveError {
     ///
     /// Example: `["local", "boxd", "evals-v3-debug"]`
     pub discovery_path: Vec<String>,
-    /// The first element after `"local"` — the directly-configured root from
-    /// which this node was reached.
-    pub root: String,
     /// Short, stable reason label matching the vocabulary from
     /// [`crate::remote_adapter::classify_proxy_failure_reason`].
     pub reason: String,
-    /// Which call failed: `"list-remotes"` or `"fetch"`.
+    /// Which call failed: `"list-remotes"`, `"fetch"`, or
+    /// `"list_remotes_after_snapshot"`.
     pub phase: String,
+}
+
+impl TransitiveError {
+    /// Returns the directly-configured root host from which this node was
+    /// reached: `discovery_path[1]` (the first element after `"local"`).
+    ///
+    /// Returns `None` when `discovery_path` has fewer than 2 elements, which
+    /// should not occur in practice but is handled defensively.
+    pub fn root(&self) -> Option<&str> {
+        self.discovery_path.get(1).map(String::as_str)
+    }
 }
 
 /// Result of a single walker run.
@@ -158,7 +167,6 @@ struct FrontierNode {
     host: String,
     dedup_key: String,
     discovery_path: Vec<String>,
-    root: String,
     /// When `true`, skip the `orchard --json` call for this node.
     ///
     /// Set for depth-1 roots whose snapshot was already fetched by
@@ -262,7 +270,6 @@ pub fn walk(roots: &[(&str, bool)], config: &WalkerConfig) -> WalkerResult {
             host: host.to_string(),
             dedup_key: key,
             discovery_path: vec!["local".to_string(), host.to_string()],
-            root: host.to_string(),
             // Skip orchard --json for depth-1 roots when the pre-walker phase
             // already fetched them via OrchardProxyAdapter.
             skip_snapshot: config.skip_depth1_snapshot,
@@ -326,7 +333,6 @@ pub fn walk(roots: &[(&str, bool)], config: &WalkerConfig) -> WalkerResult {
                                     host: child_host,
                                     dedup_key: child_key,
                                     discovery_path: child_path,
-                                    root: node.root.clone(),
                                     // Depth 2+: always fetch orchard --json.
                                     skip_snapshot: false,
                                 });
@@ -405,7 +411,6 @@ fn visit_with_timeout(
             let err = TransitiveError {
                 dedup_key: node_for_result.dedup_key.clone(),
                 discovery_path: node_for_result.discovery_path.clone(),
-                root: node_for_result.root.clone(),
                 reason,
                 phase: "fetch".to_string(),
             };
@@ -436,7 +441,6 @@ fn visit_inner(node: &FrontierNode, ssh: &dyn SshExec, cache: &SnapshotCache) ->
             return HopOutcome::Error(TransitiveError {
                 dedup_key: node.dedup_key.clone(),
                 discovery_path: node.discovery_path.clone(),
-                root: node.root.clone(),
                 reason: format!("fetch failure for {}", node.host),
                 phase: "fetch".to_string(),
             });
@@ -533,7 +537,6 @@ fn call_list_remotes(node: &FrontierNode, ssh: &dyn SshExec) -> ListRemotesResul
             return ListRemotesResult::Err(TransitiveError {
                 dedup_key: node.dedup_key.clone(),
                 discovery_path: node.discovery_path.clone(),
-                root: node.root.clone(),
                 reason,
                 phase: "list-remotes".to_string(),
             });
@@ -552,7 +555,6 @@ fn call_list_remotes(node: &FrontierNode, ssh: &dyn SshExec) -> ListRemotesResul
         return ListRemotesResult::Err(TransitiveError {
             dedup_key: node.dedup_key.clone(),
             discovery_path: node.discovery_path.clone(),
-            root: node.root.clone(),
             reason,
             phase: "list-remotes".to_string(),
         });
@@ -564,7 +566,6 @@ fn call_list_remotes(node: &FrontierNode, ssh: &dyn SshExec) -> ListRemotesResul
             return ListRemotesResult::Err(TransitiveError {
                 dedup_key: node.dedup_key.clone(),
                 discovery_path: node.discovery_path.clone(),
-                root: node.root.clone(),
                 reason: "parse failure".to_string(),
                 phase: "list-remotes".to_string(),
             });
@@ -575,7 +576,6 @@ fn call_list_remotes(node: &FrontierNode, ssh: &dyn SshExec) -> ListRemotesResul
         return ListRemotesResult::Err(TransitiveError {
             dedup_key: node.dedup_key.clone(),
             discovery_path: node.discovery_path.clone(),
-            root: node.root.clone(),
             reason: e,
             phase: "list-remotes".to_string(),
         });
@@ -988,7 +988,11 @@ mod tests {
         assert_eq!(result.errors.len(), 1, "exactly one error for C");
         let c_key = host_dedup_key("C").unwrap();
         assert_eq!(result.errors[0].dedup_key, c_key);
-        assert!(!result.errors[0].root.is_empty(), "root must be set");
+        // root() is now computed from discovery_path[1] instead of a stored field.
+        assert!(
+            result.errors[0].root().is_some(),
+            "root() must return Some for a well-formed discovery_path"
+        );
         assert!(
             !result.errors[0].discovery_path.is_empty(),
             "discovery_path must be set"

--- a/crates/orchard/src/transitive_walker.rs
+++ b/crates/orchard/src/transitive_walker.rs
@@ -72,6 +72,13 @@ pub struct WalkerConfig {
     pub per_hop_timeout: Duration,
     /// SSH executor shared across all threads in this walk.
     pub ssh: Arc<dyn SshExec>,
+    /// When `true`, skip `orchard --json` for depth-1 roots.
+    ///
+    /// Set by `refresh_and_build_with_walker_config` because those roots were
+    /// already fetched by `OrchardProxyAdapter` in the pre-walker phase.
+    /// Leave `false` (the default) when calling the walker directly in tests
+    /// or from contexts that have not pre-fetched depth-1 snapshots.
+    pub skip_depth1_snapshot: bool,
 }
 
 impl WalkerConfig {
@@ -82,6 +89,7 @@ impl WalkerConfig {
             max_depth: DEFAULT_MAX_DEPTH,
             per_hop_timeout: DEFAULT_PER_HOP_TIMEOUT,
             ssh,
+            skip_depth1_snapshot: false,
         }
     }
 
@@ -94,6 +102,15 @@ impl WalkerConfig {
     /// Overrides `per_hop_timeout`.
     pub fn with_per_hop_timeout(mut self, timeout: Duration) -> Self {
         self.per_hop_timeout = timeout;
+        self
+    }
+
+    /// Enables skipping `orchard --json` for depth-1 roots.
+    ///
+    /// Only set this when the caller has already fetched depth-1 snapshots
+    /// via `OrchardProxyAdapter` (i.e., from `refresh_and_build_with_walker_config`).
+    pub fn with_skip_depth1_snapshot(mut self) -> Self {
+        self.skip_depth1_snapshot = true;
         self
     }
 }
@@ -142,20 +159,34 @@ struct FrontierNode {
     dedup_key: String,
     discovery_path: Vec<String>,
     root: String,
+    /// When `true`, skip the `orchard --json` call for this node.
+    ///
+    /// Set for depth-1 roots whose snapshot was already fetched by
+    /// `OrchardProxyAdapter` during the pre-walker refresh phase.
+    /// The walker only needs `list-remotes` for these nodes to discover children.
+    skip_snapshot: bool,
 }
 
 /// The outcome of visiting a single node.
 enum HopOutcome {
-    /// Both calls succeeded.
+    /// The snapshot fetch succeeded and `list-remotes` returned children (possibly empty).
     Success {
         snapshot: Arc<JsonOutput>,
         /// Child hosts from `list-remotes` (`allow_transitive == true` + `orchard-proxy` only).
         children: Vec<String>,
     },
+    /// `list-remotes` failed after a successful snapshot fetch (or skip).
+    ///
+    /// The snapshot is still recorded; the error is surfaced so operators can
+    /// observe the partial failure.  No children are discovered for this node.
+    ListRemotesFailed {
+        snapshot: Arc<JsonOutput>,
+        err: TransitiveError,
+    },
     /// `orchard list-remotes --json` returned exit 127. The node is a leaf;
     /// its snapshot was fetched and is in the cache.
     Leaf,
-    /// A hard error occurred.
+    /// A hard error occurred (snapshot fetch failed, or timeout).
     Error(TransitiveError),
 }
 
@@ -177,8 +208,13 @@ type SnapshotCache = Arc<Mutex<HashMap<String, Arc<OnceLock<Option<Arc<JsonOutpu
 ///
 /// `roots` is a slice of `(host, allow_transitive)` pairs representing
 /// directly-configured `OrchardProxy` remotes.  Roots with
-/// `allow_transitive == false` have their snapshots fetched but their
-/// children are not discovered.
+/// `allow_transitive == false` are not seeded into the walker at all —
+/// their snapshots are already fetched by `OrchardProxyAdapter` in the
+/// pre-walker refresh phase, and they have no children to discover.
+///
+/// For `allow_transitive == true` roots (depth-1), the walker skips the
+/// `orchard --json` call (already done by `OrchardProxyAdapter`) and only
+/// calls `list-remotes --json` to discover transitive children.
 ///
 /// All SSH calls go through `config.ssh`, making the walker fully testable
 /// with [`crate::remote_adapter::FakeSshExec`].
@@ -196,12 +232,24 @@ pub fn walk(roots: &[(&str, bool)], config: &WalkerConfig) -> WalkerResult {
         .collect();
 
     // Seed the frontier.
+    // - Roots with allow_transitive=false are excluded: they have no children
+    //   to discover and (when skip_depth1_snapshot is set) their snapshots are
+    //   already fetched by OrchardProxyAdapter.  Mark them seen so a transitive
+    //   child cannot re-introduce them.
+    // - Roots with allow_transitive=true are seeded.  When skip_depth1_snapshot
+    //   is set, their orchard --json call is also skipped (pre-fetched by
+    //   OrchardProxyAdapter); only list-remotes is called to find children.
     let mut frontier: Vec<FrontierNode> = Vec::new();
-    for &(host, _allow) in roots {
+    for &(host, allow) in roots {
         let key = match host_dedup_key(host) {
             Ok(k) => k,
             Err(_) => continue,
         };
+        if !allow {
+            // Mark as seen so a transitive child cannot re-introduce this host.
+            seen.lock().unwrap().insert(key);
+            continue;
+        }
         let is_new = {
             let mut s = seen.lock().unwrap();
             s.insert(key.clone())
@@ -215,6 +263,9 @@ pub fn walk(roots: &[(&str, bool)], config: &WalkerConfig) -> WalkerResult {
             dedup_key: key,
             discovery_path: vec!["local".to_string(), host.to_string()],
             root: host.to_string(),
+            // Skip orchard --json for depth-1 roots when the pre-walker phase
+            // already fetched them via OrchardProxyAdapter.
+            skip_snapshot: config.skip_depth1_snapshot,
         });
     }
 
@@ -276,10 +327,23 @@ pub fn walk(roots: &[(&str, bool)], config: &WalkerConfig) -> WalkerResult {
                                     dedup_key: child_key,
                                     discovery_path: child_path,
                                     root: node.root.clone(),
+                                    // Depth 2+: always fetch orchard --json.
+                                    skip_snapshot: false,
                                 });
                             }
                         }
                     }
+                }
+                HopOutcome::ListRemotesFailed { snapshot, err } => {
+                    // Snapshot was fetched (or skipped for depth-1 roots) but
+                    // list-remotes failed.  Record the snapshot so the node's
+                    // own state is visible in the dashboard, and surface the
+                    // list-remotes failure so operators can observe the partial
+                    // failure (topology silently shrinking is worse than a
+                    // visible error).
+                    all_snapshots.push((node.discovery_path.clone(), snapshot));
+                    emit_proxy_failure_event(&err);
+                    all_errors.push(err);
                 }
                 HopOutcome::Leaf => {
                     // Snapshot was fetched before list-remotes was called; pull from cache.
@@ -357,58 +421,58 @@ fn visit_with_timeout(
 // Internal: actual hop logic
 // ---------------------------------------------------------------------------
 
-/// Executes both SSH calls for a node. No timeout enforcement here.
+/// Executes SSH calls for a node. No timeout enforcement here.
+///
+/// When `node.skip_snapshot` is `true` (depth-1 roots), the `orchard --json`
+/// call is skipped because the snapshot was already fetched by
+/// `OrchardProxyAdapter` in the pre-walker phase.  Only `list-remotes --json`
+/// is called to discover transitive children.
 fn visit_inner(node: &FrontierNode, ssh: &dyn SshExec, cache: &SnapshotCache) -> HopOutcome {
-    // Step 1: fetch orchard --json (with dedup via OnceLock).
-    let fetch_ok = fetch_snapshot(node, ssh, cache);
-    if !fetch_ok {
-        return HopOutcome::Error(TransitiveError {
-            dedup_key: node.dedup_key.clone(),
-            discovery_path: node.discovery_path.clone(),
-            root: node.root.clone(),
-            reason: format!("fetch failure for {}", node.host),
-            phase: "fetch".to_string(),
-        });
+    // Step 1: fetch orchard --json (unless this node's snapshot is already
+    // available from the pre-walker OrchardProxyAdapter phase).
+    if !node.skip_snapshot {
+        let fetch_ok = fetch_snapshot(node, ssh, cache);
+        if !fetch_ok {
+            return HopOutcome::Error(TransitiveError {
+                dedup_key: node.dedup_key.clone(),
+                discovery_path: node.discovery_path.clone(),
+                root: node.root.clone(),
+                reason: format!("fetch failure for {}", node.host),
+                phase: "fetch".to_string(),
+            });
+        }
     }
 
     // Step 2: call list-remotes to discover children.
+    let empty_snapshot = || {
+        Arc::new(JsonOutput {
+            version: 6,
+            tmux_sessions: vec![],
+            repos: vec![],
+            hosts: std::collections::HashMap::new(),
+            errors: vec![],
+        })
+    };
+
     match call_list_remotes(node, ssh) {
         ListRemotesResult::Ok(children) => {
-            let snapshot = take_cached_snapshot(cache, &node.dedup_key).unwrap_or_else(|| {
-                Arc::new(JsonOutput {
-                    version: 6,
-                    tmux_sessions: vec![],
-                    repos: vec![],
-                    hosts: std::collections::HashMap::new(),
-                    errors: vec![],
-                })
-            });
+            // For skip_snapshot nodes, take_cached_snapshot returns None (nothing
+            // was stored).  Use an empty stub — the real snapshot for this host
+            // was already merged by the pre-walker OrchardProxyAdapter phase.
+            let snapshot =
+                take_cached_snapshot(cache, &node.dedup_key).unwrap_or_else(empty_snapshot);
             HopOutcome::Success { snapshot, children }
         }
         ListRemotesResult::Leaf => HopOutcome::Leaf,
-        ListRemotesResult::Err(_err) => {
-            // list-remotes failed but snapshot was successfully fetched.
-            // Return the snapshot with empty children so the node's state is
-            // recorded. Per AC7 / "middle-hop failure does not abort the tree"
-            // — the list-remotes error is surfaced as an empty child list here;
-            // the fetch error is already excluded (fetch was ok above).
-            // NOTE: We intentionally drop the list-remotes error here rather
-            // than recording a TransitiveError because the node's own state IS
-            // available. If callers want to surface list-remotes failures they
-            // can extend this to emit an error in addition to the snapshot.
-            let snapshot = take_cached_snapshot(cache, &node.dedup_key).unwrap_or_else(|| {
-                Arc::new(JsonOutput {
-                    version: 6,
-                    tmux_sessions: vec![],
-                    repos: vec![],
-                    hosts: std::collections::HashMap::new(),
-                    errors: vec![],
-                })
-            });
-            HopOutcome::Success {
-                snapshot,
-                children: vec![],
-            }
+        ListRemotesResult::Err(mut err) => {
+            // list-remotes failed but snapshot was successfully fetched (or
+            // skip_snapshot was set, meaning the pre-walker phase handled it).
+            // Use a distinct phase label so the error is distinguishable from
+            // a full-hop failure where the snapshot was never fetched.
+            err.phase = "list_remotes_after_snapshot".to_string();
+            let snapshot =
+                take_cached_snapshot(cache, &node.dedup_key).unwrap_or_else(empty_snapshot);
+            HopOutcome::ListRemotesFailed { snapshot, err }
         }
     }
 }
@@ -1061,6 +1125,91 @@ mod tests {
             result.errors[0].reason.contains("timeout"),
             "reason must contain 'timeout', got: {}",
             result.errors[0].reason
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fix 4: allow_transitive=false root produces zero SSH calls from the walker
+    // -----------------------------------------------------------------------
+
+    /// Fix 4 — `allow_transitive=false` roots are not seeded into the walker.
+    ///
+    /// When a root is configured with `allow_transitive=false`, the walker must
+    /// make zero SSH calls for it (no `orchard --json`, no `list-remotes`).
+    /// The snapshot for such a root is handled by OrchardProxyAdapter, not
+    /// the walker.
+    #[test]
+    fn fix4_allow_transitive_false_root_produces_zero_ssh_calls() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingSshExec {
+            count: Arc<AtomicUsize>,
+        }
+        impl SshExec for CountingSshExec {
+            fn exec(&self, _host: &str, _cmd: &str) -> anyhow::Result<SshOutput> {
+                self.count.fetch_add(1, Ordering::SeqCst);
+                // Returning error is fine — the test asserts zero calls.
+                Err(anyhow::anyhow!("should not be called"))
+            }
+        }
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let ssh = Arc::new(CountingSshExec {
+            count: Arc::clone(&call_count),
+        }) as Arc<dyn SshExec>;
+
+        let config = WalkerConfig::new(ssh);
+        // Pass a root with allow_transitive=false.
+        let result = walk(&[("direct-host", false)], &config);
+
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            0,
+            "allow_transitive=false root must produce zero SSH calls from the walker"
+        );
+        assert!(
+            result.snapshots.is_empty(),
+            "allow_transitive=false root must produce no walker snapshots (snapshot handled by OrchardProxyAdapter)"
+        );
+        assert!(
+            result.errors.is_empty(),
+            "allow_transitive=false root must produce no errors"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fix 6: list-remotes failure after successful snapshot is surfaced
+    // -----------------------------------------------------------------------
+
+    /// Fix 6 — `list-remotes` failure after a successful `orchard --json` fetch
+    /// surfaces a `TransitiveError` with `phase: "list_remotes_after_snapshot"`.
+    ///
+    /// Without the fix, the walker silently returned `Success{children: vec![]}`,
+    /// causing the topology to shrink a level with no operator signal.
+    #[test]
+    fn fix6_list_remotes_failure_after_snapshot_surfaces_error() {
+        let snap_b = make_output_with_branch("issue99/b");
+
+        let mut fake = FakeSshExec::new();
+        fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+        // list-remotes fails with a non-127 exit code (network blip).
+        fake.insert("B", "orchard list-remotes --json", exit_code(1));
+
+        let result = walk(&[("B", true)], &walker(fake));
+
+        // The snapshot for B must still be recorded.
+        assert_eq!(result.snapshots.len(), 1, "B's snapshot must be present");
+        assert_eq!(result.snapshots[0].0.as_slice(), ["local", "B"]);
+
+        // A TransitiveError must be emitted for the list-remotes failure.
+        assert_eq!(
+            result.errors.len(),
+            1,
+            "list-remotes failure must surface a TransitiveError"
+        );
+        assert_eq!(
+            result.errors[0].phase, "list_remotes_after_snapshot",
+            "phase must be 'list_remotes_after_snapshot' to distinguish from full-hop failures"
         );
     }
 }

--- a/crates/orchard/src/transitive_walker.rs
+++ b/crates/orchard/src/transitive_walker.rs
@@ -1,0 +1,1061 @@
+//! BFS transitive-federation walker (issue #363, Phase 2).
+//!
+//! Traverses the orchard graph starting from directly-configured remotes that
+//! have `allow_transitive: true`. At each level all nodes are queried in
+//! parallel (level-parallel BFS). The walk terminates when:
+//!
+//! 1. No new nodes are discovered (seen-set fully covers the frontier), OR
+//! 2. The `max_depth` cap is reached (belt-and-suspenders against dedup misses).
+//!
+//! # Protocol
+//!
+//! Each hop makes TWO calls via [`SshExec`]:
+//!
+//! - `orchard --json` — fetches the state snapshot for that host.
+//! - `orchard list-remotes --json` — discovers children (grandchildren of root).
+//!   Exit 127 (command not found) is treated as a **leaf** — the host is a
+//!   pre-transitive orchard build. No [`TransitiveError`] is emitted; the
+//!   snapshot fetched above is still recorded.
+//!
+//! # Adapter dedup
+//!
+//! A per-walk `HashMap<dedup_key → Arc<OnceLock<…>>>` ensures that a diamond
+//! topology causes only one SSH round-trip for `orchard --json` on a shared leaf.
+//! The snapshot is stored as `Arc<JsonOutput>` so the same value can be
+//! shared across discovery paths without cloning.
+//!
+//! # Seen-set
+//!
+//! Keyed by [`crate::federation::host_dedup_key`]. If a host's key is already
+//! in the set it is skipped silently. The seen-set is the primary
+//! cycle-termination mechanism; `max_depth` is the safety net.
+//!
+//! # Failure handling
+//!
+//! Any SSH failure, JSON parse error, or version skew during either call records
+//! a [`TransitiveError`] and emits a `remote_adapter.proxy_failure` event to
+//! `events.jsonl`. The walk continues with other frontier nodes.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use crate::federation::{
+    ListRemotesOutput, check_list_remotes_version, emit_federation_discovered_host, host_dedup_key,
+};
+use crate::json_output::JsonOutput;
+use crate::remote_adapter::SshExec;
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+/// Default maximum BFS depth. Belt-and-suspenders cap; seen-set is the
+/// primary termination mechanism.
+pub const DEFAULT_MAX_DEPTH: u32 = 8;
+
+/// Default per-hop timeout. Each hop (both SSH calls combined) is bounded
+/// to this duration.
+pub const DEFAULT_PER_HOP_TIMEOUT: Duration = Duration::from_secs(10);
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// Configuration for a single walker run.
+pub struct WalkerConfig {
+    /// Maximum BFS depth. Traversal stops at this depth regardless of how
+    /// many new nodes would be discoverable beyond it.
+    pub max_depth: u32,
+    /// Wall-clock budget per hop. When exceeded, a [`TransitiveError`]
+    /// with `reason` containing `"timeout"` is recorded.
+    pub per_hop_timeout: Duration,
+    /// SSH executor shared across all threads in this walk.
+    pub ssh: Arc<dyn SshExec>,
+}
+
+impl WalkerConfig {
+    /// Constructs a `WalkerConfig` with [`DEFAULT_MAX_DEPTH`] and
+    /// [`DEFAULT_PER_HOP_TIMEOUT`].
+    pub fn new(ssh: Arc<dyn SshExec>) -> Self {
+        Self {
+            max_depth: DEFAULT_MAX_DEPTH,
+            per_hop_timeout: DEFAULT_PER_HOP_TIMEOUT,
+            ssh,
+        }
+    }
+
+    /// Overrides `max_depth`.
+    pub fn with_max_depth(mut self, depth: u32) -> Self {
+        self.max_depth = depth;
+        self
+    }
+
+    /// Overrides `per_hop_timeout`.
+    pub fn with_per_hop_timeout(mut self, timeout: Duration) -> Self {
+        self.per_hop_timeout = timeout;
+        self
+    }
+}
+
+/// Error recorded when a single hop fails (partially or fully).
+///
+/// The walk continues after recording a `TransitiveError`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitiveError {
+    /// `host_dedup_key()` of the failing host.
+    pub dedup_key: String,
+    /// Full discovery path from `"local"` to the failing node.
+    ///
+    /// Example: `["local", "boxd", "evals-v3-debug"]`
+    pub discovery_path: Vec<String>,
+    /// The first element after `"local"` — the directly-configured root from
+    /// which this node was reached.
+    pub root: String,
+    /// Short, stable reason label matching the vocabulary from
+    /// [`crate::remote_adapter::classify_proxy_failure_reason`].
+    pub reason: String,
+    /// Which call failed: `"list-remotes"` or `"fetch"`.
+    pub phase: String,
+}
+
+/// Result of a single walker run.
+pub struct WalkerResult {
+    /// `(discovery_path, snapshot)` — one per successfully-fetched node.
+    ///
+    /// The first element of every `discovery_path` is `"local"`.
+    /// Snapshots are wrapped in `Arc` so a diamond topology can share one
+    /// `JsonOutput` across multiple discovery paths without cloning.
+    pub snapshots: Vec<(Vec<String>, Arc<JsonOutput>)>,
+    /// Errors encountered during the walk. Non-fatal; the walk continued.
+    pub errors: Vec<TransitiveError>,
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+/// A node waiting to be visited in the BFS frontier.
+#[derive(Clone)]
+struct FrontierNode {
+    host: String,
+    dedup_key: String,
+    discovery_path: Vec<String>,
+    root: String,
+}
+
+/// The outcome of visiting a single node.
+enum HopOutcome {
+    /// Both calls succeeded.
+    Success {
+        snapshot: Arc<JsonOutput>,
+        /// Child hosts from `list-remotes` (`allow_transitive == true` + `orchard-proxy` only).
+        children: Vec<String>,
+    },
+    /// `orchard list-remotes --json` returned exit 127. The node is a leaf;
+    /// its snapshot was fetched and is in the cache.
+    Leaf,
+    /// A hard error occurred.
+    Error(TransitiveError),
+}
+
+struct LevelResult {
+    node: FrontierNode,
+    outcome: HopOutcome,
+}
+
+/// Shared memoization cache: `dedup_key → Arc<OnceLock<Option<Arc<JsonOutput>>>>`.
+///
+/// `None` inside the lock means the fetch was attempted and failed.
+type SnapshotCache = Arc<Mutex<HashMap<String, Arc<OnceLock<Option<Arc<JsonOutput>>>>>>>;
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Walks the orchard federation graph from the given `roots`.
+///
+/// `roots` is a slice of `(host, allow_transitive)` pairs representing
+/// directly-configured `OrchardProxy` remotes.  Roots with
+/// `allow_transitive == false` have their snapshots fetched but their
+/// children are not discovered.
+///
+/// All SSH calls go through `config.ssh`, making the walker fully testable
+/// with [`crate::remote_adapter::FakeSshExec`].
+pub fn walk(roots: &[(&str, bool)], config: &WalkerConfig) -> WalkerResult {
+    let seen: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+    let cache: SnapshotCache = Arc::new(Mutex::new(HashMap::new()));
+
+    let mut all_snapshots: Vec<(Vec<String>, Arc<JsonOutput>)> = Vec::new();
+    let mut all_errors: Vec<TransitiveError> = Vec::new();
+
+    // Build a fast lookup: dedup_key → allow_transitive for depth-1 roots.
+    let root_allow_transitive: HashMap<String, bool> = roots
+        .iter()
+        .filter_map(|&(host, allow)| host_dedup_key(host).ok().map(|k| (k, allow)))
+        .collect();
+
+    // Seed the frontier.
+    let mut frontier: Vec<FrontierNode> = Vec::new();
+    for &(host, _allow) in roots {
+        let key = match host_dedup_key(host) {
+            Ok(k) => k,
+            Err(_) => continue,
+        };
+        let is_new = {
+            let mut s = seen.lock().unwrap();
+            s.insert(key.clone())
+        };
+        if !is_new {
+            continue;
+        }
+        emit_federation_discovered_host(host, &key);
+        frontier.push(FrontierNode {
+            host: host.to_string(),
+            dedup_key: key,
+            discovery_path: vec!["local".to_string(), host.to_string()],
+            root: host.to_string(),
+        });
+    }
+
+    let mut depth: u32 = 1;
+
+    while !frontier.is_empty() {
+        let level_nodes: Vec<FrontierNode> = std::mem::take(&mut frontier);
+        let (tx, rx) = std::sync::mpsc::channel::<LevelResult>();
+
+        std::thread::scope(|scope| {
+            for node in &level_nodes {
+                let tx = tx.clone();
+                let ssh = Arc::clone(&config.ssh);
+                let timeout = config.per_hop_timeout;
+                let cache = Arc::clone(&cache);
+                let node = node.clone();
+
+                scope.spawn(move || {
+                    let result = visit_with_timeout(node, ssh, timeout, cache);
+                    let _ = tx.send(result);
+                });
+            }
+            drop(tx);
+        });
+        // All spawned threads have joined (scope exited).
+
+        let level_results: Vec<LevelResult> = rx.into_iter().collect();
+
+        for LevelResult { node, outcome } in level_results {
+            match outcome {
+                HopOutcome::Success { snapshot, children } => {
+                    all_snapshots.push((node.discovery_path.clone(), snapshot));
+
+                    let should_expand = if depth == 1 {
+                        root_allow_transitive
+                            .get(&node.dedup_key)
+                            .copied()
+                            .unwrap_or(false)
+                    } else {
+                        true // deeper nodes only appear because a parent advertised them
+                    };
+
+                    if should_expand && depth < config.max_depth {
+                        for child_host in children {
+                            let child_key = match host_dedup_key(&child_host) {
+                                Ok(k) => k,
+                                Err(_) => continue,
+                            };
+                            let is_new = {
+                                let mut s = seen.lock().unwrap();
+                                s.insert(child_key.clone())
+                            };
+                            if is_new {
+                                emit_federation_discovered_host(&child_host, &child_key);
+                                let mut child_path = node.discovery_path.clone();
+                                child_path.push(child_host.clone());
+                                frontier.push(FrontierNode {
+                                    host: child_host,
+                                    dedup_key: child_key,
+                                    discovery_path: child_path,
+                                    root: node.root.clone(),
+                                });
+                            }
+                        }
+                    }
+                }
+                HopOutcome::Leaf => {
+                    // Snapshot was fetched before list-remotes was called; pull from cache.
+                    if let Some(snap) = take_cached_snapshot(&cache, &node.dedup_key) {
+                        all_snapshots.push((node.discovery_path.clone(), snap));
+                    }
+                }
+                HopOutcome::Error(err) => {
+                    emit_proxy_failure_event(&err);
+                    all_errors.push(err);
+                }
+            }
+        }
+
+        depth += 1;
+    }
+
+    WalkerResult {
+        snapshots: all_snapshots,
+        errors: all_errors,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal: timeout wrapper
+// ---------------------------------------------------------------------------
+
+/// Runs [`visit_inner`] in a detached thread and waits for the result up to
+/// `timeout`. On timeout returns a `TransitiveError` and lets the inner thread
+/// run to completion in the background.
+fn visit_with_timeout(
+    node: FrontierNode,
+    ssh: Arc<dyn SshExec>,
+    timeout: Duration,
+    cache: SnapshotCache,
+) -> LevelResult {
+    let (tx, rx) = std::sync::mpsc::channel::<LevelResult>();
+
+    let node_for_thread = node;
+    let node_for_result = node_for_thread.clone();
+
+    std::thread::spawn(move || {
+        let outcome = visit_inner(&node_for_thread, ssh.as_ref(), &cache);
+        let _ = tx.send(LevelResult {
+            node: node_for_thread,
+            outcome,
+        });
+    });
+
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(_) => {
+            let secs = timeout.as_secs();
+            let reason = if secs > 0 {
+                format!("timeout ({}s)", secs)
+            } else {
+                format!("timeout ({}ms)", timeout.subsec_millis())
+            };
+            let err = TransitiveError {
+                dedup_key: node_for_result.dedup_key.clone(),
+                discovery_path: node_for_result.discovery_path.clone(),
+                root: node_for_result.root.clone(),
+                reason,
+                phase: "fetch".to_string(),
+            };
+            LevelResult {
+                node: node_for_result,
+                outcome: HopOutcome::Error(err),
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal: actual hop logic
+// ---------------------------------------------------------------------------
+
+/// Executes both SSH calls for a node. No timeout enforcement here.
+fn visit_inner(node: &FrontierNode, ssh: &dyn SshExec, cache: &SnapshotCache) -> HopOutcome {
+    // Step 1: fetch orchard --json (with dedup via OnceLock).
+    let fetch_ok = fetch_snapshot(node, ssh, cache);
+    if !fetch_ok {
+        return HopOutcome::Error(TransitiveError {
+            dedup_key: node.dedup_key.clone(),
+            discovery_path: node.discovery_path.clone(),
+            root: node.root.clone(),
+            reason: format!("fetch failure for {}", node.host),
+            phase: "fetch".to_string(),
+        });
+    }
+
+    // Step 2: call list-remotes to discover children.
+    match call_list_remotes(node, ssh) {
+        ListRemotesResult::Ok(children) => {
+            let snapshot = take_cached_snapshot(cache, &node.dedup_key).unwrap_or_else(|| {
+                Arc::new(JsonOutput {
+                    version: 6,
+                    tmux_sessions: vec![],
+                    repos: vec![],
+                    hosts: std::collections::HashMap::new(),
+                })
+            });
+            HopOutcome::Success { snapshot, children }
+        }
+        ListRemotesResult::Leaf => HopOutcome::Leaf,
+        ListRemotesResult::Err(_err) => {
+            // list-remotes failed but snapshot was successfully fetched.
+            // Return the snapshot with empty children so the node's state is
+            // recorded. Per AC7 / "middle-hop failure does not abort the tree"
+            // — the list-remotes error is surfaced as an empty child list here;
+            // the fetch error is already excluded (fetch was ok above).
+            // NOTE: We intentionally drop the list-remotes error here rather
+            // than recording a TransitiveError because the node's own state IS
+            // available. If callers want to surface list-remotes failures they
+            // can extend this to emit an error in addition to the snapshot.
+            let snapshot = take_cached_snapshot(cache, &node.dedup_key).unwrap_or_else(|| {
+                Arc::new(JsonOutput {
+                    version: 6,
+                    tmux_sessions: vec![],
+                    repos: vec![],
+                    hosts: std::collections::HashMap::new(),
+                })
+            });
+            HopOutcome::Success {
+                snapshot,
+                children: vec![],
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal: orchard --json with OnceLock dedup
+// ---------------------------------------------------------------------------
+
+/// Fetches `orchard --json` for `node` and stores the result in `cache`.
+///
+/// Returns `true` on success, `false` on failure. The `OnceLock` ensures
+/// only one thread fires the SSH call; others reuse the cached result.
+fn fetch_snapshot(node: &FrontierNode, ssh: &dyn SshExec, cache: &SnapshotCache) -> bool {
+    let lock = {
+        let mut map = cache.lock().unwrap();
+        Arc::clone(
+            map.entry(node.dedup_key.clone())
+                .or_insert_with(|| Arc::new(OnceLock::new())),
+        )
+    };
+
+    lock.get_or_init(|| {
+        let output = match ssh.exec(&node.host, "orchard --json") {
+            Ok(o) => o,
+            Err(_) => return None,
+        };
+        if output.exit_code != 0 {
+            return None;
+        }
+        let parsed: JsonOutput = match serde_json::from_str(&output.stdout) {
+            Ok(v) => v,
+            Err(_) => return None,
+        };
+        if crate::json_output::check_json_output_version(parsed.version).is_err() {
+            return None;
+        }
+        Some(Arc::new(parsed))
+    });
+
+    matches!(lock.get(), Some(Some(_)))
+}
+
+// ---------------------------------------------------------------------------
+// Internal: list-remotes
+// ---------------------------------------------------------------------------
+
+enum ListRemotesResult {
+    Ok(Vec<String>),
+    Leaf,
+    Err(TransitiveError),
+}
+
+fn call_list_remotes(node: &FrontierNode, ssh: &dyn SshExec) -> ListRemotesResult {
+    let output = match ssh.exec(&node.host, "orchard list-remotes --json") {
+        Ok(o) => o,
+        Err(e) => {
+            let reason = crate::remote_adapter::classify_proxy_failure_reason(&e.to_string());
+            return ListRemotesResult::Err(TransitiveError {
+                dedup_key: node.dedup_key.clone(),
+                discovery_path: node.discovery_path.clone(),
+                root: node.root.clone(),
+                reason,
+                phase: "list-remotes".to_string(),
+            });
+        }
+    };
+
+    if output.exit_code == 127 {
+        return ListRemotesResult::Leaf;
+    }
+
+    if output.exit_code != 0 {
+        let reason = crate::remote_adapter::classify_proxy_failure_reason(&format!(
+            "remote orchard failed (exit {})",
+            output.exit_code
+        ));
+        return ListRemotesResult::Err(TransitiveError {
+            dedup_key: node.dedup_key.clone(),
+            discovery_path: node.discovery_path.clone(),
+            root: node.root.clone(),
+            reason,
+            phase: "list-remotes".to_string(),
+        });
+    }
+
+    let parsed: ListRemotesOutput = match serde_json::from_str(&output.stdout) {
+        Ok(v) => v,
+        Err(_) => {
+            return ListRemotesResult::Err(TransitiveError {
+                dedup_key: node.dedup_key.clone(),
+                discovery_path: node.discovery_path.clone(),
+                root: node.root.clone(),
+                reason: "parse failure".to_string(),
+                phase: "list-remotes".to_string(),
+            });
+        }
+    };
+
+    if let Err(e) = check_list_remotes_version(parsed.version) {
+        return ListRemotesResult::Err(TransitiveError {
+            dedup_key: node.dedup_key.clone(),
+            discovery_path: node.discovery_path.clone(),
+            root: node.root.clone(),
+            reason: e,
+            phase: "list-remotes".to_string(),
+        });
+    }
+
+    let children: Vec<String> = parsed
+        .remotes
+        .into_iter()
+        .filter(|r| r.allow_transitive && r.kind == "orchard-proxy")
+        .map(|r| r.host)
+        .collect();
+
+    ListRemotesResult::Ok(children)
+}
+
+// ---------------------------------------------------------------------------
+// Internal: helpers
+// ---------------------------------------------------------------------------
+
+fn emit_proxy_failure_event(err: &TransitiveError) {
+    crate::events::log_event(
+        "remote_adapter.proxy_failure",
+        &[
+            ("host", serde_json::Value::String(err.dedup_key.clone())),
+            ("reason", serde_json::Value::String(err.reason.clone())),
+            ("phase", serde_json::Value::String(err.phase.clone())),
+            (
+                "discovery_path",
+                serde_json::Value::Array(
+                    err.discovery_path
+                        .iter()
+                        .map(|s| serde_json::Value::String(s.clone()))
+                        .collect(),
+                ),
+            ),
+        ],
+    );
+}
+
+fn take_cached_snapshot(cache: &SnapshotCache, dedup_key: &str) -> Option<Arc<JsonOutput>> {
+    let map = cache.lock().unwrap();
+    let lock = map.get(dedup_key)?;
+    lock.get()?.as_ref().map(Arc::clone)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::json_output::{JsonOutput, JsonRepo};
+    use crate::remote_adapter::{FakeSshExec, SshOutput};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn make_empty_output() -> JsonOutput {
+        JsonOutput {
+            version: 6,
+            tmux_sessions: vec![],
+            repos: vec![],
+            hosts: HashMap::new(),
+        }
+    }
+
+    fn make_output_with_branch(branch: &str) -> JsonOutput {
+        JsonOutput {
+            version: 6,
+            tmux_sessions: vec![],
+            repos: vec![JsonRepo {
+                slug: "owner/repo".to_string(),
+                default_branch: None,
+                main_ci_state: None,
+                worktrees: vec![crate::json_output::JsonWorktree {
+                    path: format!("/remote/{branch}"),
+                    branch: branch.to_string(),
+                    host: None,
+                    layout: "bare".to_string(),
+                    ahead_behind: None,
+                    last_commit_at: None,
+                    issue: None,
+                    pr: None,
+                    sessions: vec![],
+                    display_group: "other".to_string(),
+                    status: "ready".to_string(),
+                    status_glyph: "\u{1f7e2}".to_string(),
+                    is_main_worktree: false,
+                    last_activity_at: None,
+                }],
+            }],
+            hosts: HashMap::new(),
+        }
+    }
+
+    fn ser(output: &JsonOutput) -> String {
+        serde_json::to_string(output).unwrap()
+    }
+
+    fn list_remotes_json(children: &[(&str, bool)]) -> String {
+        let remotes: Vec<serde_json::Value> = children
+            .iter()
+            .map(|(host, allow)| {
+                serde_json::json!({
+                    "name": host,
+                    "host": host,
+                    "kind": "orchard-proxy",
+                    "path": "/remote",
+                    "allowTransitive": allow
+                })
+            })
+            .collect();
+        serde_json::json!({ "version": 1, "remotes": remotes }).to_string()
+    }
+
+    fn list_remotes_empty() -> String {
+        list_remotes_json(&[])
+    }
+
+    fn ok(stdout: &str) -> SshOutput {
+        SshOutput {
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+        }
+    }
+
+    fn exit_code(code: i32) -> SshOutput {
+        SshOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+            exit_code: code,
+        }
+    }
+
+    fn walker(fake: FakeSshExec) -> WalkerConfig {
+        WalkerConfig::new(Arc::new(fake) as Arc<dyn SshExec>)
+    }
+
+    // -----------------------------------------------------------------------
+    // AC9: Two-hop graph A -> B -> C
+    // -----------------------------------------------------------------------
+
+    /// feature:311 — two-hop graph terminates with full merged state
+    #[test]
+    fn two_hop_graph_terminates() {
+        let snap_b = make_output_with_branch("issue1/b");
+        let snap_c = make_output_with_branch("issue2/c");
+
+        let mut fake = FakeSshExec::new();
+        fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+        fake.insert(
+            "B",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("C", true)])),
+        );
+        fake.insert("C", "orchard --json", ok(&ser(&snap_c)));
+        fake.insert(
+            "C",
+            "orchard list-remotes --json",
+            ok(&list_remotes_empty()),
+        );
+
+        let result = walk(&[("B", true)], &walker(fake));
+
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert_eq!(result.snapshots.len(), 2);
+
+        let b = result
+            .snapshots
+            .iter()
+            .find(|(p, _)| p.as_slice() == ["local", "B"]);
+        let c = result
+            .snapshots
+            .iter()
+            .find(|(p, _)| p.as_slice() == ["local", "B", "C"]);
+        assert!(b.is_some(), "B must exist");
+        assert!(c.is_some(), "C must exist with full discovery path");
+
+        let (_, c_out) = c.unwrap();
+        assert_eq!(c_out.repos[0].worktrees[0].branch, "issue2/c");
+    }
+
+    // -----------------------------------------------------------------------
+    // Three-hop: A -> B -> C -> D
+    // -----------------------------------------------------------------------
+
+    /// feature:321 — three-hop terminates with full merged state
+    #[test]
+    fn three_hop_graph_terminates() {
+        let snap_b = make_empty_output();
+        let snap_c = make_empty_output();
+        let snap_d = make_output_with_branch("issue3/d");
+
+        let mut fake = FakeSshExec::new();
+        fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+        fake.insert(
+            "B",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("C", true)])),
+        );
+        fake.insert("C", "orchard --json", ok(&ser(&snap_c)));
+        fake.insert(
+            "C",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("D", true)])),
+        );
+        fake.insert("D", "orchard --json", ok(&ser(&snap_d)));
+        fake.insert(
+            "D",
+            "orchard list-remotes --json",
+            ok(&list_remotes_empty()),
+        );
+
+        let result = walk(&[("B", true)], &walker(fake));
+
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert_eq!(result.snapshots.len(), 3);
+
+        let d = result
+            .snapshots
+            .iter()
+            .find(|(p, _)| p.as_slice() == ["local", "B", "C", "D"]);
+        assert!(d.is_some(), "D must appear with full discovery path");
+        let (_, d_out) = d.unwrap();
+        assert_eq!(d_out.repos[0].worktrees[0].branch, "issue3/d");
+    }
+
+    // -----------------------------------------------------------------------
+    // AC3: Cycle A -> B -> A terminates via seen-set
+    // -----------------------------------------------------------------------
+
+    /// feature:78, feature:224 — cycle A → B → A terminates via seen-set, no error emitted
+    ///
+    /// A is a directly-configured remote root (not the local machine).  B is
+    /// A's child.  B's list-remotes advertises A back.  A is already in the
+    /// seen-set from seeding, so the walk terminates without re-visiting A.
+    #[test]
+    fn cycle_terminates_via_seen_set() {
+        let snap_a = make_empty_output();
+        let snap_b = make_empty_output();
+
+        let mut fake = FakeSshExec::new();
+        // A's SSH responses (visited at depth 1).
+        fake.insert("A", "orchard --json", ok(&ser(&snap_a)));
+        fake.insert(
+            "A",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("B", true)])),
+        );
+        // B's SSH responses (visited at depth 2).
+        fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+        // B advertises A back — cycle. A is already in seen-set so A is not re-queued.
+        fake.insert(
+            "B",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("A", true)])),
+        );
+
+        let config = WalkerConfig::new(Arc::new(fake) as Arc<dyn SshExec>).with_max_depth(100); // seen-set (not depth cap) must terminate this
+        let result = walk(&[("A", true)], &config);
+
+        assert!(
+            result.errors.is_empty(),
+            "cycle must terminate cleanly: {:?}",
+            result.errors
+        );
+        // A and B visited once each.
+        assert_eq!(result.snapshots.len(), 2, "A and B each visited once");
+        assert!(
+            result
+                .snapshots
+                .iter()
+                .any(|(p, _)| p.as_slice() == ["local", "A"]),
+            "A present"
+        );
+        assert!(
+            result
+                .snapshots
+                .iter()
+                .any(|(p, _)| p.as_slice() == ["local", "A", "B"]),
+            "B present"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC3: Diamond A -> {B, C} -> D; one SSH call for D
+    // -----------------------------------------------------------------------
+
+    /// feature:87 — diamond dedup: D's orchard --json fires exactly once
+    #[test]
+    fn diamond_dedup_single_ssh_for_leaf() {
+        let snap_b = make_empty_output();
+        let snap_c = make_empty_output();
+        let snap_d = make_output_with_branch("issue4/diamond");
+
+        let d_call_count = Arc::new(AtomicUsize::new(0));
+
+        struct CountingSshExec {
+            inner: FakeSshExec,
+            count: Arc<AtomicUsize>,
+        }
+        impl SshExec for CountingSshExec {
+            fn exec(&self, host: &str, cmd: &str) -> anyhow::Result<SshOutput> {
+                if host == "D" && cmd == "orchard --json" {
+                    self.count.fetch_add(1, Ordering::SeqCst);
+                }
+                self.inner.exec(host, cmd)
+            }
+        }
+
+        let mut fake = FakeSshExec::new();
+        fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+        fake.insert(
+            "B",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("D", true)])),
+        );
+        fake.insert("C", "orchard --json", ok(&ser(&snap_c)));
+        fake.insert(
+            "C",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("D", true)])),
+        );
+        fake.insert("D", "orchard --json", ok(&ser(&snap_d)));
+        fake.insert(
+            "D",
+            "orchard list-remotes --json",
+            ok(&list_remotes_empty()),
+        );
+
+        let ssh = Arc::new(CountingSshExec {
+            inner: fake,
+            count: Arc::clone(&d_call_count),
+        }) as Arc<dyn SshExec>;
+
+        let result = walk(&[("B", true), ("C", true)], &WalkerConfig::new(ssh));
+
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+
+        let d_snaps: Vec<_> = result
+            .snapshots
+            .iter()
+            .filter(|(_, s)| {
+                !s.repos.is_empty()
+                    && s.repos[0].worktrees.first().map(|w| w.branch.as_str())
+                        == Some("issue4/diamond")
+            })
+            .collect();
+        assert_eq!(d_snaps.len(), 1, "D must appear exactly once in snapshots");
+
+        assert_eq!(
+            d_call_count.load(Ordering::SeqCst),
+            1,
+            "D's orchard --json must fire exactly once (OnceLock dedup)"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // AC7: Middle-hop failure doesn't abort tree
+    // -----------------------------------------------------------------------
+
+    /// feature:236 — tree A -> {B, C}, B -> D, C unreachable; B and D fetched
+    #[test]
+    fn middle_hop_failure_does_not_abort_tree() {
+        let snap_b = make_empty_output();
+        let snap_d = make_output_with_branch("issue5/d");
+
+        let mut fake = FakeSshExec::new();
+        fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+        fake.insert(
+            "B",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("D", true)])),
+        );
+        fake.insert("C", "orchard --json", exit_code(255));
+        fake.insert("C", "orchard list-remotes --json", exit_code(255));
+        fake.insert("D", "orchard --json", ok(&ser(&snap_d)));
+        fake.insert(
+            "D",
+            "orchard list-remotes --json",
+            ok(&list_remotes_empty()),
+        );
+
+        let result = walk(&[("B", true), ("C", true)], &walker(fake));
+
+        assert!(
+            result
+                .snapshots
+                .iter()
+                .any(|(p, _)| p.as_slice() == ["local", "B"]),
+            "B must be present"
+        );
+        assert!(
+            result
+                .snapshots
+                .iter()
+                .any(|(p, _)| p.as_slice() == ["local", "B", "D"]),
+            "D must be present via B"
+        );
+
+        assert_eq!(result.errors.len(), 1, "exactly one error for C");
+        let c_key = host_dedup_key("C").unwrap();
+        assert_eq!(result.errors[0].dedup_key, c_key);
+        assert!(!result.errors[0].root.is_empty(), "root must be set");
+        assert!(
+            !result.errors[0].discovery_path.is_empty(),
+            "discovery_path must be set"
+        );
+        assert!(!result.errors[0].reason.is_empty(), "reason must be set");
+        assert!(!result.errors[0].phase.is_empty(), "phase must be set");
+    }
+
+    // -----------------------------------------------------------------------
+    // Exit 127 from list-remotes = leaf, not error
+    // -----------------------------------------------------------------------
+
+    /// feature:262 — exit 127 from list-remotes is a leaf, not a TransitiveError
+    #[test]
+    fn exit_127_on_list_remotes_is_leaf_not_error() {
+        let snap_b = make_output_with_branch("issue6/leaf");
+
+        let mut fake = FakeSshExec::new();
+        fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+        fake.insert("B", "orchard list-remotes --json", exit_code(127));
+
+        let result = walk(&[("B", true)], &walker(fake));
+
+        assert!(
+            result.errors.is_empty(),
+            "exit 127 must NOT produce a TransitiveError, got: {:?}",
+            result.errors
+        );
+        assert_eq!(result.snapshots.len(), 1, "B's snapshot must be present");
+        assert_eq!(result.snapshots[0].0.as_slice(), ["local", "B"]);
+    }
+
+    // -----------------------------------------------------------------------
+    // --max-depth halts traversal
+    // -----------------------------------------------------------------------
+
+    /// feature:205 — max_depth=2 halts at depth 2; D not fetched
+    #[test]
+    fn max_depth_halts_at_specified_depth() {
+        let snap_b = make_empty_output();
+        let snap_c = make_empty_output();
+
+        let mut fake = FakeSshExec::new();
+        fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+        fake.insert(
+            "B",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("C", true)])),
+        );
+        fake.insert("C", "orchard --json", ok(&ser(&snap_c)));
+        fake.insert(
+            "C",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("D", true)])),
+        );
+        // D not in FakeSshExec — visiting it would cause an error.
+
+        let config = WalkerConfig::new(Arc::new(fake) as Arc<dyn SshExec>).with_max_depth(2);
+        let result = walk(&[("B", true)], &config);
+
+        assert_eq!(
+            result.snapshots.len(),
+            2,
+            "B (depth 1) and C (depth 2) must be fetched"
+        );
+        assert!(
+            !result
+                .snapshots
+                .iter()
+                .any(|(p, _)| p.last() == Some(&"D".to_string())),
+            "D must not be fetched (depth 3 > max_depth 2)"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Seen-set alone terminates cycle (no max-depth dependency)
+    // -----------------------------------------------------------------------
+
+    /// feature:224 — cycle B -> C -> B terminates via seen-set alone
+    #[test]
+    fn seen_set_terminates_cycle_without_max_depth() {
+        let snap_b = make_empty_output();
+        let snap_c = make_empty_output();
+
+        let mut fake = FakeSshExec::new();
+        fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+        fake.insert(
+            "B",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("C", true)])),
+        );
+        fake.insert("C", "orchard --json", ok(&ser(&snap_c)));
+        fake.insert(
+            "C",
+            "orchard list-remotes --json",
+            ok(&list_remotes_json(&[("B", true)])),
+        );
+
+        let config = WalkerConfig::new(Arc::new(fake) as Arc<dyn SshExec>).with_max_depth(1000); // ensure seen-set (not depth) terminates
+        let result = walk(&[("B", true)], &config);
+
+        assert!(
+            result.errors.is_empty(),
+            "cycle terminates cleanly: {:?}",
+            result.errors
+        );
+        assert_eq!(result.snapshots.len(), 2, "B and C each visited once");
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-hop timeout fires
+    // -----------------------------------------------------------------------
+
+    /// feature:284, feature:292 — timeout fires and produces TransitiveError
+    #[test]
+    fn per_hop_timeout_fires() {
+        let timeout = Duration::from_millis(50);
+
+        struct HangingSshExec;
+        impl SshExec for HangingSshExec {
+            fn exec(&self, _host: &str, _cmd: &str) -> anyhow::Result<SshOutput> {
+                std::thread::sleep(Duration::from_secs(60));
+                unreachable!()
+            }
+        }
+
+        let config = WalkerConfig::new(Arc::new(HangingSshExec) as Arc<dyn SshExec>)
+            .with_per_hop_timeout(timeout);
+        let result = walk(&[("slow-host", true)], &config);
+
+        assert_eq!(result.snapshots.len(), 0, "timeout must prevent snapshot");
+        assert_eq!(result.errors.len(), 1, "must have one TransitiveError");
+        assert!(
+            result.errors[0].reason.contains("timeout"),
+            "reason must contain 'timeout', got: {}",
+            result.errors[0].reason
+        );
+    }
+}

--- a/crates/orchard/src/transitive_walker.rs
+++ b/crates/orchard/src/transitive_walker.rs
@@ -380,6 +380,7 @@ fn visit_inner(node: &FrontierNode, ssh: &dyn SshExec, cache: &SnapshotCache) ->
                     tmux_sessions: vec![],
                     repos: vec![],
                     hosts: std::collections::HashMap::new(),
+                    errors: vec![],
                 })
             });
             HopOutcome::Success { snapshot, children }
@@ -401,6 +402,7 @@ fn visit_inner(node: &FrontierNode, ssh: &dyn SshExec, cache: &SnapshotCache) ->
                     tmux_sessions: vec![],
                     repos: vec![],
                     hosts: std::collections::HashMap::new(),
+                    errors: vec![],
                 })
             });
             HopOutcome::Success {
@@ -578,6 +580,7 @@ mod tests {
             tmux_sessions: vec![],
             repos: vec![],
             hosts: HashMap::new(),
+            errors: vec![],
         }
     }
 
@@ -604,9 +607,11 @@ mod tests {
                     status_glyph: "\u{1f7e2}".to_string(),
                     is_main_worktree: false,
                     last_activity_at: None,
+                    discovery_path: None,
                 }],
             }],
             hosts: HashMap::new(),
+            errors: vec![],
         }
     }
 

--- a/crates/orchard/src/tui/dialogs.rs
+++ b/crates/orchard/src/tui/dialogs.rs
@@ -599,6 +599,7 @@ mod tests {
                 worktree_behind: None,
                 worktree_last_commit_at: None,
                 layout: crate::cache::WorktreeLayout::Bare,
+                discovery_path: None,
             },
             phase: Phase::InProgress,
             error: None,

--- a/crates/orchard/src/tui/fuzzy.rs
+++ b/crates/orchard/src/tui/fuzzy.rs
@@ -426,6 +426,7 @@ mod tests {
             worktree_behind: None,
             worktree_last_commit_at: None,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         }
     }
 

--- a/crates/orchard/src/tui/last_selection.rs
+++ b/crates/orchard/src/tui/last_selection.rs
@@ -301,6 +301,7 @@ mod tests {
             worktree_behind: None,
             worktree_last_commit_at: None,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         }
     }
 

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -719,6 +719,7 @@ impl App {
                     crate::session::Host::Remote(h) => Some(h.clone()),
                 };
                 let pane_target = self.resolve_pane_target(session);
+                let discovery_path = vt.row.discovery_path.clone();
                 let tx = self.tx.clone();
                 std::thread::spawn(move || {
                     let content = if let Some(host) = remote_host {
@@ -726,6 +727,7 @@ impl App {
                             &host,
                             &session_name,
                             PANE_CAPTURE_LINES,
+                            discovery_path.as_deref(),
                         )
                         .unwrap_or_default()
                     } else {

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -59,11 +59,17 @@ enum TaskEnterAction {
         host: Option<String>,
         /// When `Some`, select this pane after switching (tmux target "window.pane").
         pane_target: Option<String>,
+        /// Full discovery path for transitive SSH chaining.  `None` for local
+        /// and direct depth-1 remotes.
+        discovery_path: Option<Vec<String>>,
     },
     CreateSession {
         worktree_path: String,
         branch: Option<String>,
         host: Option<String>,
+        /// Full discovery path for transitive SSH chaining.  `None` for local
+        /// and direct depth-1 remotes.
+        discovery_path: Option<Vec<String>>,
     },
     /// Attach to or restart a standalone session.
     JoinStandalone {
@@ -491,6 +497,7 @@ impl App {
                         crate::session::Host::Local => None,
                         crate::session::Host::Remote(h) => Some(h.clone()),
                     };
+                    let discovery_path = vt.row.discovery_path.clone();
                     drop(tasks);
                     if let Some(ref h) = host
                         && self.block_if_host_unreachable(h)
@@ -503,6 +510,7 @@ impl App {
                         branch.as_deref(),
                         host.as_deref(),
                         None,
+                        discovery_path.as_deref(),
                     );
                     let _ = tmux::select_window(&session_name, window_idx);
                     return self.switch_target.is_some();
@@ -539,12 +547,14 @@ impl App {
                         branch: Some(vt.row.branch.clone()),
                         host,
                         pane_target,
+                        discovery_path: vt.row.discovery_path.clone(),
                     }
                 } else {
                     TaskEnterAction::CreateSession {
                         worktree_path: vt.row.worktree_path.clone(),
                         branch: Some(vt.row.branch.clone()),
                         host: vt.row.worktree_host.clone(),
+                        discovery_path: vt.row.discovery_path.clone(),
                     }
                 }
             });
@@ -559,6 +569,7 @@ impl App {
                 branch,
                 host,
                 pane_target,
+                discovery_path,
             }) => {
                 if let Some(ref h) = host
                     && self.block_if_host_unreachable(h)
@@ -571,6 +582,7 @@ impl App {
                     branch.as_deref(),
                     host.as_deref(),
                     None,
+                    discovery_path.as_deref(),
                 );
                 // Select specific pane after switching if a sub-row was active.
                 if let Some(ref target) = pane_target {
@@ -583,6 +595,7 @@ impl App {
                 worktree_path,
                 branch,
                 host,
+                discovery_path,
             }) => {
                 if let Some(ref h) = host
                     && self.block_if_host_unreachable(h)
@@ -598,6 +611,7 @@ impl App {
                     branch.as_deref(),
                     host.as_deref(),
                     None,
+                    discovery_path.as_deref(),
                 )
             }
             Some(TaskEnterAction::JoinStandalone {
@@ -959,6 +973,7 @@ impl App {
         branch: Option<&str>,
         remote_host: Option<&str>,
         pr: Option<&crate::types::PrInfo>,
+        discovery_path: Option<&[String]>,
     ) -> bool {
         if let Some(host) = remote_host {
             // Look up the shell preference from the matching remote config.
@@ -969,7 +984,13 @@ impl App {
                 .find_map(|repo| repo.remote_for_host(host))
                 .map(|r| r.shell.clone())
                 .unwrap_or_else(|| "ssh".to_string());
-            match remote::create_remote_proxy_session(host, session_name, worktree_path, &shell) {
+            match remote::create_remote_proxy_session(
+                host,
+                session_name,
+                worktree_path,
+                &shell,
+                discovery_path,
+            ) {
                 Ok(local_name) => {
                     self.switch_target = Some(local_name);
                     true
@@ -2589,6 +2610,7 @@ mod tests {
             display_group: group,
             is_main_worktree: false,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         }
     }
 

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -5694,6 +5694,7 @@ mod tests {
             path: "/workspace".to_string(),
             shell: "ssh".to_string(),
             kind: RemoteKind::BoxdFork,
+            allow_transitive: false,
         };
         assert_eq!(dedup_key(&boxd_fork), "boxd-fork:boxd.sh");
 
@@ -5703,6 +5704,7 @@ mod tests {
             path: "/workspace".to_string(),
             shell: "ssh".to_string(),
             kind: RemoteKind::Remmy,
+            allow_transitive: false,
         };
         assert_eq!(dedup_key(&remmy), "remmy:ubuntu@myhost");
 
@@ -5712,6 +5714,7 @@ mod tests {
             path: "/workspace".to_string(),
             shell: "ssh".to_string(),
             kind: RemoteKind::BoxdShared,
+            allow_transitive: false,
         };
         assert_eq!(dedup_key(&boxd_shared), "boxd-shared:shared.boxd.sh");
     }

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -2443,6 +2443,7 @@ mod tests {
             display_group: group,
             is_main_worktree: false,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         }
     }
 
@@ -3132,6 +3133,7 @@ mod tests {
             display_group: group,
             is_main_worktree: false,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         }
     }
 
@@ -4697,6 +4699,7 @@ mod tests {
             display_group: DisplayGroup::Other,
             is_main_worktree: false,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         }
     }
 

--- a/crates/orchard/src/tui/worktree_ops.rs
+++ b/crates/orchard/src/tui/worktree_ops.rs
@@ -38,25 +38,30 @@ pub(super) fn filter_stale(rows: &[derive::WorktreeRow]) -> Vec<derive::Worktree
 ///
 /// Handles both remote (SSH) and local worktrees. Kills any associated tmux
 /// session before removing the worktree from git.
+///
+/// For transitively-federated worktrees, `row.discovery_path` carries the
+/// hop chain and is forwarded to every remote write call so the SSH commands
+/// are routed through the correct intermediate hosts via nested SSH.
 pub(super) fn delete_task_row(
     row: &derive::WorktreeRow,
     global_config: &global_config::GlobalConfig,
 ) -> anyhow::Result<()> {
     let session_name = row.sessions.first().map(|s| s.tmux.name.as_str());
+    let dp = row.discovery_path.as_deref();
     if let Some(ref host) = row.worktree_host {
-        // Remote deletion
+        // Remote deletion — forward discovery_path for transitive hop chaining.
         if let Some(sess) = session_name {
-            let _ = remote::kill_remote_tmux_session(host, sess);
+            let _ = remote::kill_remote_tmux_session(host, sess, dp);
         }
         let slug = crate::paths::sanitize_branch_slug(&row.branch);
-        let _ = remote::remove_remote_registry_entry(host, &slug);
+        let _ = remote::remove_remote_registry_entry(host, &slug, dp);
         // Find the remote config matching this host to get the repo_path.
         let remote_cfg = global_config
             .repos
             .iter()
             .find_map(|repo| repo.remote_for_host(host));
         if let Some(remote_cfg) = remote_cfg {
-            remote::remove_remote_worktree(host, &remote_cfg.path, &row.worktree_path)?;
+            remote::remove_remote_worktree(host, &remote_cfg.path, &row.worktree_path, dp)?;
         }
         return Ok(());
     }

--- a/crates/orchard/src/watch/daemon.rs
+++ b/crates/orchard/src/watch/daemon.rs
@@ -188,9 +188,7 @@ fn refresh_transitive_federation(config: &GlobalConfig) {
             .repos
             .iter()
             .flat_map(|r| r.remotes.iter())
-            .filter(|rm| {
-                rm.kind == RemoteKind::OrchardProxy && seen.insert(rm.host.clone())
-            })
+            .filter(|rm| rm.kind == RemoteKind::OrchardProxy && seen.insert(rm.host.clone()))
             .map(|rm| (rm.host.clone(), rm.allow_transitive))
             .collect()
     };
@@ -212,7 +210,9 @@ fn refresh_transitive_federation(config: &GlobalConfig) {
     for err in &walker_result.errors {
         crate::logger::LOG.warn(&format!(
             "watch: transitive federation error for {} ({}:{}): {}",
-            err.dedup_key, err.phase, err.reason,
+            err.dedup_key,
+            err.phase,
+            err.reason,
             err.discovery_path.join(" → ")
         ));
     }
@@ -223,8 +223,8 @@ fn refresh_transitive_federation(config: &GlobalConfig) {
         if discovery_path.len() > 2 {
             // depth-2+: write snapshot to cache.
             let host = discovery_path.last().cloned().unwrap_or_default();
-            let dedup_key = crate::federation::host_dedup_key(&host)
-                .unwrap_or_else(|_| host.clone());
+            let dedup_key =
+                crate::federation::host_dedup_key(&host).unwrap_or_else(|_| host.clone());
             let _ = crate::orchard_snapshot::write_snapshot(&host, snapshot);
             topology_entries.push((discovery_path.clone(), dedup_key));
         }

--- a/crates/orchard/src/watch/daemon.rs
+++ b/crates/orchard/src/watch/daemon.rs
@@ -143,7 +143,9 @@ pub fn run(config: &GlobalConfig) -> anyhow::Result<()> {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Refreshes all sources: issues, PRs, worktrees, and tmux sessions for each repo.
+/// Refreshes all sources: issues, PRs, worktrees, tmux sessions, and runs
+/// the transitive federation walker so transitively-discovered host snapshots
+/// are written to cache before the next `build_state_with_cached_snapshots` call.
 ///
 /// Per-repo refreshes fan out concurrently so one slow GitHub API response
 /// can't delay the next repo.
@@ -161,6 +163,81 @@ fn refresh_all_sources(config: &GlobalConfig) {
     });
     if let Err(e) = cache_sources::refresh_tmux_sessions(None) {
         crate::logger::LOG.warn(&format!("watch: refresh tmux sessions failed: {e}"));
+    }
+
+    // Run the transitive federation walker so depth-2+ remotes are written to
+    // cache and picked up by the subsequent `build_state_with_cached_snapshots`.
+    refresh_transitive_federation(config);
+}
+
+/// Runs the transitive federation walker for all `allow_transitive=true`
+/// OrchardProxy roots in the config, writing per-host snapshot files and
+/// updating `federation_topology.json`.
+///
+/// Called exclusively from `refresh_all_sources` (full-refresh cycle). The
+/// written snapshots are then read back by `build_state_with_cached_snapshots`
+/// on the next state build.
+fn refresh_transitive_federation(config: &GlobalConfig) {
+    use crate::remote_adapter::{ProcessSshExec, RemoteKind};
+    use crate::transitive_walker::{WalkerConfig, walk};
+    use std::collections::HashSet;
+
+    let transitive_roots: Vec<(String, bool)> = {
+        let mut seen = HashSet::new();
+        config
+            .repos
+            .iter()
+            .flat_map(|r| r.remotes.iter())
+            .filter(|rm| {
+                rm.kind == RemoteKind::OrchardProxy && seen.insert(rm.host.clone())
+            })
+            .map(|rm| (rm.host.clone(), rm.allow_transitive))
+            .collect()
+    };
+
+    if transitive_roots.is_empty() {
+        return;
+    }
+
+    let roots_ref: Vec<(&str, bool)> = transitive_roots
+        .iter()
+        .map(|(h, a)| (h.as_str(), *a))
+        .collect();
+
+    let ssh = Arc::new(ProcessSshExec) as Arc<dyn crate::remote_adapter::SshExec>;
+    let walker_cfg = WalkerConfig::new(ssh);
+    let walker_result = walk(&roots_ref, &walker_cfg);
+
+    // Log walker errors but don't abort — partial results are still useful.
+    for err in &walker_result.errors {
+        crate::logger::LOG.warn(&format!(
+            "watch: transitive federation error for {} ({}:{}): {}",
+            err.dedup_key, err.phase, err.reason,
+            err.discovery_path.join(" → ")
+        ));
+    }
+
+    // Write per-host snapshots and collect topology entries.
+    let mut topology_entries: Vec<(Vec<String>, String)> = Vec::new();
+    for (discovery_path, snapshot) in &walker_result.snapshots {
+        if discovery_path.len() > 2 {
+            // depth-2+: write snapshot to cache.
+            let host = discovery_path.last().cloned().unwrap_or_default();
+            let dedup_key = crate::federation::host_dedup_key(&host)
+                .unwrap_or_else(|_| host.clone());
+            let _ = crate::orchard_snapshot::write_snapshot(&host, snapshot);
+            topology_entries.push((discovery_path.clone(), dedup_key));
+        }
+    }
+
+    // Persist topology so the next cold-start reads the transitive hosts.
+    if !topology_entries.is_empty() {
+        let topology = crate::federation_topology::build_topology(&topology_entries);
+        let _ = crate::federation_topology::write_topology(&topology);
+
+        // GC snapshots that are no longer in the topology.
+        let topology_read = crate::federation_topology::read_topology();
+        crate::federation_topology::gc_orphan_snapshots(topology_read.as_ref(), config);
     }
 }
 

--- a/crates/orchard/src/watch/diff.rs
+++ b/crates/orchard/src/watch/diff.rs
@@ -309,6 +309,7 @@ mod tests {
             repos: vec![],
             standalone_sessions: vec![],
             hosts: HashMap::new(),
+            transitive_errors: vec![],
         }
     }
 
@@ -326,6 +327,7 @@ mod tests {
             ahead_behind: None,
             last_commit_at: None,
             layout: crate::cache::WorktreeLayout::Bare,
+            discovery_path: None,
         }
     }
 
@@ -354,6 +356,7 @@ mod tests {
             windows: vec![],
             started_at: None,
             last_activity_at: None,
+            discovery_path: None,
         }];
         wt
     }
@@ -373,6 +376,7 @@ mod tests {
             }],
             standalone_sessions: vec![],
             hosts: HashMap::new(),
+            transitive_errors: vec![],
         }
     }
 
@@ -740,6 +744,7 @@ mod tests {
                 },
             }],
             hosts: HashMap::new(),
+            transitive_errors: vec![],
         };
 
         let mut d = seeded_debounce(&old);
@@ -781,6 +786,7 @@ mod tests {
                 },
             }],
             hosts: HashMap::new(),
+            transitive_errors: vec![],
         };
         let new = empty_state();
 

--- a/crates/orchard/tests/ac7_dashboard_nonblocking.rs
+++ b/crates/orchard/tests/ac7_dashboard_nonblocking.rs
@@ -135,6 +135,7 @@ fn orchard_json_with_cached_snapshot_returns_quickly() {
                 path: "/remote/repo".to_string(),
                 shell: "ssh".to_string(),
                 kind: RemoteKind::OrchardProxy,
+                allow_transitive: false,
             }],
         }],
         ..GlobalConfig::default()

--- a/crates/orchard/tests/ac7_dashboard_nonblocking.rs
+++ b/crates/orchard/tests/ac7_dashboard_nonblocking.rs
@@ -118,9 +118,11 @@ fn orchard_json_with_cached_snapshot_returns_quickly() {
                 ahead_behind: None,
                 last_commit_at: None,
                 last_activity_at: None,
+                discovery_path: None,
             }],
         }],
         hosts: HashMap::new(),
+        errors: vec![],
     };
 
     write_snapshot_to(host, &snapshot, cache_dir.path()).expect("write snapshot");

--- a/crates/orchard/tests/federation_transitive_e2e.rs
+++ b/crates/orchard/tests/federation_transitive_e2e.rs
@@ -136,7 +136,11 @@ fn ac9_two_hop_graph_c_worktree_has_discovery_path() {
         ok(&list_remotes_json(&[("C", true)])),
     );
     fake.insert("C", "orchard --json", ok(&ser(&snap_c)));
-    fake.insert("C", "orchard list-remotes --json", ok(&list_remotes_empty()));
+    fake.insert(
+        "C",
+        "orchard list-remotes --json",
+        ok(&list_remotes_empty()),
+    );
 
     let cfg = WalkerConfig::new(Arc::new(fake) as Arc<dyn orchard::remote_adapter::SshExec>);
     let result = walk(&[("B", true)], &cfg);
@@ -227,7 +231,11 @@ fn ac9_three_hop_graph_d_worktree_has_discovery_path() {
         ok(&list_remotes_json(&[("D", true)])),
     );
     fake.insert("D", "orchard --json", ok(&ser(&snap_d)));
-    fake.insert("D", "orchard list-remotes --json", ok(&list_remotes_empty()));
+    fake.insert(
+        "D",
+        "orchard list-remotes --json",
+        ok(&list_remotes_empty()),
+    );
 
     let cfg = WalkerConfig::new(Arc::new(fake) as Arc<dyn orchard::remote_adapter::SshExec>);
     let result = walk(&[("B", true)], &cfg);
@@ -310,8 +318,8 @@ fn ac9_cycle_graph_terminates_no_duplicates() {
         ok(&list_remotes_json(&[("A", true)])),
     );
 
-    let cfg =
-        WalkerConfig::new(Arc::new(fake) as Arc<dyn orchard::remote_adapter::SshExec>).with_max_depth(100);
+    let cfg = WalkerConfig::new(Arc::new(fake) as Arc<dyn orchard::remote_adapter::SshExec>)
+        .with_max_depth(100);
     let result = walk(&[("A", true)], &cfg);
 
     // Walk must terminate without error.
@@ -332,7 +340,10 @@ fn ac9_cycle_graph_terminates_no_duplicates() {
         .iter()
         .filter(|(p, _)| p.last().map(String::as_str) == Some("B"))
         .count();
-    assert_eq!(a_count, 1, "A must appear exactly once; seen-set prevents re-fetch");
+    assert_eq!(
+        a_count, 1,
+        "A must appear exactly once; seen-set prevents re-fetch"
+    );
     assert_eq!(b_count, 1, "B must appear exactly once");
 
     // Merge into state — both worktrees present, neither duplicated.

--- a/crates/orchard/tests/federation_transitive_e2e.rs
+++ b/crates/orchard/tests/federation_transitive_e2e.rs
@@ -1,9 +1,11 @@
-//! End-to-end regression tests for transitive federation (issue #363, AC9).
+//! End-to-end regression tests for transitive federation (issue #363, AC5 + AC9).
 //!
 //! Exercises the full walk → merge pipeline using [`FakeSshExec`] canned
 //! responses.  No real SSH is involved.
 //!
 //! Scenarios:
+//! - AC5: Write-path chaining — `kill_remote_tmux_session` with a depth-2
+//!   `discovery_path` resolves to the correct jump host and nested SSH command.
 //! - AC9: Two-hop (A → B → C): C's worktrees carry `discovery_path = ["local","B","C"]`
 //! - AC9: Three-hop (A → B → C → D): D's snapshot appears; tagged with 4-element path
 //! - AC9: Cycle (A → B → A): walk terminates, each host fetched once, no duplicates
@@ -370,4 +372,113 @@ fn ac9_cycle_graph_terminates_no_duplicates() {
     let b_dups = all_branches.iter().filter(|&&b| b == "issue22/b").count();
     assert_eq!(a_dups, 1, "A's worktree must not be duplicated");
     assert_eq!(b_dups, 1, "B's worktree must not be duplicated");
+}
+
+// ---------------------------------------------------------------------------
+// AC5 — Write-path chaining for transitive nodes
+// ---------------------------------------------------------------------------
+
+/// AC5: Given a WorktreeRow with discovery_path ["local","B","C"] (depth-2
+/// transitive topology), `chain_cmd` resolves the SSH target to "B" and the
+/// resolved command contains the nested `ssh 'C' '...'` form.
+///
+/// This proves that `kill_remote_tmux_session`, `remove_remote_worktree`, and
+/// the other write-path callers route through `build_ssh_chain` for depth-2
+/// hosts without performing a real SSH round-trip.
+#[test]
+fn ac5_write_path_depth2_routes_through_jump_host() {
+    // Topology: local → B → C (depth-2).
+    let discovery_path: Vec<String> = vec!["local".to_string(), "B".to_string(), "C".to_string()];
+
+    // Simulate what `kill_remote_tmux_session("C", "my-session", Some(&dp))` does
+    // internally: call chain_cmd to get the SSH target and chained command.
+    let inner_cmd = "tmux kill-session -t my-session";
+    let (ssh_target, chained_cmd) =
+        orchard::remote::chain_cmd("C", Some(&discovery_path), inner_cmd);
+
+    // The SSH target must be the jump host (B), not the leaf (C).
+    assert_eq!(
+        ssh_target, "B",
+        "write-path must target jump host B, not leaf host C"
+    );
+
+    // The chained command must contain a nested ssh to C.
+    assert!(
+        chained_cmd.contains("ssh") && chained_cmd.contains("C"),
+        "chained command must contain nested ssh to C; got: {chained_cmd:?}"
+    );
+
+    // Full form check: `ssh B ssh 'C' 'tmux kill-session -t my-session'`
+    let expected = orchard::federation::build_ssh_chain(&discovery_path, inner_cmd);
+    assert_eq!(
+        chained_cmd, expected,
+        "chain_cmd result must match build_ssh_chain directly; got: {chained_cmd:?}"
+    );
+}
+
+/// AC5: Depth-1 direct remote is bit-identical to before — no nesting, no regression.
+#[test]
+fn ac5_write_path_depth1_unchanged() {
+    let discovery_path: Vec<String> = vec!["local".to_string(), "B".to_string()];
+
+    let inner_cmd = "tmux kill-session -t my-session";
+    let (ssh_target, chained_cmd) =
+        orchard::remote::chain_cmd("B", Some(&discovery_path), inner_cmd);
+
+    // Depth-1: target is unchanged.
+    assert_eq!(ssh_target, "B", "depth-1 must target B directly");
+
+    // Command is passed through unchanged.
+    assert_eq!(
+        chained_cmd, inner_cmd,
+        "depth-1 command must be unchanged; got: {chained_cmd:?}"
+    );
+}
+
+/// AC5: No discovery_path (legacy / Remmy-type remotes) — completely unchanged.
+#[test]
+fn ac5_write_path_no_discovery_path_unchanged() {
+    let inner_cmd = "tmux kill-session -t my-session";
+    let (ssh_target, chained_cmd) = orchard::remote::chain_cmd("legacyhost", None, inner_cmd);
+
+    assert_eq!(
+        ssh_target, "legacyhost",
+        "no-discovery-path must target legacyhost"
+    );
+    assert_eq!(
+        chained_cmd, inner_cmd,
+        "no-discovery-path command must be unchanged; got: {chained_cmd:?}"
+    );
+}
+
+/// AC5: Three-hop chain (local → B → C → D) produces ssh B ssh 'C' ssh 'D' '...'
+/// and targets B as the jump host.
+#[test]
+fn ac5_write_path_depth3_triple_hop() {
+    let discovery_path: Vec<String> = vec![
+        "local".to_string(),
+        "B".to_string(),
+        "C".to_string(),
+        "D".to_string(),
+    ];
+
+    let inner_cmd = "tmux kill-session -t sess";
+    let (ssh_target, chained_cmd) =
+        orchard::remote::chain_cmd("D", Some(&discovery_path), inner_cmd);
+
+    // Jump host is B (the first non-local hop).
+    assert_eq!(ssh_target, "B", "3-hop chain must target B as jump host");
+
+    // Full expected form from build_ssh_chain.
+    let expected = orchard::federation::build_ssh_chain(&discovery_path, inner_cmd);
+    assert_eq!(
+        chained_cmd, expected,
+        "3-hop chain_cmd must match build_ssh_chain; got: {chained_cmd:?}"
+    );
+
+    // The chained command must contain both C and D.
+    assert!(
+        chained_cmd.contains("C") && chained_cmd.contains("D"),
+        "chained command must reference both intermediate and leaf host; got: {chained_cmd:?}"
+    );
 }

--- a/crates/orchard/tests/federation_transitive_e2e.rs
+++ b/crates/orchard/tests/federation_transitive_e2e.rs
@@ -1,0 +1,362 @@
+//! End-to-end regression tests for transitive federation (issue #363, AC9).
+//!
+//! Exercises the full walk → merge pipeline using [`FakeSshExec`] canned
+//! responses.  No real SSH is involved.
+//!
+//! Scenarios:
+//! - AC9: Two-hop (A → B → C): C's worktrees carry `discovery_path = ["local","B","C"]`
+//! - AC9: Three-hop (A → B → C → D): D's snapshot appears; tagged with 4-element path
+//! - AC9: Cycle (A → B → A): walk terminates, each host fetched once, no duplicates
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use orchard::global_config::{GlobalConfig, RemoteConfig, RepoConfig};
+use orchard::json_output::{JsonOutput, JsonRepo, JsonWorktree};
+use orchard::merge_remote::merge_remote_snapshot_with_path;
+use orchard::remote_adapter::{FakeSshExec, RemoteKind, SshOutput};
+use orchard::transitive_walker::{WalkerConfig, walk};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn ok(stdout: &str) -> SshOutput {
+    SshOutput {
+        stdout: stdout.to_string(),
+        stderr: String::new(),
+        exit_code: 0,
+    }
+}
+
+fn list_remotes_json(children: &[(&str, bool)]) -> String {
+    let remotes: Vec<serde_json::Value> = children
+        .iter()
+        .map(|(host, allow)| {
+            serde_json::json!({
+                "name": host,
+                "host": host,
+                "kind": "orchard-proxy",
+                "path": "/remote",
+                "allowTransitive": allow
+            })
+        })
+        .collect();
+    serde_json::json!({ "version": 1, "remotes": remotes }).to_string()
+}
+
+fn list_remotes_empty() -> String {
+    list_remotes_json(&[])
+}
+
+fn make_snapshot(branch: &str) -> JsonOutput {
+    JsonOutput {
+        version: 6,
+        tmux_sessions: vec![],
+        repos: vec![JsonRepo {
+            slug: "owner/repo".to_string(),
+            default_branch: None,
+            main_ci_state: None,
+            worktrees: vec![JsonWorktree {
+                path: format!("/remote/{branch}"),
+                branch: branch.to_string(),
+                host: None,
+                layout: "bare".to_string(),
+                ahead_behind: None,
+                last_commit_at: None,
+                issue: None,
+                pr: None,
+                sessions: vec![],
+                display_group: "other".to_string(),
+                status: "ready".to_string(),
+                status_glyph: "\u{1f7e2}".to_string(),
+                is_main_worktree: false,
+                last_activity_at: None,
+                discovery_path: None,
+            }],
+        }],
+        hosts: HashMap::new(),
+        errors: vec![],
+    }
+}
+
+fn ser(output: &JsonOutput) -> String {
+    serde_json::to_string(output).unwrap()
+}
+
+fn make_config(root_host: &str) -> GlobalConfig {
+    GlobalConfig {
+        repos: vec![RepoConfig {
+            slug: "owner/repo".to_string(),
+            path: "/local/repo".to_string(),
+            remotes: vec![RemoteConfig {
+                name: "root".to_string(),
+                host: root_host.to_string(),
+                path: "/remote/repo".to_string(),
+                shell: "ssh".to_string(),
+                kind: RemoteKind::OrchardProxy,
+                allow_transitive: true,
+            }],
+        }],
+        ..GlobalConfig::default()
+    }
+}
+
+/// Merges all walker snapshots into a fresh state and returns it.
+fn merge_all(
+    config: &GlobalConfig,
+    walker_snapshots: &[(Vec<String>, std::sync::Arc<JsonOutput>)],
+) -> orchard::orchard_state::OrchardState {
+    let mut state = orchard::build_state::build_state_with_hosts(config, &HashMap::new());
+    for (discovery_path, snapshot) in walker_snapshots {
+        let host = discovery_path.last().unwrap().clone();
+        let snap: JsonOutput = (*snapshot.clone()).clone();
+        merge_remote_snapshot_with_path(&mut state, snap, host, Some(discovery_path.clone()));
+    }
+    state
+}
+
+// ---------------------------------------------------------------------------
+// AC9 — Two-hop graph A (local) → B → C
+// ---------------------------------------------------------------------------
+
+/// AC9: two-hop graph terminates; C's worktrees carry discovery_path == ["local","B","C"].
+#[test]
+fn ac9_two_hop_graph_c_worktree_has_discovery_path() {
+    let snap_b = make_snapshot("issue1/b");
+    let snap_c = make_snapshot("issue2/c");
+
+    let mut fake = FakeSshExec::new();
+    fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+    fake.insert(
+        "B",
+        "orchard list-remotes --json",
+        // B advertises C with allow_transitive:true so the walker fetches C.
+        // C's own list-remotes returns empty (leaf).
+        ok(&list_remotes_json(&[("C", true)])),
+    );
+    fake.insert("C", "orchard --json", ok(&ser(&snap_c)));
+    fake.insert("C", "orchard list-remotes --json", ok(&list_remotes_empty()));
+
+    let cfg = WalkerConfig::new(Arc::new(fake) as Arc<dyn orchard::remote_adapter::SshExec>);
+    let result = walk(&[("B", true)], &cfg);
+
+    assert!(
+        result.errors.is_empty(),
+        "no errors expected for 2-hop graph; got: {:?}",
+        result.errors
+    );
+
+    // Both B and C must appear in walker snapshots.
+    let b_snap = result
+        .snapshots
+        .iter()
+        .find(|(p, _)| p.last().map(String::as_str) == Some("B"))
+        .expect("B must appear in walker snapshots");
+    let c_snap = result
+        .snapshots
+        .iter()
+        .find(|(p, _)| p.last().map(String::as_str) == Some("C"))
+        .expect("C must appear in walker snapshots");
+
+    assert_eq!(
+        b_snap.0,
+        vec!["local".to_string(), "B".to_string()],
+        "B discovery_path must be [local, B]"
+    );
+    assert_eq!(
+        c_snap.0,
+        vec!["local".to_string(), "B".to_string(), "C".to_string()],
+        "C discovery_path must be [local, B, C]"
+    );
+
+    // Merge into state and verify discovery_path on WorktreeState.
+    let config = make_config("B");
+    let state = merge_all(&config, &result.snapshots);
+
+    let c_wt = state
+        .repos
+        .iter()
+        .flat_map(|r| r.worktrees.iter())
+        .find(|w| w.branch == "issue2/c")
+        .expect("C's worktree must be present in merged state");
+
+    assert_eq!(
+        c_wt.discovery_path.as_deref(),
+        Some(["local".to_string(), "B".to_string(), "C".to_string()].as_slice()),
+        "C's WorktreeState must carry discovery_path [local, B, C]"
+    );
+
+    let b_wt = state
+        .repos
+        .iter()
+        .flat_map(|r| r.worktrees.iter())
+        .find(|w| w.branch == "issue1/b")
+        .expect("B's worktree must be present in merged state");
+
+    assert_eq!(
+        b_wt.discovery_path.as_deref(),
+        Some(["local".to_string(), "B".to_string()].as_slice()),
+        "B's WorktreeState must carry discovery_path [local, B]"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC9 — Three-hop graph A → B → C → D
+// ---------------------------------------------------------------------------
+
+/// AC9: three-hop graph terminates; D's worktrees carry discovery_path == ["local","B","C","D"].
+#[test]
+fn ac9_three_hop_graph_d_worktree_has_discovery_path() {
+    let snap_b = make_snapshot("issue10/b");
+    let snap_c = make_snapshot("issue11/c");
+    let snap_d = make_snapshot("issue12/d");
+
+    let mut fake = FakeSshExec::new();
+    fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+    fake.insert(
+        "B",
+        "orchard list-remotes --json",
+        ok(&list_remotes_json(&[("C", true)])),
+    );
+    fake.insert("C", "orchard --json", ok(&ser(&snap_c)));
+    fake.insert(
+        "C",
+        "orchard list-remotes --json",
+        // C advertises D with allow_transitive:true.
+        ok(&list_remotes_json(&[("D", true)])),
+    );
+    fake.insert("D", "orchard --json", ok(&ser(&snap_d)));
+    fake.insert("D", "orchard list-remotes --json", ok(&list_remotes_empty()));
+
+    let cfg = WalkerConfig::new(Arc::new(fake) as Arc<dyn orchard::remote_adapter::SshExec>);
+    let result = walk(&[("B", true)], &cfg);
+
+    assert!(
+        result.errors.is_empty(),
+        "no errors expected for 3-hop graph; got: {:?}",
+        result.errors
+    );
+
+    let d_entry = result
+        .snapshots
+        .iter()
+        .find(|(p, _)| p.last().map(String::as_str) == Some("D"))
+        .expect("D must appear in walker snapshots");
+
+    assert_eq!(
+        d_entry.0,
+        vec![
+            "local".to_string(),
+            "B".to_string(),
+            "C".to_string(),
+            "D".to_string(),
+        ],
+        "D discovery_path must be [local, B, C, D]"
+    );
+
+    // Merge and verify on WorktreeState.
+    let config = make_config("B");
+    let state = merge_all(&config, &result.snapshots);
+
+    let d_wt = state
+        .repos
+        .iter()
+        .flat_map(|r| r.worktrees.iter())
+        .find(|w| w.branch == "issue12/d")
+        .expect("D's worktree must be present in merged state");
+
+    assert_eq!(
+        d_wt.discovery_path.as_deref(),
+        Some(
+            [
+                "local".to_string(),
+                "B".to_string(),
+                "C".to_string(),
+                "D".to_string(),
+            ]
+            .as_slice()
+        ),
+        "D's WorktreeState must carry discovery_path [local, B, C, D]"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC9 — Cycle graph A → B → A
+// ---------------------------------------------------------------------------
+
+/// AC9: cycle graph terminates; each host fetched once; no duplicate worktrees.
+///
+/// B advertises A as a transitive remote. A is in the roots' seen-set, so B's
+/// advertisement of A is skipped. Walk terminates without error.
+#[test]
+fn ac9_cycle_graph_terminates_no_duplicates() {
+    let snap_a = make_snapshot("issue21/a");
+    let snap_b = make_snapshot("issue22/b");
+
+    let mut fake = FakeSshExec::new();
+    // A is a root with allow_transitive — it advertises B.
+    fake.insert("A", "orchard --json", ok(&ser(&snap_a)));
+    fake.insert(
+        "A",
+        "orchard list-remotes --json",
+        ok(&list_remotes_json(&[("B", true)])),
+    );
+    // B is discovered via A and advertises A back (cycle).
+    fake.insert("B", "orchard --json", ok(&ser(&snap_b)));
+    fake.insert(
+        "B",
+        "orchard list-remotes --json",
+        ok(&list_remotes_json(&[("A", true)])),
+    );
+
+    let cfg =
+        WalkerConfig::new(Arc::new(fake) as Arc<dyn orchard::remote_adapter::SshExec>).with_max_depth(100);
+    let result = walk(&[("A", true)], &cfg);
+
+    // Walk must terminate without error.
+    assert!(
+        result.errors.is_empty(),
+        "cycle must not produce errors; got: {:?}",
+        result.errors
+    );
+
+    // Each host appears exactly once.
+    let a_count = result
+        .snapshots
+        .iter()
+        .filter(|(p, _)| p.last().map(String::as_str) == Some("A"))
+        .count();
+    let b_count = result
+        .snapshots
+        .iter()
+        .filter(|(p, _)| p.last().map(String::as_str) == Some("B"))
+        .count();
+    assert_eq!(a_count, 1, "A must appear exactly once; seen-set prevents re-fetch");
+    assert_eq!(b_count, 1, "B must appear exactly once");
+
+    // Merge into state — both worktrees present, neither duplicated.
+    let config = make_config("A");
+    let state = merge_all(&config, &result.snapshots);
+
+    let all_branches: Vec<&str> = state
+        .repos
+        .iter()
+        .flat_map(|r| r.worktrees.iter())
+        .map(|w| w.branch.as_str())
+        .collect();
+
+    assert!(
+        all_branches.contains(&"issue21/a"),
+        "A's worktree must be present; branches: {all_branches:?}"
+    );
+    assert!(
+        all_branches.contains(&"issue22/b"),
+        "B's worktree must be present; branches: {all_branches:?}"
+    );
+
+    let a_dups = all_branches.iter().filter(|&&b| b == "issue21/a").count();
+    let b_dups = all_branches.iter().filter(|&&b| b == "issue22/b").count();
+    assert_eq!(a_dups, 1, "A's worktree must not be duplicated");
+    assert_eq!(b_dups, 1, "B's worktree must not be duplicated");
+}

--- a/crates/orchard/tests/federation_wire_up.rs
+++ b/crates/orchard/tests/federation_wire_up.rs
@@ -113,9 +113,11 @@ fn make_json_output_with_enriched_worktree(
                 status_glyph: "\u{1f7e2}".to_string(),
                 is_main_worktree: false,
                 last_activity_at: None,
+                discovery_path: None,
             }],
         }],
         hosts: HashMap::new(),
+        errors: vec![],
     }
 }
 

--- a/crates/orchard/tests/federation_wire_up.rs
+++ b/crates/orchard/tests/federation_wire_up.rs
@@ -38,6 +38,7 @@ fn make_config_with_proxy(host: &str) -> GlobalConfig {
                 path: "/remote/repo".to_string(),
                 shell: "ssh".to_string(),
                 kind: RemoteKind::OrchardProxy,
+                allow_transitive: false,
             }],
         }],
         ..GlobalConfig::default()

--- a/crates/orchard/tests/remote_port.rs
+++ b/crates/orchard/tests/remote_port.rs
@@ -156,6 +156,7 @@ fn dispatch_remmy_type_returns_remmy_adapter() {
         path: "~/repo".to_string(),
         shell: "ssh".to_string(),
         kind: RemoteKind::Remmy,
+        allow_transitive: false,
     };
     let ssh: Box<dyn SshExec> = Box::new(FakeSshExec::new());
     let adapter = RemoteAdapter::from_config(&cfg, ssh);
@@ -175,6 +176,7 @@ fn dispatch_boxd_shared_type_returns_boxd_shared_adapter() {
         path: "~/git-orchard-rs".to_string(),
         shell: "ssh".to_string(),
         kind: RemoteKind::BoxdShared,
+        allow_transitive: false,
     };
     let ssh: Box<dyn SshExec> = Box::new(FakeSshExec::new());
     let adapter = RemoteAdapter::from_config(&cfg, ssh);
@@ -194,6 +196,7 @@ fn dispatch_boxd_fork_type_returns_boxd_fork_adapter() {
         path: "~/langwatch".to_string(),
         shell: "ssh".to_string(),
         kind: RemoteKind::BoxdFork,
+        allow_transitive: false,
     };
     let ssh: Box<dyn SshExec> = Box::new(FakeSshExec::new());
     let adapter = RemoteAdapter::from_config(&cfg, ssh);

--- a/crates/orchard/tests/remote_port.rs
+++ b/crates/orchard/tests/remote_port.rs
@@ -723,6 +723,7 @@ fn json_output_version_bumped_to_next_and_includes_layout_field() {
         ahead_behind: None,
         last_commit_at: None,
         layout: orchard::cache::WorktreeLayout::Bare,
+        discovery_path: None,
     };
 
     // Until `WorktreeState.layout` exists, we can still test the version bump.
@@ -735,6 +736,7 @@ fn json_output_version_bumped_to_next_and_includes_layout_field() {
         }],
         standalone_sessions: vec![],
         hosts: HashMap::new(),
+        transitive_errors: vec![],
     };
 
     let output = JsonOutput::from(&state);

--- a/docs/adr/009-transitive-federation.md
+++ b/docs/adr/009-transitive-federation.md
@@ -127,7 +127,7 @@ branch does not abort the rest of the walk.
   allow onward SSH (not always guaranteed in locked-down environments).
 
 **Neutral**:
-- Depth limit defaults to 4 hops; overridable with `--max-depth` on
+- Depth limit defaults to 8 hops; overridable with `--max-depth` on
   `orchard refresh`. Deep topologies are an operational choice.
 - `host_dedup_key` normalization is best-effort. Two aliases for the same
   physical host that resolve differently will still be fetched twice;

--- a/docs/adr/009-transitive-federation.md
+++ b/docs/adr/009-transitive-federation.md
@@ -1,0 +1,134 @@
+# ADR-009: Transitive Federation — multi-hop remote discovery
+
+**Status**: Accepted
+**Date**: 2026-04-24
+**Issue**: #363
+
+---
+
+## Context
+
+ADR-008 introduced single-hop federated discovery: a local orchard instance
+SSHes into a directly-configured `orchard-proxy` remote and merges its
+`JsonOutput` snapshot. This covers the common case of a developer machine
+pulling data from one or two well-known VMs.
+
+The limitation: hosts that are only reachable *through* an intermediate host
+are invisible. A three-machine topology — `local → jump → target` — is not
+supported without explicit configuration of both `jump` and `target` as
+direct remotes in `config.json`. That requirement breaks when the intermediate
+host is outside the user's administrative control, or when hosts join/leave
+dynamically.
+
+---
+
+## Decision
+
+Extend the read-path with a **transitive BFS walker** that follows remote
+advertisements depth-first (actually level-parallel BFS) until no new hosts
+are discovered or a configurable depth limit is reached.
+
+Key design choices:
+
+### 1. `list-remotes --json` protocol extension
+
+Each orchard host exposes `orchard list-remotes --json`, returning:
+
+```json
+{ "version": 1, "remotes": [{ "name": "...", "host": "...", "kind": "orchard-proxy", "path": "...", "allowTransitive": true }] }
+```
+
+`allowTransitive: true` on an advertised remote means "this host consents to
+being walked transitively". Hosts with `allowTransitive: false` are fetched
+for their snapshot but their own remotes are not followed. This prevents
+accidental over-walking when an intermediate host has many unrelated remotes.
+
+### 2. BFS walker with cycle prevention
+
+The walker tracks a **seen-set** keyed by `host_dedup_key()` (best-effort
+normalization of SSH targets, e.g. `user@host:port → host`). A host already
+in the seen-set is skipped regardless of how many paths lead to it. This
+guarantees termination even in the presence of cycles.
+
+Walks are level-parallel: within a BFS level, all hosts are fetched
+concurrently (bounded by `per_hop_timeout`). Across levels, work is
+sequential so depth limiting and cycle detection are straightforward.
+
+### 3. `discovery_path: Option<Vec<String>>`
+
+Every `WorktreeState` and `SessionState` gains a `discovery_path` field: an
+ordered list from `"local"` to the host, e.g. `["local", "jump", "target"]`.
+This field is `None` for local worktrees and one-hop remotes that predate
+transitive federation.
+
+The `JsonWorktree` and `JsonSession` wire types also carry `discovery_path` so
+the field survives cache serialization and cold-start reconstruction.
+
+### 4. `federation_topology.json` persistence
+
+Transitively-discovered hosts and their paths are written to
+`~/.cache/orchard/federation_topology.json` after each successful walk. On
+cold start, `load_cached_snapshots` reads this file to enumerate transitive
+hosts and load their last-known snapshots without running SSH again.
+
+Topology entries that are no longer present after a walk are garbage-collected
+(`gc_orphan_snapshots`): their snapshot files are deleted so stale hosts don't
+accumulate indefinitely.
+
+### 5. Walker integration points
+
+| Entry point | Walker invoked? |
+|-------------|----------------|
+| `orchard --json` | No — cache-only (ADR-008 invariant preserved) |
+| `orchard refresh` | Yes — `refresh_and_build_with_walker_config` |
+| `orchard watch` (full poll) | Yes — `refresh_all_sources → refresh_transitive_federation` |
+| `orchard watch` (local poll) | No — local-only refresh |
+| TUI cold start | No — reads topology + cached snapshots |
+
+### 6. Write-path chaining (`build_ssh_chain`)
+
+For write operations (create worktree, kill session, transfer) that must reach
+a transitively-discovered host, `build_ssh_chain(discovery_path, cmd)` builds
+a nested SSH invocation:
+
+```
+ssh jump "ssh 'target' 'tmux ls'"
+```
+
+The outermost hop is not quoted (it's the subprocess argument). Inner hops and
+the command are POSIX single-quote-escaped with `shell_quote()`. This matches
+the standard `ProxyJump`-free pattern for nested SSH.
+
+### 7. `transitive_errors` on `OrchardState`
+
+Walker errors (SSH failure, parse failure, timeout) are collected per-host and
+surfaced on `OrchardState.transitive_errors: Vec<TransitiveError>`. The TUI
+and `--json` output expose these errors so users can diagnose connectivity
+issues. Partial results from successful hops are always kept — an error on one
+branch does not abort the rest of the walk.
+
+---
+
+## Consequences
+
+**Positive**:
+- Multi-hop topologies work with zero config beyond marking the first hop
+  as `"type": "orchard-proxy"` and `"allowTransitive": true`.
+- Cycle detection guarantees termination; no risk of infinite loops.
+- Dashboard reads remain cache-only — ADR-008's latency invariant holds.
+- Topology persistence means cold starts reconstruct the full graph without SSH.
+
+**Negative / trade-offs**:
+- `discovery_path` is `None` for data loaded from pre-v7 snapshot files (no
+  migration path; field appears on next successful refresh).
+- The `list-remotes --json` call adds one extra SSH round-trip per intermediate
+  host per `orchard refresh` cycle.
+- Write-path chaining via `build_ssh_chain` requires the intermediate hosts to
+  allow onward SSH (not always guaranteed in locked-down environments).
+
+**Neutral**:
+- Depth limit defaults to 4 hops; overridable with `--max-depth` on
+  `orchard refresh`. Deep topologies are an operational choice.
+- `host_dedup_key` normalization is best-effort. Two aliases for the same
+  physical host that resolve differently will still be fetched twice;
+  the snapshot for the second alias overwrites the first (last-writer-wins).

--- a/specs/features/federation-transitive-discovery.feature
+++ b/specs/features/federation-transitive-discovery.feature
@@ -1,0 +1,486 @@
+Feature: Transitive federation — walk the orchard graph past one hop
+  As an orchardist running many machines where some hosts spawn their own forks
+  I want registering a single remote to expose its whole subtree of orchards
+  So that dynamically-spawned children (e.g. boxd spinning up a VM fork) become visible
+  And write operations (send-keys, session launch, delete) work on transitively-discovered
+  nodes the same as on directly-registered remotes — without per-child local config changes
+
+  # Scope: transitive READ-path discovery + WRITE-path chaining. The motivating case is
+  # Mac -> boxd -> scenario-voice-agents.boxd.sh (private-network fork); the Mac cannot
+  # SSH the grandchild directly, so write ops must route through the discovery chain.
+  #
+  # Per the plan:
+  #   - JsonOutput wire version is NOT bumped (exact-whitelist check would break mixed fleets).
+  #     A new subcommand `orchard list-remotes --json` decouples topology from enrichment.
+  #   - Traversal is opt-in per root via `RemoteConfig.allow_transitive: bool` (default false).
+  #   - Dedup key is best-effort `host_dedup_key()` (NOT "canonicalize_ssh_target");
+  #     SSH aliases / ProxyJump chains cannot be resolved from the string alone.
+  #   - Walker runs ONLY in `orchard refresh` / `orchard watch`. Dashboard reads stay
+  #     cache-only (<100ms invariant from ADR-008).
+  #   - Topology persisted at `~/.cache/orchard/federation_topology.json` so cold-start
+  #     `orchard --json` returns transitive rows after the first successful walk.
+
+  Background:
+    Given a per-repo `RemoteConfig` may include `"type": "orchard-proxy"` entries
+    And `RemoteConfig` has an optional field `allow_transitive: bool` (default `false`)
+    And the new subcommand `orchard list-remotes --json` returns `{ name, host, kind, path, allow_transitive }` entries
+    And `orchard list-remotes --json` has its OWN independent version constant (lower-bound check, not exact whitelist)
+    And the walker runs only inside `orchard refresh` and `orchard watch`
+    And dashboard reads (`orchard --json`, TUI) remain cache-only
+    And the federation topology index lives at `~/.cache/orchard/federation_topology.json`
+
+  # =======================================================================
+  # AC1 — `orchard --json` returns the transitive closure of reachable nodes
+  # =======================================================================
+
+  @integration
+  Scenario: After refresh, orchard --json surfaces depth-2 nodes discovered via a depth-1 root
+    Given a root remote "boxd" configured locally with `allow_transitive: true`
+    And "boxd" advertises one child "scenario-voice-agents.boxd.sh" via `orchard list-remotes --json`
+    And a prior `orchard refresh` has written both snapshots and `federation_topology.json`
+    When the user runs `orchard --json`
+    Then the output includes worktrees from "boxd"
+    And the output includes worktrees from "scenario-voice-agents.boxd.sh"
+    And no SSH process is spawned during the `orchard --json` invocation
+
+  @integration
+  Scenario: Depth-3 transitive closure appears after refresh
+    Given a chain A -> B -> C -> D where each root forwards `allow_transitive: true`
+    And `orchard refresh` has completed one successful walk
+    When `orchard --json` runs locally
+    Then the output includes worktrees sourced from B, C, and D
+    And each node's snapshot was loaded from its cached `{safe_host}_orchard_snapshot.json`
+
+  # =======================================================================
+  # AC2 — Each node is tagged with its discovery path
+  # =======================================================================
+
+  @unit
+  Scenario: WorktreeState carries discovery_path from root to origin
+    Given a JsonOutput fetched from host "scenario-voice-agents.boxd.sh" via parent "boxd"
+    And the walker's discovery_path for that hop is `["local", "boxd", "scenario-voice-agents.boxd.sh"]`
+    When the merge folds the snapshot into OrchardState
+    Then each WorktreeState sourced from that snapshot carries `discovery_path == ["local", "boxd", "scenario-voice-agents.boxd.sh"]`
+    And each SessionState sourced from that snapshot carries the same discovery_path
+    And each HostState entry carries the same discovery_path
+
+  @unit
+  Scenario: Directly-registered (depth-1) remote has a single-parent discovery_path
+    Given a root remote "boxd" with `allow_transitive: false`
+    When a successful walk merges its snapshot
+    Then worktrees from "boxd" carry `discovery_path == ["local", "boxd"]`
+
+  # =======================================================================
+  # AC3 — Cycle prevention via seen-set (silent skip, no error, no infinite loop)
+  # =======================================================================
+
+  @unit
+  Scenario: Already-visited host is skipped silently during BFS
+    Given a cycle graph A -> B -> A (B advertises A as one of its remotes)
+    And `allow_transitive: true` on both hops
+    When the walker traverses from root A
+    Then the walker visits A once and B once — A is not re-visited
+    And no error or warning is emitted for the cycle
+    And the walk terminates
+
+  @unit
+  Scenario: Diamond graph — same grandchild reached via two parents yields one snapshot fetch
+    Given a diamond A -> {B, C} -> D where both B and C advertise D
+    And `allow_transitive: true` everywhere
+    When the walker traverses from A
+    Then D is fetched exactly once within the refresh (one OrchardProxyAdapter instance keyed by `host_dedup_key(D)`)
+    And D appears in the topology under both B's and C's subtrees via discovery_path, not as a duplicate snapshot fetch
+
+  # =======================================================================
+  # AC4 — Host identifier dedup via best-effort `host_dedup_key()`
+  # =======================================================================
+
+  @unit
+  Scenario: host_dedup_key case-folds the host portion but preserves user case
+    Given strings "boxd@VM.Boxd.Sh" and "boxd@vm.boxd.sh"
+    When `host_dedup_key` is applied to each
+    Then the two keys are equal
+
+  @unit
+  Scenario: host_dedup_key treats default SSH port as implicit
+    Given strings "boxd@vm.boxd.sh" and "boxd@vm.boxd.sh:22"
+    When `host_dedup_key` is applied to each
+    Then the two keys are equal
+    And "boxd@vm.boxd.sh:2222" produces a DIFFERENT key from both
+
+  @unit
+  Scenario: host_dedup_key strips a trailing dot on the hostname
+    Given strings "boxd@vm.boxd.sh." and "boxd@vm.boxd.sh"
+    When `host_dedup_key` is applied to each
+    Then the two keys are equal
+
+  @unit
+  Scenario: host_dedup_key normalizes IPv6 brackets consistently
+    Given "boxd@[2001:db8::1]" and "boxd@[2001:db8::1]:22"
+    When `host_dedup_key` is applied
+    Then the two keys are equal
+    And bracketed-with-nondefault-port "boxd@[2001:db8::1]:2222" is a DIFFERENT key
+
+  @unit
+  Scenario: host_dedup_key preserves distinct users on the same host
+    Given strings "alice@vm.boxd.sh" and "bob@vm.boxd.sh"
+    When `host_dedup_key` is applied to each
+    Then the two keys are NOT equal
+    And this is by design — SSH treats them as distinct identities
+
+  @unit
+  Scenario: host_dedup_key rejects malformed strings
+    Given the string "boxd@vm.boxd.sh/evil"
+    When `host_dedup_key` is applied
+    Then the call returns an error (reject paths, whitespace, backslashes)
+
+  @unit
+  Scenario: first-seen host emits federation.discovered_host event for collision visibility
+    Given the walker discovers "Boxd@VM.Boxd.Sh" for the first time in a refresh
+    When the dedup key is computed
+    Then a `federation.discovered_host` event is appended to `events.jsonl` with both the raw input and the computed key
+    And a subsequent discovery of "boxd@vm.boxd.sh" (same key) does NOT emit a new event in the same refresh
+
+  # =======================================================================
+  # AC5 — Write operations work on transitive nodes via jump-host chaining
+  # =======================================================================
+
+  @unit
+  Scenario: build_ssh_chain produces `ssh parent ssh child <cmd>` for a depth-2 target
+    Given a discovery_path `["local", "boxd", "scenario-voice-agents.boxd.sh"]`
+    And a raw command `tmux send-keys -t session:0 "hello" Enter`
+    When `build_ssh_chain(discovery_path, cmd)` is called
+    Then the result is a single shell command string that, when executed locally, runs the raw command on the leaf host via nested SSH through "boxd"
+    And arguments are shell-quoted at each nesting level so special characters survive both layers
+
+  @unit
+  Scenario: build_ssh_chain handles nested shell-metacharacter payloads
+    Given a payload containing `$`, backtick, double-quote, backslash, newline, and a Unicode codepoint outside ASCII
+    And a two-hop discovery_path
+    When `build_ssh_chain` is applied
+    Then the resulting command, when executed, delivers the payload byte-identical to the leaf host (no shell interpolation, no truncation)
+
+  @unit
+  Scenario: Depth-1 direct remote uses single SSH (unchanged behavior)
+    Given a discovery_path `["local", "boxd"]`
+    When `build_ssh_chain` is called for a send-keys command
+    Then the result is a single-level `ssh boxd <cmd>` — no nested layer, no regression on direct-remote paths
+
+  @integration
+  Scenario: send-keys to a transitively-discovered session routes through the parent chain
+    Given a recorded walker topology where leaf "scenario-voice-agents.boxd.sh" was discovered via "boxd"
+    And a fake SSH runner that records every invocation
+    When a send-keys message is dispatched to a session on the leaf host
+    Then the runner records exactly one `ssh boxd ...` invocation whose inner argv is an `ssh scenario-voice-agents.boxd.sh ...` command
+    And no direct `ssh scenario-voice-agents.boxd.sh ...` invocation is attempted from local
+
+  @integration
+  Scenario: Session launch on a transitive node uses the chain
+    Given a transitively-discovered leaf host reached through one parent
+    When the TUI Enter action launches a tmux session on a worktree at that host
+    Then the launch command executes via `ssh parent ssh leaf tmux new-session ...`
+    And on success a SessionState for that session appears in the next refresh with the correct discovery_path
+
+  @integration
+  Scenario: Worktree delete on a transitive node uses the chain
+    Given a transitively-discovered worktree two hops from local
+    When the TUI `d` action triggers `git worktree remove` on that worktree
+    Then the resulting command executes as `ssh parent ssh leaf git worktree remove ...`
+    And the worktree path is shell-quoted correctly across both SSH layers (paths with spaces, quotes, dollar-signs survive)
+
+  @integration
+  Scenario: RemoteConfig.allow_transitive = false suppresses transitive traversal for that root
+    Given a root remote "boxd" with `allow_transitive: false`
+    And "boxd" advertises one child via `orchard list-remotes --json`
+    When `orchard refresh` runs
+    Then the walker fetches "boxd" but does NOT fetch its children
+    And `federation_topology.json` records only "boxd" under that root
+    And no snapshot file is written for the child
+
+  # =======================================================================
+  # AC6 — Seen-set is the primary termination; optional `--max-depth N`
+  # =======================================================================
+
+  @unit
+  Scenario: `--max-depth` flag halts traversal at the specified depth
+    Given a chain A -> B -> C -> D with `allow_transitive: true` everywhere
+    And `orchard refresh --max-depth 2` is invoked
+    When the walker runs
+    Then D is NOT fetched (depth 3 exceeds the cap)
+    And C is fetched (depth 2 included)
+    And a diagnostic is logged naming D as "max-depth reached"
+
+  @unit
+  Scenario: Default max depth is a belt-and-suspenders cap (plan: 8)
+    Given a chain of 10 orchards A -> B -> ... -> J with `allow_transitive: true`
+    And `orchard refresh` is invoked WITHOUT `--max-depth`
+    When the walker runs
+    Then traversal stops at depth 8 (default cap from the plan — seen-set is primary guard, depth is belt-and-suspenders)
+    And hosts at depth > 8 are not fetched
+    # NOTE: issue AC6 says "no depth bound by default"; plan overrides with default 8 to guard
+    # against canonicalization misses and operator misconfig. Reconciled in /plan.
+
+  @unit
+  Scenario: Seen-set alone terminates a cycle even without --max-depth
+    Given a cycle A -> B -> A with `allow_transitive: true`
+    And no `--max-depth` is specified
+    When the walker runs
+    Then traversal terminates (seen-set short-circuits the revisit of A)
+    And the walker does NOT rely on the depth cap to terminate this cycle
+
+  # =======================================================================
+  # AC7 — Aggregate failures: one bad hop doesn't break the tree
+  # =======================================================================
+
+  @unit
+  Scenario: Middle-hop failure does not abort the walk
+    Given a tree A -> {B, C}, B -> D, and C is unreachable
+    And the fake SSH runner returns exit 255 for any `ssh C ...` invocation
+    When the walker runs from root A
+    Then B is fetched successfully
+    And D is fetched successfully (via B)
+    And the walk result contains a `TransitiveError` for C with `{ key, discovery_path, root, reason, phase }`
+    And the walker did NOT abort on C's failure
+
+  @unit
+  Scenario: TransitiveError carries discovery_path and root for debuggability
+    Given a failure at host "evals-v3-debug" reached via root "boxd"
+    When the walker records the error
+    Then the emitted TransitiveError has `root == "boxd"`
+    And `discovery_path == ["local", "boxd", "evals-v3-debug"]`
+    And `phase` identifies whether the failure was during `list-remotes` or `--json` fetch
+
+  @unit
+  Scenario: `orchard --json` surfaces a top-level errors[] array grouped for the operator
+    Given a refresh that produced two TransitiveErrors under different roots
+    When `orchard --json` reads the resulting OrchardState
+    Then the output contains an errors array at the top level
+    And each error includes `{ key, discovery_path, root, reason, phase }`
+    And errors are distinguishable by root for per-subtree triage
+
+  @integration
+  Scenario: Exit 127 from a list-remotes call is treated as a LEAF, not a failure
+    Given a remote running a v6 orchard (no `list-remotes` subcommand)
+    And the walker invokes `ssh host orchard list-remotes --json` and receives exit 127
+    When the walker classifies the result
+    Then the host is recorded as a leaf (no children discovered)
+    And NO `TransitiveError` is emitted for this host
+    And the host's own `orchard --json` snapshot is still fetched and merged
+
+  @integration
+  Scenario: Unreachable host leaves last-known snapshot visible
+    Given a prior successful snapshot at "~/.cache/orchard/scenario-voice-agents_boxd_sh_orchard_snapshot.json"
+    And on the next refresh the host is unreachable (exit 255)
+    When the walker completes
+    Then the cached snapshot on disk is NOT deleted
+    And `federation_topology.json` still lists the host under its root
+    And the dashboard renders the stale rows with the unchanged `discovery_path`
+
+  # =======================================================================
+  # AC8 — Per-hop timeout (default 10s, configurable)
+  # =======================================================================
+
+  @unit
+  Scenario: Per-hop timeout defaults to 10 seconds
+    Given `orchard refresh` is invoked WITHOUT a timeout flag
+    When the walker probes a hop that never responds
+    Then the per-hop operation is cancelled after 10 seconds
+    And a TransitiveError with reason "timeout (10s)" is recorded
+    And the walker proceeds to sibling hops
+
+  @unit
+  Scenario: `--per-hop-timeout` flag overrides the default
+    Given `orchard refresh --per-hop-timeout 3` is invoked
+    When the walker probes a slow hop
+    Then the hop is cancelled at 3 seconds
+    And the emitted TransitiveError reason reflects the 3s budget
+
+  @unit
+  Scenario: Level-parallel BFS bounds total wall-clock to depth * per-hop timeout
+    Given a tree with 5 depth-1 hops and 5 depth-2 hops under each, all slow (just under timeout)
+    And default per-hop timeout of 10s
+    When `orchard refresh` runs
+    Then the walker fetches depth-1 hosts in parallel (one level at a time)
+    And total wall-clock is bounded by 2 * 10s (depth * per-hop), NOT by 25 * 10s (nodes * per-hop)
+
+  # =======================================================================
+  # AC9 — End-to-end regression: 2-hop, 3-hop, cycle all terminate correctly
+  # =======================================================================
+
+  @e2e
+  Scenario: Two-hop graph A -> B -> C terminates with full merged state
+    Given a live topology A (local) -> B (orchard-proxy, `allow_transitive: true`) -> C (orchard-proxy, leaf)
+    And C has one worktree "issue999/demo" with a tmux session
+    When `orchard refresh` is invoked on A
+    And `orchard --json` is invoked on A
+    Then the output contains the worktree from C with `discovery_path == ["local", "B", "C"]`
+    And enrichment (pr, issue, claude, check_state, display_group) on the C worktree is preserved from C's JsonOutput (not re-derived locally)
+    And no errors[] entries are present for this walk
+
+  @e2e
+  Scenario: Three-hop graph A -> B -> C -> D terminates with full merged state
+    Given a chain of 4 orchards with `allow_transitive: true` at every non-leaf
+    And D has one worktree and one session
+    When `orchard refresh` is invoked on A
+    And `orchard --json` is invoked on A
+    Then the output includes D's worktree tagged with `discovery_path == ["local", "B", "C", "D"]`
+    And D's snapshot file exists on disk at its `host_dedup_key` path
+
+  @e2e
+  Scenario: Cycle graph A -> B -> A terminates and returns correct data
+    Given a live cycle: A lists B as a transitive-allowed remote, and B lists A
+    When `orchard refresh` is invoked on A
+    Then the walker terminates
+    And each host is fetched exactly once
+    And `orchard --json` on A returns a merged state containing both A's and B's worktrees without duplication
+
+  # =======================================================================
+  # Topology persistence + orphan GC + TTL  (plan section — not a numbered AC
+  # but load-bearing for cold-start correctness; coverage-mapped under AC1)
+  # =======================================================================
+
+  @unit
+  Scenario: federation_topology.json is written after a successful walk
+    Given a successful walk from root "boxd" discovers children `["scenario-voice-agents.boxd.sh", "evals-v3-debug"]`
+    When the walker completes
+    Then `~/.cache/orchard/federation_topology.json` exists
+    And it contains a mapping `{ "boxd": { "descendants": [...], "discovery_paths": {...} } }`
+    And the file was written atomically (tmp -> rename)
+
+  @unit
+  Scenario: load_cached_snapshots consults federation_topology.json in addition to config.repos
+    Given `federation_topology.json` lists "scenario-voice-agents.boxd.sh" under root "boxd"
+    And only "boxd" is in local `config.repos`
+    And both hosts have snapshot files on disk
+    When the TUI cold-starts and calls `load_cached_snapshots(config)`
+    Then both snapshots are loaded into the initial OrchardState
+    And the transitive host's worktrees appear in the first render (no SSH required)
+
+  @unit
+  Scenario: Orphan snapshot files are GC'd at the end of a refresh
+    Given a snapshot file "abandoned-host_orchard_snapshot.json" exists on disk
+    And `federation_topology.json` does NOT list "abandoned-host"
+    When `orchard refresh` completes its walk
+    Then the orphan snapshot file is deleted
+    And the post-refresh topology index reflects only currently-reachable hosts
+
+  @unit
+  Scenario: 7-day soft TTL on snapshot files
+    Given a snapshot file older than 7 days whose host is still in the topology
+    When `orchard refresh` runs and the host is unreachable for this refresh
+    Then the stale-but-in-topology file is NOT deleted (kept for observability)
+    And a diagnostic is logged noting the stale age
+
+  # =======================================================================
+  # list-remotes subcommand — independent versioning (plan section)
+  # =======================================================================
+
+  @unit
+  Scenario: `orchard list-remotes --json` emits its own independent version field
+    Given the new subcommand exists
+    When the user invokes `orchard list-remotes --json` locally
+    Then the output is a JSON object with `version: <u32>` and `remotes: [JsonRemoteConfig, ...]`
+    And each `JsonRemoteConfig` has `{ name, host, kind, path, allow_transitive }`
+    And the `version` constant is declared independently of `JsonOutput` (not the same constant)
+
+  @unit
+  Scenario: list-remotes version check is lower-bound, not exact-whitelist
+    Given a future version N+1 is emitted by a newer remote
+    And the local orchard declares a lower-bound of N
+    When the local walker parses the response
+    Then parsing succeeds (additive-only fields tolerated)
+    And any unknown fields are ignored
+    # This is the lesson learned from JsonOutput's exact-whitelist skew trap.
+
+  @unit
+  Scenario: v6 remote without list-remotes degrades as LEAF via exit 127
+    Given a remote on a pre-transitive orchard build (no `list-remotes` subcommand)
+    When the walker invokes `ssh host orchard list-remotes --json`
+    Then the SSH call returns exit 127
+    And the walker treats the host as a LEAF (no descendants)
+    And no `TransitiveError` is emitted
+    And the host's own `orchard --json` snapshot is still fetched and merged
+
+  # =======================================================================
+  # Global adapter dedup (plan section)
+  # =======================================================================
+
+  @unit
+  Scenario: Walker uses one OrchardProxyAdapter per host_dedup_key per refresh
+    Given a diamond topology where two discovery paths reach the same leaf
+    And the walker is wired with a factory that records adapter constructions
+    When the walker traverses the graph
+    Then the factory produced exactly ONE adapter for the leaf's `host_dedup_key`
+    And that adapter's internal OnceLock was used to share the single SSH round-trip
+
+  # =======================================================================
+  # Dashboard invariant (plan section — from ADR-008)
+  # =======================================================================
+
+  @e2e
+  Scenario: `orchard --json` stays cache-only even with transitive topology
+    Given a configured root with `allow_transitive: true` and a populated topology
+    And all transitive hosts are unreachable at this instant
+    When the user runs `orchard --json`
+    Then the command completes in under 100ms wall-clock
+    And NO SSH process is spawned during its execution
+    And the output contains the last-known cached state for every host in the topology
+
+  # =======================================================================
+  # AC Coverage Map
+  # =======================================================================
+
+  # --- AC Coverage Map ---
+  # AC1 "orchard --json returns the transitive closure of all reachable nodes, not just direct remotes"
+  #   -> "After refresh, orchard --json surfaces depth-2 nodes discovered via a depth-1 root"
+  #   -> "Depth-3 transitive closure appears after refresh"
+  #   -> "federation_topology.json is written after a successful walk"
+  #   -> "load_cached_snapshots consults federation_topology.json in addition to config.repos"
+  # AC2 "Each node in the response is tagged with its path (local -> boxd -> scenario-voice-agents)"
+  #   -> "WorktreeState carries discovery_path from root to origin"
+  #   -> "Directly-registered (depth-1) remote has a single-parent discovery_path"
+  # AC3 "Cycle prevention via seen-set — walker maintains visited set; already-seen hosts skipped silently"
+  #   -> "Already-visited host is skipped silently during BFS"
+  #   -> "Diamond graph — same grandchild reached via two parents yields one snapshot fetch"
+  #   -> "Seen-set alone terminates a cycle even without --max-depth"
+  # AC4 "Host identifier for dedup: canonical form of SSH destination"
+  #   -> "host_dedup_key case-folds the host portion but preserves user case"
+  #   -> "host_dedup_key treats default SSH port as implicit"
+  #   -> "host_dedup_key strips a trailing dot on the hostname"
+  #   -> "host_dedup_key normalizes IPv6 brackets consistently"
+  #   -> "host_dedup_key preserves distinct users on the same host"
+  #   -> "host_dedup_key rejects malformed strings"
+  #   -> "first-seen host emits federation.discovered_host event for collision visibility"
+  # AC5 "Write operations (send-keys, session launch, etc.) work on transitively-discovered nodes the same as direct remotes"
+  #   -> "build_ssh_chain produces `ssh parent ssh child <cmd>` for a depth-2 target"
+  #   -> "build_ssh_chain handles nested shell-metacharacter payloads"
+  #   -> "Depth-1 direct remote uses single SSH (unchanged behavior)"
+  #   -> "send-keys to a transitively-discovered session routes through the parent chain"
+  #   -> "Session launch on a transitive node uses the chain"
+  #   -> "Worktree delete on a transitive node uses the chain"
+  #   -> "RemoteConfig.allow_transitive = false suppresses transitive traversal for that root"
+  # AC6 "No depth bound by default (seen-set is the only termination condition); optional --max-depth N flag for diagnostic use"
+  #   -> "`--max-depth` flag halts traversal at the specified depth"
+  #   -> "Default max depth is a belt-and-suspenders cap (plan: 8)"    # RECONCILED: plan overrides issue default; seen-set remains primary termination
+  #   -> "Seen-set alone terminates a cycle even without --max-depth"
+  # AC7 "Aggregate failures: one unreachable remote does not break the whole query — response includes errors[] per-node"
+  #   -> "Middle-hop failure does not abort the walk"
+  #   -> "TransitiveError carries discovery_path and root for debuggability"
+  #   -> "`orchard --json` surfaces a top-level errors[] array grouped for the operator"
+  #   -> "Exit 127 from a list-remotes call is treated as a LEAF, not a failure"
+  #   -> "Unreachable host leaves last-known snapshot visible"
+  # AC8 "Timeout per hop (configurable, default 10s) so a slow remote doesn't stall the whole query"
+  #   -> "Per-hop timeout defaults to 10 seconds"
+  #   -> "`--per-hop-timeout` flag overrides the default"
+  #   -> "Level-parallel BFS bounds total wall-clock to depth * per-hop timeout"
+  # AC9 "Regression test: two-hop (A -> B -> C), three-hop (A -> B -> C -> D), cycle (A -> B -> A) all terminate and return correct data"
+  #   -> "Two-hop graph A -> B -> C terminates with full merged state"
+  #   -> "Three-hop graph A -> B -> C -> D terminates with full merged state"
+  #   -> "Cycle graph A -> B -> A terminates and returns correct data"
+  #
+  # Additional plan-driven scenarios (not numbered ACs but load-bearing; referenced above):
+  #   - list-remotes subcommand with independent lower-bound version check (guards against
+  #     the JsonOutput exact-whitelist skew trap)
+  #   - Global adapter dedup by host_dedup_key (prevents duplicate SSHes across diamond paths)
+  #   - 7-day soft TTL + orphan GC on snapshot files (keeps cache honest)
+  #   - Dashboard-never-blocks invariant from ADR-008 (preserved under transitive topology)


### PR DESCRIPTION
## Summary

Closes #363. Transitive federation: register a remote once, see its whole subtree.

## What ships

- **BFS walker** (`transitive_walker.rs`): discovers remote orchard instances by calling `orchard list-remotes --json` on each hop, traverses the graph up to `max_depth` (default 8), deduplicates by canonical SSH target, detects cycles.
- **`discovery_path`** stamped on every `WorktreeState` / `SessionState` so write-path operations (SSH, tmux, pane capture) route through the correct jump chain.
- **`chain_cmd`** / **`build_ssh_chain`**: compose the nested `ssh … ssh …` invocation for multi-hop commands.
- **Topology persistence** (`federation_topology.rs`): cold-start load of transitive hosts from `federation_topology.json`.
- **`orchard list-remotes --json`** subcommand: wire protocol for peer discovery.
- **Watch daemon** integration: transitive walker runs on every full refresh cycle.
- **mosh guard**: `create_remote_proxy_session` rejects mosh for depth-2+ hosts with an actionable error.
- **Cache round-trip fix**: `merge_remote.rs` was discarding `discovery_path` on load; fixed.

## Fixes from review

- Fix 1: preserve `discovery_path` through cache round-trip (was silently dropped)
- Fix 2: thread `discovery_path` through `capture_remote_pane_content`
- Fix 3: remove dead `OrchardState::discovery_path_for_host`
- Fix 4: skip `allow_transitive=false` roots in walker; avoid double-fetch of depth-1 snapshots
- Fix 5: correct DEFAULT_MAX_DEPTH in ADR-009 (4 → 8)
- Fix 6: surface `list-remotes` failures even when snapshot succeeded (`HopOutcome::ListRemotesFailed`)
- Fix 7: remove redundant `root` field from `TopologyEntry` / `TransitiveError` (computed from `discovery_path`)
- Fix 8: bail early on mosh + transitive hosts

## Test plan

- [x] All BDD scenarios in `specs/features/federation-transitive-discovery.feature` pass
- [x] Unit tests on `host_dedup_key()` / `build_ssh_chain()` / walker / topology / merge round-trip
- [x] `cargo test`, `cargo clippy --all-targets --all-features`, `cargo fmt --check` clean

## Related issue

- #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #363

# Related issue

- #363

# Related issue

- #363