### PR TITLE
fix(#361): heal must never kill the invoking tmux session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,7 +2867,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -87,6 +87,18 @@ pub struct HealFinding {
     ///
     /// When `is_self` is true, `apply_fixes` must skip the action rather than
     /// killing the session — a self-kill would terminate the running process.
+    ///
+    /// **Invariant**: `is_self` is set by matching the finding's session name
+    /// against `current_session` passed to [`diagnose`]. This assumes both
+    /// names come from the same tmux server (tmux session names are unique
+    /// within a server but NOT across servers). Callers diagnosing remote or
+    /// cross-socket sessions MUST NOT pass a `current_session` value sourced
+    /// from a different server, or the self-protection invariant breaks.
+    ///
+    /// **JSON consumers**: a finding with `is_self: true` and `severity:
+    /// error` is the "do-not-act" marker — `apply_fixes` will skip it and
+    /// `orchard heal --fix` aborts with exit 1 before reaching any action.
+    /// External tooling reading `--json` output must honour this signal.
     pub is_self: bool,
 }
 

--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -561,7 +561,11 @@ pub fn format_report(report: &HealReport, fix_results: Option<&[FixResult]>) -> 
         )
     }) {
         let icon = severity_icon(&finding.severity);
-        let suffix = if finding.is_self { " \u{2014} skipped (self)" } else { "" };
+        let suffix = if finding.is_self {
+            " \u{2014} skipped (self)"
+        } else {
+            ""
+        };
         lines.push(format!("{} {}{}", icon, finding.message, suffix));
     }
 
@@ -573,7 +577,11 @@ pub fn format_report(report: &HealReport, fix_results: Option<&[FixResult]>) -> 
         )
     }) {
         let icon = severity_icon(&finding.severity);
-        let suffix = if finding.is_self { " \u{2014} skipped (self)" } else { "" };
+        let suffix = if finding.is_self {
+            " \u{2014} skipped (self)"
+        } else {
+            ""
+        };
         lines.push(format!("{} {}{}", icon, finding.message, suffix));
     }
 
@@ -1223,7 +1231,10 @@ mod tests {
             .iter()
             .find(|f| matches!(&f.action, HealAction::KillSession(n) if n == "another"));
 
-        assert!(orchardist_finding.is_some(), "should have finding for orchardist");
+        assert!(
+            orchardist_finding.is_some(),
+            "should have finding for orchardist"
+        );
         assert!(another_finding.is_some(), "should have finding for another");
 
         assert!(
@@ -1295,10 +1306,7 @@ mod tests {
             "message must start with 'Skipped session', got: {}",
             results[0].message
         );
-        assert!(
-            results[0].error.is_none(),
-            "skip result must have no error"
-        );
+        assert!(results[0].error.is_none(), "skip result must have no error");
     }
 
     #[test]
@@ -1311,9 +1319,7 @@ mod tests {
             category: HealCategory::OrphanedSession,
             severity: Severity::Warning,
             message: "Session has no matching worktree".to_string(),
-            action: HealAction::KillSession(
-                "orchardist-test-no-such-session-issue361-xxx".into(),
-            ),
+            action: HealAction::KillSession("orchardist-test-no-such-session-issue361-xxx".into()),
             is_self: false,
         };
 
@@ -1382,7 +1388,10 @@ mod tests {
         };
 
         let result = detect_self_error(&report);
-        assert!(result.is_some(), "should return Some for self + Error finding");
+        assert!(
+            result.is_some(),
+            "should return Some for self + Error finding"
+        );
         // Confirm it is the same finding (by matching the message).
         assert_eq!(result.unwrap().message, finding.message);
     }

--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -549,7 +549,8 @@ pub fn format_report(report: &HealReport, fix_results: Option<&[FixResult]>) -> 
         )
     }) {
         let icon = severity_icon(&finding.severity);
-        lines.push(format!("{} {}", icon, finding.message));
+        let suffix = if finding.is_self { " \u{2014} skipped (self)" } else { "" };
+        lines.push(format!("{} {}{}", icon, finding.message, suffix));
     }
 
     // Print all non-session findings.
@@ -560,7 +561,8 @@ pub fn format_report(report: &HealReport, fix_results: Option<&[FixResult]>) -> 
         )
     }) {
         let icon = severity_icon(&finding.severity);
-        lines.push(format!("{} {}", icon, finding.message));
+        let suffix = if finding.is_self { " \u{2014} skipped (self)" } else { "" };
+        lines.push(format!("{} {}{}", icon, finding.message, suffix));
     }
 
     // Fix results section.
@@ -1310,6 +1312,42 @@ mod tests {
             results[0].message.starts_with("Killed session"),
             "non-self finding must go through kill path, got: {}",
             results[0].message
+        );
+    }
+
+    #[test]
+    fn format_report_annotates_is_self_findings_with_skipped_self() {
+        let report = HealReport {
+            findings: vec![HealFinding {
+                category: HealCategory::OrphanedSession,
+                severity: Severity::Warning,
+                message: "Session \"orchardist\" has no matching worktree (path: /tmp)".to_string(),
+                action: HealAction::KillSession("orchardist".to_string()),
+                is_self: true,
+            }],
+        };
+        let text = format_report(&report, None);
+        assert!(
+            text.contains("skipped (self)"),
+            "format_report must annotate is_self findings with 'skipped (self)': {text}"
+        );
+    }
+
+    #[test]
+    fn format_report_leaves_non_is_self_kill_session_findings_unchanged() {
+        let report = HealReport {
+            findings: vec![HealFinding {
+                category: HealCategory::OrphanedSession,
+                severity: Severity::Warning,
+                message: "Session \"orchardist\" has no matching worktree (path: /tmp)".to_string(),
+                action: HealAction::KillSession("orchardist".to_string()),
+                is_self: false,
+            }],
+        };
+        let text = format_report(&report, None);
+        assert!(
+            !text.contains("skipped (self)"),
+            "format_report must not annotate non-is_self findings: {text}"
         );
     }
 

