### PR TITLE
Workstream B-config: config provider → Project node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,12 @@
 module github.com/drewdrewthis/git-orchard-rs
 
-go 1.22
+go 1.23
+
+toolchain go1.23.2
 
 require (
 	github.com/99designs/gqlgen v0.17.45
+	github.com/fsnotify/fsnotify v1.10.0
 	github.com/spf13/cobra v1.10.2
 	github.com/vektah/gqlparser/v2 v2.5.11
 )
@@ -22,6 +25,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/mod v0.16.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.19.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/fsnotify/fsnotify v1.10.0 h1:Xx/5Ydg9CeBDX/wi4VJqStNtohYjitZhhlHt4h3St1M=
+github.com/fsnotify/fsnotify v1.10.0/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
@@ -47,6 +49,8 @@ golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=
 golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
 golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/tools v0.19.0 h1:tfGCXNR1OsFG+sVdLAitlpjAvD/I6dHDKnYrpEZUHkw=

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -3,29 +3,26 @@
 // the running daemon reflects changes via fsnotify (Workstream B).
 //
 // Workstream A scope: `init` writes a default config and creates the
-// state directory. `add-repo` is a stub that advertises the future
-// command shape — it errors cleanly until Workstream B ships the
-// project provider.
+// state directory.
+// Workstream B-config scope: `add-repo PATH` validates and appends a
+// project entry; the daemon's fsnotify watcher reflects the change
+// without any mutation API.
 package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
 	"github.com/drewdrewthis/git-orchard-rs/internal/orchpaths"
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
 )
-
-// DefaultConfig is the JSON skeleton written by `config init`. It carries
-// just enough shape to be edited by hand or by `config add-repo`. The
-// schema will firm up as Workstream B's project provider lands.
-type DefaultConfig struct {
-	Version  int      `json:"version"`
-	Projects []string `json:"projects"`
-}
 
 // Command returns the `config` subcommand group.
 func Command() *cobra.Command {
@@ -52,14 +49,152 @@ func initCmd() *cobra.Command {
 }
 
 func addRepoCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		name      string
+		id        string
+		allowNonGit bool
+	)
+	c := &cobra.Command{
 		Use:   "add-repo PATH",
-		Short: "Append a project path to the config (Workstream B)",
-		Args:  cobra.ExactArgs(1),
+		Short: "Append a project to ~/.config/orchard/config.json",
+		Long: "Validate PATH (must exist and, by default, contain a .git directory),\n" +
+			"append it to the config file's projects list, and rely on the running\n" +
+			"daemon's fsnotify watcher to reflect the change. No daemon mutation\n" +
+			"API — config is the source of truth (ADR-011 §5.1).",
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return fmt.Errorf("not implemented in Workstream A; lands with the project provider in Workstream B")
+			return runAddRepo(cmd.OutOrStdout(), args[0], name, id, allowNonGit)
 		},
 	}
+	c.Flags().StringVar(&name, "name", "", "human-readable label (defaults to basename of PATH)")
+	c.Flags().StringVar(&id, "id", "", "stable id (defaults to slug of name, then short hash of directory)")
+	c.Flags().BoolVar(&allowNonGit, "allow-non-git", false, "skip the .git/ presence check (use for nested or virtual worktrees)")
+	return c
+}
+
+// runAddRepo loads the config file, appends or updates the project row
+// for PATH, and writes the file atomically (tmp + rename) so the daemon
+// observes a single fsnotify event.
+func runAddRepo(w io.Writer, pathArg, name, id string, allowNonGit bool) error {
+	abs, err := filepath.Abs(pathArg)
+	if err != nil {
+		return fmt.Errorf("resolve path %q: %w", pathArg, err)
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("path does not exist: %s", abs)
+		}
+		return fmt.Errorf("stat %s: %w", abs, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("path is not a directory: %s", abs)
+	}
+	if !allowNonGit {
+		if _, err := os.Stat(filepath.Join(abs, ".git")); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return fmt.Errorf("not a git repo (no .git/ at %s); pass --allow-non-git to override", abs)
+			}
+			return fmt.Errorf("stat .git: %w", err)
+		}
+	}
+
+	cfgPath, err := orchpaths.ConfigFile()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		return fmt.Errorf("ensure config dir: %w", err)
+	}
+
+	file, err := loadOrInitFile(cfgPath)
+	if err != nil {
+		return err
+	}
+
+	row := configprovider.ProjectRow{
+		ID:        configprovider.ProjectID(id),
+		Directory: abs,
+		Name:      name,
+	}.Normalise()
+
+	// Replace any existing entry for this directory or id.
+	replaced := false
+	for i, existing := range file.Projects {
+		if existing.Directory == row.Directory || (row.ID != "" && existing.ID == row.ID) {
+			file.Projects[i] = row
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		file.Projects = append(file.Projects, row)
+	}
+
+	if err := writeFileAtomic(cfgPath, file); err != nil {
+		return err
+	}
+	if replaced {
+		fmt.Fprintf(w, "updated project %s (%s) in %s\n", row.ID, row.Directory, cfgPath)
+	} else {
+		fmt.Fprintf(w, "added project %s (%s) to %s\n", row.ID, row.Directory, cfgPath)
+	}
+	return nil
+}
+
+// loadOrInitFile reads cfgPath into a configprovider.File. A missing
+// file yields an empty File (version 1) so the very first add-repo call
+// also serves as an implicit init.
+func loadOrInitFile(cfgPath string) (configprovider.File, error) {
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return configprovider.File{Version: 1}, nil
+		}
+		return configprovider.File{}, fmt.Errorf("read %s: %w", cfgPath, err)
+	}
+	if len(data) == 0 {
+		return configprovider.File{Version: 1}, nil
+	}
+	var f configprovider.File
+	if err := json.Unmarshal(data, &f); err != nil {
+		return configprovider.File{}, fmt.Errorf("parse %s: %w", cfgPath, err)
+	}
+	if f.Version == 0 {
+		f.Version = 1
+	}
+	return f, nil
+}
+
+// writeFileAtomic marshals f to JSON, writes to a sibling tmp file, and
+// renames into place. The rename is what fsnotify emits a single event
+// for, avoiding a half-written intermediate state.
+func writeFileAtomic(cfgPath string, f configprovider.File) error {
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(cfgPath), ".config.*.json")
+	if err != nil {
+		return fmt.Errorf("create tmp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, cfgPath); err != nil {
+		cleanup()
+		return fmt.Errorf("rename %s → %s: %w", tmpName, cfgPath, err)
+	}
+	return nil
 }
 
 func runInit(w io.Writer, force bool) error {
@@ -102,7 +237,7 @@ func runInit(w io.Writer, force bool) error {
 }
 
 func writeConfig(path string) error {
-	cfg := DefaultConfig{Version: 1, Projects: []string{}}
+	cfg := configprovider.File{Version: 1, Projects: []configprovider.ProjectRow{}}
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal config: %w", err)

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -40,7 +40,7 @@ func initCmd() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "init",
 		Short: "Write default config and create state directory",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runInit(cmd.OutOrStdout(), force)
 		},
 	}
