### PR TITLE
Workstream B-git: git provider → Worktree node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
+	github.com/fsnotify/fsnotify v1.10.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -26,7 +26,20 @@ resolver:
 # Optimised types for our schema. Health.uptimeS is non-negative and fits
 # easily into int64; map GraphQL Int to Go int64 to keep parity with the
 # stdlib JSON encoder.
+#
+# Per-field overrides force gqlgen to emit a resolver method for fields
+# whose value comes from a provider rather than a struct field. The git
+# provider drives Project.worktrees; the (future) ps provider drives
+# Worktree.processes. Until ps lands, the latter resolver returns [].
 models:
   Int:
     model:
       - github.com/99designs/gqlgen/graphql.Int64
+  Project:
+    fields:
+      worktrees:
+        resolver: true
+  Worktree:
+    fields:
+      processes:
+        resolver: true

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -37,7 +37,9 @@ type Config struct {
 }
 
 type ResolverRoot interface {
+	Project() ProjectResolver
 	Query() QueryResolver
+	Worktree() WorktreeResolver
 }
 
 type DirectiveRoot struct {
@@ -62,10 +64,15 @@ type ComplexityRoot struct {
 		ResourceLoad func(childComplexity int) int
 	}
 
+	Process struct {
+		ID func(childComplexity int) int
+	}
+
 	Project struct {
 		Directory func(childComplexity int) int
 		ID        func(childComplexity int) int
 		Name      func(childComplexity int) int
+		Worktrees func(childComplexity int) int
 	}
 
 	Query struct {
@@ -83,13 +90,28 @@ type ComplexityRoot struct {
 		LoadAvg5m   func(childComplexity int) int
 		MemPercent  func(childComplexity int) int
 	}
+
+	Worktree struct {
+		Bare      func(childComplexity int) int
+		Branch    func(childComplexity int) int
+		Head      func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Path      func(childComplexity int) int
+		Processes func(childComplexity int) int
+	}
 }
 
+type ProjectResolver interface {
+	Worktrees(ctx context.Context, obj *Project) ([]*Worktree, error)
+}
 type QueryResolver interface {
 	Health(ctx context.Context) (*Health, error)
 	Host(ctx context.Context) (*Host, error)
 	Hosts(ctx context.Context) ([]*Host, error)
 	Projects(ctx context.Context) ([]*Project, error)
+}
+type WorktreeResolver interface {
+	Processes(ctx context.Context, obj *Worktree) ([]*Process, error)
 }
 
 type executableSchema struct {
@@ -195,6 +217,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Host.ResourceLoad(childComplexity), true
 
+	case "Process.id":
+		if e.complexity.Process.ID == nil {
+			break
+		}
+
+		return e.complexity.Process.ID(childComplexity), true
+
 	case "Project.directory":
 		if e.complexity.Project.Directory == nil {
 			break
@@ -215,6 +244,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Project.Name(childComplexity), true
+
+	case "Project.worktrees":
+		if e.complexity.Project.Worktrees == nil {
+			break
+		}
+
+		return e.complexity.Project.Worktrees(childComplexity), true
 
 	case "Query.health":
 		if e.complexity.Query.Health == nil {
@@ -285,6 +321,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ResourceLoad.MemPercent(childComplexity), true
+
+	case "Worktree.bare":
+		if e.complexity.Worktree.Bare == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Bare(childComplexity), true
+
+	case "Worktree.branch":
+		if e.complexity.Worktree.Branch == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Branch(childComplexity), true
+
+	case "Worktree.head":
+		if e.complexity.Worktree.Head == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Head(childComplexity), true
+
+	case "Worktree.id":
+		if e.complexity.Worktree.ID == nil {
+			break
+		}
+
+		return e.complexity.Worktree.ID(childComplexity), true
+
+	case "Worktree.path":
+		if e.complexity.Worktree.Path == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Path(childComplexity), true
+
+	case "Worktree.processes":
+		if e.complexity.Worktree.Processes == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Processes(childComplexity), true
 
 	}
 	return 0, false
@@ -391,6 +469,10 @@ var sources = []*ast.Source{
 #
 # Workstream B-config: Project node — projects declared in the orchard
 # config. Read-only; mutations go through ` + "`" + `orchard config add-repo` + "`" + `.
+#
+# Workstream B-git: Worktree node + Project.worktrees back-edge. Process
+# is forward-declared so Worktree.processes can reference it; ws-b-ps
+# fills in the rest.
 
 """
 A node in the orchard graph. Every node has a globally-unique id so
@@ -399,6 +481,14 @@ type it is.
 """
 interface Node {
   "Globally-unique id (e.g. \"Host:<machineId>\")."
+  id: ID!
+}
+
+# Process is forward-declared here so Worktree.processes can reference
+# it; the ps provider in ws-b-ps fills in the rest of the type.
+# Until that lands, Worktree.processes resolves to ` + "`" + `[]` + "`" + `.
+type Process implements Node {
+  "Stable id formatted as ` + "`" + `<host>:<pid>` + "`" + `."
   id: ID!
 }
 
@@ -495,6 +585,30 @@ type Project implements Node {
 
   "Human-readable label. Defaults to the basename of ` + "`" + `directory` + "`" + ` when not specified in the config."
   name: String!
+
+  "Worktrees discovered for this project — the project's main checkout plus everything under ` + "`" + `.git/worktrees/` + "`" + `."
+  worktrees: [Worktree!]!
+}
+
+"A git worktree — either the project's main checkout or one created with ` + "`" + `git worktree add` + "`" + `. See ADR-011 §5.1."
+type Worktree implements Node {
+  "Stable identifier formatted as ` + "`" + `<project_id>:<worktree_name>` + "`" + `. The main checkout uses the worktree name ` + "`" + `main` + "`" + `."
+  id: ID!
+
+  "Absolute filesystem path to the worktree."
+  path: String!
+
+  "Branch the worktree currently has checked out. Empty string for detached HEAD or bare worktrees."
+  branch: String!
+
+  "Resolved 40-character SHA the worktree's HEAD points at. Empty string when HEAD cannot be resolved (e.g. an unborn branch)."
+  head: String!
+
+  "True when HEAD references a deleted branch or otherwise fails to resolve to a commit. Bare worktrees still appear in the list — they just have no live branch."
+  bare: Boolean!
+
+  "Processes whose cwd lies under ` + "`" + `path` + "`" + `. Resolved by the ps provider (ws-b-ps); returns ` + "`" + `[]` + "`" + ` until that provider lands."
+  processes: [Process!]!
 }
 `, BuiltIn: false},
 }
@@ -1112,6 +1226,50 @@ func (ec *executionContext) fieldContext_Host_peers(ctx context.Context, field g
 	return fc, nil
 }
 
+func (ec *executionContext) _Process_id(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Project_id(ctx context.Context, field graphql.CollectedField, obj *Project) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Project_id(ctx, field)
 	if err != nil {
@@ -1239,6 +1397,64 @@ func (ec *executionContext) fieldContext_Project_name(ctx context.Context, field
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Project_worktrees(ctx context.Context, field graphql.CollectedField, obj *Project) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Project_worktrees(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Project().Worktrees(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*Worktree)
+	fc.Result = res
+	return ec.marshalNWorktree2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐWorktreeᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Project_worktrees(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Project",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Worktree_id(ctx, field)
+			case "path":
+				return ec.fieldContext_Worktree_path(ctx, field)
+			case "branch":
+				return ec.fieldContext_Worktree_branch(ctx, field)
+			case "head":
+				return ec.fieldContext_Worktree_head(ctx, field)
+			case "bare":
+				return ec.fieldContext_Worktree_bare(ctx, field)
+			case "processes":
+				return ec.fieldContext_Worktree_processes(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Worktree", field.Name)
 		},
 	}
 	return fc, nil
@@ -1471,6 +1687,8 @@ func (ec *executionContext) fieldContext_Query_projects(ctx context.Context, fie
 				return ec.fieldContext_Project_directory(ctx, field)
 			case "name":
 				return ec.fieldContext_Project_name(ctx, field)
+			case "worktrees":
+				return ec.fieldContext_Project_worktrees(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Project", field.Name)
 		},
@@ -1866,6 +2084,274 @@ func (ec *executionContext) fieldContext_ResourceLoad_loadAvg15m(ctx context.Con
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_id(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_path(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_path(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Path, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_path(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_branch(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_branch(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Branch, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_branch(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_head(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_head(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Head, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_head(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_bare(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_bare(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Bare, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_bare(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_processes(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_processes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Worktree().Processes(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*Process)
+	fc.Result = res
+	return ec.marshalNProcess2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcessᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_processes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Process_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Process", field.Name)
 		},
 	}
 	return fc, nil
@@ -3652,6 +4138,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
+	case Process:
+		return ec._Process(ctx, sel, &obj)
+	case *Process:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Process(ctx, sel, obj)
 	case Host:
 		return ec._Host(ctx, sel, &obj)
 	case *Host:
@@ -3666,6 +4159,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Project(ctx, sel, obj)
+	case Worktree:
+		return ec._Worktree(ctx, sel, &obj)
+	case *Worktree:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Worktree(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -3794,6 +4294,45 @@ func (ec *executionContext) _Host(ctx context.Context, sel ast.SelectionSet, obj
 	return out
 }
 
+var processImplementors = []string{"Process", "Node"}
+
+func (ec *executionContext) _Process(ctx context.Context, sel ast.SelectionSet, obj *Process) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, processImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Process")
+		case "id":
+			out.Values[i] = ec._Process_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var projectImplementors = []string{"Project", "Node"}
 
 func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, obj *Project) graphql.Marshaler {
@@ -3808,18 +4347,54 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 		case "id":
 			out.Values[i] = ec._Project_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "directory":
 			out.Values[i] = ec._Project_directory(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "name":
 			out.Values[i] = ec._Project_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "worktrees":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Project_worktrees(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4022,6 +4597,101 @@ func (ec *executionContext) _ResourceLoad(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var worktreeImplementors = []string{"Worktree", "Node"}
+
+func (ec *executionContext) _Worktree(ctx context.Context, sel ast.SelectionSet, obj *Worktree) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, worktreeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Worktree")
+		case "id":
+			out.Values[i] = ec._Worktree_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "path":
+			out.Values[i] = ec._Worktree_path(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "branch":
+			out.Values[i] = ec._Worktree_branch(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "head":
+			out.Values[i] = ec._Worktree_head(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "bare":
+			out.Values[i] = ec._Worktree_bare(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "processes":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Worktree_processes(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4503,6 +5173,60 @@ func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.Selec
 	return res
 }
 
+func (ec *executionContext) marshalNProcess2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcessᚄ(ctx context.Context, sel ast.SelectionSet, v []*Process) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNProcess2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcess(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNProcess2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcess(ctx context.Context, sel ast.SelectionSet, v *Process) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Process(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNProject2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProjectᚄ(ctx context.Context, sel ast.SelectionSet, v []*Project) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -4570,6 +5294,60 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNWorktree2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐWorktreeᚄ(ctx context.Context, sel ast.SelectionSet, v []*Worktree) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNWorktree2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐWorktree(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNWorktree2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐWorktree(ctx context.Context, sel ast.SelectionSet, v *Worktree) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Worktree(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -49,6 +49,16 @@ func (Host) IsNode() {}
 // Globally-unique id (e.g. "Host:<machineId>").
 func (this Host) GetID() string { return this.ID }
 
+type Process struct {
+	// Stable id formatted as `<host>:<pid>`.
+	ID string `json:"id"`
+}
+
+func (Process) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this Process) GetID() string { return this.ID }
+
 // A project (git repo) registered in the orchard config. The config file is the source of truth; the daemon reflects it via fsnotify.
 type Project struct {
 	// Stable identifier — slug of `name`, falling back to a short hash of `directory`. Survives re-registration.
@@ -57,6 +67,8 @@ type Project struct {
 	Directory string `json:"directory"`
 	// Human-readable label. Defaults to the basename of `directory` when not specified in the config.
 	Name string `json:"name"`
+	// Worktrees discovered for this project — the project's main checkout plus everything under `.git/worktrees/`.
+	Worktrees []*Worktree `json:"worktrees"`
 }
 
 func (Project) IsNode() {}
@@ -83,3 +95,24 @@ type ResourceLoad struct {
 	// 15-minute load average.
 	LoadAvg15m float64 `json:"loadAvg15m"`
 }
+
+// A git worktree — either the project's main checkout or one created with `git worktree add`. See ADR-011 §5.1.
+type Worktree struct {
+	// Stable identifier formatted as `<project_id>:<worktree_name>`. The main checkout uses the worktree name `main`.
+	ID string `json:"id"`
+	// Absolute filesystem path to the worktree.
+	Path string `json:"path"`
+	// Branch the worktree currently has checked out. Empty string for detached HEAD or bare worktrees.
+	Branch string `json:"branch"`
+	// Resolved 40-character SHA the worktree's HEAD points at. Empty string when HEAD cannot be resolved (e.g. an unborn branch).
+	Head string `json:"head"`
+	// True when HEAD references a deleted branch or otherwise fails to resolve to a commit. Bare worktrees still appear in the list — they just have no live branch.
+	Bare bool `json:"bare"`
+	// Processes whose cwd lies under `path`. Resolved by the ps provider (ws-b-ps); returns `[]` until that provider lands.
+	Processes []*Process `json:"processes"`
+}
+
+func (Worktree) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this Worktree) GetID() string { return this.ID }

--- a/internal/server/providers/git/adapter.go
+++ b/internal/server/providers/git/adapter.go
@@ -1,0 +1,332 @@
+package git
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GitWorktreeAdapter reads `.git/worktrees/<name>/HEAD` + `gitdir` files
+// and the project's own `.git/HEAD` directly via stdlib `os` + `bufio`.
+// It is stateless — every call resolves against the live filesystem.
+//
+// Per ADR-011 §3 adapters are stateless; the provider holds cache and
+// watcher state. The adapter only knows how to read.
+type GitWorktreeAdapter struct {
+	// projects is captured by reference: the provider mutates the slice
+	// when projects are registered; the adapter sees the latest set on
+	// every call. Concurrent registration is the provider's job to
+	// guard.
+	projects func() []Project
+}
+
+// NewGitWorktreeAdapter constructs an adapter that scans the projects
+// returned by the supplier function on each call. Callers (the
+// provider) typically wrap a sync.RWMutex-protected slice.
+func NewGitWorktreeAdapter(projects func() []Project) *GitWorktreeAdapter {
+	return &GitWorktreeAdapter{projects: projects}
+}
+
+// Fetch returns a single Worktree by id. Returns os.ErrNotExist when
+// the project or the named worktree no longer exists.
+func (a *GitWorktreeAdapter) Fetch(ctx context.Context, id WorktreeID) (Worktree, error) {
+	if err := ctx.Err(); err != nil {
+		return Worktree{}, err
+	}
+	projectID, name, ok := splitID(id)
+	if !ok {
+		return Worktree{}, fmt.Errorf("git: malformed worktree id %q", id)
+	}
+	for _, p := range a.projects() {
+		if p.ID != projectID {
+			continue
+		}
+		if name == MainWorktreeName {
+			return readMainWorktree(p)
+		}
+		return readLinkedWorktree(p, name)
+	}
+	return Worktree{}, fmt.Errorf("git: project %q: %w", projectID, fs.ErrNotExist)
+}
+
+// FetchAll lists every worktree across every registered project. Used
+// for cold boot and for full refreshes after fsnotify wakes up.
+func (a *GitWorktreeAdapter) FetchAll(ctx context.Context) (map[WorktreeID]Worktree, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out := map[WorktreeID]Worktree{}
+	for _, p := range a.projects() {
+		main, err := readMainWorktree(p)
+		if err != nil {
+			// A project the user registered but doesn't yet have a git
+			// repo in is not fatal — skip it; fsnotify will pick up
+			// the .git directory when it appears.
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("git: project %q main worktree: %w", p.ID, err)
+		}
+		out[main.ID] = main
+
+		linked, err := listLinkedWorktrees(p)
+		if err != nil {
+			return nil, fmt.Errorf("git: project %q linked worktrees: %w", p.ID, err)
+		}
+		for _, w := range linked {
+			out[w.ID] = w
+		}
+	}
+	return out, nil
+}
+
+// readMainWorktree composes the Worktree value for a project's primary
+// checkout. Branch / head come from the working tree's `.git/HEAD`
+// (resolved against `.git/refs/heads/<branch>` + `packed-refs`).
+func readMainWorktree(p Project) (Worktree, error) {
+	gitDir, err := resolveGitDir(p.Dir)
+	if err != nil {
+		return Worktree{}, fmt.Errorf("resolve gitdir: %w", err)
+	}
+	headFile := filepath.Join(gitDir, "HEAD")
+	branch, head, bare, err := readHeadFile(gitDir, headFile)
+	if err != nil {
+		return Worktree{}, fmt.Errorf("read HEAD: %w", err)
+	}
+	return Worktree{
+		ID:        NewWorktreeID(p.ID, MainWorktreeName),
+		ProjectID: p.ID,
+		Name:      MainWorktreeName,
+		Path:      CleanPath(p.Dir),
+		Branch:    branch,
+		Head:      head,
+		Bare:      bare,
+	}, nil
+}
+
+// listLinkedWorktrees enumerates entries under `.git/worktrees/`. The
+// directory may not exist (fresh repo with no `git worktree add`); that
+// is not an error.
+func listLinkedWorktrees(p Project) ([]Worktree, error) {
+	gitDir, err := resolveGitDir(p.Dir)
+	if err != nil {
+		return nil, err
+	}
+	wtRoot := filepath.Join(gitDir, "worktrees")
+	entries, err := os.ReadDir(wtRoot)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []Worktree
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		w, err := readLinkedWorktree(p, e.Name())
+		if err != nil {
+			// A partially-deleted worktree directory (post `git worktree
+			// remove` mid-flight) is not fatal — surface what we have
+			// and let fsnotify catch the next stable state.
+			if errors.Is(err, fs.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("worktree %q: %w", e.Name(), err)
+		}
+		out = append(out, w)
+	}
+	return out, nil
+}
+
+// readLinkedWorktree reads `.git/worktrees/<name>/HEAD` and `gitdir`
+// to build a Worktree. The gitdir file points at `<worktree>/.git`,
+// which is the file/dir whose parent is the worktree's root path.
+func readLinkedWorktree(p Project, name string) (Worktree, error) {
+	gitDir, err := resolveGitDir(p.Dir)
+	if err != nil {
+		return Worktree{}, err
+	}
+	wtDir := filepath.Join(gitDir, "worktrees", name)
+
+	gitdirPath := filepath.Join(wtDir, "gitdir")
+	gitdirContents, err := readTrimmed(gitdirPath)
+	if err != nil {
+		return Worktree{}, fmt.Errorf("read gitdir: %w", err)
+	}
+	// `gitdir` points at <worktree-root>/.git. Two parents up gets us
+	// the worktree root only if .git is a file (the linked-worktree
+	// case); when it's a directory the parent is already the root.
+	worktreeRoot := filepath.Dir(gitdirContents)
+
+	headFile := filepath.Join(wtDir, "HEAD")
+	branch, head, bare, err := readHeadFile(gitDir, headFile)
+	if err != nil {
+		return Worktree{}, fmt.Errorf("read HEAD for %q: %w", name, err)
+	}
+
+	return Worktree{
+		ID:        NewWorktreeID(p.ID, name),
+		ProjectID: p.ID,
+		Name:      name,
+		Path:      CleanPath(worktreeRoot),
+		Branch:    branch,
+		Head:      head,
+		Bare:      bare,
+	}, nil
+}
+
+// readHeadFile parses HEAD. Either a `ref: refs/heads/<branch>` line
+// (named branch) or a 40-char SHA (detached). The repo gitDir is
+// passed in because resolving a symbolic ref needs `refs/heads/` and
+// `packed-refs` lookups.
+//
+// Returns (branch, head, bare, err):
+//   - named branch with resolvable SHA → (branch, sha, false, nil)
+//   - named branch with NO resolvable SHA (deleted) → (branch, "", true, nil)
+//   - detached HEAD → ("", sha, false, nil)
+//   - empty / unborn / unparseable → ("", "", true, nil)
+func readHeadFile(gitDir, headFile string) (string, string, bool, error) {
+	raw, err := readTrimmed(headFile)
+	if err != nil {
+		return "", "", false, err
+	}
+	if raw == "" {
+		return "", "", true, nil
+	}
+	if strings.HasPrefix(raw, "ref:") {
+		ref := strings.TrimSpace(strings.TrimPrefix(raw, "ref:"))
+		// "refs/heads/<branch>" → branch name
+		branch := strings.TrimPrefix(ref, "refs/heads/")
+		sha, err := resolveRef(gitDir, ref)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// Deleted branch / unborn HEAD → bare worktree.
+				return branch, "", true, nil
+			}
+			return "", "", false, err
+		}
+		return branch, sha, false, nil
+	}
+	if isSHA1(raw) {
+		return "", raw, false, nil
+	}
+	return "", "", true, nil
+}
+
+// resolveRef resolves a `refs/heads/<branch>`-style ref to a 40-char
+// SHA. Looks at the loose ref file first, then the packed-refs file.
+// Returns fs.ErrNotExist if neither knows the ref.
+func resolveRef(gitDir, ref string) (string, error) {
+	loose := filepath.Join(gitDir, ref)
+	if sha, err := readTrimmed(loose); err == nil {
+		if isSHA1(sha) {
+			return sha, nil
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return "", err
+	}
+
+	packed := filepath.Join(gitDir, "packed-refs")
+	f, err := os.Open(packed) //nolint:gosec // trusted internal path
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return "", fs.ErrNotExist
+		}
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "^") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) != 2 {
+			continue
+		}
+		if parts[1] == ref && isSHA1(parts[0]) {
+			return parts[0], nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("scan packed-refs: %w", err)
+	}
+	return "", fs.ErrNotExist
+}
+
+// resolveGitDir returns the repo's .git directory for a project rooted
+// at workdir. Handles both a real directory (`<workdir>/.git/`) and a
+// gitfile (`<workdir>/.git` as a regular file with `gitdir: <path>`),
+// which appears in submodules and (some) worktree configurations.
+func resolveGitDir(workdir string) (string, error) {
+	candidate := filepath.Join(workdir, ".git")
+	info, err := os.Stat(candidate)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return candidate, nil
+	}
+	// gitfile: a regular file whose contents are `gitdir: <path>`.
+	body, err := readTrimmed(candidate)
+	if err != nil {
+		return "", err
+	}
+	gd := strings.TrimSpace(strings.TrimPrefix(body, "gitdir:"))
+	if gd == "" {
+		return "", fmt.Errorf("malformed gitfile at %q", candidate)
+	}
+	if !filepath.IsAbs(gd) {
+		gd = filepath.Join(workdir, gd)
+	}
+	return filepath.Clean(gd), nil
+}
+
+// readTrimmed reads a file and returns its contents with leading and
+// trailing whitespace stripped. Returns os.ErrNotExist unwrapped.
+func readTrimmed(path string) (string, error) {
+	b, err := os.ReadFile(path) //nolint:gosec // trusted internal path
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// isSHA1 returns true when s is a 40-char hex string. We accept both
+// upper and lower case even though git uses lower; a tolerant check
+// avoids false negatives if a user has an unusual config.
+func isSHA1(s string) bool {
+	if len(s) != 40 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// splitID parses a `<project_id>:<name>` worktree id. Returns ok=false
+// when the id is not in that shape.
+func splitID(id WorktreeID) (string, string, bool) {
+	s := string(id)
+	idx := strings.LastIndex(s, ":")
+	if idx <= 0 || idx == len(s)-1 {
+		return "", "", false
+	}
+	return s[:idx], s[idx+1:], true
+}

--- a/internal/server/providers/git/adapter_test.go
+++ b/internal/server/providers/git/adapter_test.go
@@ -1,0 +1,186 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestReadMainWorktree_AttachedHead is a fixture-grade unit test that
+// constructs a minimal `.git/` layout by hand and asserts that the
+// adapter resolves HEAD → branch → SHA correctly.
+//
+// The E2E test (git_e2e_test.go) covers the real-git path. This test
+// is here because the bare-handling branches are easier to exercise
+// with hand-crafted on-disk shapes than by deleting refs through git.
+func TestReadMainWorktree_AttachedHead(t *testing.T) {
+	repo := newFakeRepo(t)
+	repo.writeRef("refs/heads/main", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	repo.writeHEAD("ref: refs/heads/main")
+
+	a := NewGitWorktreeAdapter(func() []Project {
+		return []Project{{ID: "demo", Dir: repo.workdir}}
+	})
+
+	w, err := a.Fetch(context.Background(), NewWorktreeID("demo", MainWorktreeName))
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if w.Branch != "main" {
+		t.Errorf("branch: got %q, want %q", w.Branch, "main")
+	}
+	if w.Head != "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" {
+		t.Errorf("head: got %q", w.Head)
+	}
+	if w.Bare {
+		t.Errorf("bare: got true, want false")
+	}
+}
+
+// TestReadMainWorktree_BareWhenRefMissing covers AC4: a HEAD that
+// points at a deleted branch surfaces as bare:true without crashing.
+func TestReadMainWorktree_BareWhenRefMissing(t *testing.T) {
+	repo := newFakeRepo(t)
+	// HEAD points at a branch that does NOT exist on disk.
+	repo.writeHEAD("ref: refs/heads/lost-branch")
+
+	a := NewGitWorktreeAdapter(func() []Project {
+		return []Project{{ID: "demo", Dir: repo.workdir}}
+	})
+
+	w, err := a.Fetch(context.Background(), NewWorktreeID("demo", MainWorktreeName))
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !w.Bare {
+		t.Errorf("bare: got false, want true")
+	}
+	if w.Branch != "lost-branch" {
+		t.Errorf("branch: got %q, want %q", w.Branch, "lost-branch")
+	}
+	if w.Head != "" {
+		t.Errorf("head: got %q, want empty", w.Head)
+	}
+}
+
+// TestReadMainWorktree_DetachedHead covers detached HEAD: branch is
+// empty, head is the SHA, bare is false.
+func TestReadMainWorktree_DetachedHead(t *testing.T) {
+	repo := newFakeRepo(t)
+	repo.writeHEAD("cafebabecafebabecafebabecafebabecafebabe")
+
+	a := NewGitWorktreeAdapter(func() []Project {
+		return []Project{{ID: "demo", Dir: repo.workdir}}
+	})
+
+	w, err := a.Fetch(context.Background(), NewWorktreeID("demo", MainWorktreeName))
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if w.Branch != "" {
+		t.Errorf("branch: got %q, want empty", w.Branch)
+	}
+	if w.Head != "cafebabecafebabecafebabecafebabecafebabe" {
+		t.Errorf("head: got %q", w.Head)
+	}
+	if w.Bare {
+		t.Errorf("bare: got true, want false")
+	}
+}
+
+// TestReadHeadFile_PackedRef covers loose-ref-missing-but-packed-ref-
+// present, which happens after `git gc`.
+func TestReadHeadFile_PackedRef(t *testing.T) {
+	repo := newFakeRepo(t)
+	repo.writeFile("packed-refs",
+		"# pack-refs with: peeled fully-peeled sorted\n"+
+			"feedfacefeedfacefeedfacefeedfacefeedface refs/heads/packed\n")
+	repo.writeHEAD("ref: refs/heads/packed")
+
+	branch, head, bare, err := readHeadFile(repo.gitdir, filepath.Join(repo.gitdir, "HEAD"))
+	if err != nil {
+		t.Fatalf("readHeadFile: %v", err)
+	}
+	if branch != "packed" {
+		t.Errorf("branch: got %q", branch)
+	}
+	if head != "feedfacefeedfacefeedfacefeedfacefeedface" {
+		t.Errorf("head: got %q", head)
+	}
+	if bare {
+		t.Errorf("bare: got true, want false")
+	}
+}
+
+// TestSplitID round-trips the worktree-id format.
+func TestSplitID(t *testing.T) {
+	cases := []struct {
+		in    WorktreeID
+		pid   string
+		name  string
+		valid bool
+	}{
+		{NewWorktreeID("demo", "main"), "demo", "main", true},
+		{NewWorktreeID("foo/bar", "branch"), "foo/bar", "branch", true},
+		{WorktreeID(""), "", "", false},
+		{WorktreeID("nocolon"), "", "", false},
+		{WorktreeID(":onlyname"), "", "", false},
+		{WorktreeID("onlyid:"), "", "", false},
+	}
+	for _, c := range cases {
+		t.Run(string(c.in), func(t *testing.T) {
+			pid, name, ok := splitID(c.in)
+			if ok != c.valid {
+				t.Fatalf("ok: got %v, want %v", ok, c.valid)
+			}
+			if !ok {
+				return
+			}
+			if pid != c.pid {
+				t.Errorf("pid: got %q, want %q", pid, c.pid)
+			}
+			if name != c.name {
+				t.Errorf("name: got %q, want %q", name, c.name)
+			}
+		})
+	}
+}
+
+// fakeRepo is a hand-crafted .git directory under a temp workdir. It
+// exists so the adapter's bare/detached/packed-refs branches can be
+// exercised without invoking the real git binary.
+type fakeRepo struct {
+	t       *testing.T
+	workdir string
+	gitdir  string
+}
+
+func newFakeRepo(t *testing.T) *fakeRepo {
+	t.Helper()
+	dir := t.TempDir()
+	gitdir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(filepath.Join(gitdir, "refs", "heads"), 0o755); err != nil {
+		t.Fatalf("mkdir gitdir: %v", err)
+	}
+	return &fakeRepo{t: t, workdir: dir, gitdir: gitdir}
+}
+
+func (r *fakeRepo) writeFile(rel, body string) {
+	r.t.Helper()
+	full := filepath.Join(r.gitdir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		r.t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+		r.t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func (r *fakeRepo) writeHEAD(body string) {
+	r.writeFile("HEAD", body+"\n")
+}
+
+func (r *fakeRepo) writeRef(ref, sha string) {
+	r.writeFile(ref, sha+"\n")
+}

--- a/internal/server/providers/git/git_e2e_test.go
+++ b/internal/server/providers/git/git_e2e_test.go
@@ -1,0 +1,267 @@
+package git_test
+
+// E2E test for the git provider per Workstream B-git AC6.
+//
+// What's "E2E" here:
+//   - Real `git` binary creates fixture repos and worktrees (shellout
+//     for setup is permitted by the briefing).
+//   - Real fsnotify watches the temp directories.
+//   - Real GraphQL: the provider, resolvers, and gqlgen handler are
+//     stitched together inside a httptest.Server, and we POST queries
+//     over HTTP.
+//   - No mocks. The only "test scaffolding" types are tiny harness
+//     helpers around the real components.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server"
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
+)
+
+// staticProjectsLister is a fixture-grade resolvers.ProjectsLister
+// for the git e2e test — returns a fixed slice so the test can drive
+// Project.worktrees without standing up the config provider.
+type staticProjectsLister struct {
+	records []configprovider.Project
+}
+
+func (s *staticProjectsLister) List(_ context.Context) ([]configprovider.Project, error) {
+	out := make([]configprovider.Project, len(s.records))
+	copy(out, s.records)
+	return out, nil
+}
+
+// TestGitProvider_E2E walks the AC6 acceptance criteria end-to-end:
+//
+//  1. Create a real git repo with `git init` + an initial commit.
+//  2. Add two worktrees via `git worktree add`.
+//  3. Start the daemon's GraphQL server against the temp repo.
+//  4. Assert `query { projects { worktrees { ... } } }` returns the
+//     project's main checkout plus the two worktrees with the right
+//     branches.
+//  5. Add a third worktree; assert fsnotify causes it to appear.
+//  6. Remove the third worktree; assert it disappears.
+func TestGitProvider_E2E(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; e2e test requires real git for fixture setup")
+	}
+
+	repo := setupRepoWithCommits(t)
+
+	// Two `git worktree add` invocations: feature/a on a new branch,
+	// feature/b on a new branch.
+	worktreesParent := t.TempDir()
+	wtA := filepath.Join(worktreesParent, "a")
+	wtB := filepath.Join(worktreesParent, "b")
+	runGit(t, repo, "worktree", "add", "-b", "feature/a", wtA)
+	runGit(t, repo, "worktree", "add", "-b", "feature/b", wtB)
+
+	// Provider + resolver + httptest GraphQL server.
+	provider := gitprovider.NewProvider(nil)
+	t.Cleanup(provider.Stop)
+
+	const projectID = "demo"
+	if err := provider.AddProject(gitprovider.Project{ID: projectID, Dir: repo}); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+
+	projects := &staticProjectsLister{
+		records: []configprovider.Project{
+			{ID: configprovider.ProjectID(projectID), Directory: repo, Name: "demo"},
+		},
+	}
+
+	srv := server.New("", nil, server.WithGit(provider), server.WithProjects(projects))
+	ts := httptest.NewServer(srv.GraphQLHandler())
+	t.Cleanup(ts.Close)
+
+	// Initial assertion: 3 worktrees (main + a + b).
+	wantInitial := map[string]string{
+		"demo:main": "main",
+		"demo:a":    "feature/a",
+		"demo:b":    "feature/b",
+	}
+	gotInitial := queryWorktreeBranches(t, ts.URL)
+	if !equalMap(gotInitial, wantInitial) {
+		t.Fatalf("initial worktrees mismatch:\n got: %v\nwant: %v", gotInitial, wantInitial)
+	}
+
+	// Sanity: every returned worktree has a non-empty path + 40-char head.
+	gotInitialFull := queryWorktrees(t, ts.URL)
+	for _, w := range gotInitialFull {
+		if w.Path == "" {
+			t.Errorf("worktree %s has empty path", w.ID)
+		}
+		if len(w.Head) != 40 {
+			t.Errorf("worktree %s has malformed head %q (len=%d)", w.ID, w.Head, len(w.Head))
+		}
+		if w.Bare {
+			t.Errorf("worktree %s unexpectedly bare", w.ID)
+		}
+	}
+
+	// Add a third worktree mid-flight; assert fsnotify catches it.
+	wtC := filepath.Join(worktreesParent, "c")
+	runGit(t, repo, "worktree", "add", "-b", "feature/c", wtC)
+	wantAfterAdd := map[string]string{
+		"demo:main": "main",
+		"demo:a":    "feature/a",
+		"demo:b":    "feature/b",
+		"demo:c":    "feature/c",
+	}
+	waitFor(t, 5*time.Second, "third worktree to appear", func() bool {
+		got := queryWorktreeBranches(t, ts.URL)
+		return equalMap(got, wantAfterAdd)
+	})
+
+	// Remove the third worktree; assert it disappears.
+	runGit(t, repo, "worktree", "remove", "--force", wtC)
+	wantAfterRemove := map[string]string{
+		"demo:main": "main",
+		"demo:a":    "feature/a",
+		"demo:b":    "feature/b",
+	}
+	waitFor(t, 5*time.Second, "third worktree to disappear", func() bool {
+		got := queryWorktreeBranches(t, ts.URL)
+		return equalMap(got, wantAfterRemove)
+	})
+}
+
+// setupRepoWithCommits creates a git repo with one initial commit so
+// that HEAD resolves cleanly. Returns the absolute path to the working
+// tree.
+func setupRepoWithCommits(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGit(t, repo, "init", "-b", "main")
+	// Stable identity so commit creation doesn't fail on a CI box without
+	// a global git config.
+	runGit(t, repo, "config", "user.email", "ws-b-git@example.com")
+	runGit(t, repo, "config", "user.name", "ws-b-git")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# fixture\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repo, "add", "README.md")
+	runGit(t, repo, "commit", "-m", "initial")
+	return repo
+}
+
+// runGit shells out to git in repo and fails the test on any non-zero
+// exit. Briefing explicitly allows shell-outs for fixture setup.
+func runGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, stderr.String())
+	}
+}
+
+// gqlWorktree mirrors the GraphQL Worktree shape, decoded from JSON.
+type gqlWorktree struct {
+	ID     string `json:"id"`
+	Path   string `json:"path"`
+	Branch string `json:"branch"`
+	Head   string `json:"head"`
+	Bare   bool   `json:"bare"`
+}
+
+// queryWorktrees runs the canonical AC6 query against the test server
+// and returns the flattened slice of worktrees from all projects.
+func queryWorktrees(t *testing.T, url string) []gqlWorktree {
+	t.Helper()
+	const q = `{ projects { worktrees { id path branch head bare } } }`
+	body, _ := json.Marshal(map[string]any{"query": q})
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("graphql request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("graphql response: status %d", resp.StatusCode)
+	}
+	var out struct {
+		Data struct {
+			Projects []struct {
+				Worktrees []gqlWorktree `json:"worktrees"`
+			} `json:"projects"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out.Errors) > 0 {
+		t.Fatalf("graphql errors: %v", out.Errors)
+	}
+	var all []gqlWorktree
+	for _, p := range out.Data.Projects {
+		all = append(all, p.Worktrees...)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].ID < all[j].ID })
+	return all
+}
+
+// queryWorktreeBranches projects the result of queryWorktrees down to a
+// {worktree-id: branch} map for compact assertions.
+func queryWorktreeBranches(t *testing.T, url string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, w := range queryWorktrees(t, url) {
+		out[w.ID] = w.Branch
+	}
+	return out
+}
+
+// waitFor polls cond until it returns true or the timeout elapses, then
+// fails. The polling cadence is fast (50ms) so fsnotify-driven tests
+// don't sit idle longer than necessary.
+func waitFor(t *testing.T, timeout time.Duration, desc string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s after %v", desc, timeout)
+}
+
+// equalMap is a small deep-equality helper for the assertions; we don't
+// pull in cmp for one comparison shape.
+func equalMap(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+// silence unused import in case http is removed in a future refactor.
+var _ = fmt.Sprintf

--- a/internal/server/providers/git/provider.go
+++ b/internal/server/providers/git/provider.go
@@ -166,7 +166,7 @@ func (p *Provider) refreshKey(ctx context.Context, id WorktreeID) {
 		value: v,
 		freshness: adapter.Freshness{
 			LastFetchedAt: time.Now(),
-			Source:        adapter.FreshnessWatcherPush,
+			Source:        adapter.SourceWatcherPush,
 		},
 	}
 	p.mu.Unlock()
@@ -195,7 +195,7 @@ func (p *Provider) refreshProject(ctx context.Context, proj Project) error {
 		}
 		p.store[id] = storeEntry{
 			value:     v,
-			freshness: adapter.Freshness{LastFetchedAt: now, Source: adapter.FreshnessPoll},
+			freshness: adapter.Freshness{LastFetchedAt: now, Source: adapter.SourcePoll},
 		}
 	}
 	return nil
@@ -214,7 +214,7 @@ func (p *Provider) Get(ctx context.Context, key WorktreeID) (Worktree, adapter.F
 	if err != nil {
 		return Worktree{}, adapter.Freshness{}, err
 	}
-	fr := adapter.Freshness{LastFetchedAt: time.Now(), Source: adapter.FreshnessPoll}
+	fr := adapter.Freshness{LastFetchedAt: time.Now(), Source: adapter.SourcePoll}
 	p.mu.Lock()
 	p.store[key] = storeEntry{value: v, freshness: fr}
 	p.mu.Unlock()

--- a/internal/server/providers/git/provider.go
+++ b/internal/server/providers/git/provider.go
@@ -1,0 +1,340 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
+)
+
+// Provider implements adapter.Provider[WorktreeID, Worktree] for the
+// git backend. One instance per orchard daemon; multiple projects are
+// registered into it.
+//
+// Concurrency model:
+//   - projects is guarded by mu.
+//   - store mirrors the freshest known state; reads + writes go through mu.
+//   - Each project owns one watcher goroutine; its invalidation channel
+//     is fanned out to provider subscribers.
+//
+// The provider owns its goroutines: Stop() returns once every watcher
+// goroutine has exited.
+type Provider struct {
+	mu         sync.RWMutex
+	projects   []Project
+	store      map[WorktreeID]storeEntry
+	watchers   map[string]*watcher // keyed by project id
+	subs       map[chan adapter.InvalidationEvent[WorktreeID]]struct{}
+	subsMu     sync.Mutex
+	adapterImp *GitWorktreeAdapter
+	logger     *slog.Logger
+	wg         sync.WaitGroup
+	rootCtx    context.Context
+	rootCancel context.CancelFunc
+}
+
+type storeEntry struct {
+	value     Worktree
+	freshness adapter.Freshness
+}
+
+// NewProvider builds a provider that scans nothing until projects are
+// registered. The caller is expected to call AddProject() at boot or
+// in response to config changes.
+func NewProvider(logger *slog.Logger) *Provider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &Provider{
+		store:      map[WorktreeID]storeEntry{},
+		watchers:   map[string]*watcher{},
+		subs:       map[chan adapter.InvalidationEvent[WorktreeID]]struct{}{},
+		logger:     logger,
+		rootCtx:    ctx,
+		rootCancel: cancel,
+	}
+	p.adapterImp = NewGitWorktreeAdapter(p.snapshotProjects)
+	return p
+}
+
+// snapshotProjects is the func passed to the adapter; safe to call
+// concurrently with AddProject / RemoveProject.
+func (p *Provider) snapshotProjects() []Project {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]Project, len(p.projects))
+	copy(out, p.projects)
+	return out
+}
+
+// Adapter exposes the underlying adapter. Used by tests; resolvers must
+// depend on the Provider interface, not the concrete adapter.
+func (p *Provider) Adapter() *GitWorktreeAdapter { return p.adapterImp }
+
+// AddProject registers a project for scanning and starts a watcher for
+// it. Returns nil for duplicate IDs (idempotent re-add). The watcher
+// runs until Stop() is called.
+func (p *Provider) AddProject(proj Project) error {
+	if proj.ID == "" {
+		return fmt.Errorf("git: project id cannot be empty")
+	}
+	if proj.Dir == "" {
+		return fmt.Errorf("git: project %q dir cannot be empty", proj.ID)
+	}
+
+	p.mu.Lock()
+	for _, existing := range p.projects {
+		if existing.ID == proj.ID {
+			p.mu.Unlock()
+			return nil
+		}
+	}
+	p.projects = append(p.projects, proj)
+	p.mu.Unlock()
+
+	w, err := newWatcher(proj, p.logger)
+	if err != nil {
+		return fmt.Errorf("watcher for %q: %w", proj.ID, err)
+	}
+
+	p.mu.Lock()
+	p.watchers[proj.ID] = w
+	p.mu.Unlock()
+
+	p.wg.Add(2)
+	go func() {
+		defer p.wg.Done()
+		w.run(p.rootCtx)
+	}()
+	go func() {
+		defer p.wg.Done()
+		p.consumeInvalidations(w)
+	}()
+
+	// Cold-load the project's worktrees so subscribers querying right
+	// after registration see something.
+	if err := p.refreshProject(p.rootCtx, proj); err != nil {
+		p.logger.Warn("git initial refresh failed", "project", proj.ID, "err", err)
+	}
+	return nil
+}
+
+// Stop cancels watchers and waits for them to exit. Safe to call at
+// most once. Subsequent operations error with context.Canceled.
+func (p *Provider) Stop() {
+	p.rootCancel()
+	p.wg.Wait()
+}
+
+// consumeInvalidations forwards a watcher's events to provider
+// subscribers and triggers a per-key refresh from disk so the cached
+// value matches the next read.
+func (p *Provider) consumeInvalidations(w *watcher) {
+	for id := range w.invalidations {
+		ev := adapter.InvalidationEvent[WorktreeID]{
+			Key:    id,
+			Reason: "fs-modify",
+			At:     time.Now(),
+		}
+		// Refresh the cache first so a Get racing the broadcast sees
+		// the new value.
+		p.refreshKey(p.rootCtx, id)
+		p.broadcast(ev)
+	}
+}
+
+// refreshKey re-fetches a single key. A Fetch that returns ErrNotExist
+// removes the entry from the store; other errors leave the store as-is
+// and surface via slog.
+func (p *Provider) refreshKey(ctx context.Context, id WorktreeID) {
+	v, err := p.adapterImp.Fetch(ctx, id)
+	if err != nil {
+		p.mu.Lock()
+		delete(p.store, id)
+		p.mu.Unlock()
+		// fs.ErrNotExist is the routine "worktree was removed" path —
+		// not worth a warning.
+		p.logger.Debug("git refreshKey: removing", "id", id, "err", err)
+		return
+	}
+	p.mu.Lock()
+	p.store[id] = storeEntry{
+		value: v,
+		freshness: adapter.Freshness{
+			LastFetchedAt: time.Now(),
+			Source:        adapter.FreshnessWatcherPush,
+		},
+	}
+	p.mu.Unlock()
+}
+
+// refreshProject runs FetchAll and replaces the project's slice of the
+// store wholesale.
+func (p *Provider) refreshProject(ctx context.Context, proj Project) error {
+	all, err := p.adapterImp.FetchAll(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// Strip prior entries for this project.
+	for id := range p.store {
+		pid, _, ok := splitID(id)
+		if ok && pid == proj.ID {
+			delete(p.store, id)
+		}
+	}
+	for id, v := range all {
+		if v.ProjectID != proj.ID {
+			continue
+		}
+		p.store[id] = storeEntry{
+			value:     v,
+			freshness: adapter.Freshness{LastFetchedAt: now, Source: adapter.FreshnessPoll},
+		}
+	}
+	return nil
+}
+
+// Get implements adapter.Provider.
+func (p *Provider) Get(ctx context.Context, key WorktreeID) (Worktree, adapter.Freshness, error) {
+	p.mu.RLock()
+	if e, ok := p.store[key]; ok {
+		p.mu.RUnlock()
+		return e.value, e.freshness, nil
+	}
+	p.mu.RUnlock()
+
+	v, err := p.adapterImp.Fetch(ctx, key)
+	if err != nil {
+		return Worktree{}, adapter.Freshness{}, err
+	}
+	fr := adapter.Freshness{LastFetchedAt: time.Now(), Source: adapter.FreshnessPoll}
+	p.mu.Lock()
+	p.store[key] = storeEntry{value: v, freshness: fr}
+	p.mu.Unlock()
+	return v, fr, nil
+}
+
+// GetMany implements adapter.Provider.
+func (p *Provider) GetMany(ctx context.Context, keys []WorktreeID) (map[WorktreeID]Worktree, map[WorktreeID]adapter.Freshness, error) {
+	values := make(map[WorktreeID]Worktree, len(keys))
+	freshness := make(map[WorktreeID]adapter.Freshness, len(keys))
+	for _, k := range keys {
+		v, fr, err := p.Get(ctx, k)
+		if err != nil {
+			continue
+		}
+		values[k] = v
+		freshness[k] = fr
+	}
+	return values, freshness, nil
+}
+
+// Keys implements adapter.Provider.
+func (p *Provider) Keys(ctx context.Context) ([]WorktreeID, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]WorktreeID, 0, len(p.store))
+	for k := range p.store {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// ListByProject returns the cached worktrees for a project. Resolvers
+// hit this on the `Project.worktrees` edge — it is the hot path, so
+// it returns from the in-memory store without touching disk.
+//
+// If the cache is empty for a project (e.g. a Get missed before the
+// initial refresh completed), it falls back to a synchronous FetchAll
+// to populate; subsequent calls hit cache.
+func (p *Provider) ListByProject(ctx context.Context, projectID string) ([]Worktree, error) {
+	p.mu.RLock()
+	var out []Worktree
+	hasAny := false
+	for id, e := range p.store {
+		pid, _, ok := splitID(id)
+		if !ok || pid != projectID {
+			continue
+		}
+		hasAny = true
+		out = append(out, e.value)
+	}
+	p.mu.RUnlock()
+
+	if hasAny {
+		return out, nil
+	}
+
+	// Cold path — refresh the project synchronously.
+	var proj Project
+	p.mu.RLock()
+	for _, prj := range p.projects {
+		if prj.ID == projectID {
+			proj = prj
+			break
+		}
+	}
+	p.mu.RUnlock()
+	if proj.ID == "" {
+		return nil, nil
+	}
+	if err := p.refreshProject(ctx, proj); err != nil {
+		return nil, err
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for id, e := range p.store {
+		pid, _, ok := splitID(id)
+		if !ok || pid != projectID {
+			continue
+		}
+		out = append(out, e.value)
+	}
+	return out, nil
+}
+
+// Subscribe implements adapter.Provider. The returned channel is
+// buffered; if a subscriber is slow, it loses events (the next fetch
+// will catch them up). Channel is closed when ctx is cancelled.
+func (p *Provider) Subscribe(ctx context.Context) <-chan adapter.InvalidationEvent[WorktreeID] {
+	ch := make(chan adapter.InvalidationEvent[WorktreeID], 32)
+	p.subsMu.Lock()
+	p.subs[ch] = struct{}{}
+	p.subsMu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		p.subsMu.Lock()
+		delete(p.subs, ch)
+		p.subsMu.Unlock()
+		close(ch)
+	}()
+	return ch
+}
+
+// broadcast pushes an event to every subscriber, dropping under
+// back-pressure.
+func (p *Provider) broadcast(ev adapter.InvalidationEvent[WorktreeID]) {
+	p.subsMu.Lock()
+	defer p.subsMu.Unlock()
+	for ch := range p.subs {
+		select {
+		case ch <- ev:
+		default:
+			p.logger.Warn("git provider subscriber dropped event", "key", ev.Key)
+		}
+	}
+}
+
+// compile-time check that Provider satisfies adapter.Provider.
+var _ adapter.Provider[WorktreeID, Worktree] = (*Provider)(nil)

--- a/internal/server/providers/git/types.go
+++ b/internal/server/providers/git/types.go
@@ -1,0 +1,76 @@
+// Package git implements the git provider per ADR-011 §5.1.
+//
+// It surfaces one node — Worktree — by reading the plain-text files
+// under each registered project's `.git/worktrees/` directory plus the
+// project's own `.git/HEAD`. fsnotify drives invalidation: one watcher
+// per project, reused across re-fetches.
+//
+// We intentionally do NOT shell out to `git`. The on-disk layout is a
+// stable, documented contract (see `man gitrepository-layout`); reading
+// it directly is faster, has no fork/exec overhead, and keeps tests
+// hermetic.
+//
+// Worktree IDs are formatted `<project_id>:<worktree_name>`:
+//   - main checkout → `<project_id>:main`
+//   - linked worktree → `<project_id>:<dir under .git/worktrees/>`
+//
+// IDs survive `git worktree repair` because the directory name under
+// `.git/worktrees/` is stable; they break if a user manually renames
+// the directory, which is rare and indistinguishable from
+// add+remove from the daemon's perspective.
+package git
+
+import "path/filepath"
+
+// MainWorktreeName is the conventional last segment of a project's main
+// checkout's [WorktreeID]. The on-disk `.git/worktrees/` directory only
+// lists *linked* worktrees; the main checkout has no entry there, so
+// we synthesise this constant. Picked to be unambiguous because git
+// itself doesn't allow a linked worktree directory called `main` (it
+// would collide with `refs/heads/main` semantics for many users, and
+// the practical convention is to name worktrees after issues / topics).
+const MainWorktreeName = "main"
+
+// WorktreeID identifies a worktree across the orchard graph. Format:
+// `<project_id>:<worktree_name>`. The project_id portion is opaque to
+// this package — it comes from the caller registering the project.
+type WorktreeID string
+
+// NewWorktreeID composes an ID from a project_id and a worktree name.
+// Both arguments are required; empty strings produce a malformed id and
+// will fail subsequent parses.
+func NewWorktreeID(projectID, name string) WorktreeID {
+	return WorktreeID(projectID + ":" + name)
+}
+
+// Project carries the minimum the provider needs to scan a project: a
+// stable ID plus the absolute path to the working tree's `.git`
+// directory's parent. The git provider doesn't care about the project's
+// name or any other metadata — that's the config provider's concern.
+type Project struct {
+	ID  string
+	Dir string
+}
+
+// Worktree is the value the git provider exposes. The fields mirror
+// the GraphQL Worktree node (ADR-011 §5.1) so the resolver layer can
+// project them 1:1.
+type Worktree struct {
+	ID        WorktreeID
+	ProjectID string
+	Name      string // last segment of the ID; "main" for the main checkout
+	Path      string // absolute, cleaned with filepath.Clean
+	Branch    string // empty when detached or bare
+	Head      string // 40-char SHA, or "" when HEAD cannot be resolved
+	Bare      bool
+}
+
+// CleanPath returns p with [filepath.Clean] applied. We keep this in a
+// helper so every code path that produces a Worktree.Path normalises
+// the same way (test fixtures rely on stable equality).
+func CleanPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	return filepath.Clean(p)
+}

--- a/internal/server/providers/git/watcher.go
+++ b/internal/server/providers/git/watcher.go
@@ -1,0 +1,283 @@
+package git
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// watcher is a long-lived fsnotify watcher attached to a single project.
+// We watch three locations relevant to worktree state:
+//
+//  1. `.git/HEAD`               — main checkout's branch / detached state.
+//  2. `.git/refs/heads/`        — main checkout's head SHA per branch.
+//  3. `.git/worktrees/`         — linked worktree creation / removal.
+//  4. `.git/worktrees/*/HEAD`   — per-linked-worktree branch / detached state.
+//
+// fsnotify on macOS / Linux is non-recursive, so when `.git/worktrees/`
+// gains a new entry we have to add a watch for the new directory; and
+// when the directory itself disappears we have to drop watches.
+//
+// One watcher per project, reused across re-fetches (worker-standards
+// §2: "fsnotify watchers reuse a single watcher per provider, not one
+// per key"). The provider holds at most one watcher per project at a
+// time; re-registering a project replaces the watcher.
+type watcher struct {
+	project Project
+	fsw     *fsnotify.Watcher
+	logger  *slog.Logger
+
+	// invalidations is the channel the provider listens on. Closes when
+	// the watcher is stopped.
+	invalidations chan WorktreeID
+
+	mu      sync.Mutex
+	watched map[string]struct{} // dirs currently registered with fsw
+	stopped bool
+}
+
+func newWatcher(project Project, logger *slog.Logger) (*watcher, error) {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("fsnotify.NewWatcher: %w", err)
+	}
+	w := &watcher{
+		project:       project,
+		fsw:           fsw,
+		logger:        logger,
+		invalidations: make(chan WorktreeID, 32),
+		watched:       map[string]struct{}{},
+	}
+	return w, nil
+}
+
+// run is the watcher event loop. It blocks until ctx is cancelled or
+// the underlying fsnotify watcher errors out terminally.
+func (w *watcher) run(ctx context.Context) {
+	defer w.close()
+
+	if err := w.seedWatches(); err != nil {
+		// A project the user registered before its `.git` exists is a
+		// legitimate state (`orchard config add-repo` before `git init`)
+		// — log and bail out of seeding; we re-attempt on the next call
+		// to RefreshWatches once the directory shows up.
+		w.logger.Warn("git watcher seed failed", "project", w.project.ID, "err", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-w.fsw.Events:
+			if !ok {
+				return
+			}
+			w.handleEvent(ev)
+		case err, ok := <-w.fsw.Errors:
+			if !ok {
+				return
+			}
+			// fsnotify errors during a directory's lifecycle (e.g. ENOENT
+			// after a remove that we haven't yet reconciled) are routine
+			// — log at debug, keep looping.
+			w.logger.Debug("git watcher fsnotify err", "project", w.project.ID, "err", err)
+		}
+	}
+}
+
+// seedWatches adds the canonical directories under `.git`. Missing
+// directories are tolerated (fresh repo, project not yet `git
+// worktree`-d) and re-attempted on subsequent events.
+func (w *watcher) seedWatches() error {
+	gitDir, err := resolveGitDir(w.project.Dir)
+	if err != nil {
+		return fmt.Errorf("resolve gitdir: %w", err)
+	}
+	// addDir is best-effort: it logs at debug for non-existent dirs and
+	// fsnotify add errors. The watcher recovers via subsequent events,
+	// so seed-time errors are not propagated.
+	_ = w.addDir(gitDir) // catches HEAD changes (HEAD lives at .git/HEAD)
+
+	_ = w.addDir(filepath.Join(gitDir, "refs", "heads"))
+
+	worktreesRoot := filepath.Join(gitDir, "worktrees")
+	if err := w.addDir(worktreesRoot); err == nil {
+		// Add a watch for each existing linked worktree so per-worktree
+		// HEAD changes raise events.
+		entries, err := os.ReadDir(worktreesRoot)
+		if err == nil {
+			for _, e := range entries {
+				if e.IsDir() {
+					_ = w.addDir(filepath.Join(worktreesRoot, e.Name()))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// handleEvent translates a raw fsnotify event into one or more
+// invalidation notifications and adjusts the watch set.
+func (w *watcher) handleEvent(ev fsnotify.Event) {
+	gitDir, err := resolveGitDir(w.project.Dir)
+	if err != nil {
+		// Repo went away mid-flight; signal a main-checkout invalidation
+		// so the cache flushes and stop seeding new watches.
+		w.emit(NewWorktreeID(w.project.ID, MainWorktreeName))
+		return
+	}
+
+	rel, ok := relUnder(gitDir, ev.Name)
+	if !ok {
+		return
+	}
+
+	switch {
+	case rel == "HEAD" || strings.HasPrefix(rel, "refs/heads/"):
+		// Main checkout's branch or head-SHA changed.
+		w.emit(NewWorktreeID(w.project.ID, MainWorktreeName))
+
+	case rel == "worktrees" || rel == "worktrees"+string(filepath.Separator):
+		// The worktrees container itself changed (created / removed).
+		w.refreshWorktreesContainer(gitDir)
+
+	case strings.HasPrefix(rel, "worktrees"+string(filepath.Separator)):
+		w.handleWorktreesEvent(ev, gitDir, rel)
+	}
+}
+
+// handleWorktreesEvent handles changes inside `.git/worktrees/`. Two
+// shapes:
+//   - `worktrees/<name>` (no further segments) — a directory was created
+//     or removed; add or drop the watch and emit an invalidation for
+//     the implicated worktree id.
+//   - `worktrees/<name>/HEAD` (or anything below) — emit invalidation
+//     for that specific worktree id.
+func (w *watcher) handleWorktreesEvent(ev fsnotify.Event, gitDir, rel string) {
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) < 2 || parts[0] != "worktrees" {
+		return
+	}
+	name := parts[1]
+	full := filepath.Join(gitDir, "worktrees", name)
+
+	if len(parts) == 2 {
+		// `worktrees/<name>` itself
+		switch {
+		case ev.Has(fsnotify.Create):
+			_ = w.addDir(full)
+		case ev.Has(fsnotify.Remove), ev.Has(fsnotify.Rename):
+			w.dropDir(full)
+		}
+	}
+
+	w.emit(NewWorktreeID(w.project.ID, name))
+}
+
+// refreshWorktreesContainer is invoked when `.git/worktrees/` itself
+// changed. It re-seeds child watches for any directory that exists
+// but isn't yet watched, and drops watches for entries that are gone.
+// We always emit a main-checkout invalidation in case the container
+// removal corresponds to all-worktrees-gone.
+func (w *watcher) refreshWorktreesContainer(gitDir string) {
+	worktreesRoot := filepath.Join(gitDir, "worktrees")
+	entries, err := os.ReadDir(worktreesRoot)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// Container deleted — drop any per-worktree watches that
+			// are now under it.
+			w.mu.Lock()
+			for d := range w.watched {
+				if strings.HasPrefix(d, worktreesRoot+string(filepath.Separator)) {
+					_ = w.fsw.Remove(d)
+					delete(w.watched, d)
+				}
+			}
+			w.mu.Unlock()
+			return
+		}
+		w.logger.Debug("read worktrees dir", "err", err)
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			full := filepath.Join(worktreesRoot, e.Name())
+			_ = w.addDir(full)
+			// And surface the (re)appearance.
+			w.emit(NewWorktreeID(w.project.ID, e.Name()))
+		}
+	}
+}
+
+// addDir registers d with fsnotify if not already watched. Missing dirs
+// return nil — the caller may retry later.
+func (w *watcher) addDir(d string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, ok := w.watched[d]; ok {
+		return nil
+	}
+	if err := w.fsw.Add(d); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		w.logger.Debug("git watcher add", "dir", d, "err", err)
+		return err
+	}
+	w.watched[d] = struct{}{}
+	return nil
+}
+
+// dropDir removes a previously-registered watch. Idempotent.
+func (w *watcher) dropDir(d string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, ok := w.watched[d]; !ok {
+		return
+	}
+	_ = w.fsw.Remove(d)
+	delete(w.watched, d)
+}
+
+// emit pushes an invalidation, dropping under back-pressure rather than
+// blocking the watcher loop. The store's eventual-consistency guarantee
+// relies on the next FetchAll catching up, so a missed event here is
+// recoverable.
+func (w *watcher) emit(id WorktreeID) {
+	select {
+	case w.invalidations <- id:
+	default:
+		w.logger.Warn("git watcher invalidation dropped (channel full)",
+			"project", w.project.ID, "id", id)
+	}
+}
+
+// close tears down the underlying fsnotify watcher and closes the
+// invalidation channel. Idempotent.
+func (w *watcher) close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.stopped {
+		return
+	}
+	w.stopped = true
+	_ = w.fsw.Close()
+	close(w.invalidations)
+}
+
+// relUnder returns ev relative to root if ev is under root.
+func relUnder(root, ev string) (string, bool) {
+	rel, err := filepath.Rel(root, ev)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", false
+	}
+	return rel, true
+}

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 )
 
@@ -28,6 +29,7 @@ type Resolver struct {
 	StartedAt        time.Time
 	HostProvider     *host.Provider
 	ProjectsProvider ProjectsLister
+	Git              *gitprovider.Provider
 }
 
 // New constructs a Resolver with the daemon's start time captured. The
@@ -47,5 +49,12 @@ func (r *Resolver) WithHost(h *host.Provider) *Resolver {
 // WithProjects wires the projects-listing dependency.
 func (r *Resolver) WithProjects(p ProjectsLister) *Resolver {
 	r.ProjectsProvider = p
+	return r
+}
+
+// WithGit wires the git provider that backs Project.worktrees and
+// Worktree.* resolvers.
+func (r *Resolver) WithGit(g *gitprovider.Provider) *Resolver {
+	r.Git = g
 	return r
 }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -13,6 +13,11 @@ import (
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 )
 
+// Worktrees is the resolver for the worktrees field.
+func (r *projectResolver) Worktrees(ctx context.Context, obj *graphql1.Project) ([]*graphql1.Worktree, error) {
+	panic(fmt.Errorf("not implemented: Worktrees - worktrees"))
+}
+
 // Health is the resolver for the health field.
 func (r *queryResolver) Health(ctx context.Context) (*graphql1.Health, error) {
 	uptime := int64(time.Since(r.StartedAt).Round(time.Second).Seconds())
@@ -66,7 +71,20 @@ func (r *queryResolver) Projects(ctx context.Context) ([]*graphql1.Project, erro
 	return out, nil
 }
 
+// Processes is the resolver for the processes field.
+func (r *worktreeResolver) Processes(ctx context.Context, obj *graphql1.Worktree) ([]*graphql1.Process, error) {
+	panic(fmt.Errorf("not implemented: Processes - processes"))
+}
+
+// Project returns graphql1.ProjectResolver implementation.
+func (r *Resolver) Project() graphql1.ProjectResolver { return &projectResolver{r} }
+
 // Query returns graphql1.QueryResolver implementation.
 func (r *Resolver) Query() graphql1.QueryResolver { return &queryResolver{r} }
 
+// Worktree returns graphql1.WorktreeResolver implementation.
+func (r *Resolver) Worktree() graphql1.WorktreeResolver { return &worktreeResolver{r} }
+
+type projectResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
+type worktreeResolver struct{ *Resolver }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -11,11 +11,26 @@ import (
 	"time"
 
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 )
 
-// Worktrees is the resolver for the worktrees field.
+// Worktrees is the resolver for the worktrees field. Lists the git
+// worktrees backing this project — the main checkout plus everything
+// under `.git/worktrees/`. Returns an empty list when the git provider
+// has no records yet for this project (e.g. fresh boot before scan).
 func (r *projectResolver) Worktrees(ctx context.Context, obj *graphql1.Project) ([]*graphql1.Worktree, error) {
-	panic(fmt.Errorf("not implemented: Worktrees - worktrees"))
+	if r.Git == nil {
+		return nil, fmt.Errorf("git provider not configured")
+	}
+	worktrees, err := r.Git.ListByProject(ctx, obj.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list worktrees for project %q: %w", obj.ID, err)
+	}
+	out := make([]*graphql1.Worktree, 0, len(worktrees))
+	for _, w := range worktrees {
+		out = append(out, toGraphQLWorktree(w))
+	}
+	return out, nil
 }
 
 // Health is the resolver for the health field.
@@ -72,8 +87,12 @@ func (r *queryResolver) Projects(ctx context.Context) ([]*graphql1.Project, erro
 }
 
 // Processes is the resolver for the processes field.
-func (r *worktreeResolver) Processes(ctx context.Context, obj *graphql1.Worktree) ([]*graphql1.Process, error) {
-	panic(fmt.Errorf("not implemented: Processes - processes"))
+//
+// Placeholder until Workstream B-ps lands the ps provider. Returning
+// an empty slice satisfies the non-null `[Process!]!` schema contract
+// and keeps the rest of the graph queryable.
+func (r *worktreeResolver) Processes(_ context.Context, _ *graphql1.Worktree) ([]*graphql1.Process, error) {
+	return []*graphql1.Process{}, nil
 }
 
 // Project returns graphql1.ProjectResolver implementation.
@@ -88,3 +107,16 @@ func (r *Resolver) Worktree() graphql1.WorktreeResolver { return &worktreeResolv
 type projectResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type worktreeResolver struct{ *Resolver }
+
+// toGraphQLWorktree projects a git provider Worktree into the GraphQL
+// model. Kept as a free function so the projection logic is testable
+// without a full resolver harness.
+func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
+	return &graphql1.Worktree{
+		ID:     string(w.ID),
+		Path:   w.Path,
+		Branch: w.Branch,
+		Head:   w.Head,
+		Bare:   w.Bare,
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,9 @@
 // Workstream B-config: providers introduced by later workstreams are
 // wired through the Option pattern (WithFoo(p)), so New keeps a tight
 // signature as the provider set grows.
+//
+// Workstream B-git: WithGit wires the git provider that backs
+// Project.worktrees and Worktree.* resolvers.
 package server
 
 import (
@@ -30,6 +33,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 
 	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
 )
@@ -46,6 +50,7 @@ type Server struct {
 	logger    *slog.Logger
 	httpSrv   *http.Server
 	host      *host.Provider
+	resolver  *resolvers.Resolver
 }
 
 // Option mutates a Server during construction. Used for wiring optional
@@ -55,6 +60,11 @@ type Option func(*Server, *resolvers.Resolver)
 // WithProjects wires a projects provider into the resolver.
 func WithProjects(p resolvers.ProjectsLister) Option {
 	return func(_ *Server, r *resolvers.Resolver) { r.WithProjects(p) }
+}
+
+// WithGit wires a git provider into the resolver.
+func WithGit(g *gitprovider.Provider) Option {
+	return func(_ *Server, r *resolvers.Resolver) { r.WithGit(g) }
 }
 
 // New constructs a Server bound to addr. The host provider is constructed
@@ -78,6 +88,7 @@ func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 		startedAt: startedAt,
 		logger:    logger,
 		host:      hostProvider,
+		resolver:  res,
 	}
 	for _, opt := range opts {
 		opt(srv, res)
@@ -103,6 +114,17 @@ func (s *Server) Addr() string { return s.addr }
 // HTTPHandler returns the underlying HTTP mux for tests that wrap the
 // daemon in httptest.Server without binding a real port.
 func (s *Server) HTTPHandler() http.Handler { return s.httpSrv.Handler }
+
+// Resolver returns the resolver root the server was built with. Tests
+// that need to inject providers post-construction can use this.
+func (s *Server) Resolver() *resolvers.Resolver { return s.resolver }
+
+// GraphQLHandler returns a fresh handler bound to the server's
+// resolver. Useful for in-process tests that drive the schema through
+// httptest.Server without standing up the full HTTP listener.
+func (s *Server) GraphQLHandler() http.Handler {
+	return graphqlHandlerFor(s.resolver)
+}
 
 // Run starts providers, the HTTP server, and blocks until ctx is
 // cancelled, then drains in-flight requests with a 5-second deadline.

--- a/schema.graphql
+++ b/schema.graphql
@@ -14,6 +14,10 @@
 #
 # Workstream B-config: Project node — projects declared in the orchard
 # config. Read-only; mutations go through `orchard config add-repo`.
+#
+# Workstream B-git: Worktree node + Project.worktrees back-edge. Process
+# is forward-declared so Worktree.processes can reference it; ws-b-ps
+# fills in the rest.
 
 """
 A node in the orchard graph. Every node has a globally-unique id so
@@ -22,6 +26,14 @@ type it is.
 """
 interface Node {
   "Globally-unique id (e.g. \"Host:<machineId>\")."
+  id: ID!
+}
+
+# Process is forward-declared here so Worktree.processes can reference
+# it; the ps provider in ws-b-ps fills in the rest of the type.
+# Until that lands, Worktree.processes resolves to `[]`.
+type Process implements Node {
+  "Stable id formatted as `<host>:<pid>`."
   id: ID!
 }
 
@@ -118,4 +130,28 @@ type Project implements Node {
 
   "Human-readable label. Defaults to the basename of `directory` when not specified in the config."
   name: String!
+
+  "Worktrees discovered for this project — the project's main checkout plus everything under `.git/worktrees/`."
+  worktrees: [Worktree!]!
+}
+
+"A git worktree — either the project's main checkout or one created with `git worktree add`. See ADR-011 §5.1."
+type Worktree implements Node {
+  "Stable identifier formatted as `<project_id>:<worktree_name>`. The main checkout uses the worktree name `main`."
+  id: ID!
+
+  "Absolute filesystem path to the worktree."
+  path: String!
+
+  "Branch the worktree currently has checked out. Empty string for detached HEAD or bare worktrees."
+  branch: String!
+
+  "Resolved 40-character SHA the worktree's HEAD points at. Empty string when HEAD cannot be resolved (e.g. an unborn branch)."
+  head: String!
+
+  "True when HEAD references a deleted branch or otherwise fails to resolve to a commit. Bare worktrees still appear in the list — they just have no live branch."
+  bare: Boolean!
+
+  "Processes whose cwd lies under `path`. Resolved by the ps provider (ws-b-ps); returns `[]` until that provider lands."
+  processes: [Process!]!
 }


### PR DESCRIPTION
## Summary
- Implements the git provider per ADR-011 §5.1, surfacing the Worktree node.
- Adds `Project.worktrees` edge; `Project` minimal shape mirrors ws-b-config.
- Real-git E2E test with fsnotify + httptest GraphQL — no mocks.

## ACs
- [x] AC1 — schema additions (Node, Worktree, Project, Process forward-decl, Project.worktrees, Query.projects) — `e5aa003`
- [x] AC2 — provider at `internal/server/providers/git/` (adapter + watcher + store) — `21063ce`
- [x] AC3 — `Project.worktrees` + `Worktree.*` resolvers wired — `e9acdcc`
- [x] AC4 — bare-worktree handling (deleted branch → `bare: true`, no crash); detached HEAD handled separately — `21063ce`
- [x] AC5 — `Worktree.processes` returns `[]` placeholder until ws-b-ps lands — `e9acdcc`
- [x] AC6 — E2E test against real git + fsnotify + GraphQL (`git_e2e_test.go`) — `9dad535`
- [x] AC7 — `go test ./internal/server/providers/git/...` green; `-race -count=3` green — `9dad535`
- [x] AC8 — `golangci-lint run` clean for ws-b-git scope (pre-existing errcheck warnings in ws-a CLI code are out of scope per briefing)
- [x] AC9 — this PR

## Notes for reviewers
- Pure stdlib reads of `.git/HEAD`, `.git/refs/heads/`, `packed-refs`, `.git/worktrees/<name>/{HEAD,gitdir}`. No shellout to `git`.
- One fsnotify watcher per project; sub-watches added/dropped dynamically as worktrees come and go.
- `internal/server/adapter/` is shared utility per worker-standards §8 — ws-b-config and ws-b-ps consume the same `Provider[K,V]`/`Adapter[K,V]` contracts.
- `Project` declared with same shape as ws-b-config so the two PRs merge without conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GraphQL queries to retrieve Git projects and their worktrees with metadata including path, branch, and HEAD status.
  * Introduced `Node` interface for unified resource identification across the API.
  * Live monitoring of worktree changes with automatic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->