--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -420,6 +420,14 @@ pub fn apply_fixes(findings: &[HealFinding]) -> Vec<FixResult> {
     for finding in findings {
         match &finding.action {
             HealAction::KillSession(name) => {
+                if finding.is_self {
+                    results.push(FixResult {
+                        message: format!("Skipped session \"{}\" — refusing to kill self", name),
+                        success: true,
+                        error: None,
+                    });
+                    continue;
+                }
                 let result = tmux::kill_tmux_session(name);
                 results.push(FixResult {
                     message: format!("Killed session \"{}\"", name),
@@ -1240,5 +1248,56 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn apply_fixes_skips_kill_session_for_is_self_finding() {
+        let finding = HealFinding {
+            category: HealCategory::OrphanedSession,
+            severity: Severity::Warning,
+            message: "Session \"orchardist\" has no matching worktree".to_string(),
+            action: HealAction::KillSession("orchardist".into()),
+            is_self: true,
+        };
+
+        let results = apply_fixes(&[finding]);
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].success, "skip result must be success=true");
+        assert!(
+            results[0].message.starts_with("Skipped session"),
+            "message must start with 'Skipped session', got: {}",
+            results[0].message
+        );
+        assert!(
+            results[0].error.is_none(),
+            "skip result must have no error"
+        );
+    }
+
+    #[test]
+    fn apply_fixes_runs_kill_session_when_is_self_is_false() {
+        // Use a session name that certainly does not exist on the host.
+        // tmux kill-session on a nonexistent session emits an error to stderr
+        // but Command::status() still returns Ok — so kill_tmux_session always
+        // returns Ok for our purposes; success will be true regardless.
+        let finding = HealFinding {
+            category: HealCategory::OrphanedSession,
+            severity: Severity::Warning,
+            message: "Session has no matching worktree".to_string(),
+            action: HealAction::KillSession(
+                "orchardist-test-no-such-session-issue361-xxx".into(),
+            ),
+            is_self: false,
+        };
+
+        let results = apply_fixes(&[finding]);
+
+        assert_eq!(results.len(), 1);
+        assert!(
+            results[0].message.starts_with("Killed session"),
+            "non-self finding must go through kill path, got: {}",
+            results[0].message
+        );
     }
 }

--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -111,6 +111,18 @@ impl HealReport {
     }
 }
 
+/// Returns the first finding (if any) that is both is_self and Severity::Error.
+///
+/// When such a finding exists, the heal CLI must abort before applying any
+/// fixes — the invoking session is in an unknown-bad state, and silent
+/// repairs are unsafe. See AC #2 of issue #361.
+pub fn detect_self_error(report: &HealReport) -> Option<&HealFinding> {
+    report
+        .findings
+        .iter()
+        .find(|f| f.is_self && f.severity == Severity::Error)
+}
+
 /// Result of applying a single heal action.
 #[derive(Debug, Serialize)]
 pub struct FixResult {
@@ -1298,6 +1310,93 @@ mod tests {
             results[0].message.starts_with("Killed session"),
             "non-self finding must go through kill path, got: {}",
             results[0].message
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // detect_self_error (#361)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn detect_self_error_returns_finding_for_dead_session_directory_self() {
+        // One DeadSessionDirectory finding with is_self=true, severity Error.
+        let finding = HealFinding {
+            category: HealCategory::DeadSessionDirectory,
+            severity: Severity::Error,
+            message: "Session \"orchardist\" points to non-existent path".to_string(),
+            action: HealAction::KillSession("orchardist".to_string()),
+            is_self: true,
+        };
+        let report = HealReport {
+            findings: vec![finding.clone()],
+        };
+
+        let result = detect_self_error(&report);
+        assert!(result.is_some(), "should return Some for self + Error finding");
+        // Confirm it is the same finding (by matching the message).
+        assert_eq!(result.unwrap().message, finding.message);
+    }
+
+    #[test]
+    fn detect_self_error_returns_none_when_self_finding_is_warning_severity() {
+        // is_self=true but severity is Warning — must return None.
+        let finding = HealFinding {
+            category: HealCategory::OrphanedSession,
+            severity: Severity::Warning,
+            message: "Session has no matching worktree".to_string(),
+            action: HealAction::KillSession("orchardist".to_string()),
+            is_self: true,
+        };
+        let report = HealReport {
+            findings: vec![finding],
+        };
+
+        let result = detect_self_error(&report);
+        assert!(
+            result.is_none(),
+            "Warning-severity self finding must not trigger detect_self_error"
+        );
+    }
+
+    #[test]
+    fn detect_self_error_returns_none_when_no_self_findings() {
+        // Findings exist but none has is_self=true.
+        let finding = HealFinding {
+            category: HealCategory::DeadSessionDirectory,
+            severity: Severity::Error,
+            message: "Session points to non-existent path".to_string(),
+            action: HealAction::KillSession("other-session".to_string()),
+            is_self: false,
+        };
+        let report = HealReport {
+            findings: vec![finding],
+        };
+
+        let result = detect_self_error(&report);
+        assert!(
+            result.is_none(),
+            "no is_self findings → detect_self_error must return None"
+        );
+    }
+
+    #[test]
+    fn detect_self_error_skips_non_self_error_findings() {
+        // Severity::Error but is_self=false — must return None.
+        let finding = HealFinding {
+            category: HealCategory::DeadSessionDirectory,
+            severity: Severity::Error,
+            message: "Other session dead".to_string(),
+            action: HealAction::KillSession("other".to_string()),
+            is_self: false,
+        };
+        let report = HealReport {
+            findings: vec![finding],
+        };
+
+        let result = detect_self_error(&report);
+        assert!(
+            result.is_none(),
+            "Error severity without is_self must not trigger detect_self_error"
         );
     }
 }

--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -83,6 +83,11 @@ pub struct HealFinding {
     pub message: String,
     /// The action to take, if any.
     pub action: HealAction,
+    /// True when this finding targets the tmux session that invoked `orchard heal`.
+    ///
+    /// When `is_self` is true, `apply_fixes` must skip the action rather than
+    /// killing the session — a self-kill would terminate the running process.
+    pub is_self: bool,
 }
 
 /// The complete output of a heal diagnosis run.
@@ -162,16 +167,20 @@ pub struct HealClaudeState {
 /// - `claude_states`: stale-check candidates from `/tmp/orchard-claude-*.json`
 /// - `cache_files`: cache file names from `~/.cache/orchard/`
 /// - `known_repo_slugs`: repo slugs from global config (e.g. `["owner/repo"]`)
+/// - `current_session`: name of the tmux session invoking heal, if any.
+///   `KillSession` findings whose target matches this name will have `is_self`
+///   set to `true`, allowing callers to skip self-destructive kills.
 pub fn diagnose(
     sessions: &[TmuxSession],
     worktrees: &[HealWorktree],
     claude_states: &[HealClaudeState],
     cache_files: &[String],
     known_repo_slugs: &[String],
+    current_session: Option<&str>,
 ) -> HealReport {
     let mut findings = Vec::new();
 
-    check_sessions(sessions, worktrees, &mut findings);
+    check_sessions(sessions, worktrees, &mut findings, current_session);
     check_claude_states(claude_states, sessions, &mut findings);
     check_cache_files(cache_files, known_repo_slugs, &mut findings);
     check_worktree_pr_states(worktrees, &mut findings);
@@ -190,6 +199,7 @@ fn check_sessions(
     sessions: &[TmuxSession],
     worktrees: &[HealWorktree],
     findings: &mut Vec<HealFinding>,
+    current_session: Option<&str>,
 ) {
     let worktree_paths: Vec<&str> = worktrees.iter().map(|w| w.path.as_str()).collect();
 
@@ -200,6 +210,7 @@ fn check_sessions(
         let effective_path = session.active_pane_cwd.as_deref().unwrap_or(&session.path);
         let path_exists = Path::new(effective_path).exists();
         let path_has_worktree = worktree_paths.contains(&effective_path);
+        let is_self = current_session.map(|s| s == session.name).unwrap_or(false);
 
         if !path_exists {
             findings.push(HealFinding {
@@ -210,6 +221,7 @@ fn check_sessions(
                     session.name, effective_path
                 ),
                 action: HealAction::KillSession(session.name.clone()),
+                is_self,
             });
         } else if !path_has_worktree {
             findings.push(HealFinding {
@@ -220,6 +232,7 @@ fn check_sessions(
                     session.name, effective_path
                 ),
                 action: HealAction::KillSession(session.name.clone()),
+                is_self,
             });
         }
     }
@@ -242,6 +255,7 @@ fn check_claude_states(
                     cs.tmux_session, cs.path
                 ),
                 action: HealAction::DeleteFile(cs.path.clone()),
+                is_self: false,
             });
         }
     }
@@ -267,6 +281,7 @@ fn check_cache_files(
                     filename, repo_slug
                 ),
                 action: HealAction::DeleteFile(cache_path.to_string_lossy().to_string()),
+                is_self: false,
             });
         }
     }
@@ -288,6 +303,7 @@ fn check_worktree_pr_states(worktrees: &[HealWorktree], findings: &mut Vec<HealF
                 severity: Severity::Warning,
                 message: format!("Worktree \"{}\" is stale: {} merged", wt.path, pr_label),
                 action: HealAction::FlagForCleanup(wt.path.clone()),
+                is_self: false,
             });
         } else if pr_state.eq_ignore_ascii_case("closed") {
             findings.push(HealFinding {
@@ -298,6 +314,7 @@ fn check_worktree_pr_states(worktrees: &[HealWorktree], findings: &mut Vec<HealF
                     wt.path, pr_label
                 ),
                 action: HealAction::FlagForCleanup(wt.path.clone()),
+                is_self: false,
             });
         }
     }
@@ -315,6 +332,7 @@ fn check_worktree_issue_states(worktrees: &[HealWorktree], findings: &mut Vec<He
                 severity: Severity::Warning,
                 message: format!("Worktree \"{}\" is stale: linked issue is closed", wt.path),
                 action: HealAction::FlagForCleanup(wt.path.clone()),
+                is_self: false,
             });
         }
     }
@@ -346,6 +364,7 @@ fn check_session_naming(
                     "Rename session \"{}\" to \"{}\"",
                     session.name, expected
                 )),
+                is_self: false,
             });
         }
     }
@@ -381,6 +400,7 @@ fn check_multiple_sessions_per_worktree(
                     wt.path,
                     matching.len()
                 )),
+                is_self: false,
             });
         }
     }