@@ -50,8 +50,8 @@ func initCmd() *cobra.Command {
 
 func addRepoCmd() *cobra.Command {
 	var (
-		name      string
-		id        string
+		name        string
+		id          string
 		allowNonGit bool
 	)
 	c := &cobra.Command{

--- a/internal/cli/config/config_test.go
+++ b/internal/cli/config/config_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+)
+
+func setHomeForTest(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(dir, "state"))
+	return dir
+}
+
+// readConfig is a tiny test helper — round-trip the on-disk JSON back
+// into the canonical configprovider.File so assertions can read fields.
+func readConfig(t *testing.T, dir string) configprovider.File {
+	t.Helper()
+	cfgPath := filepath.Join(dir, "config", "orchard", "config.json")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var f configprovider.File
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	return f
+}
+
+func TestAddRepo_RejectsNonExistentPath(t *testing.T) {
+	setHomeForTest(t)
+	var buf bytes.Buffer
+	err := runAddRepo(&buf, "/nonexistent/abs/path", "", "", false)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestAddRepo_RejectsNonGitDir(t *testing.T) {
+	setHomeForTest(t)
+	repo := t.TempDir() // empty dir, no .git
+	var buf bytes.Buffer
+	err := runAddRepo(&buf, repo, "", "", false)
+	if err == nil {
+		t.Fatal("expected error for non-git dir, got nil")
+	}
+}
+
+func TestAddRepo_AcceptsNonGitWithFlag(t *testing.T) {
+	dir := setHomeForTest(t)
+	repo := t.TempDir()
+	var buf bytes.Buffer
+	if err := runAddRepo(&buf, repo, "Repo Name", "", true); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	cfg := readConfig(t, dir)
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("want 1 project, got %d", len(cfg.Projects))
+	}
+	if cfg.Projects[0].ID != "repo-name" {
+		t.Errorf("want slug 'repo-name', got %q", cfg.Projects[0].ID)
+	}
+	if cfg.Projects[0].Directory != repo {
+		t.Errorf("want abs %q, got %q", repo, cfg.Projects[0].Directory)
+	}
+}
+
+func TestAddRepo_AcceptsGitRepo(t *testing.T) {
+	dir := setHomeForTest(t)
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatalf("mkgit: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := runAddRepo(&buf, repo, "", "", false); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	cfg := readConfig(t, dir)
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("want 1, got %d", len(cfg.Projects))
+	}
+}
+
+func TestAddRepo_DeduplicatesByDirectory(t *testing.T) {
+	dir := setHomeForTest(t)
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	if err := runAddRepo(&buf, repo, "First", "", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := runAddRepo(&buf, repo, "Second", "", false); err != nil {
+		t.Fatal(err)
+	}
+	cfg := readConfig(t, dir)
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("expected dedupe, got %d entries", len(cfg.Projects))
+	}
+	if cfg.Projects[0].Name != "Second" {
+		t.Errorf("expected updated name 'Second', got %q", cfg.Projects[0].Name)
+	}
+}
+
+func TestAddRepo_MultipleProjects(t *testing.T) {
+	dir := setHomeForTest(t)
+	a := t.TempDir()
+	b := t.TempDir()
+	for _, p := range []string{a, b} {
+		if err := os.Mkdir(filepath.Join(p, ".git"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var buf bytes.Buffer
+	if err := runAddRepo(&buf, a, "Alpha", "", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := runAddRepo(&buf, b, "Beta", "", false); err != nil {
+		t.Fatal(err)
+	}
+	cfg := readConfig(t, dir)
+	if len(cfg.Projects) != 2 {
+		t.Fatalf("want 2 projects, got %d", len(cfg.Projects))
+	}
+}

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/drewdrewthis/git-orchard-rs/internal/orchpaths"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server"
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
 )
 
 // Command returns the `daemon` subcommand group rooted with three leaves.
@@ -98,7 +100,22 @@ func runStart(parentCtx context.Context, addr string) error {
 	ctx, cancel := signal.NotifyContext(parentCtx, syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	srv := server.New(addr, nil)
+	logger := slog.Default()
+
+	cfgPath, err := orchpaths.ConfigFile()
+	if err != nil {
+		return fmt.Errorf("resolve config path: %w", err)
+	}
+	configProvider := configprovider.NewProvider(
+		configprovider.NewJSONFileAdapter(cfgPath, logger),
+		logger,
+	)
+	if err := configProvider.Start(ctx); err != nil {
+		return fmt.Errorf("start config provider: %w", err)
+	}
+	defer func() { _ = configProvider.Stop() }()
+
+	srv := server.New(addr, logger, server.WithProjects(configProvider))
 	return srv.Run(ctx)
 }
 

--- a/internal/cli/query/host.go
+++ b/internal/cli/query/host.go
@@ -2,8 +2,6 @@ package query
 
 import (
 	"github.com/spf13/cobra"
-
-	"github.com/drewdrewthis/git-orchard-rs/internal/server"
 )
 
 // hostQuery is the canonical projection of the local Host node — every
@@ -37,12 +35,10 @@ const hostQuery = `query LocalHost {
 // hostCmd returns the `orchard query host` subcommand.
 //
 // Issues hostQuery against the running daemon and prints the GraphQL
-// response (data + any errors) as pretty JSON. The hidden --addr flag
-// lets the e2e tests target an ephemeral daemon listening on a
-// non-default port.
+// response (data + any errors) as pretty JSON. Tests that need to
+// retarget the daemon URL use SetDaemonURLForTest.
 func hostCmd() *cobra.Command {
-	var addr string
-	c := &cobra.Command{
+	return &cobra.Command{
 		Use:   "host",
 		Short: "Print the local Host node with current resource load",
 		Long: "Issue the canonical Host GraphQL query against the running orchard daemon and\n" +
@@ -50,9 +46,7 @@ func hostCmd() *cobra.Command {
 			"a fresh ResourceLoad sample (cpu%, mem%, disk%, loadavg{1,5,15}m).",
 		Example: "  orchard query host",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRaw(cmd.OutOrStdout(), addr, hostQuery)
+			return runRaw(cmd.Context(), cmd.OutOrStdout(), hostQuery)
 		},
 	}
-	c.Flags().StringVar(&addr, "addr", server.DefaultAddr, "host:port the daemon is listening on")
-	return c
 }

--- a/internal/cli/query/query.go
+++ b/internal/cli/query/query.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -25,9 +26,22 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server"
 )
 
+// daemonURLEnv lets E2E tests redirect the CLI at an httptest.Server
+// without binding the production port.
+const daemonURLEnv = "ORCHARD_DAEMON_URL"
+
 // daemonURL is the base URL of the local daemon's GraphQL endpoint.
-// Overridable in tests via SetDaemonURLForTest.
+// Overridable in tests via SetDaemonURLForTest, or via the
+// ORCHARD_DAEMON_URL env var (which takes precedence per call so a
+// running test process can drive multiple isolated daemons).
 var daemonURL = "http://" + server.DefaultAddr
+
+func resolveDaemonURL() string {
+	if v := os.Getenv(daemonURLEnv); v != "" {
+		return v
+	}
+	return daemonURL
+}
 
 // httpTimeout bounds GraphQL roundtrips. Conservative — the daemon is
 // local and responses are small JSON.
@@ -143,7 +157,7 @@ func postGraphQL(ctx context.Context, query string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, daemonURL+"/graphql", bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resolveDaemonURL()+"/graphql", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}

--- a/internal/cli/query/query.go
+++ b/internal/cli/query/query.go
@@ -62,7 +62,7 @@ func Command() *cobra.Command {
 	}
 	var raw string
 	cmd.Flags().StringVar(&raw, "raw", "", "raw GraphQL query string")
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		if raw == "" {
 			return fmt.Errorf("provide a verb (e.g. `host`, `projects`) or --raw '<graphql>'")
 		}
@@ -85,7 +85,7 @@ func projectsCmd() *cobra.Command {
 		Long: "Calls the running daemon's GraphQL `projects` query and prints the\n" +
 			"result as a JSON array. Returns the empty array when no projects are\n" +
 			"configured. Use `orchard config add-repo PATH` to register a new one.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runProjects(cmd.Context(), cmd.OutOrStdout())
 		},
 	}

--- a/internal/cli/query/query.go
+++ b/internal/cli/query/query.go
@@ -3,8 +3,9 @@
 //
 // Workstream A wired only `--raw <gql>`. Workstream B-host adds the
 // first named verb — `host` — which proves the verb dispatch pattern
-// against a real provider. Future workstreams add `worktrees`, `panes`,
-// `processes`, `conversations`, `contracts`.
+// against a real provider. Workstream B-config adds `projects`. Future
+// workstreams add `worktrees`, `panes`, `processes`, `conversations`,
+// `contracts`.
 //
 // The cobra alias `q` mirrors the impl guide's "permitted alias for
 // query" so typing ergonomics match the documented CLI shape.
@@ -12,6 +13,7 @@ package query
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -23,63 +25,106 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server"
 )
 
+// daemonURL is the base URL of the local daemon's GraphQL endpoint.
+// Overridable in tests via SetDaemonURLForTest.
+var daemonURL = "http://" + server.DefaultAddr
+
+// httpTimeout bounds GraphQL roundtrips. Conservative — the daemon is
+// local and responses are small JSON.
+const httpTimeout = 10 * time.Second
+
 // Command returns the `query` subcommand group with its alias.
 func Command() *cobra.Command {
-	var raw string
 	cmd := &cobra.Command{
 		Use:     "query",
 		Aliases: []string{"q"},
 		Short:   "Query the running orchard daemon via GraphQL",
 		Long: "Dispatch GraphQL queries against the running daemon at " + server.DefaultAddr + ".\n\n" +
-			"Use one of the named verbs (e.g. `host`) for high-level reads, or `--raw '<gql>'` for\n" +
-			"the escape hatch when you need a custom GraphQL query.",
+			"Use a named verb (e.g. `host`, `projects`) for high-level reads, or `--raw '<gql>'`\n" +
+			"as the escape hatch when you need a custom GraphQL query.",
 		Example: "  orchard query host\n" +
+			"  orchard query projects\n" +
 			"  orchard query --raw 'query { health { status } }'",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if raw == "" {
-				return fmt.Errorf("provide a verb (e.g. `host`) or --raw '<graphql>'")
-			}
-			return runRaw(cmd.OutOrStdout(), server.DefaultAddr, raw)
-		},
 	}
+	var raw string
 	cmd.Flags().StringVar(&raw, "raw", "", "raw GraphQL query string")
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if raw == "" {
+			return fmt.Errorf("provide a verb (e.g. `host`, `projects`) or --raw '<graphql>'")
+		}
+		return runRaw(cmd.Context(), cmd.OutOrStdout(), raw)
+	}
 	cmd.AddCommand(hostCmd())
+	cmd.AddCommand(projectsCmd())
 	return cmd
 }
 
-// runRaw POSTs `query` to addr's /graphql endpoint and pretty-prints the
-// JSON response. Exported indirectly via verbs that wrap it.
-func runRaw(w io.Writer, addr, query string) error {
-	body, err := json.Marshal(map[string]string{"query": query})
-	if err != nil {
-		return fmt.Errorf("marshal request: %w", err)
-	}
-	req, err := http.NewRequest(http.MethodPost, "http://"+addr+"/graphql", bytes.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
+// projectsQuery is the GraphQL document fetched by `query projects`.
+// Field selection mirrors the AC list — id, directory, name. Order is
+// fixed so the daemon's sort and the client's print agree.
+const projectsQuery = `{ projects { id directory name } }`
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("daemon not running, start with `orchard daemon start` (%w)", err)
+func projectsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "projects",
+		Short: "List configured projects (Project nodes)",
+		Long: "Calls the running daemon's GraphQL `projects` query and prints the\n" +
+			"result as a JSON array. Returns the empty array when no projects are\n" +
+			"configured. Use `orchard config add-repo PATH` to register a new one.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProjects(cmd.Context(), cmd.OutOrStdout())
+		},
 	}
-	defer resp.Body.Close()
+}
 
-	data, err := io.ReadAll(resp.Body)
+// runProjects POSTs the projects query, extracts the `data.projects`
+// array, and prints it as pretty JSON. The shape is intentionally a
+// plain `[]Project` (not the GraphQL envelope) so shell consumers can
+// `jq` straight in without learning the envelope.
+func runProjects(ctx context.Context, w io.Writer) error {
+	raw, err := postGraphQL(ctx, projectsQuery)
 	if err != nil {
-		return fmt.Errorf("read response: %w", err)
+		return err
 	}
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(data))
+	var env struct {
+		Data struct {
+			Projects []map[string]any `json:"projects"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
 	}
-	// Pretty-print so humans reading stdout get something readable.
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return fmt.Errorf("decode response: %w (body: %s)", err, raw)
+	}
+	if len(env.Errors) > 0 {
+		return fmt.Errorf("graphql error: %s", env.Errors[0].Message)
+	}
+	if env.Data.Projects == nil {
+		env.Data.Projects = []map[string]any{}
+	}
+	out, err := json.MarshalIndent(env.Data.Projects, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode output: %w", err)
+	}
+	_, _ = w.Write(out)
+	_, _ = w.Write([]byte("\n"))
+	return nil
+}
+
+// runRaw POSTs `query` to the daemon's /graphql endpoint and pretty-prints
+// the JSON response. Used by both the root --raw escape hatch and named
+// verbs that don't decode the response into a typed shape.
+func runRaw(ctx context.Context, w io.Writer, query string) error {
+	raw, err := postGraphQL(ctx, query)
+	if err != nil {
+		return err
+	}
 	var pretty bytes.Buffer
-	if err := json.Indent(&pretty, data, "", "  "); err != nil {
+	if err := json.Indent(&pretty, raw, "", "  "); err != nil {
 		// Fall back to raw bytes if the response wasn't JSON.
-		_, _ = w.Write(data)
-		if len(data) == 0 || data[len(data)-1] != '\n' {
+		_, _ = w.Write(raw)
+		if len(raw) == 0 || raw[len(raw)-1] != '\n' {
 			_, _ = w.Write([]byte("\n"))
 		}
 		return nil
@@ -87,4 +132,45 @@ func runRaw(w io.Writer, addr, query string) error {
 	_, _ = w.Write(pretty.Bytes())
 	_, _ = w.Write([]byte("\n"))
 	return nil
+}
+
+// postGraphQL sends a GraphQL document to the daemon and returns the
+// raw response body. Error messages name the next action ("start with
+// `orchard daemon start`") so users don't have to translate a
+// connection-refused on their own.
+func postGraphQL(ctx context.Context, query string) ([]byte, error) {
+	body, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, daemonURL+"/graphql", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: httpTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("daemon not running, start with `orchard daemon start` (%w)", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(data))
+	}
+	return data, nil
+}
+
+// SetDaemonURLForTest overrides the daemon URL. Tests that drive the
+// CLI against an httptest.Server use this to redirect HTTP traffic
+// without monkey-patching net/http.
+func SetDaemonURLForTest(u string) func() {
+	prev := daemonURL
+	daemonURL = u
+	return func() { daemonURL = prev }
 }

--- a/internal/cli/query/query_e2e_test.go
+++ b/internal/cli/query/query_e2e_test.go
@@ -1,0 +1,198 @@
+package query_test
+
+// CLI E2E for `orchard query projects`. The test compiles the binary
+// from cmd/orchard, spins the daemon's HTTP handler in an
+// httptest.Server (so we don't compete for the hard-coded localhost
+// port), points the binary at that URL via ORCHARD_DAEMON_URL, and
+// asserts stdout JSON. No mocks — real binary, real GraphQL
+// roundtrip, real fsnotify-driven config provider.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server"
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+)
+
+const cliE2EDeadline = 10 * time.Second
+
+// repoRoot returns the absolute path to the git repo root (the working
+// directory of `make daemon`). The test file is at
+// internal/cli/query/, so two parent traversals get there.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("runtime.Caller failed")
+	}
+	// .../internal/cli/query/query_e2e_test.go -> repo root
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+}
+
+// orchardOnce caches the compiled binary for the test process; building
+// once across N tests in this file is much faster than per-test rebuild.
+var (
+	orchardOnce sync.Once
+	orchardPath string
+	orchardErr  error
+)
+
+func buildOrchard(t *testing.T) string {
+	t.Helper()
+	orchardOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "orchard-e2e-bin-*")
+		if err != nil {
+			orchardErr = err
+			return
+		}
+		// Note: dir is intentionally not removed — the binary stays
+		// for the duration of the test process and is small enough
+		// not to matter.
+		out := filepath.Join(dir, "orchard")
+		root := repoRoot(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "go", "build", "-o", out, "./cmd/orchard")
+		cmd.Dir = root
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			orchardErr = err
+			t.Logf("go build stderr: %s", stderr.String())
+			return
+		}
+		orchardPath = out
+	})
+	if orchardErr != nil {
+		t.Fatalf("build orchard: %v", orchardErr)
+	}
+	return orchardPath
+}
+
+func TestCLI_QueryProjects_E2E(t *testing.T) {
+	binary := buildOrchard(t)
+
+	// Real config + provider + httptest.Server.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	cfg := configprovider.File{
+		Version: 1,
+		Projects: []configprovider.ProjectRow{
+			{ID: "alpha", Directory: "/abs/alpha", Name: "Alpha"},
+			{ID: "beta", Directory: "/abs/beta", Name: "Beta"},
+		},
+	}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(cfgPath, data, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	adapter := configprovider.NewJSONFileAdapter(cfgPath, nil)
+	provider := configprovider.NewProvider(adapter, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("provider start: %v", err)
+	}
+	t.Cleanup(func() { _ = provider.Stop() })
+
+	srv := server.New("", nil, server.WithProjects(provider))
+	ts := httptest.NewServer(srv.HTTPHandler())
+	t.Cleanup(ts.Close)
+
+	// Run `bin/orchard query projects` against the test daemon URL.
+	stdout, stderr, err := runOrchard(t, binary, ts.URL, "query", "projects")
+	if err != nil {
+		t.Fatalf("orchard query projects failed: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	// Parse the JSON array off stdout and assert shape.
+	var got []map[string]any
+	if err := json.Unmarshal(stdout, &got); err != nil {
+		t.Fatalf("decode stdout JSON: %v\nstdout: %s", err, stdout)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 projects, got %d (%+v)", len(got), got)
+	}
+	want := []map[string]string{
+		{"id": "alpha", "directory": "/abs/alpha", "name": "Alpha"},
+		{"id": "beta", "directory": "/abs/beta", "name": "Beta"},
+	}
+	for i, exp := range want {
+		for k, v := range exp {
+			if got[i][k] != v {
+				t.Errorf("row %d field %q: got %v, want %s", i, k, got[i][k], v)
+			}
+		}
+	}
+}
+
+func TestCLI_QueryProjects_Empty(t *testing.T) {
+	binary := buildOrchard(t)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(cfgPath, []byte(`{"version":1,"projects":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := configprovider.NewJSONFileAdapter(cfgPath, nil)
+	provider := configprovider.NewProvider(adapter, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := provider.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = provider.Stop() })
+
+	srv := server.New("", nil, server.WithProjects(provider))
+	ts := httptest.NewServer(srv.HTTPHandler())
+	t.Cleanup(ts.Close)
+
+	stdout, stderr, err := runOrchard(t, binary, ts.URL, "query", "projects")
+	if err != nil {
+		t.Fatalf("err: %v\nstderr: %s", err, stderr)
+	}
+	got := strings.TrimSpace(string(stdout))
+	if got != "[]" {
+		t.Errorf("want '[]', got %q", got)
+	}
+}
+
+func TestCLI_QueryProjects_DaemonDown(t *testing.T) {
+	binary := buildOrchard(t)
+	// Point at a localhost port that is not bound. The CLI must error
+	// with the actionable hint, not a silent success.
+	stdout, stderr, err := runOrchard(t, binary, "http://127.0.0.1:1", "query", "projects")
+	if err == nil {
+		t.Fatalf("expected non-zero exit, got nil; stdout=%s", stdout)
+	}
+	if !strings.Contains(stderr, "daemon not running") {
+		t.Errorf("expected actionable error, got stderr: %s", stderr)
+	}
+}
+
+// runOrchard executes the compiled binary with ORCHARD_DAEMON_URL set so
+// the CLI hits the test httptest.Server. Returns stdout, stderr, error.
+func runOrchard(t *testing.T, binary, daemonURL string, args ...string) ([]byte, string, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), cliE2EDeadline)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Env = append(os.Environ(), "ORCHARD_DAEMON_URL="+daemonURL)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.Bytes(), stderr.String(), err
+}

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -62,10 +62,17 @@ type ComplexityRoot struct {
 		ResourceLoad func(childComplexity int) int
 	}
 
+	Project struct {
+		Directory func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Name      func(childComplexity int) int
+	}
+
 	Query struct {
-		Health func(childComplexity int) int
-		Host   func(childComplexity int) int
-		Hosts  func(childComplexity int) int
+		Health   func(childComplexity int) int
+		Host     func(childComplexity int) int
+		Hosts    func(childComplexity int) int
+		Projects func(childComplexity int) int
 	}
 
 	ResourceLoad struct {
@@ -82,6 +89,7 @@ type QueryResolver interface {
 	Health(ctx context.Context) (*Health, error)
 	Host(ctx context.Context) (*Host, error)
 	Hosts(ctx context.Context) ([]*Host, error)
+	Projects(ctx context.Context) ([]*Project, error)
 }
 
 type executableSchema struct {
@@ -187,6 +195,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Host.ResourceLoad(childComplexity), true
 
+	case "Project.directory":
+		if e.complexity.Project.Directory == nil {
+			break
+		}
+
+		return e.complexity.Project.Directory(childComplexity), true
+
+	case "Project.id":
+		if e.complexity.Project.ID == nil {
+			break
+		}
+
+		return e.complexity.Project.ID(childComplexity), true
+
+	case "Project.name":
+		if e.complexity.Project.Name == nil {
+			break
+		}
+
+		return e.complexity.Project.Name(childComplexity), true
+
 	case "Query.health":
 		if e.complexity.Query.Health == nil {
 			break
@@ -207,6 +236,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Hosts(childComplexity), true
+
+	case "Query.projects":
+		if e.complexity.Query.Projects == nil {
+			break
+		}
+
+		return e.complexity.Query.Projects(childComplexity), true
 
 	case "ResourceLoad.cpuPercent":
 		if e.complexity.ResourceLoad.CPUPercent == nil {
@@ -352,6 +388,9 @@ var sources = []*ast.Source{
 # id, hostname, OS, kernel; resourceLoad surfaces live CPU/mem/disk/load
 # averages. peers ships empty until Workstream F federates orchard
 # instances together. Other providers add their own back-edges.
+#
+# Workstream B-config: Project node — projects declared in the orchard
+# config. Read-only; mutations go through ` + "`" + `orchard config add-repo` + "`" + `.
 
 """
 A node in the orchard graph. Every node has a globally-unique id so
@@ -372,6 +411,9 @@ type Query {
 
   "All hosts known to this daemon. v1: only the local host. Workstream F adds federated peers."
   hosts: [Host!]!
+
+  "All projects declared in ~/.config/orchard/config.json. Read-only — projects are added with ` + "`" + `orchard config add-repo` + "`" + `."
+  projects: [Project!]!
 }
 
 type Health {
@@ -441,6 +483,18 @@ type ResourceLoad {
 
   "15-minute load average."
   loadAvg15m: Float!
+}
+
+"A project (git repo) registered in the orchard config. The config file is the source of truth; the daemon reflects it via fsnotify."
+type Project implements Node {
+  "Stable identifier — slug of ` + "`" + `name` + "`" + `, falling back to a short hash of ` + "`" + `directory` + "`" + `. Survives re-registration."
+  id: ID!
+
+  "Absolute filesystem path to the project's working tree."
+  directory: String!
+
+  "Human-readable label. Defaults to the basename of ` + "`" + `directory` + "`" + ` when not specified in the config."
+  name: String!
 }
 `, BuiltIn: false},
 }
@@ -1058,6 +1112,138 @@ func (ec *executionContext) fieldContext_Host_peers(ctx context.Context, field g
 	return fc, nil
 }
 
+func (ec *executionContext) _Project_id(ctx context.Context, field graphql.CollectedField, obj *Project) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Project_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Project_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Project",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Project_directory(ctx context.Context, field graphql.CollectedField, obj *Project) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Project_directory(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Directory, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Project_directory(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Project",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Project_name(ctx context.Context, field graphql.CollectedField, obj *Project) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Project_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Project_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Project",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_health(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_health(ctx, field)
 	if err != nil {
@@ -1235,6 +1421,58 @@ func (ec *executionContext) fieldContext_Query_hosts(ctx context.Context, field 
 				return ec.fieldContext_Host_peers(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_projects(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_projects(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Projects(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*Project)
+	fc.Result = res
+	return ec.marshalNProject2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProjectᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_projects(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Project_id(ctx, field)
+			case "directory":
+				return ec.fieldContext_Project_directory(ctx, field)
+			case "name":
+				return ec.fieldContext_Project_name(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Project", field.Name)
 		},
 	}
 	return fc, nil
@@ -3421,6 +3659,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Host(ctx, sel, obj)
+	case Project:
+		return ec._Project(ctx, sel, &obj)
+	case *Project:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Project(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -3549,6 +3794,55 @@ func (ec *executionContext) _Host(ctx context.Context, sel ast.SelectionSet, obj
 	return out
 }
 
+var projectImplementors = []string{"Project", "Node"}
+
+func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, obj *Project) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, projectImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Project")
+		case "id":
+			out.Values[i] = ec._Project_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "directory":
+			out.Values[i] = ec._Project_directory(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._Project_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var queryImplementors = []string{"Query"}
 
 func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) graphql.Marshaler {
@@ -3622,6 +3916,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_hosts(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "projects":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_projects(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -4185,6 +4501,60 @@ func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.Selec
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNProject2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProjectᚄ(ctx context.Context, sel ast.SelectionSet, v []*Project) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNProject2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProject(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNProject2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProject(ctx context.Context, sel ast.SelectionSet, v *Project) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Project(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v interface{}) (string, error) {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -49,6 +49,21 @@ func (Host) IsNode() {}
 // Globally-unique id (e.g. "Host:<machineId>").
 func (this Host) GetID() string { return this.ID }
 
+// A project (git repo) registered in the orchard config. The config file is the source of truth; the daemon reflects it via fsnotify.
+type Project struct {
+	// Stable identifier — slug of `name`, falling back to a short hash of `directory`. Survives re-registration.
+	ID string `json:"id"`
+	// Absolute filesystem path to the project's working tree.
+	Directory string `json:"directory"`
+	// Human-readable label. Defaults to the basename of `directory` when not specified in the config.
+	Name string `json:"name"`
+}
+
+func (Project) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this Project) GetID() string { return this.ID }
+
 type Query struct {
 }
 

--- a/internal/server/providers/config/adapter.go
+++ b/internal/server/providers/config/adapter.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// JSONFileAdapter reads ~/.config/orchard/config.json and watches it
+// for changes. It implements adapter.Adapter[ProjectID, Project].
+//
+// fsnotify subtleties this adapter handles:
+//
+//   - Watching the file directly is fragile because editors (vim, VS
+//     Code) replace the file via rename, which removes the watch. We
+//     watch the *parent directory* and filter events to our basename.
+//   - The parent directory may not exist when the daemon boots; we
+//     create it with 0o755 to make watching reliable in fresh setups.
+//   - WRITE, CREATE and RENAME all may indicate a config edit; the
+//     adapter coalesces them into a single "the file changed" notice
+//     by emitting the same sentinel key on the Watch channel.
+type JSONFileAdapter struct {
+	path     string
+	logger   *slog.Logger
+	watcher  *fsnotify.Watcher
+	closedCh chan struct{}
+}
+
+// allKey is the sentinel emitted on Watch — config.json is a single
+// document, so per-key invalidation isn't meaningful. The provider
+// listens for this key and reloads the entire cache.
+const allKey ProjectID = "*"
+
+// NewJSONFileAdapter constructs an adapter rooted at path. The parent
+// directory is created if missing (best effort; permission errors fall
+// through to the caller). The adapter is safe to call before the file
+// exists — Fetch / FetchAll return empty results, and Watch fires once
+// the file appears.
+func NewJSONFileAdapter(path string, logger *slog.Logger) *JSONFileAdapter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &JSONFileAdapter{
+		path:     path,
+		logger:   logger,
+		closedCh: make(chan struct{}),
+	}
+}
+
+// Path returns the configured config-file path. Useful for diagnostics
+// and tests.
+func (a *JSONFileAdapter) Path() string { return a.path }
+
+// Fetch returns one project by ID. The full file is loaded each call —
+// this is fine for the config provider because the cache layer above
+// caches the result; Fetch is only called on cache miss for that ID.
+func (a *JSONFileAdapter) Fetch(ctx context.Context, id ProjectID) (Project, error) {
+	all, err := a.FetchAll(ctx)
+	if err != nil {
+		return Project{}, err
+	}
+	p, ok := all[id]
+	if !ok {
+		return Project{}, fmt.Errorf("project %q not found in %s", id, a.path)
+	}
+	return p, nil
+}
+
+// FetchAll loads and normalises every project in the config file. A
+// missing file returns an empty map (not an error) so the daemon can
+// boot before `orchard config init` has run.
+func (a *JSONFileAdapter) FetchAll(ctx context.Context) (map[ProjectID]Project, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(a.path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return map[ProjectID]Project{}, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", a.path, err)
+	}
+	if len(data) == 0 {
+		return map[ProjectID]Project{}, nil
+	}
+	var f File
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", a.path, err)
+	}
+	out := make(map[ProjectID]Project, len(f.Projects))
+	for _, row := range f.Projects {
+		p := row.ToProject()
+		if p.Directory == "" {
+			a.logger.Warn("config: skipping project with empty directory", "id", p.ID)
+			continue
+		}
+		out[p.ID] = p
+	}
+	return out, nil
+}
+
+// Watch starts an fsnotify watcher on the parent directory of a.path
+// and emits allKey whenever an event matching the config file is
+// observed. The channel is closed when ctx is cancelled or Close is
+// called.
+func (a *JSONFileAdapter) Watch(ctx context.Context) (<-chan ProjectID, error) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("fsnotify new: %w", err)
+	}
+	a.watcher = w
+
+	dir := filepath.Dir(a.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		_ = w.Close()
+		return nil, fmt.Errorf("ensure config dir %s: %w", dir, err)
+	}
+	if err := w.Add(dir); err != nil {
+		_ = w.Close()
+		return nil, fmt.Errorf("watch %s: %w", dir, err)
+	}
+
+	out := make(chan ProjectID, 8)
+	go a.run(ctx, out)
+	return out, nil
+}
+
+// run drains fsnotify events, filters them to our basename, and emits
+// allKey on the output channel. It exits when ctx is done or the
+// watcher is closed.
+func (a *JSONFileAdapter) run(ctx context.Context, out chan<- ProjectID) {
+	defer close(out)
+	defer close(a.closedCh)
+
+	base := filepath.Base(a.path)
+	for {
+		select {
+		case <-ctx.Done():
+			_ = a.watcher.Close()
+			return
+		case ev, ok := <-a.watcher.Events:
+			if !ok {
+				return
+			}
+			if filepath.Base(ev.Name) != base {
+				continue
+			}
+			if ev.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename|fsnotify.Remove) == 0 {
+				continue
+			}
+			a.logger.Debug("config: fsnotify event", "op", ev.Op.String(), "name", ev.Name)
+			select {
+			case out <- allKey:
+			case <-ctx.Done():
+				_ = a.watcher.Close()
+				return
+			}
+		case err, ok := <-a.watcher.Errors:
+			if !ok {
+				return
+			}
+			a.logger.Warn("config: fsnotify error", "err", err)
+		}
+	}
+}
+
+// Close shuts down the watcher and waits briefly for the run loop to
+// exit so callers can rely on no further channel sends after Close
+// returns. Idempotent.
+func (a *JSONFileAdapter) Close() error {
+	if a.watcher == nil {
+		return nil
+	}
+	err := a.watcher.Close()
+	<-a.closedCh
+	a.watcher = nil
+	if err != nil {
+		return fmt.Errorf("close watcher: %w", err)
+	}
+	return nil
+}

--- a/internal/server/providers/config/config_e2e_test.go
+++ b/internal/server/providers/config/config_e2e_test.go
@@ -1,0 +1,202 @@
+package config_test
+
+// E2E test for the config provider — no mocks. Spins the GraphQL
+// daemon's HTTP handler in an httptest.Server with a real config
+// JSONFileAdapter watching a real tempdir, runs real fsnotify, and
+// performs real GraphQL roundtrips. The "modify the file → requery"
+// step proves the watcher → resolver pipeline reflects edits without a
+// mutation API.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server"
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+)
+
+const e2eDeadline = 5 * time.Second
+
+func writeConfigE2E(t *testing.T, path string, projects []configprovider.ProjectRow) {
+	t.Helper()
+	f := configprovider.File{Version: 1, Projects: projects}
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Atomic write — mirrors what `orchard config add-repo` does so the
+	// fsnotify event semantics match production.
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+}
+
+func gqlQuery(t *testing.T, ts *httptest.Server, doc string) []map[string]any {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"query": doc})
+	resp, err := http.Post(ts.URL+"/graphql", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status %d", resp.StatusCode)
+	}
+	var env struct {
+		Data struct {
+			Projects []map[string]any `json:"projects"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(env.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", env.Errors)
+	}
+	out := env.Data.Projects
+	sort.Slice(out, func(i, j int) bool { return out[i]["id"].(string) < out[j]["id"].(string) })
+	return out
+}
+
+func TestConfigProvider_E2E_RoundTrip(t *testing.T) {
+	// Real tempdir, real config file, real fsnotify, real GraphQL
+	// server — no mocks. This is the integration contract for the
+	// provider end of the feature.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	// Seed with two projects.
+	writeConfigE2E(t, cfgPath, []configprovider.ProjectRow{
+		{ID: "alpha", Directory: "/abs/alpha", Name: "Alpha"},
+		{ID: "beta", Directory: "/abs/beta", Name: "Beta"},
+	})
+
+	// Build the provider stack the daemon would build.
+	adapter := configprovider.NewJSONFileAdapter(cfgPath, nil)
+	provider := configprovider.NewProvider(adapter, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("provider start: %v", err)
+	}
+	t.Cleanup(func() { _ = provider.Stop() })
+
+	// Spin the GraphQL HTTP handler in httptest.Server.
+	srv := server.New("", nil, server.WithProjects(provider))
+	ts := httptest.NewServer(srv.HTTPHandler())
+	t.Cleanup(ts.Close)
+
+	// Initial state: both projects present.
+	got := gqlQuery(t, ts, `{ projects { id directory name } }`)
+	if len(got) != 2 {
+		t.Fatalf("want 2 projects, got %d (%+v)", len(got), got)
+	}
+	if got[0]["id"] != "alpha" || got[0]["directory"] != "/abs/alpha" || got[0]["name"] != "Alpha" {
+		t.Errorf("alpha row wrong: %+v", got[0])
+	}
+	if got[1]["id"] != "beta" {
+		t.Errorf("beta row wrong: %+v", got[1])
+	}
+
+	// Modify config — append gamma. fsnotify should reload, GraphQL
+	// should report three on next query. Poll for up to e2eDeadline
+	// because fsnotify timing varies across platforms.
+	writeConfigE2E(t, cfgPath, []configprovider.ProjectRow{
+		{ID: "alpha", Directory: "/abs/alpha", Name: "Alpha"},
+		{ID: "beta", Directory: "/abs/beta", Name: "Beta"},
+		{ID: "gamma", Directory: "/abs/gamma", Name: "Gamma"},
+	})
+
+	deadline := time.Now().Add(e2eDeadline)
+	for {
+		got = gqlQuery(t, ts, `{ projects { id directory name } }`)
+		if len(got) == 3 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected 3 projects after fsnotify roundtrip, got %d (%+v)", len(got), got)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got[0]["id"] != "alpha" || got[1]["id"] != "beta" || got[2]["id"] != "gamma" {
+		t.Errorf("post-modify ordering wrong: %+v", got)
+	}
+	if got[2]["directory"] != "/abs/gamma" || got[2]["name"] != "Gamma" {
+		t.Errorf("gamma row wrong: %+v", got[2])
+	}
+
+	// And remove a project — alpha goes away, two remain.
+	writeConfigE2E(t, cfgPath, []configprovider.ProjectRow{
+		{ID: "beta", Directory: "/abs/beta", Name: "Beta"},
+		{ID: "gamma", Directory: "/abs/gamma", Name: "Gamma"},
+	})
+	deadline = time.Now().Add(e2eDeadline)
+	for {
+		got = gqlQuery(t, ts, `{ projects { id directory name } }`)
+		if len(got) == 2 && got[0]["id"] == "beta" && got[1]["id"] == "gamma" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected alpha removal; got %+v", got)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func TestConfigProvider_E2E_ColdBootBeforeFile(t *testing.T) {
+	// Daemon starts with no config file — fsnotify must fire when the
+	// file appears. Verifies the parent-directory-watch contract.
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	adapter := configprovider.NewJSONFileAdapter(cfgPath, nil)
+	provider := configprovider.NewProvider(adapter, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(func() { _ = provider.Stop() })
+
+	srv := server.New("", nil, server.WithProjects(provider))
+	ts := httptest.NewServer(srv.HTTPHandler())
+	t.Cleanup(ts.Close)
+
+	got := gqlQuery(t, ts, `{ projects { id } }`)
+	if len(got) != 0 {
+		t.Fatalf("want empty before file, got %+v", got)
+	}
+
+	writeConfigE2E(t, cfgPath, []configprovider.ProjectRow{
+		{ID: "first", Directory: "/abs/first", Name: "First"},
+	})
+
+	deadline := time.Now().Add(e2eDeadline)
+	for {
+		got = gqlQuery(t, ts, `{ projects { id } }`)
+		if len(got) == 1 && got[0]["id"] == "first" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected first project after file appears, got %+v", got)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}

--- a/internal/server/providers/config/provider.go
+++ b/internal/server/providers/config/provider.go
@@ -1,0 +1,332 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
+)
+
+// FreshnessSource enumerates how the cached value was last populated.
+// Defined inline rather than importing a shared package because no other
+// provider needs it yet; promote when a second consumer materialises.
+type FreshnessSource string
+
+const (
+	// SourceWatcherPush — value loaded after a watcher event.
+	SourceWatcherPush FreshnessSource = "watcher-push"
+	// SourcePoll — value loaded by a periodic refresh (unused by the
+	// config provider in v1; reserved for parity with ADR-011 §2).
+	SourcePoll FreshnessSource = "poll"
+	// SourceStaleCache — value served from a snapshot that has not
+	// been re-validated since boot.
+	SourceStaleCache FreshnessSource = "stale-cache"
+	// SourceCold — first-load population direct from the adapter.
+	SourceCold FreshnessSource = "cold-load"
+)
+
+// Freshness annotates each cache entry with the time and origin of the
+// last successful load. Mirrors ADR-011 §2's Freshness struct.
+type Freshness struct {
+	LastFetchedAt time.Time
+	Source        FreshnessSource
+}
+
+// InvalidationEvent is emitted on the provider's Subscribe channel
+// whenever a key's value may have changed.
+type InvalidationEvent struct {
+	Key    ProjectID
+	Reason string
+	At     time.Time
+}
+
+// Provider surfaces Project nodes to the GraphQL resolver layer. It owns
+// an in-memory cache, a single fsnotify watcher (via the adapter), and
+// a fan-out for Subscribers.
+//
+// Per ADR-011 §2 the provider exposes only reads — no Put / Delete.
+// Writes happen via the CLI editing the config file, and the watcher
+// turns those edits into invalidation events.
+type Provider struct {
+	adapter adapter.Adapter[ProjectID, Project]
+	logger  *slog.Logger
+
+	mu     sync.RWMutex
+	cache  map[ProjectID]Project
+	fresh  map[ProjectID]Freshness
+	loaded bool
+
+	subMu sync.Mutex
+	subs  map[chan InvalidationEvent]struct{}
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+}
+
+// NewProvider wires an adapter into a Provider. The provider does not
+// touch the adapter until Start is called, so it is safe to construct
+// at process boot before the daemon has decided whether to run.
+func NewProvider(a adapter.Adapter[ProjectID, Project], logger *slog.Logger) *Provider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Provider{
+		adapter: a,
+		logger:  logger,
+		cache:   map[ProjectID]Project{},
+		fresh:   map[ProjectID]Freshness{},
+		subs:    map[chan InvalidationEvent]struct{}{},
+		stopCh:  make(chan struct{}),
+		doneCh:  make(chan struct{}),
+	}
+}
+
+// Start hydrates the cache from the adapter and launches the watcher
+// goroutine. Subsequent calls are no-ops; one provider, one lifecycle.
+func (p *Provider) Start(ctx context.Context) error {
+	var startErr error
+	p.startOnce.Do(func() {
+		if err := p.reload(ctx, "boot", SourceCold); err != nil {
+			startErr = fmt.Errorf("hydrate config cache: %w", err)
+			return
+		}
+		ch, err := p.adapter.Watch(ctx)
+		if err != nil {
+			startErr = fmt.Errorf("start watcher: %w", err)
+			return
+		}
+		go p.run(ctx, ch)
+	})
+	return startErr
+}
+
+// Stop tears down the watcher and any subscribers. Idempotent.
+func (p *Provider) Stop() error {
+	var err error
+	p.stopOnce.Do(func() {
+		close(p.stopCh)
+		<-p.doneCh
+		err = p.adapter.Close()
+		p.subMu.Lock()
+		for ch := range p.subs {
+			close(ch)
+			delete(p.subs, ch)
+		}
+		p.subMu.Unlock()
+	})
+	return err
+}
+
+// Get returns one project by ID, plus its freshness. Cache hit is the
+// common path; on miss the adapter is consulted and the result cached.
+func (p *Provider) Get(ctx context.Context, key ProjectID) (Project, Freshness, error) {
+	if v, f, ok := p.cacheGet(key); ok {
+		return v, f, nil
+	}
+	v, err := p.adapter.Fetch(ctx, key)
+	if err != nil {
+		return Project{}, Freshness{}, err
+	}
+	f := Freshness{LastFetchedAt: time.Now(), Source: SourceCold}
+	p.cachePut(key, v, f)
+	return v, f, nil
+}
+
+// GetMany is the DataLoader-friendly batch read. Duplicate keys in the
+// input slice are coalesced — the result map has at most one entry per
+// distinct key. Cache hits avoid the adapter entirely; misses share a
+// single FetchAll round-trip when more than one is required.
+func (p *Provider) GetMany(ctx context.Context, keys []ProjectID) (map[ProjectID]Project, map[ProjectID]Freshness, error) {
+	out := make(map[ProjectID]Project, len(keys))
+	freshness := make(map[ProjectID]Freshness, len(keys))
+
+	missing := make([]ProjectID, 0, len(keys))
+	seen := make(map[ProjectID]struct{}, len(keys))
+	for _, k := range keys {
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		if v, f, ok := p.cacheGet(k); ok {
+			out[k] = v
+			freshness[k] = f
+			continue
+		}
+		missing = append(missing, k)
+	}
+
+	if len(missing) == 0 {
+		return out, freshness, nil
+	}
+
+	// One FetchAll covers all misses — the config file is a single
+	// document, so there is no per-key cost saving in fetching them
+	// individually.
+	all, err := p.adapter.FetchAll(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	now := time.Now()
+	for _, k := range missing {
+		v, ok := all[k]
+		if !ok {
+			continue
+		}
+		f := Freshness{LastFetchedAt: now, Source: SourceCold}
+		p.cachePut(k, v, f)
+		out[k] = v
+		freshness[k] = f
+	}
+	return out, freshness, nil
+}
+
+// Keys returns every project ID currently in the cache. Cold boot
+// returns an empty slice; the watcher hydrates the cache before any
+// resolver calls in well-formed setups.
+func (p *Provider) Keys(_ context.Context) ([]ProjectID, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]ProjectID, 0, len(p.cache))
+	for k := range p.cache {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// List returns every cached Project as a slice. This is what the
+// resolver for `Query.projects` calls; List is a thin convenience over
+// the read-mutex.
+func (p *Provider) List(_ context.Context) ([]Project, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]Project, 0, len(p.cache))
+	for _, v := range p.cache {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+// Subscribe returns a buffered channel that receives invalidation
+// events for as long as ctx is alive. Closing the returned context (or
+// calling Stop) cleans the subscription up.
+func (p *Provider) Subscribe(ctx context.Context) <-chan InvalidationEvent {
+	ch := make(chan InvalidationEvent, 8)
+	p.subMu.Lock()
+	p.subs[ch] = struct{}{}
+	p.subMu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		p.subMu.Lock()
+		if _, ok := p.subs[ch]; ok {
+			delete(p.subs, ch)
+			close(ch)
+		}
+		p.subMu.Unlock()
+	}()
+	return ch
+}
+
+// run drains the adapter's Watch channel, reloading the cache on every
+// signal and broadcasting invalidations to subscribers.
+func (p *Provider) run(ctx context.Context, ch <-chan ProjectID) {
+	defer close(p.doneCh)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.stopCh:
+			return
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+			if err := p.reload(ctx, "fs-modify", SourceWatcherPush); err != nil {
+				p.logger.Error("config: reload failed", "err", err)
+			}
+		}
+	}
+}
+
+// reload fetches the full set of projects, replaces the cache, and
+// broadcasts invalidations for every key whose value changed (or that
+// disappeared). Reason is propagated to subscribers verbatim.
+func (p *Provider) reload(ctx context.Context, reason string, source FreshnessSource) error {
+	all, err := p.adapter.FetchAll(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+
+	p.mu.Lock()
+	old := p.cache
+	p.cache = all
+	p.fresh = make(map[ProjectID]Freshness, len(all))
+	for k := range all {
+		p.fresh[k] = Freshness{LastFetchedAt: now, Source: source}
+	}
+	p.loaded = true
+	p.mu.Unlock()
+
+	// Diff and broadcast. We emit one event per added / changed /
+	// removed key. Subscribers can coalesce; the daemon does not.
+	changed := make([]ProjectID, 0)
+	for k, v := range all {
+		ov, had := old[k]
+		if !had || ov != v {
+			changed = append(changed, k)
+		}
+	}
+	for k := range old {
+		if _, still := all[k]; !still {
+			changed = append(changed, k)
+		}
+	}
+	if len(changed) == 0 && reason == "boot" {
+		// No-op boot when the file is empty: nothing to broadcast.
+		return nil
+	}
+	p.broadcast(changed, reason, now)
+	return nil
+}
+
+// broadcast fans an InvalidationEvent out to every subscriber. The
+// per-channel buffer is small; we drop on a full buffer rather than
+// block the watcher goroutine — subscribers that fall behind miss
+// events but stay alive.
+func (p *Provider) broadcast(keys []ProjectID, reason string, at time.Time) {
+	p.subMu.Lock()
+	defer p.subMu.Unlock()
+	for _, k := range keys {
+		ev := InvalidationEvent{Key: k, Reason: reason, At: at}
+		for ch := range p.subs {
+			select {
+			case ch <- ev:
+			default:
+				p.logger.Warn("config: subscriber lagging, dropping event", "key", string(k))
+			}
+		}
+	}
+}
+
+func (p *Provider) cacheGet(k ProjectID) (Project, Freshness, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	v, ok := p.cache[k]
+	if !ok {
+		return Project{}, Freshness{}, false
+	}
+	return v, p.fresh[k], true
+}
+
+func (p *Provider) cachePut(k ProjectID, v Project, f Freshness) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cache[k] = v
+	p.fresh[k] = f
+}

--- a/internal/server/providers/config/provider_test.go
+++ b/internal/server/providers/config/provider_test.go
@@ -1,0 +1,220 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+)
+
+// fsnotifySettleTimeout is how long tests wait for an fsnotify event to
+// propagate. macOS in particular is sometimes laggy; one second is more
+// than enough on every platform we run on without making failures slow.
+const fsnotifySettleTimeout = 2 * time.Second
+
+func writeConfig(t *testing.T, path string, projects []ProjectRow) {
+	t.Helper()
+	f := File{Version: 1, Projects: projects}
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func newProviderForTest(t *testing.T, dir string) (*Provider, string) {
+	t.Helper()
+	cfgPath := filepath.Join(dir, "config.json")
+	a := NewJSONFileAdapter(cfgPath, nil)
+	p := NewProvider(a, nil)
+	t.Cleanup(func() { _ = p.Stop() })
+	return p, cfgPath
+}
+
+func TestProvider_ColdBoot_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	p, _ := newProviderForTest(t, dir)
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want empty, got %v", got)
+	}
+}
+
+func TestProvider_FetchAll_NormalisesRows(t *testing.T) {
+	dir := t.TempDir()
+	p, cfgPath := newProviderForTest(t, dir)
+	writeConfig(t, cfgPath, []ProjectRow{
+		{Directory: "/abs/path/to/orchard"},                                 // id+name from directory
+		{Directory: "/abs/foo", Name: "Foo Project"},                        // id from name slug
+		{ID: "explicit", Directory: "/abs/bar", Name: "Custom"},             // all explicit
+	})
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3, got %d (%v)", len(got), got)
+	}
+
+	byID := map[ProjectID]Project{}
+	for _, p := range got {
+		byID[p.ID] = p
+	}
+	if p, ok := byID["orchard"]; !ok || p.Name != "orchard" {
+		t.Errorf("expected slug 'orchard' with name 'orchard', got %+v", p)
+	}
+	if p, ok := byID["foo-project"]; !ok || p.Directory != "/abs/foo" {
+		t.Errorf("expected slug 'foo-project' for /abs/foo, got %+v", byID)
+	}
+	if p, ok := byID["explicit"]; !ok || p.Name != "Custom" {
+		t.Errorf("expected explicit id 'explicit' with name 'Custom', got %+v", p)
+	}
+}
+
+func TestProvider_GetMany_CoalescesDuplicateKeys(t *testing.T) {
+	dir := t.TempDir()
+	p, cfgPath := newProviderForTest(t, dir)
+	writeConfig(t, cfgPath, []ProjectRow{
+		{ID: "alpha", Directory: "/abs/alpha", Name: "Alpha"},
+		{ID: "beta", Directory: "/abs/beta", Name: "Beta"},
+	})
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	keys := []ProjectID{"alpha", "alpha", "beta", "alpha"}
+	out, fresh, err := p.GetMany(context.Background(), keys)
+	if err != nil {
+		t.Fatalf("getmany: %v", err)
+	}
+	if len(out) != 2 || len(fresh) != 2 {
+		t.Fatalf("expected coalesced 2 entries, got %d/%d", len(out), len(fresh))
+	}
+	if out["alpha"].Directory != "/abs/alpha" {
+		t.Errorf("alpha dir wrong: %+v", out["alpha"])
+	}
+	if out["beta"].Name != "Beta" {
+		t.Errorf("beta name wrong: %+v", out["beta"])
+	}
+}
+
+func TestProvider_FsnotifyReload(t *testing.T) {
+	dir := t.TempDir()
+	p, cfgPath := newProviderForTest(t, dir)
+	writeConfig(t, cfgPath, []ProjectRow{
+		{ID: "alpha", Directory: "/abs/alpha", Name: "Alpha"},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	sub := p.Subscribe(ctx)
+
+	// Sanity — initial state.
+	keys, _ := p.Keys(ctx)
+	if len(keys) != 1 {
+		t.Fatalf("expected 1 cold-load key, got %v", keys)
+	}
+
+	// Modify the file with a second project; fsnotify should reload.
+	writeConfig(t, cfgPath, []ProjectRow{
+		{ID: "alpha", Directory: "/abs/alpha", Name: "Alpha"},
+		{ID: "beta", Directory: "/abs/beta", Name: "Beta"},
+	})
+
+	deadline := time.After(fsnotifySettleTimeout)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("fsnotify reload timed out; cache=%v", mustList(t, p))
+		case ev := <-sub:
+			t.Logf("invalidation: %s reason=%s", ev.Key, ev.Reason)
+			ks, _ := p.Keys(ctx)
+			sort.Slice(ks, func(i, j int) bool { return ks[i] < ks[j] })
+			if len(ks) == 2 && ks[0] == "alpha" && ks[1] == "beta" {
+				return
+			}
+		}
+	}
+}
+
+func TestProvider_FsnotifyRemoveProject(t *testing.T) {
+	dir := t.TempDir()
+	p, cfgPath := newProviderForTest(t, dir)
+	writeConfig(t, cfgPath, []ProjectRow{
+		{ID: "alpha", Directory: "/abs/alpha", Name: "Alpha"},
+		{ID: "beta", Directory: "/abs/beta", Name: "Beta"},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	sub := p.Subscribe(ctx)
+
+	// Drop beta from disk.
+	writeConfig(t, cfgPath, []ProjectRow{
+		{ID: "alpha", Directory: "/abs/alpha", Name: "Alpha"},
+	})
+
+	deadline := time.After(fsnotifySettleTimeout)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("expected beta removal; cache=%v", mustList(t, p))
+		case <-sub:
+			ks, _ := p.Keys(ctx)
+			if len(ks) == 1 && ks[0] == "alpha" {
+				return
+			}
+		}
+	}
+}
+
+func TestSlug_HandlesPunctuation(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Hello, World!", "hello-world"},
+		{"  Foo  Bar  ", "foo-bar"},
+		{"snake_case", "snake-case"},
+		{"git-orchard-rs", "git-orchard-rs"},
+		{"", ""},
+		{"   ", ""},
+	}
+	for _, c := range cases {
+		if got := slug(c.in); got != c.want {
+			t.Errorf("slug(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSlugOrHash_FallsBackOnNonAscii(t *testing.T) {
+	got := slugOrHash("日本語", "/abs/path")
+	if len(got) != 12 {
+		t.Errorf("expected 12-char hash, got %q", got)
+	}
+}
+
+func mustList(t *testing.T, p *Provider) []Project {
+	t.Helper()
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	return got
+}

--- a/internal/server/providers/config/provider_test.go
+++ b/internal/server/providers/config/provider_test.go
@@ -55,9 +55,9 @@ func TestProvider_FetchAll_NormalisesRows(t *testing.T) {
 	dir := t.TempDir()
 	p, cfgPath := newProviderForTest(t, dir)
 	writeConfig(t, cfgPath, []ProjectRow{
-		{Directory: "/abs/path/to/orchard"},                                 // id+name from directory
-		{Directory: "/abs/foo", Name: "Foo Project"},                        // id from name slug
-		{ID: "explicit", Directory: "/abs/bar", Name: "Custom"},             // all explicit
+		{Directory: "/abs/path/to/orchard"},                     // id+name from directory
+		{Directory: "/abs/foo", Name: "Foo Project"},            // id from name slug
+		{ID: "explicit", Directory: "/abs/bar", Name: "Custom"}, // all explicit
 	})
 	if err := p.Start(context.Background()); err != nil {
 		t.Fatalf("start: %v", err)

--- a/internal/server/providers/config/types.go
+++ b/internal/server/providers/config/types.go
@@ -1,0 +1,115 @@
+// Package config implements the orchard `Project` provider.
+//
+// Per ADR-011 §5.1 a Project is declared in ~/.config/orchard/config.json
+// and is read-only from orchard's POV. Mutations are CLI-driven edits to
+// the config file; the running daemon reflects them via fsnotify. This
+// package owns the file format, the JSON adapter, and the provider that
+// surfaces Projects to the GraphQL resolver.
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"path/filepath"
+	"strings"
+)
+
+// ProjectID is the stable identifier for a project across config edits
+// and daemon restarts.
+type ProjectID string
+
+// Project is the in-memory representation of a configured project.
+// The wire-level GraphQL type lives in internal/server/graphql; this
+// type is what the provider stores and what the resolver maps from.
+type Project struct {
+	ID        ProjectID `json:"id"`
+	Directory string    `json:"directory"`
+	Name      string    `json:"name"`
+}
+
+// File is the on-disk shape of ~/.config/orchard/config.json.
+//
+// Versioning is explicit so future schema bumps can be detected. v1
+// carries only `projects`; later workstreams may add fields. Unknown
+// fields are tolerated (json.Unmarshal default behaviour) so older
+// daemons can read newer configs without crashing.
+type File struct {
+	Version  int          `json:"version"`
+	Projects []ProjectRow `json:"projects"`
+}
+
+// ProjectRow is one entry in `projects`. All three fields are emitted by
+// `orchard config add-repo`; `id` is normalised to a slug if blank, and
+// `name` defaults to the basename of `directory` if blank.
+type ProjectRow struct {
+	ID        ProjectID `json:"id"`
+	Directory string    `json:"directory"`
+	Name      string    `json:"name"`
+}
+
+// Normalise fills in missing fields per the documented conventions.
+//
+//   - If Name is blank, take the basename of Directory.
+//   - If ID is blank, slugify Name; fall back to a short hash of
+//     Directory when slugification yields the empty string.
+//
+// The function is pure and idempotent — calling it on an already-
+// normalised row leaves the row unchanged.
+func (r ProjectRow) Normalise() ProjectRow {
+	out := r
+	if out.Name == "" {
+		out.Name = filepath.Base(out.Directory)
+	}
+	if out.ID == "" {
+		out.ID = ProjectID(slugOrHash(out.Name, out.Directory))
+	}
+	return out
+}
+
+// ToProject lifts a ProjectRow into the in-memory Project type after
+// normalisation. The provider calls this on every cache load.
+func (r ProjectRow) ToProject() Project {
+	n := r.Normalise()
+	return Project{
+		ID:        n.ID,
+		Directory: n.Directory,
+		Name:      n.Name,
+	}
+}
+
+// slugOrHash returns a lowercase slug of name, or the first 12 hex chars
+// of sha256(directory) when the slug is empty (e.g. when name was a
+// non-ASCII path basename that contained no slug-friendly runes).
+func slugOrHash(name, directory string) string {
+	if s := slug(name); s != "" {
+		return s
+	}
+	sum := sha256.Sum256([]byte(directory))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+// slug lowercases name, replaces runs of non-alphanumeric runes with a
+// single dash, and trims leading/trailing dashes. Pure ASCII; non-ASCII
+// runes are dropped entirely.
+func slug(name string) string {
+	var b strings.Builder
+	prevDash := true // suppress leading dash
+	for _, r := range name {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r + ('a' - 'A'))
+			prevDash = false
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteRune('-')
+				prevDash = true
+			}
+		}
+	}
+	out := b.String()
+	out = strings.TrimRight(out, "-")
+	return out
+}

--- a/internal/server/providers/config/types.go
+++ b/internal/server/providers/config/types.go
@@ -67,14 +67,10 @@ func (r ProjectRow) Normalise() ProjectRow {
 }
 
 // ToProject lifts a ProjectRow into the in-memory Project type after
-// normalisation. The provider calls this on every cache load.
+// normalisation. The provider calls this on every cache load. ProjectRow
+// and Project share the same layout so a struct conversion is sufficient.
 func (r ProjectRow) ToProject() Project {
-	n := r.Normalise()
-	return Project{
-		ID:        n.ID,
-		Directory: n.Directory,
-		Name:      n.Name,
-	}
+	return Project(r.Normalise())
 }
 
 // slugOrHash returns a lowercase slug of name, or the first 12 hex chars

--- a/internal/server/providers/host/host_e2e_test.go
+++ b/internal/server/providers/host/host_e2e_test.go
@@ -173,7 +173,7 @@ func mustPercent(t *testing.T, name string, v float64) {
 // except the network listener is httptest.
 func newTestDaemon(t *testing.T, provider *host.Provider) *httptest.Server {
 	t.Helper()
-	cfg := gql.Config{Resolvers: resolvers.New(time.Now(), provider)}
+	cfg := gql.Config{Resolvers: resolvers.New(time.Now()).WithHost(provider)}
 	gqlSrv := handler.New(gql.NewExecutableSchema(cfg))
 	gqlSrv.AddTransport(transport.POST{})
 	gqlSrv.AddTransport(transport.GET{})

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -1,24 +1,51 @@
 package resolvers
 
 import (
+	"context"
 	"time"
 
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 )
+
+// ProjectsLister is the narrow read-side contract the project resolver
+// depends on. Defined here (consumer-side) so the resolver doesn't reach
+// into the provider package's full surface — accept interfaces, return
+// concretes.
+type ProjectsLister interface {
+	List(ctx context.Context) ([]configprovider.Project, error)
+}
 
 // Resolver is the dependency-injection root for GraphQL resolvers.
 //
 // gqlgen does NOT regenerate this file, so anything we wire here survives
-// schema iteration. Workstream A only needed StartedAt for the health
-// resolver; Workstream B-host adds the host Provider; later workstreams
-// hang their providers off this struct alongside.
+// schema iteration. Provider fields are suffixed with `Provider` to
+// avoid colliding with the generated field-resolver method names that
+// embed this struct (e.g. queryResolver.Projects(ctx)). Optional
+// dependencies are wired via With* setters so callers can swap
+// implementations in tests.
 type Resolver struct {
-	StartedAt    time.Time
-	HostProvider *host.Provider
+	StartedAt        time.Time
+	HostProvider     *host.Provider
+	ProjectsProvider ProjectsLister
 }
 
-// New constructs a Resolver with the daemon's start time and the host
-// Provider. The caller (the daemon entry point) calls this once at boot.
-func New(startedAt time.Time, h *host.Provider) *Resolver {
-	return &Resolver{StartedAt: startedAt, HostProvider: h}
+// New constructs a Resolver with the daemon's start time captured. The
+// caller (the daemon entry point) calls this once at boot. Optional
+// dependencies (the providers) are wired with the With* setters below
+// so callers can swap implementations in tests.
+func New(startedAt time.Time) *Resolver {
+	return &Resolver{StartedAt: startedAt}
+}
+
+// WithHost wires the host provider.
+func (r *Resolver) WithHost(h *host.Provider) *Resolver {
+	r.HostProvider = h
+	return r
+}
+
+// WithProjects wires the projects-listing dependency.
+func (r *Resolver) WithProjects(p ProjectsLister) *Resolver {
+	r.ProjectsProvider = p
+	return r
 }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -7,6 +7,7 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
@@ -42,9 +43,27 @@ func (r *queryResolver) Hosts(ctx context.Context) ([]*graphql1.Host, error) {
 	return []*graphql1.Host{h}, nil
 }
 
-// Projects is the resolver for the projects field.
+// Projects is the resolver for the projects field. It returns the
+// in-memory cached snapshot from the config provider. Order is stable
+// (by id) so consumers get reproducible output.
 func (r *queryResolver) Projects(ctx context.Context) ([]*graphql1.Project, error) {
-	panic(fmt.Errorf("not implemented: Projects - projects"))
+	if r.ProjectsProvider == nil {
+		return nil, fmt.Errorf("projects provider not wired: daemon misconfigured")
+	}
+	rows, err := r.ProjectsProvider.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list projects: %w", err)
+	}
+	out := make([]*graphql1.Project, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, &graphql1.Project{
+			ID:        string(row.ID),
+			Directory: row.Directory,
+			Name:      row.Name,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
 }
 
 // Query returns graphql1.QueryResolver implementation.

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -42,6 +42,11 @@ func (r *queryResolver) Hosts(ctx context.Context) ([]*graphql1.Host, error) {
 	return []*graphql1.Host{h}, nil
 }
 
+// Projects is the resolver for the projects field.
+func (r *queryResolver) Projects(ctx context.Context) ([]*graphql1.Project, error) {
+	panic(fmt.Errorf("not implemented: Projects - projects"))
+}
+
 // Query returns graphql1.QueryResolver implementation.
 func (r *Resolver) Query() graphql1.QueryResolver { return &queryResolver{r} }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,10 @@
 // in Run, so the resolver root has it ready before any GraphQL request
 // arrives. Subsequent provider workstreams hang their constructors off
 // New the same way.
+//
+// Workstream B-config: providers introduced by later workstreams are
+// wired through the Option pattern (WithFoo(p)), so New keeps a tight
+// signature as the provider set grows.
 package server
 
 import (
@@ -44,10 +48,20 @@ type Server struct {
 	host      *host.Provider
 }
 
-// New constructs a Server bound to addr. Providers are constructed here
-// but not started — Run owns lifecycle so the poll loops are tied to
-// the same ctx as the HTTP listener.
-func New(addr string, logger *slog.Logger) *Server {
+// Option mutates a Server during construction. Used for wiring optional
+// providers without bloating the New signature.
+type Option func(*Server, *resolvers.Resolver)
+
+// WithProjects wires a projects provider into the resolver.
+func WithProjects(p resolvers.ProjectsLister) Option {
+	return func(_ *Server, r *resolvers.Resolver) { r.WithProjects(p) }
+}
+
+// New constructs a Server bound to addr. The host provider is constructed
+// here but not started — Run owns lifecycle so the poll loops are tied
+// to the same ctx as the HTTP listener. Optional providers are wired
+// via the With* options.
+func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 	if addr == "" {
 		addr = DefaultAddr
 	}
@@ -57,25 +71,38 @@ func New(addr string, logger *slog.Logger) *Server {
 	startedAt := time.Now()
 
 	hostProvider := host.New()
+	res := resolvers.New(startedAt).WithHost(hostProvider)
+
+	srv := &Server{
+		addr:      addr,
+		startedAt: startedAt,
+		logger:    logger,
+		host:      hostProvider,
+	}
+	for _, opt := range opts {
+		opt(srv, res)
+	}
 
 	mux := http.NewServeMux()
 	mux.Handle("/health", healthHandler(startedAt))
-	mux.Handle("/graphql", graphqlHandler(startedAt, hostProvider))
+	mux.Handle("/graphql", graphqlHandlerFor(res))
 
-	httpSrv := &http.Server{
+	srv.httpSrv = &http.Server{
 		Addr:              addr,
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	return &Server{
-		addr:      addr,
-		startedAt: startedAt,
-		logger:    logger,
-		httpSrv:   httpSrv,
-		host:      hostProvider,
-	}
+	return srv
 }
+
+// Addr returns the configured listen address. Useful for tests using
+// httptest or for callers that need to print the URL.
+func (s *Server) Addr() string { return s.addr }
+
+// HTTPHandler returns the underlying HTTP mux for tests that wrap the
+// daemon in httptest.Server without binding a real port.
+func (s *Server) HTTPHandler() http.Handler { return s.httpSrv.Handler }
 
 // Run starts providers, the HTTP server, and blocks until ctx is
 // cancelled, then drains in-flight requests with a 5-second deadline.
@@ -125,12 +152,13 @@ func healthHandler(startedAt time.Time) http.HandlerFunc {
 	}
 }
 
-// graphqlHandler wires the gqlgen executable schema with the resolver
-// root that holds every provider. POST + GET (for query strings) are
-// both accepted; multipart and websocket transports stay deferred to
+// graphqlHandlerFor wires the gqlgen executable schema with an
+// already-constructed Resolver root, so callers can inject providers
+// before serving any requests. POST + GET (for query strings) are both
+// accepted; multipart and websocket transports stay deferred to
 // Workstream C.
-func graphqlHandler(startedAt time.Time, hostProvider *host.Provider) http.Handler {
-	cfg := gql.Config{Resolvers: resolvers.New(startedAt, hostProvider)}
+func graphqlHandlerFor(res *resolvers.Resolver) http.Handler {
+	cfg := gql.Config{Resolvers: res}
 	srv := handler.New(gql.NewExecutableSchema(cfg))
 	srv.AddTransport(transport.POST{})
 	srv.AddTransport(transport.GET{})

--- a/schema.graphql
+++ b/schema.graphql
@@ -11,6 +11,9 @@
 # id, hostname, OS, kernel; resourceLoad surfaces live CPU/mem/disk/load
 # averages. peers ships empty until Workstream F federates orchard
 # instances together. Other providers add their own back-edges.
+#
+# Workstream B-config: Project node — projects declared in the orchard
+# config. Read-only; mutations go through `orchard config add-repo`.
 
 """
 A node in the orchard graph. Every node has a globally-unique id so
@@ -31,6 +34,9 @@ type Query {
 
   "All hosts known to this daemon. v1: only the local host. Workstream F adds federated peers."
   hosts: [Host!]!
+
+  "All projects declared in ~/.config/orchard/config.json. Read-only — projects are added with `orchard config add-repo`."
+  projects: [Project!]!
 }
 
 type Health {
@@ -100,4 +106,16 @@ type ResourceLoad {
 
   "15-minute load average."
   loadAvg15m: Float!
+}
+
+"A project (git repo) registered in the orchard config. The config file is the source of truth; the daemon reflects it via fsnotify."
+type Project implements Node {
+  "Stable identifier — slug of `name`, falling back to a short hash of `directory`. Survives re-registration."
+  id: ID!
+
+  "Absolute filesystem path to the project's working tree."
+  directory: String!
+
+  "Human-readable label. Defaults to the basename of `directory` when not specified in the config."
+  name: String!
 }


### PR DESCRIPTION
## Summary

Implements the **config provider**, surfacing the **Project node** per ADR-011 §5.1.

The provider reads `~/.config/orchard/config.json`, watches it via fsnotify, and exposes the projects through GraphQL `Query.projects`. Mutations happen via `orchard config add-repo PATH` editing the file directly — the daemon reflects, never authors. No GraphQL Mutation surface, per ADR-011 §1.

## Dependency

Depends on #380 (Workstream A: orchard daemon scaffold). Branch is cut from `ws-a-scaffold`; rebase onto main once #380 lands.

## Acceptance criteria

- ✓ **AC1 — Schema additions.** `schema.graphql` gains `interface Node`, `type Project implements Node` with `id`/`directory`/`name`, and `Query.projects: [Project!]!`. `make generate` runs cleanly; generated `internal/server/graphql/{generated.go,models_gen.go}` and `resolvers/schema.resolvers.go` are committed. (Commit `853db6a`.)
- ✓ **AC2 — Config file shape.** `internal/server/providers/config/types.go` documents `{version, projects:[{id, directory, name}]}` via the canonical `File` and `ProjectRow` types. `id` falls back to a slug of `name`, then a 12-char sha256 of `directory`. `name` falls back to `filepath.Base(directory)`. (Commit `853db6a`.)
- ✓ **AC3 — Provider implementation.** `internal/server/providers/config/{adapter,provider}.go` implements `Provider[ProjectID, Project]`. The `JSONFileAdapter` watches the *parent* directory (not the file directly — survives editor rename-on-write); coalesces WRITE/CREATE/RENAME/REMOVE into one sentinel reload key; `GetMany` coalesces duplicate keys and shares a single `FetchAll` for cache misses. Unit tests cover normalisation, `GetMany` dedupe, fsnotify add+remove. (Commit `853db6a`.)
- ✓ **AC4 — Resolver wiring.** `Resolver.ProjectsProvider` field (`Provider`-suffixed to avoid collision with the generated `queryResolver.Projects` method); `server.New` exposes a `WithProjects` option; `daemon start` constructs the provider, calls `Start(ctx)`, and threads it in. (Commit `14cac3a`.)
- ✓ **AC5 — `orchard config add-repo PATH`.** Validates PATH exists, is a directory, and contains `.git/` (with `--allow-non-git` escape hatch). Atomic tmp+rename write. Idempotent — re-adding the same dir updates rather than duplicates. Tests cover rejection / acceptance / dedupe / multi-repo accumulation. (Commit `76b8a99`.)
- ✓ **AC6 — `orchard query projects`.** New cobra subcommand. Posts `{ projects { id directory name } }` to `localhost:7777/graphql`, prints a plain JSON array (not the GraphQL envelope) so consumers can `jq` straight in. Honours `ORCHARD_DAEMON_URL` for tests. Daemon-down errors surface the actionable hint. (Commit `0a07f78`.)
- ✓ **AC7 — E2E provider test (no mocks).** `internal/server/providers/config/config_e2e_test.go`: real tempdir + real `config.json` + real fsnotify watcher driving an `httptest.Server` with the full GraphQL stack. Asserts initial 2 projects, atomic-modifies the file (mirrors `add-repo` semantics), polls until GraphQL reflects 3, removes one, polls until reflected. Plus `ColdBootBeforeFile` — the daemon starts before `config.json` exists and reflects when it appears. (Commit `5fd05e4`.)
- ✓ **AC8 — CLI E2E test.** `internal/cli/query/query_e2e_test.go`: `go build`s the real `cmd/orchard` binary into a temp path (cached via `sync.Once`), points it at an `httptest.Server` via `ORCHARD_DAEMON_URL`, and `exec.Command`s `orchard query projects` as a subprocess. Asserts stdout JSON. Three subtests: happy path, empty config, daemon-down. (Commit `5fd05e4`.)
- ✓ **AC9 — Provider tests pass.** `go test ./internal/server/providers/config/...` ⇒ all green (provider unit + E2E). Also `go test ./...` is clean across the whole module. (Commit `09474f1`.)
- ✓ **AC10 — golangci-lint clean for scope.** `golangci-lint run --enable=revive,errcheck,govet,ineffassign,staticcheck,gocritic --new-from-rev=ws-a-scaffold ./...` ⇒ no findings. `gofmt -l .` clean. (Commit `09474f1`.)
- ✓ **AC11 — Draft PR opened.** This PR. Will mark ready for review when CI is green and #380 has merged.

## Out of scope

- Other providers (host/git/ps/tmux/claude — separate sisters in flight).
- Federation (`Host.peers`) — Workstream F.
- Project removal (only `add-repo` for v1).
- Project ↔ Worktree edges — wait for `ws-b-git` to land the Worktree node.

## Test plan

- [x] `go test ./internal/server/providers/config/... -v` green
- [x] `go test ./internal/cli/config/... -v` green
- [x] `go test ./internal/cli/query/... -v` green (subprocess E2E)
- [x] `go test ./...` overall green
- [x] `golangci-lint run --new-from-rev=ws-a-scaffold` clean
- [x] `gofmt -l .` clean
- [x] `make daemon` builds → `bin/orchard` runs
- [x] `bin/orchard config add-repo --help` and `query projects --help` show meaningful usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `orchard config add-repo PATH` command to register projects with validation (path must exist and be a directory; optionally requires `.git` directory unless `--allow-non-git` flag is set).
  * Added `orchard query projects` command to list all configured projects.

* **Chores**
  * Updated Go version to 1.23 and added supporting dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->