### PR TITLE
feat(#374,#375): orchard --json is a live read; add sessions --json

### DIFF
--- a/crates/orchard/src/lib.rs
+++ b/crates/orchard/src/lib.rs
@@ -41,6 +41,7 @@ pub mod remote_adapter;
 pub mod restore;
 pub mod review_comment;
 pub mod session;
+pub mod sessions_index;
 pub mod setup_remote;
 pub mod shell;
 pub mod signal;

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -19,7 +19,6 @@ use orchard::heal;
 use orchard::hook_enrich;
 use orchard::json_output::JsonOutput;
 use orchard::logger;
-use orchard::merge_remote;
 use orchard::setup_remote;
 use orchard::shell;
 use orchard::tui;
@@ -106,6 +105,7 @@ fn main() {
         "hook-enrich" => handle_hook_enrich(transcript_path.as_deref()),
         "webhook-serve" => handle_webhook_serve(&args),
         "list-remotes" => handle_list_remotes(json_flag),
+        "sessions" => handle_sessions(json_flag),
         _ => {
             if json_flag {
                 handle_json();
@@ -350,16 +350,31 @@ fn handle_chat(target: Option<&str>, message: Option<&str>) {
     }
 }
 
-/// Builds the versioned JSON output from **cached** state only.
+/// Builds the versioned JSON output from a **live** refresh — never cache.
 ///
-/// `orchard --json` reads the last-written cache files and snapshots; it does
-/// NOT probe hosts, make SSH calls, or fetch from GitHub. This keeps the
-/// command instant and non-blocking. For fresh data, run `orchard refresh`
-/// first (or let `orchard watch` run in the background).
+/// Freshness contract (issue #374): `orchard --json` is the source of truth,
+/// not a cache view. It runs the same refresh path as `orchard refresh`
+/// (probes hosts, fetches remote worktrees and tmux sessions over SSH,
+/// re-runs `git worktree list` and `tmux list-panes` locally, refreshes
+/// GitHub issues/PRs) before serialising. The TUI keeps its cache-fast
+/// path; `--json` does not.
+///
+/// Practical implications for callers:
+/// - Latency tracks the slowest reachable host's SSH round-trip plus the
+///   GitHub API. Unreachable hosts are bounded by reachability-probe
+///   timeouts. Use `orchard watch` if you need a low-latency feed.
+/// - Side effect: caches written by `orchard refresh` (`~/.cache/orchard/*`)
+///   are also written here. Subsequent TUI cold-starts benefit from this.
 fn build_output() -> JsonOutput {
     let config = global_config::load_global_config();
-    let hosts = cache::read_host_reachability();
-    let state = merge_remote::build_state_with_cached_snapshots(&config, &hosts);
+    let state = build_state::refresh_and_build(&config);
+
+    // Persist host reachability so subsequent cache-only reads
+    // (TUI cold start, watch daemon) can populate OrchardState.hosts.
+    if let Err(e) = cache::write_host_reachability(&state.hosts) {
+        logger::LOG.warn(&format!("--json: failed to persist host reachability: {e}"));
+    }
+
     JsonOutput::from(&state)
 }
 
@@ -370,6 +385,47 @@ fn handle_json() {
         std::process::exit(1);
     });
     println!("{json}");
+}
+
+/// Handles `orchard sessions --json` — comprehensive sessions index keyed by host.
+///
+/// Returns every tmux session known to orchard across all managed hosts (not
+/// just orchard-managed ones), classified by relationship to worktrees and
+/// the protected-session list. Each entry carries `host` inline so consumers
+/// like the orchardist's `/prune` skill can route per-host actions without
+/// inferring from output order.
+///
+/// Freshness contract (issue #375) matches `--json`: this is a live read,
+/// not a cache view. We refresh every reachable remote tmux source over
+/// SSH plus the local `tmux list-panes` before classifying. `orchard
+/// refresh` and the on-disk caches are reused as a side effect.
+///
+/// Wire format is versioned independently from `--json` (its own
+/// `SESSIONS_INDEX_VERSION`), so additions here cannot break consumers of the
+/// worktree-centric `--json` output.
+fn handle_sessions(json: bool) {
+    if !json {
+        eprintln!(
+            "orchard sessions: only `--json` output is currently supported.\n\
+             Usage: orchard sessions --json"
+        );
+        std::process::exit(2);
+    }
+
+    let config = global_config::load_global_config();
+
+    // Live refresh: drive the same refresh path that `--json` uses so the
+    // output reflects the actual state of every reachable host. The
+    // sessions index re-reads from the freshly-written caches afterwards.
+    // See `build_state::refresh_and_build` for the full source list.
+    let _state = build_state::refresh_and_build(&config);
+
+    let output = orchard::sessions_index::build_sessions_index(&config);
+    let serialized = serde_json::to_string_pretty(&output).unwrap_or_else(|e| {
+        eprintln!("Error serializing JSON: {e}");
+        std::process::exit(1);
+    });
+    println!("{serialized}");
 }
 
 /// Handles `orchard refresh` — probes hosts, fetches remote data, writes
@@ -557,9 +613,19 @@ fn print_usage() {
   orchard heal                   Audit and repair drifted state (dry run)
   orchard heal --fix             Apply all safe automatic repairs
   orchard heal --json            Output health check results as JSON
+  orchard sessions --json        Print every tmux session across all managed hosts
+                                   (worktree-attached, orphan, detached-claude, or
+                                   protected) — host-tagged at the data plane.
+                                   Live read: refreshes every reachable remote
+                                   tmux source over SSH plus the local tmux state
+                                   before classifying.
   orchard refresh                Probe hosts, fetch from remotes, update caches, exit.
-                                   Run before `orchard --json` for fresh data, or let
-                                   `orchard watch` run in the background.
+                                   Hot-loads the same caches that `orchard --json`
+                                   and `orchard sessions --json` already refresh;
+                                   useful when you want the side effects (warmed
+                                   caches for the TUI cold start) without the JSON
+                                   output. Use `orchard watch` for a continuous
+                                   background refresh.
   orchard watch                  Run event-driven watch daemon (Ctrl-C to stop)
   orchard watch --subscribe --id <id> --session <session> [--pane <pane>]
                                    Register a tmux subscriber for watch events
@@ -571,8 +637,11 @@ fn print_usage() {
 
 Options:
   --version, -V  Print version and exit
-  --json         Output cached worktree data as JSON and exit (reads last-written
-                 cache; run `orchard refresh` first for fresh data)
+  --json         Output worktree data as JSON and exit. Live read — performs
+                 the same refresh as `orchard refresh` (SSH probes, remote
+                 worktree + tmux fetches, local git/tmux re-stat, GitHub
+                 issue/PR refresh) before serialising. The TUI uses a cache
+                 path; --json does not.
   --schema       Print the JSON Schema for --json output and exit
 
 Navigation:

--- a/crates/orchard/src/sessions_index.rs
+++ b/crates/orchard/src/sessions_index.rs
@@ -1,0 +1,675 @@
+//! Comprehensive sessions index for the `orchard sessions --json` subcommand.
+//!
+//! Issues #374 / #375: the orchardist's `/prune` skill needs a single source
+//! of truth for "every tmux session orchard knows about, on every managed
+//! host, classified by relationship to worktrees and protection status." The
+//! existing `orchard --json` output only carries sessions tied to a worktree
+//! plus the explicitly-configured standalone list — that is too narrow for
+//! pruning decisions.
+//!
+//! This module is a pure function over the on-disk caches: callers refresh
+//! the local tmux cache inline (`sources::tmux::refresh_local`) and rely on
+//! `orchard refresh` / `orchard watch` for remote freshness. No SSH, no
+//! `tmux` invocations, no network calls happen here.
+//!
+//! The wire format is versioned independently from `JsonOutput`
+//! (`SESSIONS_INDEX_VERSION`) so additions to this index cannot force a
+//! version bump on the worktree-centric `--json` output that the rest of the
+//! ecosystem already consumes.
+
+use std::collections::HashSet;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::cache::{self, CachedTmuxSession, CachedWorktree};
+use crate::global_config::GlobalConfig;
+use crate::session::active_pane_cwd;
+
+/// Wire-format version for `orchard sessions --json` output.
+///
+/// Bump this when the shape of [`SessionsIndexOutput`] or
+/// [`SessionRecord`] changes in a way consumers need to detect (added
+/// required fields, removed fields, changed field meanings). Pure additions
+/// of optional fields do NOT require a bump.
+pub const SESSIONS_INDEX_VERSION: u32 = 1;
+
+/// Hardcoded list of always-protected session names.
+///
+/// These are the orchardist-side daemon and oracle sessions whose loss would
+/// require manual recovery. The list is intentionally small and curated;
+/// users can extend protection by adding entries to `tmux_sessions` in
+/// `~/.config/orchard/config.json`, which feed into the same `protected`
+/// flag here.
+///
+/// Pinned by issue #375. Order is not significant — equality is by name.
+pub const PROTECTED_SESSION_KEEPERS: &[&str] = &[
+    "orchardist",
+    "technician",
+    "krusty_brain",
+    "langwatch_main",
+    "git-orchard-rs_main",
+    "scenario_main",
+    "claude-remote_main",
+    "orchard-oss-audit",
+];
+
+/// Top-level versioned wire format for `orchard sessions --json`.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionsIndexOutput {
+    /// Schema version for this output. See [`SESSIONS_INDEX_VERSION`].
+    pub version: u32,
+    /// Every tmux session known across local and configured remote hosts.
+    ///
+    /// Sessions are NOT grouped by host — each entry carries `host` inline so
+    /// downstream tooling (the orchardist `/prune` skill, ad-hoc scripts) can
+    /// route per-host actions without inferring from list position.
+    pub sessions: Vec<SessionRecord>,
+}
+
+/// One tmux session record in the sessions index.
+///
+/// Field semantics mirror what the orchardist needs for pruning decisions:
+///
+/// - `host` — `"local"` or the SSH target string (e.g. `"boxd@gpu-box"`).
+/// - `command` — foreground command of the session's active pane (e.g.
+///   `"claude"`, `"zsh"`, `"nvim"`).
+/// - `cwd` — current working directory of the active pane.
+/// - `protected` — `true` when the session name matches a configured
+///   `tmux_sessions` entry or the hardcoded keepers list.
+/// - `classification` — see [`SessionClassification`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRecord {
+    /// Tmux session name.
+    pub name: String,
+    /// Host identifier: `"local"` or the SSH target string.
+    pub host: String,
+    /// Foreground command of the active pane (empty string if unknown).
+    pub command: String,
+    /// Working directory of the active pane (empty string if unknown).
+    pub cwd: String,
+    /// True when the session name is in the protected set (config
+    /// `tmux_sessions` entries OR the [`PROTECTED_SESSION_KEEPERS`] list).
+    pub protected: bool,
+    /// Classification used by the `/prune` skill.
+    pub classification: SessionClassification,
+}
+
+/// How a tmux session relates to orchard's tracked state.
+///
+/// The four variants are mutually exclusive and computed in priority order:
+/// `Protected` wins over everything; otherwise `WorktreeAttached` wins over
+/// `DetachedClaude`; the residual is `Orphan`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum SessionClassification {
+    /// Active-pane cwd is inside a tracked worktree path.
+    WorktreeAttached,
+    /// Session name matches `^issue\d+`, foreground is `claude`, AND the
+    /// active-pane cwd is NOT inside any tracked worktree. These are the
+    /// "Claude session whose worktree was already pruned" survivors that the
+    /// orchardist needs to find.
+    DetachedClaude,
+    /// In the protected set (config or hardcoded keepers). Always safe.
+    Protected,
+    /// None of the above — candidate for `/prune`.
+    Orphan,
+}
+
+/// Builds the sessions index by reading on-disk caches.
+///
+/// Pure function over caches: callers must refresh the local tmux cache
+/// inline (`sources::tmux::refresh_local()`) before calling this so the
+/// freshness contract from issue #374/#375 holds for the local host.
+pub fn build_sessions_index(config: &GlobalConfig) -> SessionsIndexOutput {
+    // 1. Gather worktree paths from every configured repo (local + remote).
+    //    This drives the `WorktreeAttached` classification.
+    let worktree_paths = collect_all_worktree_paths(config);
+
+    // 2. Build the protected-name set: hardcoded keepers + configured
+    //    `tmux_sessions` entries. Both contribute to `protected` AND to the
+    //    `Protected` classification.
+    let protected_names = build_protected_set(config);
+
+    // 3. Read sessions from the local cache and from every configured remote
+    //    host's tmux cache, then classify each.
+    let mut sessions: Vec<SessionRecord> = Vec::new();
+
+    // Local sessions.
+    let local = cache::read_cache::<CachedTmuxSession>(&cache::tmux_cache_path(None)).entries;
+    for s in &local {
+        sessions.push(classify_session(
+            s,
+            "local",
+            &worktree_paths,
+            &protected_names,
+        ));
+    }
+
+    // Remote sessions: one cache file per unique remote host across all repos.
+    // Dedup by host string to avoid double-counting when the same host
+    // appears in multiple repos.
+    let mut hosts_seen: HashSet<String> = HashSet::new();
+    for repo in &config.repos {
+        for remote in &repo.remotes {
+            if !hosts_seen.insert(remote.host.clone()) {
+                continue;
+            }
+            let entries =
+                cache::read_cache::<CachedTmuxSession>(&cache::tmux_cache_path(Some(&remote.host)))
+                    .entries;
+            for s in &entries {
+                sessions.push(classify_session(
+                    s,
+                    &remote.host,
+                    &worktree_paths,
+                    &protected_names,
+                ));
+            }
+        }
+    }
+
+    // Stable, deterministic order: by host then by name. The orchardist's
+    // `/prune` skill diffs JSON across runs, so a stable order avoids noise.
+    sessions.sort_by(|a, b| a.host.cmp(&b.host).then_with(|| a.name.cmp(&b.name)));
+
+    SessionsIndexOutput {
+        version: SESSIONS_INDEX_VERSION,
+        sessions,
+    }
+}
+
+/// Reads every per-repo worktrees + remote_worktrees cache and returns the
+/// flat set of worktree filesystem paths.
+fn collect_all_worktree_paths(config: &GlobalConfig) -> Vec<String> {
+    let mut paths = Vec::new();
+    for repo in &config.repos {
+        let local = cache::read_cache::<CachedWorktree>(&cache::cache_path(
+            repo.owner(),
+            repo.repo_name(),
+            "worktrees",
+        ))
+        .entries;
+        for w in local {
+            if !w.is_bare {
+                paths.push(w.path);
+            }
+        }
+        // Remote worktrees only matter when a repo declares remotes.
+        if !repo.remotes.is_empty() {
+            let remote = cache::read_cache::<CachedWorktree>(&cache::cache_path(
+                repo.owner(),
+                repo.repo_name(),
+                "remote_worktrees",
+            ))
+            .entries;
+            for w in remote {
+                if !w.is_bare {
+                    paths.push(w.path);
+                }
+            }
+        }
+    }
+    paths
+}
+
+/// Returns the set of session names treated as protected.
+fn build_protected_set(config: &GlobalConfig) -> HashSet<String> {
+    let mut set: HashSet<String> = PROTECTED_SESSION_KEEPERS
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    for cfg in &config.tmux_sessions {
+        set.insert(cfg.name.clone());
+    }
+    set
+}
+
+/// Classifies one cached session into a [`SessionRecord`].
+fn classify_session(
+    session: &CachedTmuxSession,
+    host: &str,
+    worktree_paths: &[String],
+    protected_names: &HashSet<String>,
+) -> SessionRecord {
+    // Active-pane cwd: prefer the explicit active flag; fall back to the
+    // session's first-window path so older cache rows still classify.
+    let cwd = active_pane_cwd(session).unwrap_or_else(|| session.path.clone());
+
+    // Active-pane command, mirroring the cwd lookup so command/cwd come from
+    // the same pane.
+    let command = active_pane_command(session).unwrap_or_default();
+
+    let protected = protected_names.contains(&session.name);
+    let classification = classify(&session.name, &cwd, &command, worktree_paths, protected);
+
+    SessionRecord {
+        name: session.name.clone(),
+        host: host.to_string(),
+        command,
+        cwd,
+        protected,
+        classification,
+    }
+}
+
+/// Returns the foreground command of the active pane, falling back to the
+/// first pane row when no `pane_active=1` flag is set (pre-AC cache rows).
+fn active_pane_command(s: &CachedTmuxSession) -> Option<String> {
+    s.pane_active
+        .iter()
+        .enumerate()
+        .find(|(_, flag)| flag.as_str() == "1")
+        .and_then(|(i, _)| s.pane_commands.get(i))
+        .or_else(|| s.pane_commands.first())
+        .filter(|c| !c.is_empty())
+        .cloned()
+}
+
+/// Pure classification logic — exposed for unit testing.
+///
+/// Priority order: `Protected` > `WorktreeAttached` > `DetachedClaude` >
+/// `Orphan`. The first three are mutually exclusive by construction; only
+/// the residual receives `Orphan`.
+pub(crate) fn classify(
+    session_name: &str,
+    cwd: &str,
+    command: &str,
+    worktree_paths: &[String],
+    protected: bool,
+) -> SessionClassification {
+    if protected {
+        return SessionClassification::Protected;
+    }
+
+    let inside_worktree = !cwd.is_empty()
+        && worktree_paths
+            .iter()
+            .any(|wt| crate::paths::session_belongs_to_worktree(cwd, wt));
+    if inside_worktree {
+        return SessionClassification::WorktreeAttached;
+    }
+
+    if is_detached_claude(session_name, command) {
+        return SessionClassification::DetachedClaude;
+    }
+
+    SessionClassification::Orphan
+}
+
+/// Returns true when the session name matches `^issue\d+` AND the foreground
+/// command is `claude`. The cwd-not-worktree check is already enforced by
+/// the call site (this is reached only after `WorktreeAttached` was rejected).
+fn is_detached_claude(session_name: &str, command: &str) -> bool {
+    matches_issue_prefix(session_name) && command_is_claude(command)
+}
+
+/// Matches `^issue\d+` — the launch convention orchard uses for per-issue
+/// sessions (e.g. `issue374/...`, `issue123_main`).
+fn matches_issue_prefix(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix("issue") else {
+        return false;
+    };
+    let mut iter = rest.chars();
+    let Some(first) = iter.next() else {
+        return false;
+    };
+    first.is_ascii_digit()
+}
+
+/// Returns true when the foreground command looks like `claude` (e.g.
+/// `claude`, `claude --resume`, `node /path/claude`). Case-insensitive token
+/// match against the literal word `claude`, mirroring `PaneInfo::has_claude`.
+fn command_is_claude(command: &str) -> bool {
+    let lower = command.to_lowercase();
+    lower.split_whitespace().any(|tok| {
+        tok == "claude"
+            || tok.ends_with("/claude")
+            || tok.ends_with("\\claude")
+            || tok == "claude.exe"
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn paths(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    fn empty_protected() -> HashSet<String> {
+        HashSet::new()
+    }
+
+    // -- classify() ----------------------------------------------------------
+
+    #[test]
+    fn classify_protected_wins_over_everything() {
+        let wts = paths(&["/work/repo/wt"]);
+        let cls = classify(
+            "orchardist",
+            "/work/repo/wt/sub", // would be WorktreeAttached otherwise
+            "claude",
+            &wts,
+            true, // protected
+        );
+        assert_eq!(cls, SessionClassification::Protected);
+    }
+
+    #[test]
+    fn classify_worktree_attached_when_cwd_inside_worktree() {
+        let wts = paths(&["/work/repo/wt-foo"]);
+        let cls = classify(
+            "issue42_main",
+            "/work/repo/wt-foo/src",
+            "claude",
+            &wts,
+            false,
+        );
+        assert_eq!(cls, SessionClassification::WorktreeAttached);
+    }
+
+    #[test]
+    fn classify_detached_claude_when_issue_prefix_and_claude_outside_worktree() {
+        let wts = paths(&["/work/other/wt"]);
+        let cls = classify("issue374/feature", "/tmp/somewhere", "claude", &wts, false);
+        assert_eq!(cls, SessionClassification::DetachedClaude);
+    }
+
+    #[test]
+    fn classify_orphan_when_random_session_outside_worktree() {
+        let wts = paths(&["/work/repo/wt"]);
+        let cls = classify("random-session", "/tmp", "zsh", &wts, false);
+        assert_eq!(cls, SessionClassification::Orphan);
+    }
+
+    #[test]
+    fn classify_orphan_when_no_cwd_and_not_claude_or_protected() {
+        let wts = paths(&["/work/repo/wt"]);
+        let cls = classify("scratch", "", "zsh", &wts, false);
+        assert_eq!(cls, SessionClassification::Orphan);
+    }
+
+    #[test]
+    fn classify_detached_claude_requires_claude_command() {
+        let wts = paths(&["/work/repo/wt"]);
+        // issue prefix, outside worktree, but command is zsh — must NOT be detached-claude.
+        let cls = classify("issue999_main", "/tmp", "zsh", &wts, false);
+        assert_eq!(cls, SessionClassification::Orphan);
+    }
+
+    #[test]
+    fn classify_detached_claude_requires_issue_prefix() {
+        let wts = paths(&["/work/repo/wt"]);
+        // not issue prefix, claude command, outside worktree — must NOT be detached-claude.
+        let cls = classify("scratch", "/tmp", "claude", &wts, false);
+        assert_eq!(cls, SessionClassification::Orphan);
+    }
+
+    #[test]
+    fn classify_worktree_attached_beats_detached_claude_when_inside_worktree() {
+        let wts = paths(&["/work/repo/wt-foo"]);
+        let cls = classify("issue374_main", "/work/repo/wt-foo", "claude", &wts, false);
+        assert_eq!(cls, SessionClassification::WorktreeAttached);
+    }
+
+    // -- matches_issue_prefix() ---------------------------------------------
+
+    #[test]
+    fn matches_issue_prefix_basic() {
+        assert!(matches_issue_prefix("issue1"));
+        assert!(matches_issue_prefix("issue42_main"));
+        assert!(matches_issue_prefix("issue374/branch"));
+        assert!(matches_issue_prefix("issue999"));
+    }
+
+    #[test]
+    fn matches_issue_prefix_rejects_non_digit_after_issue() {
+        assert!(!matches_issue_prefix("issue"));
+        assert!(!matches_issue_prefix("issuesXY"));
+        assert!(!matches_issue_prefix("issue_main"));
+    }
+
+    #[test]
+    fn matches_issue_prefix_rejects_no_prefix() {
+        assert!(!matches_issue_prefix("orchardist"));
+        assert!(!matches_issue_prefix("main"));
+        assert!(!matches_issue_prefix(""));
+    }
+
+    // -- command_is_claude() ------------------------------------------------
+
+    #[test]
+    fn command_is_claude_bare() {
+        assert!(command_is_claude("claude"));
+    }
+
+    #[test]
+    fn command_is_claude_with_args() {
+        assert!(command_is_claude("claude --resume"));
+        assert!(command_is_claude("claude --model opus"));
+    }
+
+    #[test]
+    fn command_is_claude_absolute_path() {
+        assert!(command_is_claude("/usr/local/bin/claude"));
+        assert!(command_is_claude("node /opt/claude --foo"));
+    }
+
+    #[test]
+    fn command_is_claude_case_insensitive() {
+        assert!(command_is_claude("Claude"));
+        assert!(command_is_claude("CLAUDE --resume"));
+    }
+
+    #[test]
+    fn command_is_claude_rejects_non_claude() {
+        assert!(!command_is_claude("zsh"));
+        assert!(!command_is_claude("nvim claude.md"));
+        assert!(!command_is_claude(""));
+    }
+
+    // -- build_protected_set() ----------------------------------------------
+
+    #[test]
+    fn build_protected_set_contains_hardcoded_keepers() {
+        let cfg = GlobalConfig::default();
+        let set = build_protected_set(&cfg);
+        for name in PROTECTED_SESSION_KEEPERS {
+            assert!(set.contains(*name), "missing keeper: {name}");
+        }
+    }
+
+    #[test]
+    fn build_protected_set_includes_configured_tmux_sessions() {
+        let cfg = GlobalConfig {
+            tmux_sessions: vec![crate::session::StandaloneConfig {
+                name: "shepherd".to_string(),
+                command: "echo".to_string(),
+                cwd: "/tmp".to_string(),
+                start_on_launch: false,
+            }],
+            ..GlobalConfig::default()
+        };
+        let set = build_protected_set(&cfg);
+        assert!(set.contains("shepherd"));
+        assert!(set.contains("orchardist"));
+    }
+
+    // -- active_pane_command() ---------------------------------------------
+
+    fn make_session_with_panes(commands: &[&str], active_idx: Option<usize>) -> CachedTmuxSession {
+        let cmds: Vec<String> = commands.iter().map(|s| s.to_string()).collect();
+        let targets: Vec<String> = (0..cmds.len()).map(|i| format!("0.{i}")).collect();
+        let active: Vec<String> = (0..cmds.len())
+            .map(|i| {
+                if Some(i) == active_idx {
+                    "1".to_string()
+                } else {
+                    "0".to_string()
+                }
+            })
+            .collect();
+        CachedTmuxSession {
+            name: "test".to_string(),
+            path: "/tmp".to_string(),
+            pane_targets: targets,
+            pane_titles: vec![],
+            pane_commands: cmds,
+            window_names: vec![],
+            window_active: vec![],
+            window_layouts: vec![],
+            pane_paths: vec![],
+            pane_active: active,
+            host: None,
+            created_at: None,
+            last_activity_at: None,
+            last_output_lines: vec![],
+            claude_state_raw: None,
+        }
+    }
+
+    #[test]
+    fn active_pane_command_returns_command_at_active_index() {
+        let s = make_session_with_panes(&["zsh", "claude", "nvim"], Some(1));
+        assert_eq!(active_pane_command(&s).as_deref(), Some("claude"));
+    }
+
+    #[test]
+    fn active_pane_command_falls_back_to_first_when_no_active() {
+        let s = make_session_with_panes(&["zsh", "claude"], None);
+        assert_eq!(active_pane_command(&s).as_deref(), Some("zsh"));
+    }
+
+    #[test]
+    fn active_pane_command_none_when_empty() {
+        let s = make_session_with_panes(&[], None);
+        assert!(active_pane_command(&s).is_none());
+    }
+
+    // -- classify_session() (integration) -----------------------------------
+
+    fn make_session(
+        name: &str,
+        path: &str,
+        commands: &[&str],
+        active_idx: Option<usize>,
+        active_paths: &[&str],
+    ) -> CachedTmuxSession {
+        let mut s = make_session_with_panes(commands, active_idx);
+        s.name = name.to_string();
+        s.path = path.to_string();
+        s.pane_paths = active_paths.iter().map(|p| (*p).to_string()).collect();
+        s
+    }
+
+    #[test]
+    fn classify_session_uses_active_pane_cwd() {
+        let s = make_session(
+            "issue42",
+            "/wrong/path",
+            &["zsh", "claude"],
+            Some(1),
+            &["/wrong/path", "/work/repo/wt-foo"],
+        );
+        let wts = paths(&["/work/repo/wt-foo"]);
+        let protected = empty_protected();
+        let rec = classify_session(&s, "local", &wts, &protected);
+        assert_eq!(rec.cwd, "/work/repo/wt-foo");
+        assert_eq!(rec.command, "claude");
+        assert_eq!(rec.classification, SessionClassification::WorktreeAttached);
+        assert!(!rec.protected);
+    }
+
+    #[test]
+    fn classify_session_orphan_outside_worktree() {
+        let s = make_session("scratch-utils", "/tmp", &["zsh"], Some(0), &["/tmp"]);
+        let wts = paths(&["/work/repo/wt-foo"]);
+        let protected = empty_protected();
+        let rec = classify_session(&s, "local", &wts, &protected);
+        assert_eq!(rec.classification, SessionClassification::Orphan);
+        assert_eq!(rec.host, "local");
+    }
+
+    #[test]
+    fn classify_session_protected_when_in_set() {
+        let s = make_session(
+            "orchardist",
+            "/home/user",
+            &["claude"],
+            Some(0),
+            &["/home/user"],
+        );
+        let wts = paths(&[]);
+        let mut protected = HashSet::new();
+        protected.insert("orchardist".to_string());
+        let rec = classify_session(&s, "boxd@gpu-box", &wts, &protected);
+        assert!(rec.protected);
+        assert_eq!(rec.classification, SessionClassification::Protected);
+        assert_eq!(rec.host, "boxd@gpu-box");
+    }
+
+    #[test]
+    fn classify_session_falls_back_to_session_path_when_no_active_flag() {
+        // Old cache rows have no pane_active flags. Fall back to session.path.
+        let mut s = make_session_with_panes(&["claude"], None);
+        s.name = "issue999_main".to_string();
+        s.path = "/work/repo/wt-foo/src".to_string();
+        // pane_paths empty → cwd resolves from session.path.
+        let wts = paths(&["/work/repo/wt-foo"]);
+        let protected = empty_protected();
+        let rec = classify_session(&s, "local", &wts, &protected);
+        assert_eq!(rec.cwd, "/work/repo/wt-foo/src");
+        assert_eq!(rec.classification, SessionClassification::WorktreeAttached);
+    }
+
+    // -- build_sessions_index() integration tests ---------------------------
+
+    #[test]
+    fn build_sessions_index_empty_config_returns_empty() {
+        let cfg = GlobalConfig::default();
+        let out = build_sessions_index(&cfg);
+        assert_eq!(out.version, SESSIONS_INDEX_VERSION);
+        // Note: this reads ~/.cache/orchard which may not exist in test env;
+        // sessions list may be non-empty depending on test isolation. The
+        // important contract here is the version field.
+    }
+
+    #[test]
+    fn output_serializes_with_camel_case_classification_kebab() {
+        let out = SessionsIndexOutput {
+            version: SESSIONS_INDEX_VERSION,
+            sessions: vec![SessionRecord {
+                name: "issue42_main".to_string(),
+                host: "local".to_string(),
+                command: "claude".to_string(),
+                cwd: "/work/repo/wt-foo".to_string(),
+                protected: false,
+                classification: SessionClassification::WorktreeAttached,
+            }],
+        };
+        let v: serde_json::Value = serde_json::to_value(&out).unwrap();
+        assert_eq!(v["version"], SESSIONS_INDEX_VERSION);
+        let sess = &v["sessions"][0];
+        assert_eq!(sess["name"], "issue42_main");
+        assert_eq!(sess["host"], "local");
+        assert_eq!(sess["classification"], "worktree-attached");
+        assert_eq!(sess["protected"], false);
+    }
+
+    #[test]
+    fn output_serializes_classification_variants_kebab_case() {
+        for (variant, expected) in [
+            (SessionClassification::WorktreeAttached, "worktree-attached"),
+            (SessionClassification::DetachedClaude, "detached-claude"),
+            (SessionClassification::Protected, "protected"),
+            (SessionClassification::Orphan, "orphan"),
+        ] {
+            let v = serde_json::to_value(variant).unwrap();
+            assert_eq!(v, serde_json::Value::String(expected.to_string()));
+        }
+    }
+}

--- a/crates/orchard/tests/ac7_dashboard_nonblocking.rs
+++ b/crates/orchard/tests/ac7_dashboard_nonblocking.rs
@@ -1,10 +1,16 @@
-//! AC7 — `orchard --json` is cache-only; `orchard refresh` is the explicit
-//! fresh-data entry point.
+//! AC7 (post-#374): `orchard --json` is a live read but is bounded — it
+//! never blocks on hosts that aren't configured and the cached-snapshot
+//! merge path stays fast.
 //!
-//! Scenarios covered:
-//! - `orchard --json` spawns no SSH even with a configured OrchardProxy remote.
-//! - `orchard --json` with a cached snapshot returns the cached worktree quickly.
-//! - `orchard refresh --help` (or `orchard refresh`) exits cleanly (subcommand exists).
+//! Issues #374 / #375 reversed the original AC7 "cache-only" contract:
+//! `orchard --json` now refreshes every reachable source before serialising.
+//! The non-blocking guarantees we still hold are:
+//! - Empty config → zero SSH calls and zero hang risk (proven by the
+//!   no-ssh-spawned test below — a fake ssh in PATH is never invoked).
+//! - The cached-snapshot merge function used by the TUI cold-start
+//!   (`build_state_with_cached_snapshots_from`) still returns under 500ms,
+//!   independent of `--json`'s live behaviour.
+//! - `orchard refresh` continues to work as a standalone entry point.
 
 use std::collections::HashMap;
 use std::time::Instant;
@@ -18,20 +24,23 @@ use orchard::remote_adapter::RemoteKind;
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
-// AC7 scenario 1: `orchard --json` spawns no SSH
+// AC7 scenario 1: `orchard --json` with no configured remotes spawns no SSH
 //
-// We prove this deterministically by placing a fake `ssh` wrapper script at
-// the front of PATH. The wrapper writes a marker file when invoked. After the
-// `orchard --json` run we assert the marker file does NOT exist.
+// Even though `--json` is now a live read (issue #374), an empty config still
+// means zero SSH activity. We prove this deterministically with a fake `ssh`
+// wrapper that writes a marker on invocation.
 // ---------------------------------------------------------------------------
 
-/// `orchard --json` must never invoke `ssh`, even when an OrchardProxy remote
-/// is configured. Reads are cache-only; SSH only happens inside `orchard refresh`
-/// or `orchard watch`.
+/// `orchard --json` must not invoke `ssh` when no remotes are configured.
 ///
-/// We verify this by placing a fake `ssh` wrapper in a tempdir and prepending
-/// it to PATH. If `orchard --json` calls `ssh`, the wrapper writes
-/// `ssh-called.marker`. After the run we assert the marker is absent.
+/// Post-#374 `--json` is a live read that DOES probe SSH for any configured
+/// remote — but with an empty global config there are no remotes to probe,
+/// so no `ssh` invocation is expected. The fake `ssh` wrapper never fires.
+///
+/// (Tests that exercise SSH probing on configured remotes belong in the
+/// federation / remote-adapter test suites; this test guards the empty-config
+/// boundary so a regression in `refresh_and_build` cannot accidentally call
+/// SSH on a non-remote.)
 #[test]
 fn orchard_json_reads_cache_only_no_ssh_spawned() {
     let home_dir = TempDir::new().expect("create temp home");

--- a/crates/orchard/tests/json_freshness_integration.rs
+++ b/crates/orchard/tests/json_freshness_integration.rs
@@ -408,9 +408,15 @@ fn sessions_json_classifies_session_inside_worktree_as_worktree_attached() {
 }
 
 /// A session with `^issue\d+` name + `claude` command + cwd outside any
-/// known worktree classifies as `DetachedClaude`. Approximates the `claude`
-/// command via a no-op shell script named `claude` so the foreground command
-/// reads as `claude`.
+/// known worktree classifies as `DetachedClaude`.
+///
+/// We don't have a real `claude` binary in CI, so we approximate by hard-
+/// linking `sleep` to a binary named `claude` and running that. tmux reads
+/// `pane_current_command` from `/proc/PID/comm` (kernel field, set from
+/// argv[0] basename), so the comm reads as `claude` even though the
+/// underlying executable is `sleep`. Hard-link rather than shell shim
+/// avoids the layered-process problem (a shell + exec sleep would expose
+/// `sleep` on CI runners where the shell exits first).
 #[cfg(unix)]
 #[test]
 fn sessions_json_classifies_orphaned_claude_with_issue_name_as_detached_claude() {
@@ -421,16 +427,22 @@ fn sessions_json_classifies_orphaned_claude_with_issue_name_as_detached_claude()
     let home = TempDir::new().expect("create home");
     write_minimal_config(home.path());
 
-    // We need tmux's `pane_current_command` to read as "claude". Put a
-    // shim called `claude` on PATH that just sleeps — tmux reports the
-    // foreground process name from /proc, so the comm name will be "claude".
-    let bin_dir = home.path().join("bin");
-    std::fs::create_dir_all(&bin_dir).expect("mkdir bin");
-    let claude_shim = bin_dir.join("claude");
-    std::fs::write(&claude_shim, "#!/bin/sh\nexec sleep 30\n").expect("write claude shim");
-    set_executable(&claude_shim);
+    let claude_bin = match make_fake_claude_binary(home.path()) {
+        Some(p) => p,
+        None => {
+            eprintln!("could not create fake claude binary — skipping");
+            return;
+        }
+    };
 
-    harness.create_session_with_path("issue999_main", "/tmp", "claude", bin_dir.to_str().unwrap());
+    // Run the fake-claude binary with an absolute path so we don't depend
+    // on tmux session PATH propagation. tmux's `pane_current_command`
+    // reports the basename of argv[0], which is `claude` here.
+    harness.create_session(
+        "issue999_main",
+        "/tmp",
+        &format!("{} 30", claude_bin.display()),
+    );
 
     let out = run_orchard_sessions_json_with_tmux(home.path(), &harness);
     let rec = out
@@ -587,27 +599,6 @@ impl TmuxHarness {
             .expect("tmux new-session");
         assert!(status.success(), "tmux new-session failed for {name}");
     }
-
-    /// Variant of [`Self::create_session`] that prepends `extra_path` to the
-    /// tmux session's `PATH`. Used to put a shim binary in front of system
-    /// binaries (e.g. a no-op `claude` script).
-    fn create_session_with_path(&self, name: &str, cwd: &str, command: &str, extra_path: &str) {
-        let new_path = format!(
-            "{}:{}",
-            extra_path,
-            std::env::var("PATH").unwrap_or_default()
-        );
-        let status = std::process::Command::new("tmux")
-            .arg("-S")
-            .arg(&self.socket)
-            .args(["new-session", "-d", "-s", name, "-c", cwd])
-            .arg("-e")
-            .arg(format!("PATH={new_path}"))
-            .arg(command)
-            .status()
-            .expect("tmux new-session");
-        assert!(status.success(), "tmux new-session failed for {name}");
-    }
 }
 
 #[cfg(unix)]
@@ -683,4 +674,43 @@ fn which_tmux() -> String {
 fn set_executable(path: &Path) {
     use std::os::unix::fs::PermissionsExt;
     let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755));
+}
+
+/// Creates a binary at `home/bin/claude` that, when run, behaves like
+/// `sleep` but is reported by tmux's `pane_current_command` as `claude`.
+///
+/// Returns the absolute path to the new binary, or `None` if we couldn't
+/// locate `sleep` to copy/link from. The returned path is suitable for
+/// passing to a tmux `new-session` command line.
+///
+/// Strategy: copy `sleep` into a file named `claude`. tmux reads
+/// `pane_current_command` from `/proc/PID/comm`, which the kernel sets
+/// from the basename of argv[0]. Both copy-then-rename and hard-link
+/// achieve this; we use copy because hard-link fails across filesystems
+/// (e.g. /tmp on tmpfs vs /usr on ext4).
+#[cfg(unix)]
+fn make_fake_claude_binary(home: &Path) -> Option<std::path::PathBuf> {
+    let bin_dir = home.join("bin");
+    std::fs::create_dir_all(&bin_dir).ok()?;
+    let dest = bin_dir.join("claude");
+
+    // Locate the real `sleep` binary.
+    let sleep_path = std::process::Command::new("which")
+        .arg("sleep")
+        .output()
+        .ok()?;
+    if !sleep_path.status.success() {
+        return None;
+    }
+    let real_sleep = String::from_utf8_lossy(&sleep_path.stdout)
+        .trim()
+        .to_string();
+    if real_sleep.is_empty() {
+        return None;
+    }
+
+    // Copy `sleep` to `claude` (NOT a hard link — fails across mounts).
+    std::fs::copy(&real_sleep, &dest).ok()?;
+    set_executable(&dest);
+    Some(dest)
 }

--- a/crates/orchard/tests/json_freshness_integration.rs
+++ b/crates/orchard/tests/json_freshness_integration.rs
@@ -1,0 +1,686 @@
+//! Integration tests for `orchard --json` and `orchard sessions --json`
+//! freshness contracts (issues #374, #375).
+//!
+//! `--json` is a live read: it must reflect a `git worktree remove` (or any
+//! other local mutation) by the time the next invocation returns. The TUI's
+//! cache-fast path is unaffected — these tests only exercise the CLI JSON
+//! contract.
+mod common;
+
+use std::path::Path;
+
+use assert_cmd::Command;
+use orchard::sessions_index::{
+    PROTECTED_SESSION_KEEPERS, SESSIONS_INDEX_VERSION, SessionsIndexOutput,
+};
+use serde_json::Value;
+use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+/// Initialises a parent-of-repo + bare-repo + linked worktree layout that
+/// mirrors the production orchard convention.
+///
+/// The on-disk shape produced (rooted at `parent`):
+///
+/// ```text
+/// parent/
+/// ├── repo/             ← regular clone, the orchard `path` for the repo
+/// └── worktrees/
+///     └── worktree-foo/ ← linked worktree on branch `foo`
+/// ```
+///
+/// Returns `(repo_path, worktree_path)` — both absolute. The repo at
+/// `repo_path` always has at least one commit on its default branch so
+/// `git worktree add` can succeed.
+struct TestRepoLayout {
+    /// Owns the parent directory; dropped at end of test.
+    _parent: TempDir,
+    repo_path: std::path::PathBuf,
+    worktree_path: std::path::PathBuf,
+    branch: String,
+}
+
+impl TestRepoLayout {
+    fn new(branch: &str) -> Self {
+        let parent = TempDir::new().expect("create temp parent dir");
+        let repo_path = parent.path().join("repo");
+        let worktrees_dir = parent.path().join("worktrees");
+        std::fs::create_dir_all(&repo_path).expect("mkdir repo");
+        std::fs::create_dir_all(&worktrees_dir).expect("mkdir worktrees");
+
+        // git init + identity + initial commit so the default branch exists.
+        run_git(&repo_path, &["init", "-b", "main"]);
+        run_git(&repo_path, &["config", "user.email", "test@example.com"]);
+        run_git(&repo_path, &["config", "user.name", "Test"]);
+        std::fs::write(repo_path.join("README.md"), "test\n").expect("seed file");
+        run_git(&repo_path, &["add", "README.md"]);
+        run_git(&repo_path, &["commit", "-m", "init"]);
+
+        // Add a linked worktree on a new branch.
+        let worktree_path = worktrees_dir.join(format!("worktree-{branch}"));
+        run_git(
+            &repo_path,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                worktree_path.to_str().expect("utf-8 worktree path"),
+            ],
+        );
+
+        Self {
+            _parent: parent,
+            repo_path,
+            worktree_path,
+            branch: branch.to_string(),
+        }
+    }
+
+    fn remove_worktree(&self) {
+        run_git(
+            &self.repo_path,
+            &[
+                "worktree",
+                "remove",
+                "-f",
+                self.worktree_path.to_str().expect("utf-8 worktree path"),
+            ],
+        );
+    }
+}
+
+fn run_git(cwd: &Path, args: &[&str]) {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|e| panic!("git {args:?} failed to start: {e}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} exited non-zero in {}: stderr={}",
+        cwd.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Writes a global orchard config with a single managed repo at `repo_path`.
+///
+/// Schema mirrors `~/.config/orchard/config.json`. The `slug` is intentionally
+/// deterministic so the per-repo cache filenames are stable across runs.
+fn write_orchard_config(home: &Path, slug: &str, repo_path: &Path) {
+    let config_dir = home.join(".config/orchard");
+    std::fs::create_dir_all(&config_dir).expect("mkdir config");
+    let config = serde_json::json!({
+        "repos": [{
+            "slug": slug,
+            "path": repo_path.to_str().expect("utf-8 repo path"),
+            "remotes": []
+        }],
+        "tmux_sessions": []
+    });
+    std::fs::write(
+        config_dir.join("config.json"),
+        serde_json::to_string_pretty(&config).expect("serialize config"),
+    )
+    .expect("write config.json");
+}
+
+/// Runs `orchard --json` with `home` as `HOME` and returns the parsed output.
+fn run_orchard_json(home: &Path) -> Value {
+    let assert = Command::cargo_bin("orchard")
+        .expect("orchard binary must exist")
+        .arg("--json")
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env_remove("TMUX")
+        .assert()
+        .success();
+    let stdout = assert.get_output().stdout.clone();
+    let s = String::from_utf8(stdout).expect("utf-8 stdout");
+    serde_json::from_str(&s).unwrap_or_else(|e| panic!("invalid JSON: {e}\nstdout was:\n{s}"))
+}
+
+/// Runs `orchard sessions --json` and returns the parsed [`SessionsIndexOutput`].
+fn run_orchard_sessions_json(home: &Path) -> SessionsIndexOutput {
+    let assert = Command::cargo_bin("orchard")
+        .expect("orchard binary must exist")
+        .args(["sessions", "--json"])
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env_remove("TMUX")
+        .assert()
+        .success();
+    let stdout = assert.get_output().stdout.clone();
+    let s = String::from_utf8(stdout).expect("utf-8 stdout");
+    serde_json::from_str(&s)
+        .unwrap_or_else(|e| panic!("invalid sessions JSON: {e}\nstdout was:\n{s}"))
+}
+
+// ---------------------------------------------------------------------------
+// AC #374-3 — worktree removal reflected in --json output
+// ---------------------------------------------------------------------------
+
+/// `orchard --json` reflects `git worktree remove` immediately on the next
+/// invocation. This is the headline freshness contract for issue #374.
+///
+/// Steps:
+/// 1. Build a parent/repo/worktrees layout with one tracked worktree on
+///    branch `flake`.
+/// 2. First `orchard --json` — assert the worktree path is present.
+/// 3. `git worktree remove -f <path>`.
+/// 4. Second `orchard --json` — assert the worktree path is absent.
+///
+/// The two invocations are issued back-to-back; no `orchard refresh` is
+/// inserted between them. The contract is that `--json` is the source of
+/// truth, not a cache view.
+#[test]
+fn json_reflects_worktree_remove_on_next_invocation() {
+    let layout = TestRepoLayout::new("flake");
+    let home = TempDir::new().expect("create home");
+    let slug = "owner/repo";
+    write_orchard_config(home.path(), slug, &layout.repo_path);
+
+    // First read: worktree should be present.
+    let before = run_orchard_json(home.path());
+    let before_paths = collect_worktree_paths(&before, slug);
+    let wt_str = layout.worktree_path.to_string_lossy().into_owned();
+    assert!(
+        before_paths.iter().any(|p| p == &wt_str),
+        "worktree path should be present before removal; got {before_paths:?}"
+    );
+
+    // Mutate: remove the worktree.
+    layout.remove_worktree();
+
+    // Second read: worktree must NOT appear.
+    let after = run_orchard_json(home.path());
+    let after_paths = collect_worktree_paths(&after, slug);
+    assert!(
+        !after_paths.iter().any(|p| p == &wt_str),
+        "worktree path must not appear after `git worktree remove`; \
+         orchard --json is supposed to be live, not cached.\n\
+         got paths: {after_paths:?}"
+    );
+}
+
+/// Same shape as [`json_reflects_worktree_remove_on_next_invocation`] but
+/// asserts the symmetric direction: a freshly-added worktree shows up
+/// without an explicit `orchard refresh`.
+#[test]
+fn json_reflects_worktree_add_on_next_invocation() {
+    let parent = TempDir::new().expect("create parent");
+    let repo_path = parent.path().join("repo");
+    let worktrees_dir = parent.path().join("worktrees");
+    std::fs::create_dir_all(&repo_path).expect("mkdir repo");
+    std::fs::create_dir_all(&worktrees_dir).expect("mkdir worktrees");
+
+    run_git(&repo_path, &["init", "-b", "main"]);
+    run_git(&repo_path, &["config", "user.email", "test@example.com"]);
+    run_git(&repo_path, &["config", "user.name", "Test"]);
+    std::fs::write(repo_path.join("README.md"), "test\n").expect("seed file");
+    run_git(&repo_path, &["add", "README.md"]);
+    run_git(&repo_path, &["commit", "-m", "init"]);
+
+    let home = TempDir::new().expect("create home");
+    let slug = "owner/repo";
+    write_orchard_config(home.path(), slug, &repo_path);
+
+    // Baseline: only the main worktree exists, no `flake` branch.
+    let before = run_orchard_json(home.path());
+    let before_branches = collect_worktree_branches(&before, slug);
+    assert!(
+        !before_branches.iter().any(|b| b == "flake"),
+        "branch 'flake' must not exist before add; got {before_branches:?}"
+    );
+
+    // Mutate: add a new linked worktree.
+    let new_worktree = worktrees_dir.join("worktree-flake");
+    run_git(
+        &repo_path,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "flake",
+            new_worktree.to_str().expect("utf-8 worktree path"),
+        ],
+    );
+
+    // Second read: branch must now be present.
+    let after = run_orchard_json(home.path());
+    let after_branches = collect_worktree_branches(&after, slug);
+    assert!(
+        after_branches.iter().any(|b| b == "flake"),
+        "branch 'flake' should be present after `git worktree add`; got {after_branches:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC #374-2 — help text documents freshness contract
+// ---------------------------------------------------------------------------
+
+/// `orchard --help` documents that `--json` is a live read.
+///
+/// AC #374-2 calls for documenting expected freshness in `orchard --help`.
+/// We assert on substrings rather than literal text so help-text rewords
+/// don't break the test, but the substrings must be present.
+#[test]
+fn help_documents_json_freshness_contract() {
+    let assert = Command::cargo_bin("orchard")
+        .expect("orchard binary must exist")
+        .arg("--help")
+        .assert()
+        .success();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("--json") && (stderr.contains("Live") || stderr.contains("live")),
+        "help text must describe --json as a live read; got:\n{stderr}"
+    );
+}
+
+/// `orchard --help` mentions `orchard sessions --json` so users can discover it.
+#[test]
+fn help_mentions_sessions_subcommand() {
+    let assert = Command::cargo_bin("orchard")
+        .expect("orchard binary must exist")
+        .arg("--help")
+        .assert()
+        .success();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains("orchard sessions --json"),
+        "help text must mention `orchard sessions --json`; got:\n{stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC #375-* — `orchard sessions --json` shape and classification
+// ---------------------------------------------------------------------------
+
+/// `orchard sessions --json` returns a parseable [`SessionsIndexOutput`] even
+/// with an empty config — this proves the wire format and the version
+/// constant are wired up end-to-end.
+#[test]
+fn sessions_json_returns_versioned_output_with_empty_config() {
+    let home = TempDir::new().expect("create home");
+    // Minimal config so load_global_config doesn't read the host's real one.
+    let config_dir = home.path().join(".config/orchard");
+    std::fs::create_dir_all(&config_dir).expect("mkdir config");
+    let config = serde_json::json!({"repos": [], "tmux_sessions": []});
+    std::fs::write(
+        config_dir.join("config.json"),
+        serde_json::to_string_pretty(&config).unwrap(),
+    )
+    .expect("write config");
+
+    let out = run_orchard_sessions_json(home.path());
+    assert_eq!(out.version, SESSIONS_INDEX_VERSION);
+    // Without any tmux state we can't assert specific sessions exist; just
+    // confirm the `sessions` field deserialised (it's a Vec, possibly empty).
+    let _: usize = out.sessions.len();
+}
+
+/// Every record returned by `orchard sessions --json` must carry a non-empty
+/// `host` field (#375-3). With no remotes configured the only host is
+/// `"local"`, but the assertion shape is universal.
+#[test]
+fn sessions_json_every_record_carries_host_field() {
+    let layout = TestRepoLayout::new("flake");
+    let home = TempDir::new().expect("create home");
+    write_orchard_config(home.path(), "owner/repo", &layout.repo_path);
+
+    let out = run_orchard_sessions_json(home.path());
+    for s in &out.sessions {
+        assert!(
+            !s.host.is_empty(),
+            "every session record must have a host; got: {s:?}"
+        );
+    }
+}
+
+/// Sessions with names in the hardcoded keepers list must classify as
+/// `Protected` and have `protected: true`. Uses a real tmux server on an
+/// **isolated socket** so the test does not pollute or depend on the
+/// developer's main tmux state.
+#[cfg(unix)]
+#[test]
+fn sessions_json_classifies_hardcoded_keeper_as_protected() {
+    let Some(harness) = TmuxHarness::start("orchard-prot") else {
+        eprintln!("tmux not available — skipping");
+        return;
+    };
+    let home = TempDir::new().expect("create home");
+    write_minimal_config(home.path());
+
+    let keeper = PROTECTED_SESSION_KEEPERS[0];
+    harness.create_session(keeper, "/tmp", "sleep 30");
+
+    let out = run_orchard_sessions_json_with_tmux(home.path(), &harness);
+    let rec = out
+        .sessions
+        .iter()
+        .find(|s| s.name == keeper)
+        .unwrap_or_else(|| panic!("no record for keeper '{keeper}'; got {out:?}"));
+    assert!(rec.protected, "keeper must have protected=true: {rec:?}");
+    assert_eq!(
+        rec.classification,
+        orchard::sessions_index::SessionClassification::Protected,
+        "keeper must classify as Protected: {rec:?}"
+    );
+    assert_eq!(rec.host, "local");
+}
+
+/// A session whose active-pane cwd is INSIDE a tracked worktree path
+/// classifies as `WorktreeAttached`. Uses real tmux + real worktree so the
+/// full pipeline (git worktree → cache → classify) is exercised.
+#[cfg(unix)]
+#[test]
+fn sessions_json_classifies_session_inside_worktree_as_worktree_attached() {
+    let Some(harness) = TmuxHarness::start("orchard-wt") else {
+        eprintln!("tmux not available — skipping");
+        return;
+    };
+    let layout = TestRepoLayout::new("flake");
+    let home = TempDir::new().expect("create home");
+    write_orchard_config(home.path(), "owner/repo", &layout.repo_path);
+
+    let cwd_inside = layout.worktree_path.to_string_lossy().into_owned();
+    let session_name = format!("issue42_{}_main", layout.branch);
+    harness.create_session(&session_name, &cwd_inside, "sleep 30");
+
+    let out = run_orchard_sessions_json_with_tmux(home.path(), &harness);
+    let rec = out
+        .sessions
+        .iter()
+        .find(|s| s.name == session_name)
+        .unwrap_or_else(|| panic!("expected session {session_name}, got {out:?}"));
+    assert_eq!(
+        rec.classification,
+        orchard::sessions_index::SessionClassification::WorktreeAttached,
+        "session inside worktree path must classify as WorktreeAttached: {rec:?}"
+    );
+    assert!(!rec.protected);
+    assert_eq!(rec.host, "local");
+}
+
+/// A session with `^issue\d+` name + `claude` command + cwd outside any
+/// known worktree classifies as `DetachedClaude`. Approximates the `claude`
+/// command via a no-op shell script named `claude` so the foreground command
+/// reads as `claude`.
+#[cfg(unix)]
+#[test]
+fn sessions_json_classifies_orphaned_claude_with_issue_name_as_detached_claude() {
+    let Some(harness) = TmuxHarness::start("orchard-detached") else {
+        eprintln!("tmux not available — skipping");
+        return;
+    };
+    let home = TempDir::new().expect("create home");
+    write_minimal_config(home.path());
+
+    // We need tmux's `pane_current_command` to read as "claude". Put a
+    // shim called `claude` on PATH that just sleeps — tmux reports the
+    // foreground process name from /proc, so the comm name will be "claude".
+    let bin_dir = home.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mkdir bin");
+    let claude_shim = bin_dir.join("claude");
+    std::fs::write(&claude_shim, "#!/bin/sh\nexec sleep 30\n").expect("write claude shim");
+    set_executable(&claude_shim);
+
+    harness.create_session_with_path("issue999_main", "/tmp", "claude", bin_dir.to_str().unwrap());
+
+    let out = run_orchard_sessions_json_with_tmux(home.path(), &harness);
+    let rec = out
+        .sessions
+        .iter()
+        .find(|s| s.name == "issue999_main")
+        .unwrap_or_else(|| panic!("seeded session must appear; got {out:?}"));
+    assert_eq!(
+        rec.classification,
+        orchard::sessions_index::SessionClassification::DetachedClaude,
+        "issue\\d+ + claude + cwd-outside-worktree → DetachedClaude: {rec:?}"
+    );
+    assert_eq!(rec.host, "local");
+    assert_eq!(rec.command, "claude");
+}
+
+/// A session with a non-issue name + non-claude command + cwd outside any
+/// worktree classifies as `Orphan` — the residual bucket and the `/prune`
+/// skill's primary target.
+#[cfg(unix)]
+#[test]
+fn sessions_json_classifies_random_unrelated_session_as_orphan() {
+    let Some(harness) = TmuxHarness::start("orchard-orphan") else {
+        eprintln!("tmux not available — skipping");
+        return;
+    };
+    let home = TempDir::new().expect("create home");
+    write_minimal_config(home.path());
+
+    harness.create_session("scratch-utils", "/tmp", "sleep 30");
+
+    let out = run_orchard_sessions_json_with_tmux(home.path(), &harness);
+    let rec = out
+        .sessions
+        .iter()
+        .find(|s| s.name == "scratch-utils")
+        .unwrap_or_else(|| panic!("seeded session must appear; got {out:?}"));
+    assert_eq!(
+        rec.classification,
+        orchard::sessions_index::SessionClassification::Orphan,
+        "non-issue + non-claude + outside-worktree → Orphan: {rec:?}"
+    );
+    assert!(!rec.protected);
+}
+
+// ---------------------------------------------------------------------------
+// helpers (private to this test file)
+// ---------------------------------------------------------------------------
+
+/// Returns the list of worktree `path` values for `slug` from a parsed
+/// `JsonOutput`. Empty vec when the repo isn't present.
+fn collect_worktree_paths(out: &Value, slug: &str) -> Vec<String> {
+    let Some(repos) = out.get("repos").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    let Some(repo) = repos
+        .iter()
+        .find(|r| r.get("slug").and_then(|s| s.as_str()) == Some(slug))
+    else {
+        return Vec::new();
+    };
+    let Some(wts) = repo.get("worktrees").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    wts.iter()
+        .filter_map(|w| {
+            w.get("path")
+                .and_then(|p| p.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect()
+}
+
+/// Returns the list of worktree `branch` values for `slug` from a parsed
+/// `JsonOutput`. Empty vec when the repo isn't present.
+fn collect_worktree_branches(out: &Value, slug: &str) -> Vec<String> {
+    let Some(repos) = out.get("repos").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    let Some(repo) = repos
+        .iter()
+        .find(|r| r.get("slug").and_then(|s| s.as_str()) == Some(slug))
+    else {
+        return Vec::new();
+    };
+    let Some(wts) = repo.get("worktrees").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    wts.iter()
+        .filter_map(|w| {
+            w.get("branch")
+                .and_then(|b| b.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect()
+}
+
+/// Writes a minimal config (no repos, no remotes) so `load_global_config`
+/// doesn't read the host's real config.
+fn write_minimal_config(home: &Path) {
+    let config_dir = home.join(".config/orchard");
+    std::fs::create_dir_all(&config_dir).expect("mkdir config");
+    let config = serde_json::json!({"repos": [], "tmux_sessions": []});
+    std::fs::write(
+        config_dir.join("config.json"),
+        serde_json::to_string_pretty(&config).unwrap(),
+    )
+    .expect("write config");
+}
+
+/// Owns an isolated tmux server (its own socket file), so created sessions
+/// don't collide with the developer's real tmux state. On drop, the server
+/// is killed and the socket dir is cleaned up by `_dir`.
+///
+/// `start("prefix")` returns `None` when tmux is not on PATH or fails to
+/// start (e.g. CI without tmux available). Callers can early-return without
+/// failing the test.
+#[cfg(unix)]
+struct TmuxHarness {
+    /// Owns the socket directory; dropped at end of test.
+    _dir: TempDir,
+    /// Path to the socket the isolated tmux server listens on.
+    socket: std::path::PathBuf,
+}
+
+#[cfg(unix)]
+impl TmuxHarness {
+    fn start(prefix: &str) -> Option<Self> {
+        let dir = TempDir::new().ok()?;
+        // Short directory path: tmux socket paths have an OS-level length
+        // limit (~108 bytes on Linux), so we keep the socket name short.
+        let socket = dir.path().join(prefix);
+
+        // Kick the server alive by issuing a `start-server` command.
+        let status = std::process::Command::new("tmux")
+            .arg("-S")
+            .arg(&socket)
+            .arg("start-server")
+            .status()
+            .ok()?;
+        if !status.success() {
+            return None;
+        }
+        Some(Self { _dir: dir, socket })
+    }
+
+    /// Creates a tmux session named `name` running `command` from `cwd`.
+    fn create_session(&self, name: &str, cwd: &str, command: &str) {
+        let status = std::process::Command::new("tmux")
+            .arg("-S")
+            .arg(&self.socket)
+            .args(["new-session", "-d", "-s", name, "-c", cwd, command])
+            .status()
+            .expect("tmux new-session");
+        assert!(status.success(), "tmux new-session failed for {name}");
+    }
+
+    /// Variant of [`Self::create_session`] that prepends `extra_path` to the
+    /// tmux session's `PATH`. Used to put a shim binary in front of system
+    /// binaries (e.g. a no-op `claude` script).
+    fn create_session_with_path(&self, name: &str, cwd: &str, command: &str, extra_path: &str) {
+        let new_path = format!(
+            "{}:{}",
+            extra_path,
+            std::env::var("PATH").unwrap_or_default()
+        );
+        let status = std::process::Command::new("tmux")
+            .arg("-S")
+            .arg(&self.socket)
+            .args(["new-session", "-d", "-s", name, "-c", cwd])
+            .arg("-e")
+            .arg(format!("PATH={new_path}"))
+            .arg(command)
+            .status()
+            .expect("tmux new-session");
+        assert!(status.success(), "tmux new-session failed for {name}");
+    }
+}
+
+#[cfg(unix)]
+impl Drop for TmuxHarness {
+    fn drop(&mut self) {
+        // Best-effort: kill the server so its child processes (sleep) exit.
+        let _ = std::process::Command::new("tmux")
+            .arg("-S")
+            .arg(&self.socket)
+            .arg("kill-server")
+            .status();
+    }
+}
+
+/// Same shape as [`run_orchard_sessions_json`] but routes the binary's tmux
+/// invocations to the harness's isolated socket via a wrapper script on PATH.
+#[cfg(unix)]
+fn run_orchard_sessions_json_with_tmux(home: &Path, harness: &TmuxHarness) -> SessionsIndexOutput {
+    let bin_dir = home.join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("mkdir bin");
+    install_tmux_wrapper(&bin_dir, &harness.socket);
+    let path = format!(
+        "{}:{}",
+        bin_dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let assert = Command::cargo_bin("orchard")
+        .expect("orchard binary must exist")
+        .args(["sessions", "--json"])
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("PATH", &path)
+        .env_remove("TMUX")
+        .assert()
+        .success();
+    let stdout = assert.get_output().stdout.clone();
+    let s = String::from_utf8(stdout).expect("utf-8 stdout");
+    serde_json::from_str(&s)
+        .unwrap_or_else(|e| panic!("invalid sessions JSON: {e}\nstdout was:\n{s}"))
+}
+
+/// Installs a `tmux` wrapper script in `bin_dir` that forces every tmux
+/// invocation to use `socket` instead of the system default.
+///
+/// orchard's tmux source calls `tmux list-panes -a -F ...` (no `-S` flag),
+/// which would otherwise read the user's real tmux server. Prepending this
+/// wrapper to PATH redirects every call.
+#[cfg(unix)]
+fn install_tmux_wrapper(bin_dir: &Path, socket: &Path) {
+    let real_tmux = which_tmux();
+    let wrapper = bin_dir.join("tmux");
+    let socket_str = socket.display();
+    let script = format!("#!/bin/sh\nexec {real_tmux} -S {socket_str} \"$@\"\n");
+    std::fs::write(&wrapper, script).expect("write tmux wrapper");
+    set_executable(&wrapper);
+}
+
+/// Returns the absolute path to the system `tmux`, falling back to the bare
+/// command name if `which` is unavailable. Used by `install_tmux_wrapper` to
+/// avoid a wrapper-calls-itself loop.
+#[cfg(unix)]
+fn which_tmux() -> String {
+    let out = std::process::Command::new("which").arg("tmux").output();
+    match out {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_string(),
+        _ => "/usr/bin/tmux".to_string(),
+    }
+}
+
+/// Sets `0o755` on `path`. Best-effort.
+#[cfg(unix)]
+fn set_executable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755));
+}

--- a/docs/adr/010-json-is-live-tui-is-cached.md
+++ b/docs/adr/010-json-is-live-tui-is-cached.md
@@ -1,0 +1,147 @@
+# ADR-010: `--json` is the live read; the TUI keeps the cached fast path
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-27
+
+## Context
+
+Two consumers read orchard's unified data model:
+
+1. **The TUI dashboard** — long-lived, redrawn many times per second, shown
+   to a human. It must start instantly and tolerate stale data while a
+   background refresh catches up; the human can wait a few seconds for the
+   PR review counts to update without losing flow.
+2. **External scripts and other agents** — `orchard --json`, the new
+   `orchard sessions --json`, the orchardist's `/prune` skill, ad-hoc
+   pipelines. Each invocation is a one-shot call whose answer is then acted
+   on by code: `gh pr close`, `tmux kill-session`, `git worktree remove`.
+
+These two consumers have **opposite freshness requirements**.
+
+Pre-#374 we had ADR-008's wire protocol and a single freshness contract:
+both the TUI and `--json` used `build_state_with_cached_snapshots`. That
+broke `/prune`. After a `git worktree remove` the worktree lingered in
+`orchard --json` until either `orchard refresh` ran or the watch daemon
+caught up — anywhere from a few seconds to a few minutes. The orchardist
+had no way to know which, so it gave up on the data plane and shelled out
+to per-host `ssh` queries to verify state. That defeated the point of
+shipping a unified CLI: every consumer was inventing its own freshness
+strategy.
+
+Issues #374 and #375 made the contract explicit: `orchard --json` must
+reflect a `git worktree remove` (or any local mutation) within ~5 seconds
+of the next invocation, with no manual `orchard refresh` step between them.
+
+Three approaches we considered:
+
+1. **Keep `--json` cache-only, add a `--refresh` flag.** Smaller diff but
+   pushes the freshness decision onto every caller; `/prune` ends up wrapping
+   `orchard refresh && orchard --json` everywhere, and forgetting the
+   refresh is silent corruption.
+2. **Watcher-driven cache invalidation.** A filesystem watcher would notice
+   `git worktree remove` and re-stat. Solves the local case but doesn't
+   handle remote SSH targets and adds a long-lived background process to a
+   one-shot CLI. Out of scope for this PR.
+3. **Make `--json` a live read.** Whatever the cost — SSH probes, local git
+   re-stat, GitHub fetch — pay it on the call. Simple contract, no opt-in,
+   no per-script refresh discipline.
+
+We picked option 3. The architecture already supports it:
+`build_state::refresh_and_build` is the same code path `orchard refresh`
+uses. The `--json` handler now calls it, then serialises to `JsonOutput`.
+
+## Decision
+
+`orchard --json` and `orchard sessions --json` are **live reads**. They
+synchronously refresh every reachable source — `git worktree list` per
+configured repo, `tmux list-panes` locally and on every reachable remote
+SSH target, `gh` for issues and PRs — before serialising. Cache files
+written by previous invocations are overwritten as a side effect.
+
+The TUI keeps the cache-fast path: cold-start renders from
+`build_state_with_cached_snapshots`, then a background refresh catches up
+and re-renders. None of this changes for #374.
+
+### Mental model: cache files are the inter-service queue
+
+Each source service writes its own cache file
+(`~/.cache/orchard/{owner}_{repo}_worktrees.json`,
+`~/.cache/orchard/{host}_tmux_sessions.json`, etc.). The cache is the
+shared datastore between services and consumers:
+
+- **TUI** reads the datastore at read time.
+- **`--json`** tells every service to update its file, then reads.
+
+This is the natural "update then return" pattern Drew called out — the
+files are durable state, services are responsible for keeping their slice
+fresh, and `--json` orchestrates the refresh fan-out across them.
+
+### Concrete changes
+
+- `main::build_output()` calls `build_state::refresh_and_build` instead of
+  `merge_remote::build_state_with_cached_snapshots`.
+- New `orchard sessions --json` subcommand routes through the same
+  `refresh_and_build` path before invoking `sessions_index::build_sessions_index`.
+- `--help` documents the live-read contract for both subcommands.
+- `architecture.md` is updated to describe the two modes correctly.
+
+### Latency contract
+
+`--json` latency tracks the slowest reachable host's SSH round-trip plus
+the GitHub API. Unreachable hosts are bounded by the reachability-probe
+timeout in `sources::hosts`. Empty config (no remotes, no repos) returns
+in tens of milliseconds — the AC7 test suite proves this and now also
+guards "empty config → zero SSH calls".
+
+If a caller needs a low-latency feed (sub-second polling, dashboards),
+they should use `orchard watch` and tail `events.jsonl`, not
+`orchard --json`.
+
+## Consequences
+
+### Pros
+
+- **`/prune` works without ceremony.** A user-driven `git worktree remove`
+  followed immediately by `orchard --json` shows the post-state correctly,
+  with no `orchard refresh` step.
+- **Single freshness contract per binary.** Every external consumer can
+  trust `--json` without knowing about `refresh`, `watch`, or cache TTLs.
+- **`--json` warms caches as a side effect.** Subsequent TUI cold-starts
+  see fresher data, since `refresh_and_build` writes every cache file it
+  touches.
+
+### Cons
+
+- **`--json` can block on SSH.** A flaky remote slows down every script
+  that calls `--json`. Mitigations: per-host probe timeouts, parallel
+  fan-out, no fallback (an unreachable host is reported as unreachable
+  rather than retried in-band).
+- **GitHub API budget.** Each `--json` triggers a `gh` call per repo.
+  Heavy scripted use could exhaust the rate limit. Mitigation: `gh` caches
+  responses; orchard's per-source SWR layer further damps re-fetches when
+  cache is fresh.
+- **Test isolation.** Tests that pre-seed the local tmux cache to assert
+  classification logic stop working — the live refresh overwrites the
+  seed. Tests that need fixed tmux state must spin up an isolated tmux
+  socket (see `tests/json_freshness_integration.rs`'s `TmuxHarness`).
+
+### Reversal
+
+If the latency cost proves too high in practice, we can re-introduce a
+`--cached` opt-out flag on `--json` without changing the default. That
+gives sophisticated callers an escape hatch while keeping `/prune` and
+ad-hoc consumers correct by default.
+
+## Related
+
+- ADR-001: cache architecture (per-source files, no computed state on disk).
+- ADR-008: federated discovery — remote `orchard --json` is the wire protocol
+  for cross-machine reads. ADR-008's freshness assumption is now consistent
+  with this ADR: a remote `orchard --json` invocation is itself live,
+  so a local `orchard --json` calling out to it gets a live remote view.
+- Issues #374, #375.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,8 +71,16 @@ ssh probe         ──→  (in-memory only)                     ┘         �
   Two-phase refresh: fast locals first (git, tmux, claude files), then slow
   remotes (GitHub API, SSH). Re-renders after each phase.
 
-- **JSON mode**: fetches fresh data from all sources. Never returns cached
-  results. Produces a versioned `JsonOutput` for scripting.
+- **JSON mode** (`orchard --json`, `orchard sessions --json`): always live —
+  performs the same synchronous refresh as `orchard refresh` (SSH probes,
+  remote worktree + tmux fetches, local git/tmux re-stat, GitHub issue/PR
+  refresh) before serialising. Never returns cached results. Produces a
+  versioned `JsonOutput` for scripting. The latency is bounded by the slowest
+  reachable host's SSH round-trip plus the GitHub API; unreachable hosts are
+  bounded by reachability-probe timeouts. The freshness contract belongs to
+  `--json`: `git worktree remove` and `tmux kill-session` are observable in
+  the next `orchard --json` invocation, not pending a background refresh.
+  See ADR-010 for the design rationale.
 
 Both modes produce an `OrchardState` — the single unified data model.
 
@@ -387,3 +395,4 @@ discovery only. See ADR-008 for the decision rationale.
 - **ADR-006**: TEA pattern for TUI event handling
 - **ADR-007**: Session data model (TmuxSessionInfo → EnrichedSession composition)
 - **ADR-008**: Federated discovery — remote `orchard --json` is the wire protocol for read-path enrichment; failures surface explicitly (no silent legacy fallback); dashboard reads are cache-only
+- **ADR-010**: `orchard --json` (and `orchard sessions --json`) is the live read; the TUI keeps the cached fast path. Reverses ADR-008's cache-only `--json` clause.


### PR DESCRIPTION
## Summary

Reverses the cache-only contract on `orchard --json` so that downstream agents (the orchardist's `/prune` skill in particular) can trust the data plane as the single source of truth — no `orchard refresh && orchard --json` two-step required. Adds a new `orchard sessions --json` subcommand that returns every tmux session orchard knows about across managed hosts, classified by relationship to worktrees and protection status.

Closes #374
Closes #375

## What changed

### `orchard --json` is now a live read

Calls `build_state::refresh_and_build` instead of `merge_remote::build_state_with_cached_snapshots`. Synchronously refreshes every reachable source (local git, local tmux, remote tmux over SSH, GitHub issues/PRs) before serialising. The TUI is unchanged — it keeps using the cached fast path. ADR-010 spells out the two-mode design.

### New: `orchard sessions --json`

Returns `{ version, sessions: [{ name, host, command, cwd, protected, classification }, ...] }`. Each record carries `host` inline (`"local"` or the SSH target). `classification` is one of `worktree-attached`, `detached-claude`, `protected`, or `orphan`, computed in priority order. The hardcoded keepers list (orchardist, technician, krusty_brain, langwatch_main, git-orchard-rs_main, scenario_main, claude-remote_main, orchard-oss-audit) is exposed as the public `PROTECTED_SESSION_KEEPERS` constant. Wire format is versioned independently from `JsonOutput` so additions here cannot break the existing schema.

### Documentation

- New ADR-010: \`orchard --json\` is the live read; the TUI keeps the cached fast path.
- \`docs/architecture.md\` updated: data-flow section now describes JSON mode as live and references ADR-010.
- \`orchard --help\` documents the live-read contract for both subcommands.

## Tests

- **28 new unit tests** in \`sessions_index\` — classification priority, hardcoded keepers, configured \`tmux_sessions\` extension, the \`^issue\d+\` + claude branch, active-pane lookup, kebab-case serialization.
- **10 new integration tests** in \`tests/json_freshness_integration.rs\`:
  - AC #374-3: \`git worktree remove\` reflected in the next \`orchard --json\`, with no \`orchard refresh\` between them.
  - AC #375-5: classification end-to-end via an **isolated tmux socket harness** so tests don't pollute or depend on the developer's main tmux server.
  - help text and host-field invariants.
- \`tests/ac7_dashboard_nonblocking.rs\`: docstrings updated for the new contract; the empty-config-spawns-no-SSH guard remains.

## Test plan

- [x] \`cargo test -p orchard --tests\` — all integration suites green (only pre-existing webhook-tailer flake unrelated to this PR).
- [x] \`cargo test -p orchard --lib sessions_index\` — 28/28 pass.
- [x] \`cargo clippy -p orchard --tests -- -D warnings\` — clean.
- [x] \`cargo fmt -p orchard --check\` — clean.
- [x] Smoke test: \`./target/release/orchard sessions --json\` on real environment correctly classifies the active worktree session as \`worktree-attached\` and orphan sessions as \`orphan\`.
- [x] Smoke test: \`./target/release/orchard --json\` reflects current state (live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #374

# Related issue

- #374