@@ -683,7 +703,7 @@ mod tests {
             "/tmp/nonexistent-worktree",
         )];
         let worktrees = vec![make_worktree("/workspace/main", "main")];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
 
         // Path doesn't exist → DeadSessionDirectory, not orphaned
         let finding = &report.findings[0];
@@ -696,7 +716,7 @@ mod tests {
         // Use a real path that exists but is not a worktree.
         let sessions = vec![make_session("myrepo_old-feature", "/tmp")];
         let worktrees = vec![make_worktree("/workspace/main", "main")];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
 
         let finding = report
             .findings
@@ -717,7 +737,7 @@ mod tests {
     fn detect_dead_session_directory() {
         let sessions = vec![make_session("myrepo_gone", "/tmp/nonexistent-path-xyz")];
         let worktrees = vec![];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
 
         let finding = report
             .findings
@@ -740,7 +760,7 @@ mod tests {
             path: "/tmp/orchard-claude-abc123.json".to_string(),
             tmux_session: "myrepo_dead".to_string(),
         }];
-        let report = diagnose(&sessions, &[], &claude_states, &[], &[]);
+        let report = diagnose(&sessions, &[], &claude_states, &[], &[], None);
 
         let finding = report
             .findings
@@ -759,7 +779,7 @@ mod tests {
             path: "/tmp/orchard-claude-abc123.json".to_string(),
             tmux_session: "myrepo_live".to_string(),
         }];
-        let report = diagnose(&sessions, &[], &claude_states, &[], &[]);
+        let report = diagnose(&sessions, &[], &claude_states, &[], &[], None);
 
         let stale = report
             .findings
@@ -779,7 +799,7 @@ mod tests {
     fn detect_stale_cache_file_for_unknown_repo() {
         let cache_files = vec!["ghost_repo_issues.json".to_string()];
         let known_slugs = vec!["owner/my-project".to_string()];
-        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs);
+        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs, None);
 
         let finding = report
             .findings
@@ -793,7 +813,7 @@ mod tests {
     fn no_stale_cache_finding_for_known_repo() {
         let cache_files = vec!["owner_myproject_issues.json".to_string()];
         let known_slugs = vec!["owner/myproject".to_string()];
-        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs);
+        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs, None);
 
         let stale = report
             .findings
@@ -806,7 +826,7 @@ mod tests {
     fn tmux_sessions_cache_file_ignored() {
         let cache_files = vec!["tmux_sessions.json".to_string()];
         let known_slugs: Vec<String> = vec![];
-        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs);
+        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs, None);
 
         let stale = report
             .findings
@@ -824,7 +844,7 @@ mod tests {
         let mut wt = make_worktree(".worktrees/issue3-tests", "issue3/tests");
         wt.pr_state = Some("merged".to_string());
         wt.pr_number = Some(12);
-        let report = diagnose(&[], &[wt], &[], &[], &[]);
+        let report = diagnose(&[], &[wt], &[], &[], &[], None);
 
         let finding = report
             .findings
@@ -844,7 +864,7 @@ mod tests {
         let mut wt = make_worktree(".worktrees/issue5-fix", "issue5/fix");
         wt.pr_state = Some("closed".to_string());
         wt.pr_number = Some(15);
-        let report = diagnose(&[], &[wt], &[], &[], &[]);
+        let report = diagnose(&[], &[wt], &[], &[], &[], None);
 
         let finding = report
             .findings
@@ -858,7 +878,7 @@ mod tests {
         let mut wt = make_worktree(".worktrees/issue3-tests", "issue3/tests");
         wt.pr_state = Some("merged".to_string());
         wt.pr_number = Some(12);
-        let report = diagnose(&[], &[wt], &[], &[], &[]);
+        let report = diagnose(&[], &[wt], &[], &[], &[], None);
 
         let results = apply_fixes(&report.findings);
         // FlagForCleanup produces a result but does not kill/delete anything.
@@ -875,7 +895,7 @@ mod tests {
     fn flag_worktree_with_closed_issue_no_pr() {
         let mut wt = make_worktree(".worktrees/issue8-refactor", "issue8/refactor");
         wt.issue_state = Some("closed".to_string());
-        let report = diagnose(&[], &[wt], &[], &[], &[]);
+        let report = diagnose(&[], &[wt], &[], &[], &[], None);
 
         let finding = report
             .findings
@@ -890,7 +910,7 @@ mod tests {
         let mut wt = make_worktree(".worktrees/issue8-refactor", "issue8/refactor");
         wt.issue_state = Some("closed".to_string());
         wt.pr_state = Some("open".to_string());
-        let report = diagnose(&[], &[wt], &[], &[], &[]);
+        let report = diagnose(&[], &[wt], &[], &[], &[], None);
 
         let issue_finding = report
             .findings
@@ -911,7 +931,7 @@ mod tests {
         let sessions = vec![make_session("wrong-name", "/workspace/feature-login")];
         let mut wt = make_worktree("/workspace/feature-login", "feature/login");
         wt.expected_session_name = Some("myrepo_feature-login".to_string());
-        let report = diagnose(&sessions, &[wt], &[], &[], &[]);
+        let report = diagnose(&sessions, &[wt], &[], &[], &[], None);
 
         let finding = report
             .findings
@@ -930,7 +950,7 @@ mod tests {
         )];
         let mut wt = make_worktree("/workspace/feature-login", "feature/login");
         wt.expected_session_name = Some("myrepo_feature-login".to_string());
-        let report = diagnose(&sessions, &[wt], &[], &[], &[]);
+        let report = diagnose(&sessions, &[wt], &[], &[], &[], None);
 
         let mismatch = report
             .findings
@@ -950,7 +970,7 @@ mod tests {
             make_session("extra-session", "/workspace/issue10-api"),
         ];
         let wt = make_worktree("/workspace/issue10-api", "issue10/api");
-        let report = diagnose(&sessions, &[wt], &[], &[], &[]);
+        let report = diagnose(&sessions, &[wt], &[], &[], &[], None);
 
         let finding = report
             .findings
@@ -972,7 +992,7 @@ mod tests {
         let path = tmp.to_string_lossy().to_string();
         let sessions = vec![make_session("myrepo_main", &path)];
         let worktrees = vec![make_worktree(&path, "main")];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
 
         assert!(report.is_all_ok(), "should report all-ok");
         assert_eq!(report.findings.len(), 0);
@@ -986,7 +1006,7 @@ mod tests {
     fn format_report_suggests_fix_when_actionable() {
         let sessions = vec![make_session("orphan", "/tmp")];
         let worktrees = vec![];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
         let text = format_report(&report, None);
 
         assert!(
@@ -1002,7 +1022,7 @@ mod tests {
         let path = tmp.to_string_lossy().to_string();
         let sessions = vec![make_session("myrepo_main", &path)];
         let worktrees = vec![make_worktree(&path, "main")];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
         let text = format_report(&report, None);
 
         assert!(
@@ -1082,7 +1102,7 @@ mod tests {
         };
 
         let worktrees = vec![make_worktree(&worktree_path, "issue297/fix")];
-        let report = diagnose(&[session], &worktrees, &[], &[], &[]);
+        let report = diagnose(&[session], &worktrees, &[], &[], &[], None);
 
         let bad = report.findings.iter().find(|f| {
             matches!(
@@ -1116,8 +1136,109 @@ mod tests {
                 severity: Severity::Warning,
                 message: "orphaned".to_string(),
                 action: HealAction::KillSession("orphan".to_string()),
+                is_self: false,
             }],
         };
         assert!(!report.is_all_ok());
+    }
+
+    // -----------------------------------------------------------------------
+    // Self-protection: is_self flag (#361)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn diagnose_marks_kill_session_finding_as_is_self_when_name_matches_current_session() {
+        // Session "orchardist" at /tmp — path exists but no matching worktree
+        // → OrphanedSession with KillSession("orchardist").
+        let sessions = vec![make_session("orchardist", "/tmp")];
+        let worktrees: Vec<HealWorktree> = vec![];
+
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| matches!(&f.action, HealAction::KillSession(n) if n == "orchardist"));
+        assert!(
+            finding.is_some(),
+            "should produce a KillSession(\"orchardist\") finding"
+        );
+        assert!(
+            finding.unwrap().is_self,
+            "KillSession finding for current session must have is_self == true"
+        );
+    }
+
+    #[test]
+    fn diagnose_does_not_mark_non_matching_kill_session_findings_as_is_self() {
+        // Two sessions at /tmp, no worktrees → two OrphanedSession findings.
+        let sessions = vec![
+            make_session("orchardist", "/tmp"),
+            make_session("another", "/tmp"),
+        ];
+        let worktrees: Vec<HealWorktree> = vec![];
+
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+
+        let orchardist_finding = report
+            .findings
+            .iter()
+            .find(|f| matches!(&f.action, HealAction::KillSession(n) if n == "orchardist"));
+        let another_finding = report
+            .findings
+            .iter()
+            .find(|f| matches!(&f.action, HealAction::KillSession(n) if n == "another"));
+
+        assert!(orchardist_finding.is_some(), "should have finding for orchardist");
+        assert!(another_finding.is_some(), "should have finding for another");
+
+        assert!(
+            orchardist_finding.unwrap().is_self,
+            "orchardist finding must have is_self == true"
+        );
+        assert!(
+            !another_finding.unwrap().is_self,
+            "another finding must have is_self == false"
+        );
+    }
+
+    #[test]
+    fn diagnose_with_current_session_none_never_sets_is_self_true() {
+        // Session "orchardist" at /tmp, no worktrees → KillSession, current_session = None.
+        let sessions = vec![make_session("orchardist", "/tmp")];
+        let worktrees: Vec<HealWorktree> = vec![];
+
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+
+        for finding in &report.findings {
+            assert!(
+                !finding.is_self,
+                "is_self must be false when current_session is None, but found is_self=true on: {:?}",
+                finding
+            );
+        }
+    }
+
+    #[test]
+    fn is_self_is_false_on_findings_whose_action_is_not_kill_session() {
+        // A stale Claude state file produces DeleteFile — not KillSession.
+        // is_self must remain false regardless of current_session.
+        let sessions: Vec<TmuxSession> = vec![];
+        let claude_states = vec![HealClaudeState {
+            path: "/tmp/orchard-claude-abc123.json".to_string(),
+            tmux_session: "anything".to_string(),
+        }];
+
+        let report = diagnose(&sessions, &[], &claude_states, &[], &[], Some("anything"));
+
+        for finding in &report.findings {
+            if !matches!(finding.action, HealAction::KillSession(_)) {
+                assert!(
+                    !finding.is_self,
+                    "is_self must be false on non-KillSession finding: {:?}",
+                    finding
+                );
+            }
+        }
     }
 }

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -213,6 +213,10 @@ fn handle_heal(fix: bool, json: bool) {
         eprintln!("heal: tmux cache refresh failed (using cached data): {e}");
     }
 
+    // Capture the invoking session name before building the sessions list so
+    // diagnose() can mark self-targeting KillSession findings with is_self=true.
+    let current_session = orchard::tmux::current_session_name();
+
     // Build TmuxSession list from the cache, enriching each entry with the
     // live active-pane cwd derived from pane_paths + pane_active.
     let sessions: Vec<TmuxSession> = read_cache::<CachedTmuxSession>(&tmux_cache_path(None))
@@ -244,8 +248,22 @@ fn handle_heal(fix: bool, json: bool) {
         &claude_states,
         &cache_files,
         &known_slugs,
-        None, // Phase 4 will wire in the current tmux session name
+        current_session.as_deref(),
     );
+
+    // Abort before applying any destructive fixes when the invoking session
+    // has an Error-severity self-classification. A session in an unknown-bad
+    // state cannot safely kill itself. Dry-run and JSON modes always continue
+    // so consumers see the is_self danger flag without triggering the abort.
+    if fix {
+        if let Some(self_err) = heal::detect_self_error(&report) {
+            eprintln!(
+                "orchard heal: refusing to kill the session I'm running in; run from outside tmux"
+            );
+            eprintln!("  finding: {}", self_err.message);
+            std::process::exit(1);
+        }
+    }
 
     if json {
         let output = serde_json::to_string_pretty(&report).unwrap_or_else(|e| {

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -255,14 +255,14 @@ fn handle_heal(fix: bool, json: bool) {
     // has an Error-severity self-classification. A session in an unknown-bad
     // state cannot safely kill itself. Dry-run and JSON modes always continue
     // so consumers see the is_self danger flag without triggering the abort.
-    if fix {
-        if let Some(self_err) = heal::detect_self_error(&report) {
-            eprintln!(
-                "orchard heal: refusing to kill the session I'm running in; run from outside tmux"
-            );
-            eprintln!("  finding: {}", self_err.message);
-            std::process::exit(1);
-        }
+    if fix
+        && let Some(self_err) = heal::detect_self_error(&report)
+    {
+        eprintln!(
+            "orchard heal: refusing to kill the session I'm running in; run from outside tmux"
+        );
+        eprintln!("  finding: {}", self_err.message);
+        std::process::exit(1);
     }
 
     if json {

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -244,6 +244,7 @@ fn handle_heal(fix: bool, json: bool) {
         &claude_states,
         &cache_files,
         &known_slugs,
+        None, // Phase 4 will wire in the current tmux session name
     );
 
     if json {

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -255,9 +255,7 @@ fn handle_heal(fix: bool, json: bool) {
     // has an Error-severity self-classification. A session in an unknown-bad
     // state cannot safely kill itself. Dry-run and JSON modes always continue
     // so consumers see the is_self danger flag without triggering the abort.
-    if fix
-        && let Some(self_err) = heal::detect_self_error(&report)
-    {
+    if fix && let Some(self_err) = heal::detect_self_error(&report) {
         eprintln!(
             "orchard heal: refusing to kill the session I'm running in; run from outside tmux"
         );

--- a/crates/orchard/src/tmux.rs
+++ b/crates/orchard/src/tmux.rs
@@ -3,7 +3,7 @@
 //! Lists active sessions, resolves pane titles, creates new sessions for
 //! worktrees, switches the current client to a session, and orchestrates the
 //! full "switch to worktree" flow including PR-aware notification banners.
-use std::process::Command;
+use std::process::{Command, Output};
 
 use anyhow::{Context, Result};
 
@@ -390,6 +390,50 @@ pub fn create_session(opts: &SwitchToSessionOptions) -> Result<()> {
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Current-session detection
+// ---------------------------------------------------------------------------
+
+/// Inner implementation, accepting the `$TMUX` env value and an executor
+/// closure. Extracted for hermetic unit testing without env-var manipulation.
+///
+/// `tmux_var` is the value of `$TMUX` (pass `None` to simulate "not inside tmux").
+/// `exec` is called to run `tmux display-message -p '#S'`; it must return an
+/// `std::io::Result<Output>`.
+pub(crate) fn current_session_name_inner(
+    tmux_var: Option<&str>,
+    exec: impl Fn() -> std::io::Result<Output>,
+) -> Option<String> {
+    // Not inside tmux — $TMUX is unset.
+    tmux_var?;
+
+    let output = exec().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let name = String::from_utf8_lossy(&output.stdout);
+    let trimmed = name.trim().to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+/// Returns the name of the tmux session this process is running inside, if any.
+///
+/// Returns `None` when not inside tmux (`$TMUX` env var unset) or when
+/// `tmux display-message -p '#S'` fails (e.g. the tmux server is gone).
+/// The returned string is trimmed of trailing whitespace/newlines.
+pub fn current_session_name() -> Option<String> {
+    let tmux_var = std::env::var("TMUX").ok();
+    current_session_name_inner(tmux_var.as_deref(), || {
+        Command::new("tmux")
+            .args(["display-message", "-p", "#S"])
+            .output()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -573,5 +617,35 @@ mod tests {
         // not exist tmux exits non-zero, so the function must return Err.
         let result = zoom_pane("nonexistent-session-xyz", "0.0");
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // current_session_name
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn current_session_name_returns_none_when_tmux_env_unset() {
+        // Pass None for tmux_var to simulate $TMUX being unset.
+        // The exec closure must never be called in this case.
+        let result = current_session_name_inner(None, || {
+            panic!("exec should not be called when TMUX is unset");
+        });
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn current_session_name_returns_some_when_inside_tmux() {
+        // This test is only meaningful when actually running inside tmux.
+        if std::env::var("TMUX").is_err() {
+            return;
+        }
+        let name = current_session_name();
+        assert!(name.is_some(), "expected Some(_) when inside tmux");
+        let name = name.unwrap();
+        assert!(!name.is_empty(), "session name must not be empty");
+        assert!(
+            !name.contains('\n'),
+            "session name must not contain newlines"
+        );
     }
 }

--- a/crates/orchard/tests/heal_test.rs
+++ b/crates/orchard/tests/heal_test.rs
@@ -504,3 +504,64 @@ fn regression_heal_must_never_kill_invoking_session() {
         "heal --fix must emit a skip result for the invoking session \"orchardist\""
     );
 }
+
+// ---------------------------------------------------------------------------
+// Self-protection: format_report annotates is_self findings (#361)
+// ---------------------------------------------------------------------------
+
+/// AC #3 (dry-run): format_report marks the invoking session as "skipped (self)".
+#[test]
+fn format_report_marks_invoking_session_as_skipped() {
+    // Session "orchardist" at /tmp — path exists but no matching worktree
+    // → OrphanedSession with KillSession("orchardist") and is_self=true.
+    let sessions = vec![session("orchardist", "/tmp")];
+    let worktrees: Vec<orchard::heal::HealWorktree> = vec![];
+
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+    let text = format_report(&report, None);
+
+    assert!(
+        text.contains("skipped (self)"),
+        "format_report must annotate the invoking session as 'skipped (self)': {text}"
+    );
+    assert!(
+        text.contains("orchardist"),
+        "format_report output must mention the session name 'orchardist': {text}"
+    );
+}
+
+/// AC #3 (JSON): the is_self field is serialized and exposed for the invoking session finding.
+#[test]
+fn json_output_exposes_is_self_field() {
+    let sessions = vec![session("orchardist", "/tmp")];
+    let worktrees: Vec<orchard::heal::HealWorktree> = vec![];
+
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+    let json_str = serde_json::to_string(&report).expect("serialize report");
+    let json: serde_json::Value = serde_json::from_str(&json_str).expect("parse json");
+
+    let findings = json
+        .get("findings")
+        .expect("should have findings field")
+        .as_array()
+        .expect("findings should be an array");
+
+    // Find the finding whose action targets "orchardist".
+    let orchardist_finding = findings.iter().find(|f| {
+        f.get("action")
+            .and_then(|a| a.get("value"))
+            .and_then(|v| v.as_str())
+            .map(|s| s == "orchardist")
+            .unwrap_or(false)
+    });
+
+    assert!(
+        orchardist_finding.is_some(),
+        "should find a finding targeting orchardist in JSON: {json_str}"
+    );
+    assert_eq!(
+        orchardist_finding.unwrap().get("is_self"),
+        Some(&serde_json::Value::Bool(true)),
+        "is_self must be true for the invoking session finding: {json_str}"
+    );
+}

--- a/crates/orchard/tests/heal_test.rs
+++ b/crates/orchard/tests/heal_test.rs
@@ -414,3 +414,44 @@ fn json_output_contains_findings_array() {
         assert!(first.get("action").is_some(), "finding should have action");
     }
 }
+
+// ---------------------------------------------------------------------------
+// Regression: must never kill self (#361)
+// ---------------------------------------------------------------------------
+
+/// Regression for issue #361: heal --fix from inside a tmux session must not kill the invoking session.
+#[test]
+fn regression_heal_must_never_kill_invoking_session() {
+    // Build a TmuxSession named "orchardist" pointing to /tmp.
+    // /tmp exists on disk so we don't trip the dead-path (DeadSessionDirectory) branch,
+    // but there is no matching worktree → this produces an OrphanedSession finding
+    // with action KillSession("orchardist").
+    let sessions = vec![session("orchardist", "/tmp")];
+    let worktrees: Vec<orchard::heal::HealWorktree> = vec![];
+
+    // Pass `Some("orchardist")` as the `current_session` argument.
+    // TODAY diagnose() only accepts 5 positional args — this 6th arg is the one
+    // the fix will add. Passing it here causes a compile error, which is the
+    // expected failing-first signal for Phase 1 of TDD.
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+
+    let fix_results = orchard::heal::apply_fixes(&report.findings);
+
+    // The invoking session must NOT be killed.
+    let killed = fix_results
+        .iter()
+        .any(|r| r.message.starts_with("Killed session \"orchardist\""));
+    assert!(
+        !killed,
+        "heal --fix must not kill the invoking session \"orchardist\""
+    );
+
+    // There must be at least one skip result for the invoking session.
+    let skipped = fix_results
+        .iter()
+        .any(|r| r.message.starts_with("Skipped session \"orchardist\""));
+    assert!(
+        skipped,
+        "heal --fix must emit a skip result for the invoking session \"orchardist\""
+    );
+}

--- a/crates/orchard/tests/heal_test.rs
+++ b/crates/orchard/tests/heal_test.rs
@@ -615,8 +615,10 @@ fn regression_full_pipeline_from_inside_named_tmux_session_never_kills_self() {
 ///
 /// This test pins down that `is_self` is computed from the session name match
 /// alone — not from pane state or active_pane_cwd. Two scenarios are checked:
+///
 /// 1. Plain session (no active_pane_cwd).
 /// 2. Session with active_pane_cwd set (simulating a sister window that has cd'd elsewhere).
+///
 /// Both must produce `is_self == true`.
 #[test]
 fn regression_sister_window_of_invoking_session_is_still_treated_as_self() {

--- a/crates/orchard/tests/heal_test.rs
+++ b/crates/orchard/tests/heal_test.rs
@@ -4,6 +4,7 @@
 /// corresponding to acceptance criteria from `specs/features/orchard-heal.feature`.
 use orchard::heal::{
     HealAction, HealCategory, HealClaudeState, HealWorktree, Severity, diagnose, format_report,
+    apply_fixes,
 };
 use orchard::types::TmuxSession;
 
@@ -418,6 +419,54 @@ fn json_output_contains_findings_array() {
 // ---------------------------------------------------------------------------
 // Regression: must never kill self (#361)
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Self-protection: outside tmux (#361)
+// ---------------------------------------------------------------------------
+
+/// When current_session is None (running outside tmux), no self-protection is
+/// applied: the OrphanedSession finding has is_self == false, and apply_fixes
+/// goes through the kill path (not the skip path) for an otherwise-applicable
+/// KillSession action.
+///
+/// Using a session name that cannot exist on the host so the kill is harmless.
+#[test]
+fn outside_tmux_no_self_protection_applied() {
+    // Use a unique session name that will not exist on any test runner.
+    let session_name = "orchardist-test-issue361-no-such-session";
+
+    // Session at /tmp — path exists but no matching worktree → OrphanedSession.
+    let sessions = vec![session(session_name, "/tmp")];
+    let worktrees: Vec<HealWorktree> = vec![];
+
+    // current_session = None simulates running outside tmux.
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.category == HealCategory::OrphanedSession);
+    assert!(
+        finding.is_some(),
+        "should produce an OrphanedSession finding: {:?}",
+        report.findings
+    );
+    assert!(
+        !finding.unwrap().is_self,
+        "is_self must be false when current_session is None"
+    );
+
+    // apply_fixes must go through the kill path, not skip.
+    let fix_results = apply_fixes(&report.findings);
+    let kill_result = fix_results
+        .iter()
+        .find(|r| r.message.starts_with("Killed session"));
+    assert!(
+        kill_result.is_some(),
+        "apply_fixes must attempt kill (not skip) when is_self=false; got: {:?}",
+        fix_results.iter().map(|r| &r.message).collect::<Vec<_>>()
+    );
+}
 
 /// Regression for issue #361: heal --fix from inside a tmux session must not kill the invoking session.
 #[test]

--- a/crates/orchard/tests/heal_test.rs
+++ b/crates/orchard/tests/heal_test.rs
@@ -4,7 +4,7 @@
 /// corresponding to acceptance criteria from `specs/features/orchard-heal.feature`.
 use orchard::heal::{
     HealAction, HealCategory, HealClaudeState, HealWorktree, Severity, diagnose, format_report,
-    apply_fixes,
+    apply_fixes, detect_self_error,
 };
 use orchard::types::TmuxSession;
 
@@ -563,5 +563,157 @@ fn json_output_exposes_is_self_field() {
         orchardist_finding.unwrap().get("is_self"),
         Some(&serde_json::Value::Bool(true)),
         "is_self must be true for the invoking session finding: {json_str}"
+    );
+}
+
+// Regression: must never kill self (#361) — full coverage
+
+/// Full pipeline test: the invoking session is skipped while unrelated orphans are
+/// still killed.
+///
+/// Proves that self-protection isolates only the invoking session; other orphaned
+/// sessions that don't match the current session name still go through the kill path.
+#[test]
+fn regression_full_pipeline_from_inside_named_tmux_session_never_kills_self() {
+    // Both sessions point to /tmp (exists but not a worktree) → two OrphanedSession findings.
+    // Use a name that certainly does not exist on the test runner for the orphan.
+    let orphan_name = "myrepo_old-feature-test-issue361";
+    let sessions = vec![
+        session("orchardist", "/tmp"),
+        session(orphan_name, "/tmp"),
+    ];
+    let worktrees: Vec<HealWorktree> = vec![];
+
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+    let fix_results = apply_fixes(&report.findings);
+
+    // Self must be skipped, not killed.
+    let skipped = fix_results
+        .iter()
+        .any(|r| r.message.starts_with("Skipped session \"orchardist\""));
+    assert!(
+        skipped,
+        "must emit a skip result for the invoking session \"orchardist\"; got: {:?}",
+        fix_results.iter().map(|r| &r.message).collect::<Vec<_>>()
+    );
+
+    // Non-self orphan must still go through the kill path.
+    let killed = fix_results
+        .iter()
+        .any(|r| r.message.starts_with(&format!("Killed session \"{}\"", orphan_name)));
+    assert!(
+        killed,
+        "must attempt kill for non-self orphan \"{}\"; got: {:?}",
+        orphan_name,
+        fix_results.iter().map(|r| &r.message).collect::<Vec<_>>()
+    );
+}
+
+/// Sister windows inside the same tmux session share the `#S` session name.
+/// `current_session_name()` returns the session name regardless of which window
+/// invoked the command, so name-based self-detection covers sister windows automatically.
+///
+/// This test pins down that `is_self` is computed from the session name match
+/// alone — not from pane state or active_pane_cwd. Two scenarios are checked:
+/// 1. Plain session (no active_pane_cwd).
+/// 2. Session with active_pane_cwd set (simulating a sister window that has cd'd elsewhere).
+/// Both must produce `is_self == true`.
+#[test]
+fn regression_sister_window_of_invoking_session_is_still_treated_as_self() {
+    use orchard::types::TmuxSession;
+
+    // Scenario 1: plain session — no active_pane_cwd.
+    {
+        let sessions = vec![TmuxSession {
+            name: "orchardist".to_string(),
+            path: "/tmp".to_string(),
+            attached: false,
+            pane_title: None,
+            active_pane_cwd: None,
+        }];
+        let worktrees: Vec<HealWorktree> = vec![];
+
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::OrphanedSession);
+        assert!(
+            finding.is_some(),
+            "scenario 1: should produce an OrphanedSession finding"
+        );
+        assert!(
+            finding.unwrap().is_self,
+            "scenario 1 (no active_pane_cwd): is_self must be true when session name matches current_session"
+        );
+    }
+
+    // Scenario 2: session with active_pane_cwd set to an existing path — simulates a
+    // sister window that has cd'd to a different (but real) directory. The session name
+    // still matches current_session, so is_self must still be true regardless of the
+    // active pane path. We use /tmp so the path-exists check passes and we stay in the
+    // OrphanedSession branch (no matching worktree).
+    {
+        let sessions = vec![TmuxSession {
+            name: "orchardist".to_string(),
+            path: "/tmp".to_string(),
+            attached: false,
+            pane_title: None,
+            active_pane_cwd: Some("/tmp".to_string()),
+        }];
+        let worktrees: Vec<HealWorktree> = vec![];
+
+        let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.category == HealCategory::OrphanedSession);
+        assert!(
+            finding.is_some(),
+            "scenario 2: should produce an OrphanedSession finding"
+        );
+        assert!(
+            finding.unwrap().is_self,
+            "scenario 2 (with active_pane_cwd): is_self must be true — sister windows share \
+             the session name, so name-based self-detection covers them automatically"
+        );
+    }
+}
+
+/// Negative case for AC #2: only Error-severity self findings trigger the abort path.
+/// A Warning-severity OrphanedSession with is_self=true must NOT cause detect_self_error
+/// to return Some — that would abort heal for a normally "unregistered standalone session"
+/// classification, which is overly aggressive.
+#[test]
+fn regression_warning_severity_self_does_not_trigger_abort_path() {
+    // Session "orchardist" at /tmp — real path → OrphanedSession (Warning severity).
+    let sessions = vec![session("orchardist", "/tmp")];
+    let worktrees: Vec<HealWorktree> = vec![];
+
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+
+    // Confirm we actually got a self finding at Warning severity.
+    let self_finding = report
+        .findings
+        .iter()
+        .find(|f| f.is_self && f.category == HealCategory::OrphanedSession);
+    assert!(
+        self_finding.is_some(),
+        "test precondition: should have an OrphanedSession finding with is_self=true"
+    );
+    assert_eq!(
+        self_finding.unwrap().severity,
+        Severity::Warning,
+        "test precondition: the self finding must be Warning severity (not Error)"
+    );
+
+    // The abort gate must NOT fire for Warning-severity self findings.
+    let abort = detect_self_error(&report);
+    assert!(
+        abort.is_none(),
+        "detect_self_error must return None for Warning-severity self finding; \
+         only Error-severity self findings should abort the heal run"
     );
 }

--- a/crates/orchard/tests/heal_test.rs
+++ b/crates/orchard/tests/heal_test.rs
@@ -3,8 +3,8 @@
 /// These tests exercise the `heal::diagnose` pure function with realistic inputs,
 /// corresponding to acceptance criteria from `specs/features/orchard-heal.feature`.
 use orchard::heal::{
-    HealAction, HealCategory, HealClaudeState, HealWorktree, Severity, diagnose, format_report,
-    apply_fixes, detect_self_error,
+    HealAction, HealCategory, HealClaudeState, HealWorktree, Severity, apply_fixes,
+    detect_self_error, diagnose, format_report,
 };
 use orchard::types::TmuxSession;
 
@@ -578,10 +578,7 @@ fn regression_full_pipeline_from_inside_named_tmux_session_never_kills_self() {
     // Both sessions point to /tmp (exists but not a worktree) → two OrphanedSession findings.
     // Use a name that certainly does not exist on the test runner for the orphan.
     let orphan_name = "myrepo_old-feature-test-issue361";
-    let sessions = vec![
-        session("orchardist", "/tmp"),
-        session(orphan_name, "/tmp"),
-    ];
+    let sessions = vec![session("orchardist", "/tmp"), session(orphan_name, "/tmp")];
     let worktrees: Vec<HealWorktree> = vec![];
 
     let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
@@ -598,9 +595,10 @@ fn regression_full_pipeline_from_inside_named_tmux_session_never_kills_self() {
     );
 
     // Non-self orphan must still go through the kill path.
-    let killed = fix_results
-        .iter()
-        .any(|r| r.message.starts_with(&format!("Killed session \"{}\"", orphan_name)));
+    let killed = fix_results.iter().any(|r| {
+        r.message
+            .starts_with(&format!("Killed session \"{}\"", orphan_name))
+    });
     assert!(
         killed,
         "must attempt kill for non-self orphan \"{}\"; got: {:?}",

--- a/crates/orchard/tests/heal_test.rs
+++ b/crates/orchard/tests/heal_test.rs
@@ -47,7 +47,7 @@ fn dry_run_reports_findings_without_applying_fixes() {
         tmux_session: "myrepo_dead".to_string(),
     }];
 
-    let report = diagnose(&sessions, &worktrees, &claude_states, &[], &[]);
+    let report = diagnose(&sessions, &worktrees, &claude_states, &[], &[], None);
 
     // Orphaned session finding.
     let orphan = report
@@ -85,7 +85,7 @@ fn all_healthy_when_sessions_match_worktrees() {
     let sessions = vec![session("myrepo_main", &tmp)];
     let worktrees = vec![worktree(&tmp, "main")];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
 
     assert_eq!(report.findings.len(), 0, "should have no findings");
     assert!(report.is_all_ok());
@@ -108,7 +108,7 @@ fn orphaned_session_detected_when_path_exists_but_no_worktree_matches() {
     let sessions = vec![session("myrepo_old-feature", "/tmp")];
     let worktrees = vec![worktree("/workspace/other", "main")];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
 
     let finding = report
         .findings
@@ -138,7 +138,7 @@ fn dead_session_directory_detected_for_nonexistent_path() {
     )];
     let worktrees = vec![];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
 
     let finding = report
         .findings
@@ -162,7 +162,7 @@ fn stale_claude_state_detected_for_dead_session() {
         tmux_session: "myrepo_dead".to_string(),
     }];
 
-    let report = diagnose(&sessions, &[], &claude_states, &[], &[]);
+    let report = diagnose(&sessions, &[], &claude_states, &[], &[], None);
 
     let finding = report
         .findings
@@ -186,7 +186,7 @@ fn no_stale_claude_state_when_session_is_alive() {
         tmux_session: "myrepo_live".to_string(),
     }];
 
-    let report = diagnose(&sessions, &[], &claude_states, &[], &[]);
+    let report = diagnose(&sessions, &[], &claude_states, &[], &[], None);
 
     let stale = report
         .findings
@@ -208,7 +208,7 @@ fn stale_cache_file_flagged_for_unknown_repo() {
     let cache_files = vec!["ghost_repo_issues.json".to_string()];
     let known_slugs = vec!["owner/known-project".to_string()];
 
-    let report = diagnose(&[], &[], &[], &cache_files, &known_slugs);
+    let report = diagnose(&[], &[], &[], &cache_files, &known_slugs, None);
 
     let finding = report
         .findings
@@ -225,7 +225,7 @@ fn no_stale_cache_for_known_repo() {
     let cache_files = vec!["owner_myrepo_issues.json".to_string()];
     let known_slugs = vec!["owner/myrepo".to_string()];
 
-    let report = diagnose(&[], &[], &[], &cache_files, &known_slugs);
+    let report = diagnose(&[], &[], &[], &cache_files, &known_slugs, None);
 
     let stale = report
         .findings
@@ -245,7 +245,7 @@ fn merged_pr_worktree_flagged_for_manual_cleanup() {
     wt.pr_state = Some("merged".to_string());
     wt.pr_number = Some(12);
 
-    let report = diagnose(&[], &[wt], &[], &[], &[]);
+    let report = diagnose(&[], &[wt], &[], &[], &[], None);
 
     let finding = report
         .findings
@@ -266,7 +266,7 @@ fn closed_pr_worktree_flagged() {
     wt.pr_state = Some("closed".to_string());
     wt.pr_number = Some(15);
 
-    let report = diagnose(&[], &[wt], &[], &[], &[]);
+    let report = diagnose(&[], &[wt], &[], &[], &[], None);
 
     let finding = report
         .findings
@@ -282,7 +282,7 @@ fn fix_does_not_auto_delete_merged_pr_worktrees() {
     wt.pr_state = Some("merged".to_string());
     wt.pr_number = Some(12);
 
-    let report = diagnose(&[], &[wt], &[], &[], &[]);
+    let report = diagnose(&[], &[wt], &[], &[], &[], None);
     let fix_results = orchard::heal::apply_fixes(&report.findings);
 
     // All results should be FlagForCleanup (not KillSession or DeleteFile).
@@ -305,7 +305,7 @@ fn closed_issue_worktree_flagged_when_no_pr() {
     let mut wt = worktree(".worktrees/issue8-refactor", "issue8/refactor");
     wt.issue_state = Some("closed".to_string());
 
-    let report = diagnose(&[], &[wt], &[], &[], &[]);
+    let report = diagnose(&[], &[wt], &[], &[], &[], None);
 
     let finding = report
         .findings
@@ -329,7 +329,7 @@ fn session_naming_mismatch_detected() {
     let mut wt = worktree("/workspace/feature-login", "feature/login");
     wt.expected_session_name = Some("myrepo_feature-login".to_string());
 
-    let report = diagnose(&sessions, &[wt], &[], &[], &[]);
+    let report = diagnose(&sessions, &[wt], &[], &[], &[], None);
 
     let finding = report
         .findings
@@ -353,7 +353,7 @@ fn multiple_sessions_per_worktree_detected() {
     ];
     let wt = worktree("/workspace/issue10-api", "issue10/api");
 
-    let report = diagnose(&sessions, &[wt], &[], &[], &[]);
+    let report = diagnose(&sessions, &[wt], &[], &[], &[], None);
 
     let finding = report
         .findings
@@ -374,7 +374,7 @@ fn report_format_includes_icons() {
     let sessions = vec![session("orphan", "/tmp")]; // /tmp is a real path but not a worktree
     let worktrees = vec![];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
     let text = format_report(&report, None);
 
     // Should contain at least one icon character.
@@ -389,7 +389,7 @@ fn json_output_contains_findings_array() {
     let sessions = vec![session("orphan", "/tmp")];
     let worktrees = vec![];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[]);
+    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
     let json_str = serde_json::to_string(&report).expect("serialize report");
     let json: serde_json::Value = serde_json::from_str(&json_str).expect("parse json");
 

--- a/specs/features/heal-must-never-kill-self.feature
+++ b/specs/features/heal-must-never-kill-self.feature
@@ -1,0 +1,215 @@
+Feature: heal must never kill the invoking tmux session
+  As an orchard user running `orchard heal --fix` from inside a tmux session
+  I want heal to identify the session it is running in and refuse to kill it
+  So that running heal can never destroy the agent that just asked for cleanup
+
+  Background:
+    Given a repo with orchard configured
+    And tmux is available
+
+  # --- AC 1: Self-detection and exclusion from kill set ---
+
+  @e2e
+  Scenario: heal --fix from inside tmux excludes the invoking session from the kill set
+    Given the user is inside tmux session "orchardist"
+    And tmux session "orchardist" has no matching worktree (would otherwise be classified as orphan)
+    And tmux session "myrepo_old-feature" also has no matching worktree
+    When the user runs "orchard heal --fix"
+    Then the invoking session "orchardist" is NOT killed
+    And the orchard process continues running to completion
+    And tmux session "myrepo_old-feature" IS killed
+    And the report shows the invoking session was skipped
+
+  @integration
+  Scenario: handle_heal reads the invoking session name from tmux before diagnosing
+    Given the user is inside tmux session "orchardist"
+    When handle_heal runs
+    Then it queries the current tmux session name via "tmux display-message -p '#S'"
+    And it passes the resulting session name as current_session to diagnose
+
+  @integration
+  Scenario: outside tmux, heal behaves as before with no self-protection applied
+    Given the user is NOT inside tmux (the TMUX env var is unset)
+    And tmux session "myrepo_old-feature" has no matching worktree
+    When the user runs "orchard heal --fix"
+    Then current_session is None
+    And no finding is flagged is_self
+    And tmux session "myrepo_old-feature" IS killed
+
+  @integration
+  Scenario: $TMUX is set but tmux display-message fails (server gone)
+    Given the TMUX env var is set
+    And "tmux display-message -p '#S'" returns a non-zero exit code
+    When current_session_name is called
+    Then it returns None without panicking
+    And heal proceeds with no self-protection (degrades gracefully)
+
+  @unit
+  Scenario: diagnose marks a KillSession finding as is_self when name matches current_session
+    Given a tmux session named "orchardist" with no matching worktree
+    And current_session = Some("orchardist")
+    When diagnose is invoked
+    Then the resulting finding for "orchardist" has action KillSession("orchardist")
+    And that finding has is_self = true
+
+  @unit
+  Scenario: diagnose does not mark non-matching KillSession findings as is_self
+    Given a tmux session named "myrepo_old-feature" with no matching worktree
+    And current_session = Some("orchardist")
+    When diagnose is invoked
+    Then the finding for "myrepo_old-feature" has is_self = false
+
+  @unit
+  Scenario: diagnose with current_session = None never sets is_self = true
+    Given multiple orphaned tmux sessions
+    And current_session = None
+    When diagnose is invoked
+    Then every finding has is_self = false
+
+  @unit
+  Scenario: is_self is false on findings whose action is not KillSession
+    Given a stale claude state file
+    And a stale cache entry
+    And a worktree for a merged PR
+    And current_session = Some("orchardist")
+    When diagnose is invoked
+    Then the StaleClaudeState finding has is_self = false
+    And the StaleCache finding has is_self = false
+    And the MergedPrWorktree finding has is_self = false
+
+  @unit
+  Scenario: apply_fixes never invokes kill_tmux_session for an is_self finding
+    Given a finding with action KillSession("orchardist") and is_self = true
+    When apply_fixes runs
+    Then tmux::kill_tmux_session is NOT called for "orchardist"
+    And a FixResult is recorded with success = true
+    And the FixResult message starts with "Skipped session"
+    And the FixResult message mentions "refusing to kill self"
+
+  # --- AC 2: Abort with clear error when invoking session is Error-severity ---
+
+  @e2e
+  Scenario: heal --fix aborts when the invoking session is classified Error severity
+    Given the user is inside tmux session "orchardist"
+    And tmux session "orchardist" points to a working directory that no longer exists
+    And the resulting finding has severity Error and is_self = true
+    When the user runs "orchard heal --fix"
+    Then the process prints "refusing to kill the session I'm running in; run from outside tmux" to stderr
+    And the process exits with a non-zero status code
+    And NO fixes from apply_fixes are executed
+    And tmux session "orchardist" is NOT killed
+
+  @integration
+  Scenario: Warning-severity self finding does not trigger abort
+    Given the user is inside tmux session "orchardist"
+    And tmux session "orchardist" is classified as orphan with severity Warning and is_self = true
+    And tmux session "myrepo_old-feature" is also orphaned with severity Warning
+    When the user runs "orchard heal --fix"
+    Then the process does NOT abort
+    And apply_fixes runs to completion
+    And tmux session "orchardist" is skipped (not killed)
+    And tmux session "myrepo_old-feature" IS killed
+
+  @unit
+  Scenario: handle_heal detects an Error-severity is_self finding before applying any fixes
+    Given a HealReport containing one finding with severity = Error, is_self = true, action = KillSession("orchardist")
+    And other findings of various severities
+    When the abort-check pass runs
+    Then it returns an abort signal with the AC-specified error message
+    And apply_fixes is never invoked
+
+  # --- AC 3: Dry-run marks the invoking session as "skipped (self)" ---
+
+  @e2e
+  Scenario: heal --dry-run from inside tmux clearly marks the invoking session as skipped (self)
+    Given the user is inside tmux session "orchardist"
+    And tmux session "orchardist" has no matching worktree (would otherwise be classified as orphan)
+    When the user runs "orchard heal --dry-run"
+    Then the output includes the string "skipped (self)" on the line for "orchardist"
+    And no sessions are killed
+    And no files are deleted
+
+  @integration
+  Scenario: format_report renders is_self findings with a "skipped (self)" annotation
+    Given a HealFinding with action KillSession("orchardist") and is_self = true
+    When format_report is invoked
+    Then the output for that finding contains "skipped (self)"
+    And the warning icon is preserved
+
+  @integration
+  Scenario: --json output exposes is_self on findings
+    Given the user is inside tmux session "orchardist"
+    And tmux session "orchardist" would be classified as orphan
+    When the user runs "orchard heal --json"
+    Then the output is valid JSON
+    And the finding for "orchardist" has "is_self": true
+    And other findings have "is_self": false
+
+  @unit
+  Scenario: format_report leaves non-is_self KillSession findings unchanged
+    Given a HealFinding with action KillSession("myrepo_old-feature") and is_self = false
+    When format_report is invoked
+    Then the output for that finding does NOT contain "skipped (self)"
+
+  # --- AC 4: Regression coverage of the self-kill path ---
+
+  @integration
+  Scenario: regression — full pipeline from inside the named tmux session never kills self
+    Given the user is inside tmux session "orchardist"
+    And tmux session "orchardist" matches no worktree and no StandaloneConfig entry
+    When diagnose runs with current_session = Some("orchardist")
+    And apply_fixes runs over the resulting findings
+    Then no call to tmux::kill_tmux_session targets "orchardist"
+    And the FixResult collection contains a "Skipped session" entry for "orchardist"
+
+  @integration
+  Scenario: regression — sister window of the invoking session is still treated as self
+    Given the user is inside a sister window of tmux session "orchardist"
+    And "tmux display-message -p '#S'" still returns "orchardist" (outer session name)
+    When the user runs "orchard heal --fix"
+    Then current_session = Some("orchardist")
+    And the orchardist session is skipped, not killed
+
+  @unit
+  Scenario: helper tmux::current_session_name returns None when TMUX env var is unset
+    Given the TMUX environment variable is not set
+    When current_session_name is called
+    Then it returns None
+    And it does not shell out to tmux
+
+  @unit
+  Scenario: helper tmux::current_session_name returns Some(name) when inside tmux
+    Given the TMUX environment variable is set
+    And "tmux display-message -p '#S'" returns "orchardist" with exit code 0
+    When current_session_name is called
+    Then it returns Some("orchardist")
+
+  # --- AC Coverage Map ---
+  # AC 1: "heal --fix detects invoking tmux session via $TMUX / tmux display-message and excludes it from the kill set"
+  #   → @e2e Scenario: heal --fix from inside tmux excludes the invoking session from the kill set
+  #   → @integration Scenario: handle_heal reads the invoking session name from tmux before diagnosing
+  #   → @integration Scenario: outside tmux, heal behaves as before with no self-protection applied
+  #   → @integration Scenario: $TMUX is set but tmux display-message fails (server gone)
+  #   → @unit Scenario: diagnose marks a KillSession finding as is_self when name matches current_session
+  #   → @unit Scenario: diagnose does not mark non-matching KillSession findings as is_self
+  #   → @unit Scenario: diagnose with current_session = None never sets is_self = true
+  #   → @unit Scenario: is_self is false on findings whose action is not KillSession
+  #   → @unit Scenario: apply_fixes never invokes kill_tmux_session for an is_self finding
+  #
+  # AC 2: "If the invoking session IS classified as stale/orphan, heal --fix aborts with a clear error"
+  #   → @e2e Scenario: heal --fix aborts when the invoking session is classified Error severity
+  #   → @integration Scenario: Warning-severity self finding does not trigger abort
+  #   → @unit Scenario: handle_heal detects an Error-severity is_self finding before applying any fixes
+  #
+  # AC 3: "heal --dry-run from inside the same session prints what it *would* do without killing anything,
+  #        and clearly marks the invoking session as 'skipped (self)'"
+  #   → @e2e Scenario: heal --dry-run from inside tmux clearly marks the invoking session as skipped (self)
+  #   → @integration Scenario: format_report renders is_self findings with a "skipped (self)" annotation
+  #   → @integration Scenario: --json output exposes is_self on findings
+  #   → @unit Scenario: format_report leaves non-is_self KillSession findings unchanged
+  #
+  # AC 4: "Regression test covers the self-kill path"
+  #   → @integration Scenario: regression — full pipeline from inside the named tmux session never kills self
+  #   → @integration Scenario: regression — sister window of the invoking session is still treated as self
+  #   → @unit Scenario: helper tmux::current_session_name returns None when TMUX env var is unset
+  #   → @unit Scenario: helper tmux::current_session_name returns Some(name) when inside tmux


### PR DESCRIPTION
Closes #361.

## Summary

`orchard heal --fix` from inside tmux session `orchardist` was killing its own host session. The heal pipeline had no concept of "the invoking session" — `diagnose` classified the caller's session as `OrphanedSession` and `apply_fixes` ran `tmux kill-session` against it.

This PR threads the invoking session name from the shell into the pure `diagnose` core, marks matching findings as `is_self`, guards `apply_fixes` against self-kill, and aborts the CLI with a clear error if the caller's session is classified at `Error` severity.

## Status

🚧 In progress. First commit is the failing regression test; subsequent commits implement the fix per the plan in the issue body.

## Test plan

- [ ] Regression test compiles & passes (was red on first commit by design)
- [ ] \`cargo test --workspace -p orchard\` green
- [ ] Manual: \`orchard heal --fix\` from inside a tmux session named X classified as orphan → output shows \`Skipped session "X" — refusing to kill self\`, session still alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #361

# Related issue

- #361

# Related issue

- #361

# Related issue

- #361

# Related issue

- #361

# Related issue

- #361

# Related issue

- #361

# Related issue

- #361

# Related issue

- #361

# Related issue

- #361