### PR TITLE
Workstream B-ps: ps provider → Process node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
-	github.com/fsnotify/fsnotify v1.10.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -43,3 +43,28 @@ models:
     fields:
       processes:
         resolver: true
+
+  # Host.processes accepts a filter argument, so route it through a custom
+  # resolver instead of struct-field auto-binding. The resolver consults the
+  # ps provider and applies the filter at the resolver layer (ADR-011 §6).
+  Host:
+    fields:
+      processes:
+        resolver: true
+
+  # Process is materialised by the ps provider's resolver layer. `args` and
+  # `cwd` are slow-path fields per ADR-011 §5.1 — they need their own
+  # resolvers so we can opt-in to the extra ps / lsof shellouts only when
+  # the field is actually selected.
+  Process:
+    fields:
+      host:
+        resolver: true
+      args:
+        resolver: true
+      cwd:
+        resolver: true
+      worktree:
+        resolver: true
+      claudeInstance:
+        resolver: true

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -33,6 +33,7 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/orchpaths"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server"
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 )
 
 // Command returns the `daemon` subcommand group rooted with three leaves.
@@ -115,7 +116,15 @@ func runStart(parentCtx context.Context, addr string) error {
 	}
 	defer func() { _ = configProvider.Stop() }()
 
-	srv := server.New(addr, logger, server.WithProjects(configProvider))
+	// Wire the ps provider for the local host. The host id is "local"
+	// for v1 — the host provider (Workstream G) replaces this with a
+	// real machine id once it lands.
+	psProvider := ps.New(ps.NewAdapter("local"), logger)
+
+	srv := server.New(addr, logger,
+		server.WithProjects(configProvider),
+		server.WithPS(psProvider),
+	)
 	return srv.Run(ctx)
 }
 

--- a/internal/cli/query/processes.go
+++ b/internal/cli/query/processes.go
@@ -1,0 +1,151 @@
+// Package query — `orchard query processes` subcommand. Prints a JSON
+// list of processes matching the given filters by hitting the local
+// daemon's GraphQL surface.
+package query
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// processesCmd implements `orchard query processes`. Mirrors the impl
+// guide CLI shape: --by-cwd PATH and --command CMD, JSON output.
+func processesCmd() *cobra.Command {
+	var byCwd, byCommand string
+	c := &cobra.Command{
+		Use:   "processes",
+		Short: "List processes visible to the local ps adapter (JSON)",
+		Long: "Query the running orchard daemon for processes. " +
+			"Filters compose: --by-cwd narrows by cwd prefix, --command by basename. " +
+			"With no filters, every process visible to ps is returned.",
+		Example: "  orchard query processes\n" +
+			"  orchard query processes --command claude\n" +
+			"  orchard query processes --by-cwd /Users/me/workspace",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProcesses(cmd.Context(), cmd.OutOrStdout(), byCwd, byCommand)
+		},
+	}
+	c.Flags().StringVar(&byCwd, "by-cwd", "", "filter by cwd prefix")
+	c.Flags().StringVar(&byCommand, "command", "", "filter by command basename (e.g. 'claude')")
+	return c
+}
+
+// processesQuery is the GraphQL query the CLI sends. Selecting the
+// slow-path `args` and `cwd` fields here is intentional: a user asking
+// `orchard query processes` expects a complete view, and the resolver's
+// per-pid lsof cost is bounded by the filter (or the whole table when
+// the user really wants the whole table).
+const processesQuery = `query Processes($filter: ProcessFilter) {
+  host {
+    id
+    processes(filter: $filter) {
+      id
+      pid
+      ppid
+      command
+      args
+      cwd
+      startedAt
+      cpuPercent
+      memBytes
+      tty
+    }
+  }
+}`
+
+// processesResponse is the JSON shape returned to the user. We project
+// the GraphQL response into a flat list because nesting under host
+// would be needless ceremony for a single-host CLI.
+type processesResponse struct {
+	Host      string            `json:"host"`
+	Processes []processesEntry  `json:"processes"`
+	Errors    []json.RawMessage `json:"errors,omitempty"`
+}
+
+type processesEntry struct {
+	ID         string   `json:"id"`
+	Pid        int64    `json:"pid"`
+	Ppid       int64    `json:"ppid"`
+	Command    string   `json:"command"`
+	Args       []string `json:"args,omitempty"`
+	Cwd        *string  `json:"cwd,omitempty"`
+	StartedAt  string   `json:"startedAt"`
+	CPUPercent float64  `json:"cpuPercent"`
+	MemBytes   int64    `json:"memBytes"`
+	Tty        *string  `json:"tty,omitempty"`
+}
+
+func runProcesses(ctx context.Context, w io.Writer, byCwd, byCommand string) error {
+	filter := map[string]any{}
+	if byCwd != "" {
+		filter["cwdPrefix"] = byCwd
+	}
+	if byCommand != "" {
+		filter["commandIn"] = []string{byCommand}
+	}
+
+	var variables map[string]any
+	if len(filter) > 0 {
+		variables = map[string]any{"filter": filter}
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"query":     processesQuery,
+		"variables": variables,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resolveDaemonURL()+"/graphql", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("daemon not running, start with `orchard daemon start` (%w)", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var envelope struct {
+		Data struct {
+			Host struct {
+				ID        string           `json:"id"`
+				Processes []processesEntry `json:"processes"`
+			} `json:"host"`
+		} `json:"data"`
+		Errors []json.RawMessage `json:"errors"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	out := processesResponse{
+		Host:      envelope.Data.Host.ID,
+		Processes: envelope.Data.Host.Processes,
+		Errors:    envelope.Errors,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		return fmt.Errorf("encode output: %w", err)
+	}
+	return nil
+}

--- a/internal/cli/query/processes.go
+++ b/internal/cli/query/processes.go
@@ -114,7 +114,7 @@ func runProcesses(ctx context.Context, w io.Writer, byCwd, byCommand string) err
 	if err != nil {
 		return fmt.Errorf("daemon not running, start with `orchard daemon start` (%w)", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/internal/cli/query/query.go
+++ b/internal/cli/query/query.go
@@ -54,22 +54,24 @@ func Command() *cobra.Command {
 		Aliases: []string{"q"},
 		Short:   "Query the running orchard daemon via GraphQL",
 		Long: "Dispatch GraphQL queries against the running daemon at " + server.DefaultAddr + ".\n\n" +
-			"Use a named verb (e.g. `host`, `projects`) for high-level reads, or `--raw '<gql>'`\n" +
-			"as the escape hatch when you need a custom GraphQL query.",
+			"Use a named verb (e.g. `host`, `projects`, `processes`) for high-level reads,\n" +
+			"or `--raw '<gql>'` as the escape hatch when you need a custom GraphQL query.",
 		Example: "  orchard query host\n" +
 			"  orchard query projects\n" +
+			"  orchard query processes\n" +
 			"  orchard query --raw 'query { health { status } }'",
 	}
 	var raw string
 	cmd.Flags().StringVar(&raw, "raw", "", "raw GraphQL query string")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		if raw == "" {
-			return fmt.Errorf("provide a verb (e.g. `host`, `projects`) or --raw '<graphql>'")
+			return fmt.Errorf("provide a verb (e.g. `host`, `projects`, `processes`) or --raw '<graphql>'")
 		}
 		return runRaw(cmd.Context(), cmd.OutOrStdout(), raw)
 	}
 	cmd.AddCommand(hostCmd())
 	cmd.AddCommand(projectsCmd())
+	cmd.AddCommand(processesCmd())
 	return cmd
 }
 

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -37,6 +37,8 @@ type Config struct {
 }
 
 type ResolverRoot interface {
+	Host() HostResolver
+	Process() ProcessResolver
 	Project() ProjectResolver
 	Query() QueryResolver
 	Worktree() WorktreeResolver
@@ -46,6 +48,10 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	ClaudeInstance struct {
+		ID func(childComplexity int) int
+	}
+
 	Health struct {
 		Status  func(childComplexity int) int
 		UptimeS func(childComplexity int) int
@@ -60,12 +66,25 @@ type ComplexityRoot struct {
 		MachineID    func(childComplexity int) int
 		Os           func(childComplexity int) int
 		Peers        func(childComplexity int) int
+		Processes    func(childComplexity int, filter *ProcessFilter) int
 		Reachable    func(childComplexity int) int
 		ResourceLoad func(childComplexity int) int
 	}
 
 	Process struct {
-		ID func(childComplexity int) int
+		Args           func(childComplexity int) int
+		CPUPercent     func(childComplexity int) int
+		ClaudeInstance func(childComplexity int) int
+		Command        func(childComplexity int) int
+		Cwd            func(childComplexity int) int
+		Host           func(childComplexity int) int
+		ID             func(childComplexity int) int
+		MemBytes       func(childComplexity int) int
+		Pid            func(childComplexity int) int
+		Ppid           func(childComplexity int) int
+		StartedAt      func(childComplexity int) int
+		Tty            func(childComplexity int) int
+		Worktree       func(childComplexity int) int
 	}
 
 	Project struct {
@@ -101,6 +120,18 @@ type ComplexityRoot struct {
 	}
 }
 
+type HostResolver interface {
+	Processes(ctx context.Context, obj *Host, filter *ProcessFilter) ([]*Process, error)
+}
+type ProcessResolver interface {
+	Host(ctx context.Context, obj *Process) (*Host, error)
+
+	Args(ctx context.Context, obj *Process) ([]string, error)
+	Cwd(ctx context.Context, obj *Process) (*string, error)
+
+	Worktree(ctx context.Context, obj *Process) (*Worktree, error)
+	ClaudeInstance(ctx context.Context, obj *Process) (*ClaudeInstance, error)
+}
 type ProjectResolver interface {
 	Worktrees(ctx context.Context, obj *Project) ([]*Worktree, error)
 }
@@ -132,6 +163,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	ec := executionContext{nil, e, 0, 0, nil}
 	_ = ec
 	switch typeName + "." + field {
+
+	case "ClaudeInstance.id":
+		if e.complexity.ClaudeInstance.ID == nil {
+			break
+		}
+
+		return e.complexity.ClaudeInstance.ID(childComplexity), true
 
 	case "Health.status":
 		if e.complexity.Health.Status == nil {
@@ -203,6 +241,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Host.Peers(childComplexity), true
 
+	case "Host.processes":
+		if e.complexity.Host.Processes == nil {
+			break
+		}
+
+		args, err := ec.field_Host_processes_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Host.Processes(childComplexity, args["filter"].(*ProcessFilter)), true
+
 	case "Host.reachable":
 		if e.complexity.Host.Reachable == nil {
 			break
@@ -217,12 +267,96 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Host.ResourceLoad(childComplexity), true
 
+	case "Process.args":
+		if e.complexity.Process.Args == nil {
+			break
+		}
+
+		return e.complexity.Process.Args(childComplexity), true
+
+	case "Process.cpuPercent":
+		if e.complexity.Process.CPUPercent == nil {
+			break
+		}
+
+		return e.complexity.Process.CPUPercent(childComplexity), true
+
+	case "Process.claudeInstance":
+		if e.complexity.Process.ClaudeInstance == nil {
+			break
+		}
+
+		return e.complexity.Process.ClaudeInstance(childComplexity), true
+
+	case "Process.command":
+		if e.complexity.Process.Command == nil {
+			break
+		}
+
+		return e.complexity.Process.Command(childComplexity), true
+
+	case "Process.cwd":
+		if e.complexity.Process.Cwd == nil {
+			break
+		}
+
+		return e.complexity.Process.Cwd(childComplexity), true
+
+	case "Process.host":
+		if e.complexity.Process.Host == nil {
+			break
+		}
+
+		return e.complexity.Process.Host(childComplexity), true
+
 	case "Process.id":
 		if e.complexity.Process.ID == nil {
 			break
 		}
 
 		return e.complexity.Process.ID(childComplexity), true
+
+	case "Process.memBytes":
+		if e.complexity.Process.MemBytes == nil {
+			break
+		}
+
+		return e.complexity.Process.MemBytes(childComplexity), true
+
+	case "Process.pid":
+		if e.complexity.Process.Pid == nil {
+			break
+		}
+
+		return e.complexity.Process.Pid(childComplexity), true
+
+	case "Process.ppid":
+		if e.complexity.Process.Ppid == nil {
+			break
+		}
+
+		return e.complexity.Process.Ppid(childComplexity), true
+
+	case "Process.startedAt":
+		if e.complexity.Process.StartedAt == nil {
+			break
+		}
+
+		return e.complexity.Process.StartedAt(childComplexity), true
+
+	case "Process.tty":
+		if e.complexity.Process.Tty == nil {
+			break
+		}
+
+		return e.complexity.Process.Tty(childComplexity), true
+
+	case "Process.worktree":
+		if e.complexity.Process.Worktree == nil {
+			break
+		}
+
+		return e.complexity.Process.Worktree(childComplexity), true
 
 	case "Project.directory":
 		if e.complexity.Project.Directory == nil {
@@ -371,7 +505,9 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e, 0, 0, make(chan graphql.DeferredResult)}
-	inputUnmarshalMap := graphql.BuildUnmarshalerMap()
+	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+		ec.unmarshalInputProcessFilter,
+	)
 	first := true
 
 	switch rc.Operation.Operation {
@@ -473,6 +609,10 @@ var sources = []*ast.Source{
 # Workstream B-git: Worktree node + Project.worktrees back-edge. Process
 # is forward-declared so Worktree.processes can reference it; ws-b-ps
 # fills in the rest.
+#
+# Workstream B-ps: full Process node + Host.processes(filter). Edges
+# to Worktree (via cwd) and ClaudeInstance (via foreground claude pid)
+# stay placeholder until their owning workstreams land.
 
 """
 A node in the orchard graph. Every node has a globally-unique id so
@@ -484,12 +624,74 @@ interface Node {
   id: ID!
 }
 
-# Process is forward-declared here so Worktree.processes can reference
-# it; the ps provider in ws-b-ps fills in the rest of the type.
-# Until that lands, Worktree.processes resolves to ` + "`" + `[]` + "`" + `.
+# Process is an OS-level process surfaced via the ` + "`" + `ps` + "`" + ` adapter.
+# Identity: (host_id, pid). Lifetime: alive AND visible to ps.
+# Not enumerable from root — reach via ` + "`" + `host.processes` + "`" + ` etc.
+# See ADR-011 §5.1.
 type Process implements Node {
   "Stable id formatted as ` + "`" + `<host>:<pid>` + "`" + `."
   id: ID!
+
+  "Host this process is running on."
+  host: Host!
+
+  "Process id."
+  pid: Int!
+
+  "Parent process id (0 for kernel/launchd-rooted processes)."
+  ppid: Int!
+
+  "Command basename (e.g. 'sleep', 'claude'). Cheap, always populated."
+  command: String!
+
+  "Full argv. Slow path — opt-in (separate ` + "`" + `ps -wwax -o pid,args` + "`" + ` lookup)."
+  args: [String!]
+
+  "Current working directory. Slow path — opt-in (lsof on macOS, /proc on Linux)."
+  cwd: String
+
+  "Process start time (RFC3339 if parseable, otherwise the raw ` + "`" + `lstart` + "`" + ` field)."
+  startedAt: String!
+
+  "CPU percent as reported by ps."
+  cpuPercent: Float!
+
+  "Resident memory in bytes (RSS * 1024 from ps)."
+  memBytes: Int!
+
+  "Controlling terminal, or null if none."
+  tty: String
+
+  # Cross-provider edges — placeholders until their owning workstreams land.
+  # ws-b-git wires ` + "`" + `worktree` + "`" + ` via cwd → git worktree lookup;
+  # ws-b-claudeinstance (Wave 3) wires ` + "`" + `claudeInstance` + "`" + ` as the back-edge
+  # from a Claude pid.
+
+  "Worktree this process is running inside, derived from cwd. Null until ws-b-git wires the lookup."
+  worktree: Worktree
+
+  "Claude instance back-edge — populated when this pid is the foreground claude pid. Null until ws-b-claudeinstance lands."
+  claudeInstance: ClaudeInstance
+}
+
+# Forward-declared placeholder. ws-b-claudeinstance replaces this with the
+# real ClaudeInstance node (pane, process, account, state, …).
+type ClaudeInstance {
+  "Stable id; ws-b-claudeinstance formalises (host_id, claudePid)."
+  id: ID!
+}
+
+# ProcessFilter is applied at the resolver layer over the cached process
+# list. Multiple filters are AND-combined.
+input ProcessFilter {
+  "Match processes whose command basename is in this list."
+  commandIn: [String!]
+
+  "Match processes whose cwd starts with this prefix. Forces cwd resolution."
+  cwdPrefix: String
+
+  "Match processes by pid."
+  pidIn: [Int!]
 }
 
 type Query {
@@ -549,6 +751,9 @@ type Host implements Node {
 
   "Peer hosts this daemon federates with. v1: always empty; Workstream F populates."
   peers: [Host!]!
+
+  "Processes visible to this host's ` + "`" + `ps` + "`" + ` adapter, optionally filtered."
+  processes(filter: ProcessFilter): [Process!]!
 }
 
 """
@@ -618,6 +823,21 @@ var parsedSchema = gqlparser.MustLoadSchema(sources...)
 
 // region    ***************************** args.gotpl *****************************
 
+func (ec *executionContext) field_Host_processes_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *ProcessFilter
+	if tmp, ok := rawArgs["filter"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+		arg0, err = ec.unmarshalOProcessFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcessFilter(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["filter"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -670,6 +890,50 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _ClaudeInstance_id(ctx context.Context, field graphql.CollectedField, obj *ClaudeInstance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ClaudeInstance_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ClaudeInstance_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ClaudeInstance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
 
 func (ec *executionContext) _Health_status(ctx context.Context, field graphql.CollectedField, obj *Health) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Health_status(ctx, field)
@@ -1219,9 +1483,94 @@ func (ec *executionContext) fieldContext_Host_peers(ctx context.Context, field g
 				return ec.fieldContext_Host_lastSeenAt(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
+			case "processes":
+				return ec.fieldContext_Host_processes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Host_processes(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_processes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Host().Processes(rctx, obj, fc.Args["filter"].(*ProcessFilter))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*Process)
+	fc.Result = res
+	return ec.marshalNProcess2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcessᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_processes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Process_id(ctx, field)
+			case "host":
+				return ec.fieldContext_Process_host(ctx, field)
+			case "pid":
+				return ec.fieldContext_Process_pid(ctx, field)
+			case "ppid":
+				return ec.fieldContext_Process_ppid(ctx, field)
+			case "command":
+				return ec.fieldContext_Process_command(ctx, field)
+			case "args":
+				return ec.fieldContext_Process_args(ctx, field)
+			case "cwd":
+				return ec.fieldContext_Process_cwd(ctx, field)
+			case "startedAt":
+				return ec.fieldContext_Process_startedAt(ctx, field)
+			case "cpuPercent":
+				return ec.fieldContext_Process_cpuPercent(ctx, field)
+			case "memBytes":
+				return ec.fieldContext_Process_memBytes(ctx, field)
+			case "tty":
+				return ec.fieldContext_Process_tty(ctx, field)
+			case "worktree":
+				return ec.fieldContext_Process_worktree(ctx, field)
+			case "claudeInstance":
+				return ec.fieldContext_Process_claudeInstance(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Process", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Host_processes_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -1265,6 +1614,561 @@ func (ec *executionContext) fieldContext_Process_id(ctx context.Context, field g
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_host(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_host(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Process().Host(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*Host)
+	fc.Result = res
+	return ec.marshalNHost2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHost(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_host(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Host_id(ctx, field)
+			case "machineId":
+				return ec.fieldContext_Host_machineId(ctx, field)
+			case "hostname":
+				return ec.fieldContext_Host_hostname(ctx, field)
+			case "os":
+				return ec.fieldContext_Host_os(ctx, field)
+			case "kernel":
+				return ec.fieldContext_Host_kernel(ctx, field)
+			case "address":
+				return ec.fieldContext_Host_address(ctx, field)
+			case "reachable":
+				return ec.fieldContext_Host_reachable(ctx, field)
+			case "resourceLoad":
+				return ec.fieldContext_Host_resourceLoad(ctx, field)
+			case "lastSeenAt":
+				return ec.fieldContext_Host_lastSeenAt(ctx, field)
+			case "peers":
+				return ec.fieldContext_Host_peers(ctx, field)
+			case "processes":
+				return ec.fieldContext_Host_processes(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_pid(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_pid(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Pid, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_pid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_ppid(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_ppid(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Ppid, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_ppid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_command(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_command(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Command, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_command(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_args(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_args(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Process().Args(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_args(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_cwd(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_cwd(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Process().Cwd(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_cwd(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_startedAt(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_startedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.StartedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_startedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_cpuPercent(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_cpuPercent(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CPUPercent, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_cpuPercent(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_memBytes(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_memBytes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MemBytes, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_memBytes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_tty(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_tty(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Tty, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_tty(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_worktree(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_worktree(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Process().Worktree(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*Worktree)
+	fc.Result = res
+	return ec.marshalOWorktree2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐWorktree(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_worktree(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Worktree_id(ctx, field)
+			case "path":
+				return ec.fieldContext_Worktree_path(ctx, field)
+			case "branch":
+				return ec.fieldContext_Worktree_branch(ctx, field)
+			case "head":
+				return ec.fieldContext_Worktree_head(ctx, field)
+			case "bare":
+				return ec.fieldContext_Worktree_bare(ctx, field)
+			case "processes":
+				return ec.fieldContext_Worktree_processes(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Worktree", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Process_claudeInstance(ctx context.Context, field graphql.CollectedField, obj *Process) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Process_claudeInstance(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Process().ClaudeInstance(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*ClaudeInstance)
+	fc.Result = res
+	return ec.marshalOClaudeInstance2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐClaudeInstance(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Process_claudeInstance(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Process",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ClaudeInstance_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
 		},
 	}
 	return fc, nil
@@ -1569,6 +2473,8 @@ func (ec *executionContext) fieldContext_Query_host(ctx context.Context, field g
 				return ec.fieldContext_Host_lastSeenAt(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
+			case "processes":
+				return ec.fieldContext_Host_processes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -1635,6 +2541,8 @@ func (ec *executionContext) fieldContext_Query_hosts(ctx context.Context, field 
 				return ec.fieldContext_Host_lastSeenAt(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
+			case "processes":
+				return ec.fieldContext_Host_processes(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -2350,6 +3258,30 @@ func (ec *executionContext) fieldContext_Worktree_processes(ctx context.Context,
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Process_id(ctx, field)
+			case "host":
+				return ec.fieldContext_Process_host(ctx, field)
+			case "pid":
+				return ec.fieldContext_Process_pid(ctx, field)
+			case "ppid":
+				return ec.fieldContext_Process_ppid(ctx, field)
+			case "command":
+				return ec.fieldContext_Process_command(ctx, field)
+			case "args":
+				return ec.fieldContext_Process_args(ctx, field)
+			case "cwd":
+				return ec.fieldContext_Process_cwd(ctx, field)
+			case "startedAt":
+				return ec.fieldContext_Process_startedAt(ctx, field)
+			case "cpuPercent":
+				return ec.fieldContext_Process_cpuPercent(ctx, field)
+			case "memBytes":
+				return ec.fieldContext_Process_memBytes(ctx, field)
+			case "tty":
+				return ec.fieldContext_Process_tty(ctx, field)
+			case "worktree":
+				return ec.fieldContext_Process_worktree(ctx, field)
+			case "claudeInstance":
+				return ec.fieldContext_Process_claudeInstance(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Process", field.Name)
 		},
@@ -4130,6 +5062,47 @@ func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Conte
 
 // region    **************************** input.gotpl *****************************
 
+func (ec *executionContext) unmarshalInputProcessFilter(ctx context.Context, obj interface{}) (ProcessFilter, error) {
+	var it ProcessFilter
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"commandIn", "cwdPrefix", "pidIn"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "commandIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("commandIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CommandIn = data
+		case "cwdPrefix":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("cwdPrefix"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CwdPrefix = data
+		case "pidIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("pidIn"))
+			data, err := ec.unmarshalOInt2ᚕint64ᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PidIn = data
+		}
+	}
+
+	return it, nil
+}
+
 // endregion **************************** input.gotpl *****************************
 
 // region    ************************** interface.gotpl ***************************
@@ -4174,6 +5147,45 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 // endregion ************************** interface.gotpl ***************************
 
 // region    **************************** object.gotpl ****************************
+
+var claudeInstanceImplementors = []string{"ClaudeInstance"}
+
+func (ec *executionContext) _ClaudeInstance(ctx context.Context, sel ast.SelectionSet, obj *ClaudeInstance) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, claudeInstanceImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ClaudeInstance")
+		case "id":
+			out.Values[i] = ec._ClaudeInstance_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
 
 var healthImplementors = []string{"Health"}
 
@@ -4233,22 +5245,22 @@ func (ec *executionContext) _Host(ctx context.Context, sel ast.SelectionSet, obj
 		case "id":
 			out.Values[i] = ec._Host_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "machineId":
 			out.Values[i] = ec._Host_machineId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "hostname":
 			out.Values[i] = ec._Host_hostname(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "os":
 			out.Values[i] = ec._Host_os(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "kernel":
 			out.Values[i] = ec._Host_kernel(ctx, field, obj)
@@ -4257,20 +5269,56 @@ func (ec *executionContext) _Host(ctx context.Context, sel ast.SelectionSet, obj
 		case "reachable":
 			out.Values[i] = ec._Host_reachable(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "resourceLoad":
 			out.Values[i] = ec._Host_resourceLoad(ctx, field, obj)
 		case "lastSeenAt":
 			out.Values[i] = ec._Host_lastSeenAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "peers":
 			out.Values[i] = ec._Host_peers(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "processes":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Host_processes(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4308,8 +5356,208 @@ func (ec *executionContext) _Process(ctx context.Context, sel ast.SelectionSet, 
 		case "id":
 			out.Values[i] = ec._Process_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "host":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Process_host(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "pid":
+			out.Values[i] = ec._Process_pid(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "ppid":
+			out.Values[i] = ec._Process_ppid(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "command":
+			out.Values[i] = ec._Process_command(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "args":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Process_args(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "cwd":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Process_cwd(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "startedAt":
+			out.Values[i] = ec._Process_startedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "cpuPercent":
+			out.Values[i] = ec._Process_cpuPercent(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "memBytes":
+			out.Values[i] = ec._Process_memBytes(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "tty":
+			out.Values[i] = ec._Process_tty(ctx, field, obj)
+		case "worktree":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Process_worktree(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "claudeInstance":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Process_claudeInstance(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -5629,11 +6877,102 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	return res
 }
 
+func (ec *executionContext) marshalOClaudeInstance2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐClaudeInstance(ctx context.Context, sel ast.SelectionSet, v *ClaudeInstance) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ClaudeInstance(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOInt2ᚕint64ᚄ(ctx context.Context, v interface{}) ([]int64, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]int64, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNInt2int64(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOInt2ᚕint64ᚄ(ctx context.Context, sel ast.SelectionSet, v []int64) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNInt2int64(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) unmarshalOProcessFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcessFilter(ctx context.Context, v interface{}) (*ProcessFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputProcessFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) marshalOResourceLoad2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐResourceLoad(ctx context.Context, sel ast.SelectionSet, v *ResourceLoad) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
 	return ec._ResourceLoad(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v interface{}) (*string, error) {
@@ -5650,6 +6989,13 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 	}
 	res := graphql.MarshalString(*v)
 	return res
+}
+
+func (ec *executionContext) marshalOWorktree2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐWorktree(ctx context.Context, sel ast.SelectionSet, v *Worktree) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Worktree(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -11,6 +11,11 @@ type Node interface {
 	GetID() string
 }
 
+type ClaudeInstance struct {
+	// Stable id; ws-b-claudeinstance formalises (host_id, claudePid).
+	ID string `json:"id"`
+}
+
 type Health struct {
 	// Daemon health status — 'ok' when serving.
 	Status string `json:"status"`
@@ -42,6 +47,8 @@ type Host struct {
 	LastSeenAt string `json:"lastSeenAt"`
 	// Peer hosts this daemon federates with. v1: always empty; Workstream F populates.
 	Peers []*Host `json:"peers"`
+	// Processes visible to this host's `ps` adapter, optionally filtered.
+	Processes []*Process `json:"processes"`
 }
 
 func (Host) IsNode() {}
@@ -52,12 +59,45 @@ func (this Host) GetID() string { return this.ID }
 type Process struct {
 	// Stable id formatted as `<host>:<pid>`.
 	ID string `json:"id"`
+	// Host this process is running on.
+	Host *Host `json:"host"`
+	// Process id.
+	Pid int64 `json:"pid"`
+	// Parent process id (0 for kernel/launchd-rooted processes).
+	Ppid int64 `json:"ppid"`
+	// Command basename (e.g. 'sleep', 'claude'). Cheap, always populated.
+	Command string `json:"command"`
+	// Full argv. Slow path — opt-in (separate `ps -wwax -o pid,args` lookup).
+	Args []string `json:"args,omitempty"`
+	// Current working directory. Slow path — opt-in (lsof on macOS, /proc on Linux).
+	Cwd *string `json:"cwd,omitempty"`
+	// Process start time (RFC3339 if parseable, otherwise the raw `lstart` field).
+	StartedAt string `json:"startedAt"`
+	// CPU percent as reported by ps.
+	CPUPercent float64 `json:"cpuPercent"`
+	// Resident memory in bytes (RSS * 1024 from ps).
+	MemBytes int64 `json:"memBytes"`
+	// Controlling terminal, or null if none.
+	Tty *string `json:"tty,omitempty"`
+	// Worktree this process is running inside, derived from cwd. Null until ws-b-git wires the lookup.
+	Worktree *Worktree `json:"worktree,omitempty"`
+	// Claude instance back-edge — populated when this pid is the foreground claude pid. Null until ws-b-claudeinstance lands.
+	ClaudeInstance *ClaudeInstance `json:"claudeInstance,omitempty"`
 }
 
 func (Process) IsNode() {}
 
 // Globally-unique id (e.g. "Host:<machineId>").
 func (this Process) GetID() string { return this.ID }
+
+type ProcessFilter struct {
+	// Match processes whose command basename is in this list.
+	CommandIn []string `json:"commandIn,omitempty"`
+	// Match processes whose cwd starts with this prefix. Forces cwd resolution.
+	CwdPrefix *string `json:"cwdPrefix,omitempty"`
+	// Match processes by pid.
+	PidIn []int64 `json:"pidIn,omitempty"`
+}
 
 // A project (git repo) registered in the orchard config. The config file is the source of truth; the daemon reflects it via fsnotify.
 type Project struct {

--- a/internal/server/providers/ps/adapter.go
+++ b/internal/server/providers/ps/adapter.go
@@ -1,0 +1,292 @@
+package ps
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+// PsAdapter shells out to `ps`. Stateless per ADR-011 §3 — the calling
+// provider owns the cache and the watcher loop.
+//
+// macOS-only for v1 (per briefing "Out of scope: Linux"). The package
+// builds on Linux (the parser is OS-agnostic) but the cwd resolver is
+// stubbed there until a /proc-based fallback is added.
+type PsAdapter struct {
+	hostID string
+
+	// pollInterval drives Watch's tick rate. Briefing AC2 fixes 3s.
+	pollInterval time.Duration
+
+	// runner is overridable for tests so we can inject a fake `ps`.
+	runner CommandRunner
+}
+
+// CommandRunner is the test seam. Production wires execRunner.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// execRunner is the real implementation: it shells out via os/exec.
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("%s %v: %w", name, args, err)
+	}
+	return out, nil
+}
+
+// NewAdapter constructs a PsAdapter for the given host id. The host id
+// is the prefix of every ProcessID this adapter materialises.
+func NewAdapter(hostID string) *PsAdapter {
+	return &PsAdapter{
+		hostID:       hostID,
+		pollInterval: 3 * time.Second,
+		runner:       execRunner{},
+	}
+}
+
+// WithRunner returns a copy of a using the given runner. For tests.
+func (a *PsAdapter) WithRunner(r CommandRunner) *PsAdapter {
+	cp := *a
+	cp.runner = r
+	return &cp
+}
+
+// WithPollInterval returns a copy of a with a new poll interval. For
+// tests that want a snappier loop.
+func (a *PsAdapter) WithPollInterval(d time.Duration) *PsAdapter {
+	cp := *a
+	cp.pollInterval = d
+	return &cp
+}
+
+// HostID exposes the host prefix used in ProcessIDs.
+func (a *PsAdapter) HostID() string { return a.hostID }
+
+// PollInterval returns the configured tick rate. The provider uses it
+// to drive the Watch loop.
+func (a *PsAdapter) PollInterval() time.Duration { return a.pollInterval }
+
+// Fetch returns the Process for a single pid. Implemented as "FetchAll
+// + lookup" because `ps -p` has the same overhead as `ps -ax` in
+// practice and avoids a second parser path.
+func (a *PsAdapter) Fetch(ctx context.Context, key ProcessID) (Process, error) {
+	all, err := a.FetchAll(ctx)
+	if err != nil {
+		return Process{}, err
+	}
+	p, ok := all[key]
+	if !ok {
+		return Process{}, fmt.Errorf("ps: pid %d not found", key.PID)
+	}
+	return p, nil
+}
+
+// FetchAll runs `ps -ax -o pid,ppid,user,tty,%cpu,rss,lstart,command`
+// and parses every row into a Process keyed by ProcessID. Errors only
+// when ps fails to run or the output header is unrecognisable; transient
+// per-line parse failures are silently dropped.
+func (a *PsAdapter) FetchAll(ctx context.Context) (map[ProcessID]Process, error) {
+	out, err := a.runner.Run(ctx, "ps", "-ax", "-o", "pid,ppid,user,tty,%cpu,rss,lstart,command")
+	if err != nil {
+		return nil, fmt.Errorf("ps: shell out: %w", err)
+	}
+	procs, err := parsePs(a.hostID, string(out))
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[ProcessID]Process, len(procs))
+	for _, p := range procs {
+		m[p.ID] = p
+	}
+	return m, nil
+}
+
+// FetchArgs returns argv for the given pids in one shellout. macOS ps
+// supports -wwax for unbounded line width — required because daemon
+// argv routinely exceed the default 80-column wrap.
+func (a *PsAdapter) FetchArgs(ctx context.Context, pids []int) (map[int][]string, error) {
+	if len(pids) == 0 {
+		return map[int][]string{}, nil
+	}
+	out, err := a.runner.Run(ctx, "ps", "-wwax", "-o", "pid,args")
+	if err != nil {
+		return nil, fmt.Errorf("ps args: shell out: %w", err)
+	}
+	all, err := parseArgs(string(out))
+	if err != nil {
+		return nil, err
+	}
+	// Filter to requested pids — keeps the response size proportional to
+	// the resolver's actual ask, not the whole process table.
+	want := make(map[int]struct{}, len(pids))
+	for _, p := range pids {
+		want[p] = struct{}{}
+	}
+	filtered := make(map[int][]string, len(pids))
+	for pid, argv := range all {
+		if _, ok := want[pid]; ok {
+			filtered[pid] = argv
+		}
+	}
+	return filtered, nil
+}
+
+// FetchCwds returns cwd for the given pids. macOS uses lsof per pid;
+// Linux reads /proc/<pid>/cwd. v1 ships macOS only — Linux returns an
+// empty map and no error so resolvers degrade gracefully.
+func (a *PsAdapter) FetchCwds(ctx context.Context, pids []int) (map[int]string, error) {
+	if len(pids) == 0 {
+		return map[int]string{}, nil
+	}
+	if runtime.GOOS != "darwin" {
+		// Linux fallback lives in a future PR. Surface "not implemented"
+		// as an empty result rather than an error so a worktree on
+		// Linux can still serve everything else.
+		return map[int]string{}, nil
+	}
+	return a.fetchCwdsDarwin(ctx, pids)
+}
+
+// fetchCwdsDarwin calls lsof once per pid (cheap on macOS, no
+// privileged access required for self-owned processes). lsof returns
+// non-zero when the pid no longer exists; we treat that as "no cwd"
+// rather than an error.
+func (a *PsAdapter) fetchCwdsDarwin(ctx context.Context, pids []int) (map[int]string, error) {
+	out := make(map[int]string, len(pids))
+	for _, pid := range pids {
+		cwd, err := a.lsofCwd(ctx, pid)
+		if err != nil {
+			// Log and continue — one missing cwd shouldn't kill the
+			// rest of the batch. Resolvers see nil for that pid.
+			continue
+		}
+		if cwd != "" {
+			out[pid] = cwd
+		}
+	}
+	return out, nil
+}
+
+// lsofCwd parses `lsof -a -d cwd -p <pid> -F n` output. Using the -F
+// (field) format gives us a stable machine-parseable shape:
+//
+//	p<pid>
+//	n<cwd>
+//
+// We pluck the `n` line. Empty result means lsof had nothing (pid gone,
+// or no cwd entry) and is returned as ("", nil).
+func (a *PsAdapter) lsofCwd(ctx context.Context, pid int) (string, error) {
+	out, err := a.runner.Run(ctx, "lsof", "-a", "-d", "cwd", "-p", fmt.Sprintf("%d", pid), "-F", "n")
+	if err != nil {
+		return "", err
+	}
+	for _, line := range splitLines(out) {
+		if len(line) == 0 || line[0] != 'n' {
+			continue
+		}
+		return line[1:], nil
+	}
+	return "", nil
+}
+
+// Watch polls FetchAll on a.pollInterval and emits every key whose value
+// changed since the last tick (additions, value-modifications, removals).
+// Closes the returned channel when ctx is cancelled.
+//
+// The provider is the consumer; it diffs against its store and forwards
+// the changed keys as InvalidationEvents. The adapter only returns keys
+// that the *adapter* sees as changed in its own snapshot-of-snapshot
+// — this duplicates a tiny amount of state, but keeping the diff inside
+// the adapter lets it cope with tests that don't run a full provider.
+func (a *PsAdapter) Watch(ctx context.Context) (<-chan ProcessID, error) {
+	out := make(chan ProcessID, 64)
+	go func() {
+		defer close(out)
+		var prior map[ProcessID]Process
+		ticker := time.NewTicker(a.pollInterval)
+		defer ticker.Stop()
+		// Emit the initial snapshot immediately so a fresh subscriber
+		// doesn't have to wait pollInterval for the first event.
+		a.tick(ctx, &prior, out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				a.tick(ctx, &prior, out)
+			}
+		}
+	}()
+	return out, nil
+}
+
+// tick runs one poll cycle and pushes changed keys to out.
+func (a *PsAdapter) tick(ctx context.Context, prior *map[ProcessID]Process, out chan<- ProcessID) {
+	current, err := a.FetchAll(ctx)
+	if err != nil {
+		// Transient errors (shell exec failure, parser hiccup) are
+		// logged at the provider layer; the adapter just skips this
+		// tick rather than collapse the watcher.
+		return
+	}
+	for k, v := range current {
+		old, ok := (*prior)[k]
+		if !ok || !processEqualsHotPath(old, v) {
+			select {
+			case out <- k:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+	for k := range *prior {
+		if _, ok := current[k]; !ok {
+			select {
+			case out <- k:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+	*prior = current
+}
+
+// Close is a no-op for the ps adapter (no long-lived handles).
+func (a *PsAdapter) Close() error { return nil }
+
+// processEqualsHotPath compares the fields the watcher cares about for
+// invalidation. CPU and memory shift on every poll for every running
+// process; treating them as "always changed" would emit an event per
+// pid per tick — useless noise for subscribers. We compare only the
+// stable hot-path fields and let consumers re-fetch on demand.
+func processEqualsHotPath(a, b Process) bool {
+	return a.PPID == b.PPID &&
+		a.User == b.User &&
+		a.TTY == b.TTY &&
+		a.Command == b.Command &&
+		a.StartedRaw == b.StartedRaw
+}
+
+// splitLines yields each newline-terminated chunk of buf. Used by lsof
+// -F parsing where stdlib bufio.Scanner is overkill.
+func splitLines(buf []byte) []string {
+	out := make([]string, 0, 4)
+	start := 0
+	for i, b := range buf {
+		if b == '\n' {
+			out = append(out, string(buf[start:i]))
+			start = i + 1
+		}
+	}
+	if start < len(buf) {
+		out = append(out, string(buf[start:]))
+	}
+	return out
+}

--- a/internal/server/providers/ps/adapter_test.go
+++ b/internal/server/providers/ps/adapter_test.go
@@ -1,0 +1,141 @@
+package ps
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestAdapter_FetchAll_RealPs invokes the actual `ps` binary on the host
+// and asserts the test process itself (os.Getpid) is in the result.
+// Worker-standards §3: provider tests run against real backends.
+func TestAdapter_FetchAll_RealPs(t *testing.T) {
+	a := NewAdapter("local")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	all, err := a.FetchAll(ctx)
+	if err != nil {
+		t.Fatalf("FetchAll: %v", err)
+	}
+	self := ProcessID{Host: "local", PID: os.Getpid()}
+	got, ok := all[self]
+	if !ok {
+		t.Fatalf("test process pid %d not in ps result (size=%d)", os.Getpid(), len(all))
+	}
+	if got.Command == "" {
+		t.Errorf("test process command basename should be non-empty, got %q", got.Command)
+	}
+	if got.PPID == 0 {
+		t.Errorf("test process should have a non-zero parent pid, got 0")
+	}
+}
+
+// TestAdapter_Watch_EmitsOnSpawn proves the watcher detects a real
+// subprocess appearing in the process table and emits its key.
+func TestAdapter_Watch_EmitsOnSpawn(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skipf("ps watcher test is darwin/linux only")
+	}
+	a := NewAdapter("local").WithPollInterval(150 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	ch, err := a.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	// Drain the initial-snapshot burst before spawning so the assertion
+	// is unambiguous: we want to see the spawn-pid AFTER the burst ends.
+	drainBurst(t, ch, 500*time.Millisecond)
+
+	cmd := exec.CommandContext(ctx, "sleep", "5")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep subprocess: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}()
+
+	want := ProcessID{Host: "local", PID: cmd.Process.Pid}
+	deadline := time.After(4 * time.Second)
+	for {
+		select {
+		case got, ok := <-ch:
+			if !ok {
+				t.Fatalf("watch channel closed before pid %d appeared", want.PID)
+			}
+			if got == want {
+				return // success
+			}
+		case <-deadline:
+			t.Fatalf("did not observe spawn of pid %d within deadline", want.PID)
+		}
+	}
+}
+
+// TestAdapter_FetchCwds_RealLsof asks for the test process's cwd and
+// asserts it matches os.Getwd. macOS only — Linux returns empty until
+// the /proc fallback lands.
+func TestAdapter_FetchCwds_RealLsof(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skipf("lsof cwd test is darwin only (Linux uses /proc which is not yet wired)")
+	}
+	a := NewAdapter("local")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cwds, err := a.FetchCwds(ctx, []int{os.Getpid()})
+	if err != nil {
+		t.Fatalf("FetchCwds: %v", err)
+	}
+	got, ok := cwds[os.Getpid()]
+	if !ok {
+		t.Fatalf("cwd missing for self pid %d", os.Getpid())
+	}
+	want, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	if got != want {
+		t.Errorf("cwd = %q, want %q", got, want)
+	}
+}
+
+// TestAdapter_FetchArgs_RealPs verifies that argv resolution finds the
+// `go test` binary invocation (which always has a -test.* flag).
+func TestAdapter_FetchArgs_RealPs(t *testing.T) {
+	a := NewAdapter("local")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	args, err := a.FetchArgs(ctx, []int{os.Getpid()})
+	if err != nil {
+		t.Fatalf("FetchArgs: %v", err)
+	}
+	got, ok := args[os.Getpid()]
+	if !ok || len(got) == 0 {
+		t.Fatalf("argv missing for self pid %d", os.Getpid())
+	}
+}
+
+// drainBurst consumes events that arrive within window. Used to swallow
+// the initial watcher snapshot so subsequent assertions can target the
+// post-snapshot deltas only.
+func drainBurst(t *testing.T, ch <-chan ProcessID, window time.Duration) {
+	t.Helper()
+	deadline := time.After(window)
+	for {
+		select {
+		case <-ch:
+			// keep draining
+		case <-deadline:
+			return
+		}
+	}
+}

--- a/internal/server/providers/ps/batchloader.go
+++ b/internal/server/providers/ps/batchloader.go
@@ -1,0 +1,151 @@
+package ps
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// batchLoader coalesces concurrent single-key Loads into a single
+// multi-key fetch. It mirrors the DataLoader pattern but lives inside
+// the provider so the slow-path opt-in fields don't need WS-C wiring
+// to enjoy batched shellouts.
+//
+// Two trigger conditions kick a flush:
+//
+//  1. The pending set reaches `maxBatch`.
+//  2. `wait` elapses since the first Load in the current batch.
+//
+// The fetcher receives the deduped key set and returns a map; missing
+// keys come back as zero values to the waiting Load callers.
+//
+// WS-C will replace this with graph-gophers/dataloader/v7. The shape
+// is intentionally compatible.
+type batchLoader[K comparable, V any] struct {
+	wait     time.Duration
+	maxBatch int
+	fetch    func(ctx context.Context, keys []K) (map[K]V, error)
+
+	mu      sync.Mutex
+	pending map[K][]chan loadResult[V]
+	timer   *time.Timer
+}
+
+type loadResult[V any] struct {
+	v   V
+	err error
+}
+
+func newBatchLoader[K comparable, V any](
+	wait time.Duration,
+	maxBatch int,
+	fetch func(ctx context.Context, keys []K) (map[K]V, error),
+) *batchLoader[K, V] {
+	return &batchLoader[K, V]{
+		wait:     wait,
+		maxBatch: maxBatch,
+		fetch:    fetch,
+		pending:  make(map[K][]chan loadResult[V]),
+	}
+}
+
+// Load enqueues one key and returns its value once the next batch
+// completes. Cancellation of ctx returns ctx.Err() and orphan-drops
+// the waiter — the batch still runs for other waiters.
+func (l *batchLoader[K, V]) Load(ctx context.Context, key K) (V, error) {
+	ch := make(chan loadResult[V], 1)
+	l.enqueue(ctx, key, ch)
+	select {
+	case <-ctx.Done():
+		var zero V
+		return zero, ctx.Err()
+	case r := <-ch:
+		return r.v, r.err
+	}
+}
+
+// LoadMany enqueues every key and waits for all of them. Useful when
+// the resolver already knows the full set up-front (e.g. CLI filter
+// by-cwd over the cached pid list).
+func (l *batchLoader[K, V]) LoadMany(ctx context.Context, keys []K) (map[K]V, error) {
+	if len(keys) == 0 {
+		return map[K]V{}, nil
+	}
+	results := make(map[K]V, len(keys))
+	chans := make(map[K]chan loadResult[V], len(keys))
+	for _, k := range keys {
+		ch := make(chan loadResult[V], 1)
+		chans[k] = ch
+		l.enqueue(ctx, k, ch)
+	}
+	for k, ch := range chans {
+		select {
+		case <-ctx.Done():
+			return results, ctx.Err()
+		case r := <-ch:
+			if r.err != nil {
+				return results, r.err
+			}
+			results[k] = r.v
+		}
+	}
+	return results, nil
+}
+
+// enqueue adds a (key, waiter) pair to the pending batch and arms the
+// flush timer if this is the first waiter for the current batch.
+func (l *batchLoader[K, V]) enqueue(ctx context.Context, key K, ch chan loadResult[V]) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.pending[key] = append(l.pending[key], ch)
+	if len(l.pending) >= l.maxBatch {
+		l.flushLocked(ctx)
+		return
+	}
+	if l.timer == nil {
+		l.timer = time.AfterFunc(l.wait, func() {
+			l.mu.Lock()
+			defer l.mu.Unlock()
+			l.flushLocked(ctx)
+		})
+	}
+}
+
+// flushLocked runs one batch under l.mu. Releases the lock before the
+// fetcher runs so concurrent Loads can start the *next* batch while the
+// current one is in flight.
+func (l *batchLoader[K, V]) flushLocked(ctx context.Context) {
+	if l.timer != nil {
+		l.timer.Stop()
+		l.timer = nil
+	}
+	if len(l.pending) == 0 {
+		return
+	}
+	batch := l.pending
+	l.pending = make(map[K][]chan loadResult[V])
+
+	keys := make([]K, 0, len(batch))
+	for k := range batch {
+		keys = append(keys, k)
+	}
+
+	go func() {
+		results, err := l.fetch(ctx, keys)
+		for k, waiters := range batch {
+			for _, w := range waiters {
+				if err != nil {
+					w <- loadResult[V]{err: err}
+					continue
+				}
+				v, ok := results[k]
+				if !ok {
+					var zero V
+					w <- loadResult[V]{v: zero}
+					continue
+				}
+				w <- loadResult[V]{v: v}
+			}
+		}
+	}()
+}

--- a/internal/server/providers/ps/doc.go
+++ b/internal/server/providers/ps/doc.go
@@ -1,0 +1,19 @@
+// Package ps implements the orchard ps provider per ADR-011 §5.1.
+//
+// It surfaces the Process node — every OS process visible to `ps -ax` on
+// the local host. Identity is `(host_id, pid)` formatted as `<host>:<pid>`.
+//
+// Hot path (always populated by the watcher tick):
+//   - pid, ppid, command (basename), tty, cpuPercent, memBytes, startedAt
+//
+// Slow path (opt-in; the resolver pays per requested field):
+//   - args:  separate `ps -wwax -o pid,args` lookup
+//   - cwd:   per-pid `lsof -a -d cwd -p <pid>` (macOS) / /proc/<pid>/cwd (Linux)
+//
+// Watcher: poll every 3s. There is no native push for ps; we re-run
+// FetchAll, diff, and emit InvalidationEvents for every key whose value
+// changed (including removed keys whose process died).
+//
+// See ADR-011, plans/2026-05-04-orchard-implementation-guide.md, and
+// .claude-context/BRIEFING.md (this workstream's spec).
+package ps

--- a/internal/server/providers/ps/goos.go
+++ b/internal/server/providers/ps/goos.go
@@ -1,0 +1,7 @@
+package ps
+
+import "runtime"
+
+// osGOOS exposes runtime.GOOS through a package-level seam. Centralised
+// here so tests and the cwd path agree on the same value.
+func osGOOS() string { return runtime.GOOS }

--- a/internal/server/providers/ps/parse.go
+++ b/internal/server/providers/ps/parse.go
@@ -1,0 +1,234 @@
+package ps
+
+import (
+	"bufio"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// psHeader is the canonical column set the adapter requests; the parser
+// validates the header to catch silent format drifts (e.g. an ancient ps).
+const psHeader = "PID PPID USER TTY %CPU RSS STARTED COMMAND"
+
+// lstartLayout matches BSD/Darwin `lstart` output and the equivalent
+// Linux ps STARTED column when invoked with the same -o lstart flag.
+// `_2` consumes a leading space for single-digit days.
+const lstartLayout = "Mon Jan _2 15:04:05 2006"
+
+// parsePs converts the raw stdout of `ps -ax -o pid,ppid,user,tty,%cpu,rss,lstart,command`
+// into a slice of Process values keyed for the given host. Lines that
+// don't parse are skipped with no error — ps occasionally emits transient
+// noise (a process exiting mid-format) that is not worth aborting over.
+func parsePs(host, raw string) ([]Process, error) {
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	if !scanner.Scan() {
+		return nil, fmt.Errorf("ps: empty output")
+	}
+	if err := validateHeader(scanner.Text()); err != nil {
+		return nil, err
+	}
+
+	var out []Process
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		p, ok := parseLine(host, line)
+		if ok {
+			out = append(out, p)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("ps: scan: %w", err)
+	}
+	return out, nil
+}
+
+// validateHeader normalises the ps header (collapsing repeated spaces)
+// and compares against the expected column ordering. A mismatch means
+// the adapter was invoked with a different -o flag, or ps has been
+// upgraded to a format the parser doesn't understand.
+func validateHeader(line string) error {
+	got := strings.Join(strings.Fields(line), " ")
+	if got != psHeader {
+		return fmt.Errorf("ps: unexpected header %q (want %q)", got, psHeader)
+	}
+	return nil
+}
+
+// parseLine consumes one ps data line. Returns ok=false on malformed
+// lines so the scanner loop can skip them rather than abort.
+func parseLine(host, line string) (Process, bool) {
+	// First six tokens: pid, ppid, user, tty, %cpu, rss.
+	cursor, pidStr, ok := nextField(line, 0)
+	if !ok {
+		return Process{}, false
+	}
+	cursor, ppidStr, ok := nextField(line, cursor)
+	if !ok {
+		return Process{}, false
+	}
+	cursor, user, ok := nextField(line, cursor)
+	if !ok {
+		return Process{}, false
+	}
+	cursor, ttyRaw, ok := nextField(line, cursor)
+	if !ok {
+		return Process{}, false
+	}
+	cursor, cpuStr, ok := nextField(line, cursor)
+	if !ok {
+		return Process{}, false
+	}
+	cursor, rssStr, ok := nextField(line, cursor)
+	if !ok {
+		return Process{}, false
+	}
+
+	// Next five tokens make up the lstart timestamp ("Mon Jan _2 HH:MM:SS YYYY").
+	// We consume them by tracking the cursor and joining the spans verbatim,
+	// because the embedded double-space (single-digit day) matters to time.Parse.
+	startStart := skipSpaces(line, cursor)
+	cursor = startStart
+	for i := 0; i < 5; i++ {
+		var ok2 bool
+		cursor, _, ok2 = nextField(line, cursor)
+		if !ok2 {
+			return Process{}, false
+		}
+	}
+	startEnd := cursor
+	startedRaw := strings.TrimSpace(line[startStart:startEnd])
+
+	// Everything after the lstart block (skipping the separator whitespace)
+	// is the COMMAND tail. We keep the raw form (with argv) for slow-path
+	// matching but compute a basename for the cheap `command` field.
+	commandRaw := strings.TrimRight(strings.TrimLeft(line[startEnd:], " \t"), " \t")
+	if commandRaw == "" {
+		return Process{}, false
+	}
+
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return Process{}, false
+	}
+	ppid, err := strconv.Atoi(ppidStr)
+	if err != nil {
+		return Process{}, false
+	}
+	cpu, err := strconv.ParseFloat(cpuStr, 64)
+	if err != nil {
+		return Process{}, false
+	}
+	rssKB, err := strconv.ParseInt(rssStr, 10, 64)
+	if err != nil {
+		return Process{}, false
+	}
+
+	tty := ttyRaw
+	if tty == "??" || tty == "?" {
+		tty = ""
+	}
+
+	startedAt, err := time.ParseInLocation(lstartLayout, startedRaw, time.Local)
+	if err != nil {
+		// Keep going with a zero StartedAt — startedRaw still surfaces in StartedRaw.
+		startedAt = time.Time{}
+	}
+
+	return Process{
+		ID:         ProcessID{Host: host, PID: pid},
+		PPID:       ppid,
+		User:       user,
+		TTY:        tty,
+		CPUPercent: cpu,
+		MemBytes:   rssKB * 1024,
+		StartedAt:  startedAt,
+		StartedRaw: startedRaw,
+		Command:    commandBasename(commandRaw),
+		CommandRaw: commandRaw,
+	}, true
+}
+
+// commandBasename pulls the executable basename from the COMMAND tail.
+// COMMAND on macOS ps may include the full path plus argv; we want the
+// short program name so `command` filters work on `claude`, `sleep`, etc.
+func commandBasename(raw string) string {
+	// Cut at the first whitespace — anything after is argv.
+	progPath := raw
+	if idx := strings.IndexAny(progPath, " \t"); idx >= 0 {
+		progPath = progPath[:idx]
+	}
+	return filepath.Base(progPath)
+}
+
+// nextField returns the cursor after the next whitespace-delimited token
+// in s starting at offset, plus the token itself. ok=false when offset
+// is past the end of the line or no token is found.
+func nextField(s string, offset int) (int, string, bool) {
+	start := skipSpaces(s, offset)
+	if start >= len(s) {
+		return offset, "", false
+	}
+	end := start
+	for end < len(s) && s[end] != ' ' && s[end] != '\t' {
+		end++
+	}
+	if end == start {
+		return offset, "", false
+	}
+	return end, s[start:end], true
+}
+
+// skipSpaces advances offset past spaces and tabs in s.
+func skipSpaces(s string, offset int) int {
+	for offset < len(s) && (s[offset] == ' ' || s[offset] == '\t') {
+		offset++
+	}
+	return offset
+}
+
+// parseArgs converts the raw output of `ps -wwax -o pid,args` into a
+// pid → argv map. The first line is the header `  PID ARGS`. Each
+// subsequent line is `<pid> <space-joined-argv>`.
+func parseArgs(raw string) (map[int][]string, error) {
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	if !scanner.Scan() {
+		return nil, fmt.Errorf("ps args: empty output")
+	}
+	header := strings.Join(strings.Fields(scanner.Text()), " ")
+	if header != "PID ARGS" && header != "PID COMMAND" {
+		return nil, fmt.Errorf("ps args: unexpected header %q", header)
+	}
+	out := make(map[int][]string)
+	for scanner.Scan() {
+		line := scanner.Text()
+		cursor, pidStr, ok := nextField(line, 0)
+		if !ok {
+			continue
+		}
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+		// Everything past the pid token (after its trailing whitespace) is argv.
+		argsStart := skipSpaces(line, cursor)
+		if argsStart >= len(line) {
+			out[pid] = nil
+			continue
+		}
+		argv := strings.Fields(line[argsStart:])
+		out[pid] = argv
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("ps args: scan: %w", err)
+	}
+	return out, nil
+}

--- a/internal/server/providers/ps/parse_test.go
+++ b/internal/server/providers/ps/parse_test.go
@@ -6,14 +6,14 @@ import (
 	"time"
 )
 
-// fixture mirrors a verbatim chunk of macOS `ps -ax -o pid,ppid,user,tty,%cpu,rss,lstart,command`.
-// Captured from a live darwin/arm64 host on 2026-05-04 so the parser is
-// exercised against the actual output shape rather than a synthetic
-// approximation.
+// fixture mirrors the column layout of macOS `ps -ax -o pid,ppid,user,tty,%cpu,rss,lstart,command`.
+// Synthesised from the documented column shape so the parser is exercised
+// against the real header/whitespace contract; usernames and pids are
+// generic placeholders.
 const fixturePsHeaderAndRows = `  PID  PPID USER             TTY       %CPU    RSS STARTED                      COMMAND
     1     0 root             ??         1.5  13088 Sun May  3 15:38:46 2026     /sbin/launchd
-  262   797 hope             ??         0.0  18432 Sun May  3 16:06:57 2026     /Applications/Docker.app/Contents/MacOS/com.docker.virtualization --kernel /foo --cmdline init=/initd
-17729 17726 hope             s001       0.0   1856 Tue Mar 23 10:00:00 2026     -zsh
+  262   797 alice            ??         0.0  18432 Sun May  3 16:06:57 2026     /Applications/Docker.app/Contents/MacOS/com.docker.virtualization --kernel /foo --cmdline init=/initd
+17729 17726 alice            s001       0.0   1856 Tue Mar 23 10:00:00 2026     -zsh
 99999     1 root             ??         0.0    100 Mon Jan 12 00:00:00 2026     /usr/libexec/UserEventAgent (System)
 `
 

--- a/internal/server/providers/ps/parse_test.go
+++ b/internal/server/providers/ps/parse_test.go
@@ -1,0 +1,175 @@
+package ps
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixture mirrors a verbatim chunk of macOS `ps -ax -o pid,ppid,user,tty,%cpu,rss,lstart,command`.
+// Captured from a live darwin/arm64 host on 2026-05-04 so the parser is
+// exercised against the actual output shape rather than a synthetic
+// approximation.
+const fixturePsHeaderAndRows = `  PID  PPID USER             TTY       %CPU    RSS STARTED                      COMMAND
+    1     0 root             ??         1.5  13088 Sun May  3 15:38:46 2026     /sbin/launchd
+  262   797 hope             ??         0.0  18432 Sun May  3 16:06:57 2026     /Applications/Docker.app/Contents/MacOS/com.docker.virtualization --kernel /foo --cmdline init=/initd
+17729 17726 hope             s001       0.0   1856 Tue Mar 23 10:00:00 2026     -zsh
+99999     1 root             ??         0.0    100 Mon Jan 12 00:00:00 2026     /usr/libexec/UserEventAgent (System)
+`
+
+func TestParsePs_HappyPath(t *testing.T) {
+	procs, err := parsePs("local", fixturePsHeaderAndRows)
+	if err != nil {
+		t.Fatalf("parsePs: %v", err)
+	}
+	if got, want := len(procs), 4; got != want {
+		t.Fatalf("len(procs) = %d, want %d", got, want)
+	}
+
+	// Spot-check the first row — short, well-known.
+	first := procs[0]
+	if first.ID.Host != "local" {
+		t.Errorf("ID.Host = %q, want %q", first.ID.Host, "local")
+	}
+	if first.ID.PID != 1 {
+		t.Errorf("ID.PID = %d, want 1", first.ID.PID)
+	}
+	if first.PPID != 0 {
+		t.Errorf("PPID = %d, want 0", first.PPID)
+	}
+	if first.User != "root" {
+		t.Errorf("User = %q, want root", first.User)
+	}
+	if first.TTY != "" {
+		t.Errorf(`TTY for "??" should normalise to "", got %q`, first.TTY)
+	}
+	if first.CPUPercent != 1.5 {
+		t.Errorf("CPUPercent = %v, want 1.5", first.CPUPercent)
+	}
+	if first.MemBytes != 13088*1024 {
+		t.Errorf("MemBytes = %d, want %d", first.MemBytes, 13088*1024)
+	}
+	if first.Command != "launchd" {
+		t.Errorf("Command basename = %q, want launchd", first.Command)
+	}
+	if !strings.HasPrefix(first.CommandRaw, "/sbin/launchd") {
+		t.Errorf("CommandRaw = %q, want /sbin/launchd…", first.CommandRaw)
+	}
+	wantStart := time.Date(2026, time.May, 3, 15, 38, 46, 0, time.Local)
+	if !first.StartedAt.Equal(wantStart) {
+		t.Errorf("StartedAt = %v, want %v", first.StartedAt, wantStart)
+	}
+
+	// Verify the long-argv row keeps the full COMMAND tail in CommandRaw.
+	docker := procs[1]
+	if docker.Command != "com.docker.virtualization" {
+		t.Errorf("Command = %q, want com.docker.virtualization", docker.Command)
+	}
+	if !strings.Contains(docker.CommandRaw, "--cmdline init=/initd") {
+		t.Errorf("CommandRaw should preserve argv, got %q", docker.CommandRaw)
+	}
+
+	// Verify a real TTY survives.
+	zsh := procs[2]
+	if zsh.TTY != "s001" {
+		t.Errorf("TTY = %q, want s001", zsh.TTY)
+	}
+	if zsh.Command != "-zsh" {
+		t.Errorf("Command = %q, want -zsh (login shell argv0 is preserved verbatim)", zsh.Command)
+	}
+
+	// Verify a row with parenthesised "agent name" — UserEventAgent (System).
+	agent := procs[3]
+	if agent.Command != "UserEventAgent" {
+		t.Errorf("Command = %q, want UserEventAgent", agent.Command)
+	}
+	if !strings.Contains(agent.CommandRaw, "(System)") {
+		t.Errorf("CommandRaw should keep agent label, got %q", agent.CommandRaw)
+	}
+}
+
+func TestParsePs_RejectsUnknownHeader(t *testing.T) {
+	bad := "PID NAME\n1 launchd\n"
+	if _, err := parsePs("local", bad); err == nil {
+		t.Fatal("expected error on unknown header, got nil")
+	}
+}
+
+func TestParsePs_SkipsMalformedLines(t *testing.T) {
+	// One bad line in the middle should not stop the parser; the good
+	// rows must still come through.
+	mixed := `  PID  PPID USER             TTY       %CPU    RSS STARTED                      COMMAND
+    1     0 root             ??         1.5  13088 Sun May  3 15:38:46 2026     /sbin/launchd
+not a process line at all
+    2     0 root             ??         0.5  10000 Sun May  3 15:38:47 2026     /sbin/foo
+`
+	procs, err := parsePs("local", mixed)
+	if err != nil {
+		t.Fatalf("parsePs: %v", err)
+	}
+	if got := len(procs); got != 2 {
+		t.Fatalf("len(procs) = %d, want 2 (one malformed row skipped)", got)
+	}
+}
+
+func TestParsePs_EmptyInput(t *testing.T) {
+	if _, err := parsePs("local", ""); err == nil {
+		t.Fatal("expected error on empty input")
+	}
+}
+
+func TestParseArgs_HappyPath(t *testing.T) {
+	fixture := `  PID ARGS
+    1 /sbin/launchd
+  262 /Applications/Docker.app/Contents/MacOS/com.docker.virtualization --kernel /foo
+17729 -zsh
+`
+	got, err := parseArgs(fixture)
+	if err != nil {
+		t.Fatalf("parseArgs: %v", err)
+	}
+	if want := []string{"/sbin/launchd"}; !equalStrings(got[1], want) {
+		t.Errorf("argv[1] = %v, want %v", got[1], want)
+	}
+	if got[262][0] != "/Applications/Docker.app/Contents/MacOS/com.docker.virtualization" {
+		t.Errorf("argv[262][0] = %q, want docker path", got[262][0])
+	}
+	if got[262][1] != "--kernel" || got[262][2] != "/foo" {
+		t.Errorf("argv[262] tail = %v, want [--kernel /foo]", got[262][1:])
+	}
+	if want := []string{"-zsh"}; !equalStrings(got[17729], want) {
+		t.Errorf("argv[17729] = %v, want %v", got[17729], want)
+	}
+}
+
+func TestProcessID_RoundTrip(t *testing.T) {
+	id := ProcessID{Host: "local", PID: 17729}
+	parsed, err := ParseProcessID(id.String())
+	if err != nil {
+		t.Fatalf("ParseProcessID: %v", err)
+	}
+	if parsed != id {
+		t.Errorf("round-trip: got %+v, want %+v", parsed, id)
+	}
+}
+
+func TestProcessID_RejectsMalformed(t *testing.T) {
+	cases := []string{"", "no-colon", "host:not-a-number", ":42", "host:"}
+	for _, c := range cases {
+		if _, err := ParseProcessID(c); err == nil {
+			t.Errorf("ParseProcessID(%q): expected error, got nil", c)
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/server/providers/ps/provider.go
+++ b/internal/server/providers/ps/provider.go
@@ -1,0 +1,239 @@
+package ps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	provider "github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/store"
+)
+
+// Provider is the orchard-side facade over PsAdapter. Owns the cache,
+// the watcher loop, and the invalidation fanout. Resolvers depend on
+// this concrete type via its Provider[ProcessID, Process] interface
+// satisfaction (worker-standards §5(D)).
+type Provider struct {
+	adapter *PsAdapter
+	store   *store.Store[ProcessID, Process]
+	logger  *slog.Logger
+
+	// subs tracks live Subscribe channels for fanout. The provider drops
+	// events on slow consumers (best-effort push per ADR-011 §2).
+	subsMu sync.Mutex
+	subs   []chan provider.InvalidationEvent[ProcessID]
+
+	// argsLoader and cwdLoader are per-resolver-call DataLoaders for the
+	// slow-path opt-in fields. Each call to LoadArgs / LoadCwd batches
+	// over a short window. Future Workstream C will swap these for
+	// proper per-request DataLoaders.
+	argsLoader *batchLoader[int, []string]
+	cwdLoader  *batchLoader[int, string]
+}
+
+// New constructs a Provider for the given host. The watcher starts when
+// Start is called — letting tests construct without spawning goroutines.
+func New(adapter *PsAdapter, logger *slog.Logger) *Provider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	p := &Provider{
+		adapter: adapter,
+		store:   store.New[ProcessID, Process](),
+		logger:  logger,
+	}
+	p.argsLoader = newBatchLoader[int, []string](20*time.Millisecond, 512, func(ctx context.Context, pids []int) (map[int][]string, error) {
+		return adapter.FetchArgs(ctx, pids)
+	})
+	p.cwdLoader = newBatchLoader[int, string](20*time.Millisecond, 128, func(ctx context.Context, pids []int) (map[int]string, error) {
+		return adapter.FetchCwds(ctx, pids)
+	})
+	return p
+}
+
+// HostID exposes the host id the provider materialises ProcessIDs for.
+// Resolvers use this to construct host nodes.
+func (p *Provider) HostID() string { return p.adapter.HostID() }
+
+// Start launches the watcher loop. It blocks until the first
+// FetchAll returns (so resolvers don't see an empty cache on cold boot)
+// or until ctx fires. Subsequent ticks run in the background.
+//
+// Returns the adapter's first-fetch error so callers can fail fast on
+// fundamentally-broken environments (no `ps` on PATH, etc.).
+func (p *Provider) Start(ctx context.Context) error {
+	// Synchronous initial fetch so the cache is warm before resolvers run.
+	first, err := p.adapter.FetchAll(ctx)
+	if err != nil {
+		return fmt.Errorf("ps provider: initial fetch: %w", err)
+	}
+	p.store.ReplaceAll(first, provider.SourcePoll, processEqualsHotPath)
+
+	// Background watcher.
+	ch, err := p.adapter.Watch(ctx)
+	if err != nil {
+		return fmt.Errorf("ps provider: watch: %w", err)
+	}
+	go p.consumeWatcher(ctx, ch)
+	return nil
+}
+
+// consumeWatcher drains the adapter's Watch channel, refreshes the
+// store, and fans out InvalidationEvents to subscribers.
+func (p *Provider) consumeWatcher(ctx context.Context, in <-chan ProcessID) {
+	for range in {
+		// Watcher is "something changed" — re-fetch full state and let
+		// the store compute the precise delta.
+		all, err := p.adapter.FetchAll(ctx)
+		if err != nil {
+			p.logger.Warn("ps provider: refetch failed", "err", err)
+			continue
+		}
+		changed := p.store.ReplaceAll(all, provider.SourcePoll, processEqualsHotPath)
+		now := time.Now()
+		for _, k := range changed {
+			p.fanout(provider.InvalidationEvent[ProcessID]{Key: k, Reason: "poll", At: now})
+		}
+		// Drain any pending events the adapter pushed in the same tick.
+		// We've already refetched; consuming them prevents redundant
+		// FetchAlls without losing data.
+		for {
+			select {
+			case <-in:
+				continue
+			default:
+			}
+			break
+		}
+	}
+}
+
+// fanout pushes an event to every subscriber. Slow consumers get
+// dropped — orchard's "subscribers MUST drain promptly" contract.
+func (p *Provider) fanout(ev provider.InvalidationEvent[ProcessID]) {
+	p.subsMu.Lock()
+	defer p.subsMu.Unlock()
+	for _, ch := range p.subs {
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+}
+
+// Get returns a Process from the store, falling back to the adapter on
+// a miss. Freshness reflects the store's record for cache hits, or
+// SourcePoll for adapter-served misses.
+func (p *Provider) Get(ctx context.Context, key ProcessID) (Process, provider.Freshness, error) {
+	if v, f, ok := p.store.Get(key); ok {
+		return v, f, nil
+	}
+	v, err := p.adapter.Fetch(ctx, key)
+	if err != nil {
+		return Process{}, provider.Freshness{}, err
+	}
+	p.store.Put(key, v, provider.SourcePoll)
+	v2, f, ok := p.store.Get(key)
+	if !ok {
+		return v, provider.Freshness{LastFetchedAt: time.Now(), Source: provider.SourcePoll}, nil
+	}
+	return v2, f, nil
+}
+
+// GetMany batches a multi-key read against the cache. Misses are not
+// fetched individually — for the ps provider, a missing key means the
+// process exited; returning a hole is more honest than re-shelling
+// to ps for each one. Resolvers can call Get for a single missing key
+// if they really care.
+func (p *Provider) GetMany(ctx context.Context, keys []ProcessID) (map[ProcessID]Process, map[ProcessID]provider.Freshness, error) {
+	values := make(map[ProcessID]Process, len(keys))
+	freshness := make(map[ProcessID]provider.Freshness, len(keys))
+	for _, k := range keys {
+		if v, f, ok := p.store.Get(k); ok {
+			values[k] = v
+			freshness[k] = f
+		}
+	}
+	return values, freshness, nil
+}
+
+// Keys returns every process currently in the cache. Resolvers that
+// want the full population (e.g. Host.processes with no filter) call
+// this and then Snapshot via List.
+func (p *Provider) Keys(ctx context.Context) ([]ProcessID, error) {
+	return p.store.Keys(), nil
+}
+
+// List returns a snapshot of every cached Process. Convenience method
+// that the resolver layer prefers over Keys + GetMany.
+func (p *Provider) List() []Process {
+	snap := p.store.Snapshot()
+	out := make([]Process, 0, len(snap))
+	for _, v := range snap {
+		out = append(out, v)
+	}
+	return out
+}
+
+// Subscribe registers a new fanout channel and returns it. The channel
+// closes when ctx is cancelled.
+func (p *Provider) Subscribe(ctx context.Context) <-chan provider.InvalidationEvent[ProcessID] {
+	ch := make(chan provider.InvalidationEvent[ProcessID], 32)
+	p.subsMu.Lock()
+	p.subs = append(p.subs, ch)
+	p.subsMu.Unlock()
+	go func() {
+		<-ctx.Done()
+		p.subsMu.Lock()
+		defer p.subsMu.Unlock()
+		for i, c := range p.subs {
+			if c == ch {
+				p.subs = append(p.subs[:i], p.subs[i+1:]...)
+				break
+			}
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+// Refresh forces an immediate poll cycle. Useful for tests and for the
+// CLI's `query processes` command which wants fresh data on each call.
+func (p *Provider) Refresh(ctx context.Context) error {
+	all, err := p.adapter.FetchAll(ctx)
+	if err != nil {
+		return err
+	}
+	changed := p.store.ReplaceAll(all, provider.SourcePoll, processEqualsHotPath)
+	now := time.Now()
+	for _, k := range changed {
+		p.fanout(provider.InvalidationEvent[ProcessID]{Key: k, Reason: "refresh", At: now})
+	}
+	return nil
+}
+
+// LoadArgs returns argv for the given pids. Batches via the per-provider
+// loader so a query selecting `args` on N processes makes one shellout.
+func (p *Provider) LoadArgs(ctx context.Context, pids []int) (map[int][]string, error) {
+	return p.argsLoader.LoadMany(ctx, pids)
+}
+
+// LoadCwd returns cwd for a single pid. The resolver typically asks one
+// at a time as it walks the result list; the loader coalesces them.
+func (p *Provider) LoadCwd(ctx context.Context, pid int) (string, error) {
+	return p.cwdLoader.Load(ctx, pid)
+}
+
+// LoadCwds returns cwd for multiple pids. Used by the CLI's
+// --by-cwd filter, which forces resolution before applying the prefix.
+func (p *Provider) LoadCwds(ctx context.Context, pids []int) (map[int]string, error) {
+	return p.cwdLoader.LoadMany(ctx, pids)
+}
+
+// ErrNotFound is returned by Get when the key is missing AND the
+// adapter cannot fetch it (e.g. process gone). Callers can use
+// errors.Is to distinguish from other errors.
+var ErrNotFound = errors.New("ps: process not found")

--- a/internal/server/providers/ps/provider_test.go
+++ b/internal/server/providers/ps/provider_test.go
@@ -1,0 +1,166 @@
+package ps
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestProvider_StartHydratesCache spins up the provider against the real
+// `ps` binary, asserts Start returns nil, and confirms the cache is
+// non-empty (every machine has at least the test process and init).
+func TestProvider_StartHydratesCache(t *testing.T) {
+	p := New(NewAdapter("local").WithPollInterval(200*time.Millisecond), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	keys, err := p.Keys(ctx)
+	if err != nil {
+		t.Fatalf("Keys: %v", err)
+	}
+	if len(keys) == 0 {
+		t.Fatal("cache empty after Start; expected at least the test process")
+	}
+
+	self := ProcessID{Host: "local", PID: os.Getpid()}
+	v, _, err := p.Get(ctx, self)
+	if err != nil {
+		t.Fatalf("Get(self): %v", err)
+	}
+	if v.ID != self {
+		t.Errorf("Get(self).ID = %v, want %v", v.ID, self)
+	}
+}
+
+// TestProvider_ListSnapshotIncludesSelf is a smoke test for the List
+// helper used by the resolver layer.
+func TestProvider_ListSnapshotIncludesSelf(t *testing.T) {
+	p := New(NewAdapter("local").WithPollInterval(time.Hour), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	found := false
+	for _, proc := range p.List() {
+		if proc.ID.PID == os.Getpid() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("List did not include self pid %d", os.Getpid())
+	}
+}
+
+// TestProvider_LoadCwdResolvesSelf exercises the slow-path cwd loader
+// against the test process, proving the batch loader plumbs through to
+// the adapter and back.
+func TestProvider_LoadCwdResolvesSelf(t *testing.T) {
+	if !isDarwin() {
+		t.Skip("cwd loader test is darwin-only for v1")
+	}
+	p := New(NewAdapter("local").WithPollInterval(time.Hour), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	cwd, err := p.LoadCwd(ctx, os.Getpid())
+	if err != nil {
+		t.Fatalf("LoadCwd: %v", err)
+	}
+	want, _ := os.Getwd()
+	if cwd != want {
+		t.Errorf("LoadCwd(self) = %q, want %q", cwd, want)
+	}
+}
+
+// TestProvider_LoadArgsResolvesSelf exercises the slow-path args loader.
+func TestProvider_LoadArgsResolvesSelf(t *testing.T) {
+	p := New(NewAdapter("local").WithPollInterval(time.Hour), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got, err := p.LoadArgs(ctx, []int{os.Getpid()})
+	if err != nil {
+		t.Fatalf("LoadArgs: %v", err)
+	}
+	argv, ok := got[os.Getpid()]
+	if !ok || len(argv) == 0 {
+		t.Fatalf("argv missing for self pid %d", os.Getpid())
+	}
+	// `go test` invocations always include the test binary's argv0;
+	// it should at least mention "test" or end with .test
+	if !strings.Contains(strings.Join(argv, " "), "test") {
+		t.Errorf("argv unexpectedly missing 'test' marker: %v", argv)
+	}
+}
+
+// TestProvider_SubscribeReceivesInvalidations forces a Refresh after
+// adding the test process and confirms the subscriber sees the keys.
+func TestProvider_SubscribeReceivesInvalidations(t *testing.T) {
+	p := New(NewAdapter("local").WithPollInterval(time.Hour), nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	subCtx, subCancel := context.WithCancel(ctx)
+	defer subCancel()
+	ch := p.Subscribe(subCtx)
+
+	// Forcing a Refresh should emit zero invalidations (cache matches),
+	// so we mutate the store via a manual delete to trigger an "add"
+	// event on the next Refresh. Provider.store is unexported; reach
+	// for the public seam by killing the prior cache via ReplaceAll.
+	p.store.ReplaceAll(map[ProcessID]Process{}, "test", processEqualsHotPath)
+
+	if err := p.Refresh(ctx); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	gotAny := false
+	for {
+		select {
+		case <-ch:
+			gotAny = true
+			if gotAny {
+				return
+			}
+		case <-deadline:
+			if !gotAny {
+				t.Fatal("subscriber received no invalidation events after Refresh")
+			}
+			return
+		}
+	}
+}
+
+// isDarwin is a tiny helper rather than importing runtime in every test.
+func isDarwin() bool {
+	return runtimeGOOS() == "darwin"
+}
+
+// runtimeGOOS exists so the compiler doesn't optimise the runtime read
+// into a constant — keeps the cwd test guarded at runtime instead of
+// at build time, which matters when GOOS-cross-compiling for review.
+func runtimeGOOS() string {
+	return goosValue
+}
+
+// goosValue is wired by an init in goos_*.go (or here directly). Using
+// a package-level variable keeps the test file independent of build tags.
+var goosValue = osGOOS()

--- a/internal/server/providers/ps/ps_e2e_test.go
+++ b/internal/server/providers/ps/ps_e2e_test.go
@@ -1,0 +1,193 @@
+// Package ps — end-to-end test for AC7.
+//
+// This test does what the briefing demands: real `ps`, real subprocess,
+// real GraphQL handler hosted in `httptest.Server`. No mocks. The
+// provider polls at 150ms so the test loop converges quickly.
+//
+// Shape:
+//  1. Construct ps.Provider with a real PsAdapter on a 150ms tick.
+//  2. Wire it through the gqlgen handler the daemon would wire.
+//  3. Spawn `sleep 30`.
+//  4. Wait for the provider to observe the new pid.
+//  5. POST `query { host { processes(filter:{pidIn:[<pid>]}) { command pid cwd } } }`
+//     and assert the spawned process is returned with the expected basename.
+//  6. Kill the subprocess.
+//  7. Wait for the provider's next tick to evict it.
+//  8. Re-POST the same query and assert an empty result list.
+package ps_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+
+	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+)
+
+// TestPS_E2E_SpawnAndDisappear is the AC7 test: real subprocess + real ps
+// + real graphql handler. macOS + Linux only — Windows lacks the `ps` we
+// shell out to.
+func TestPS_E2E_SpawnAndDisappear(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skipf("ps e2e is darwin/linux only (no ps binary on %s)", runtime.GOOS)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Provider: real adapter, snappy poll interval so the test sees
+	// spawn/exit transitions inside the deadline budget.
+	provider := ps.New(ps.NewAdapter("local").WithPollInterval(150*time.Millisecond), nil)
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("provider Start: %v", err)
+	}
+
+	// gqlgen handler with the resolver root pointed at our provider.
+	resolver := resolvers.New(time.Now()).WithPS(provider)
+	gqlSrv := handler.New(gql.NewExecutableSchema(gql.Config{Resolvers: resolver}))
+	gqlSrv.AddTransport(transport.POST{})
+
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", gqlSrv)
+	httpSrv := httptest.NewServer(mux)
+	defer httpSrv.Close()
+	graphqlURL := httpSrv.URL + "/graphql"
+
+	// Spawn `sleep 30` — long enough that it's guaranteed alive across
+	// the visibility-poll window. We always kill it before the test exits.
+	cmd := exec.CommandContext(ctx, "sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep subprocess: %v", err)
+	}
+	pid := cmd.Process.Pid
+	cleanup := func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	}
+	defer cleanup()
+
+	// AC7 step 5: spawn must be visible in `host.processes`.
+	if err := waitForProcessVisible(t, ctx, graphqlURL, pid, "sleep", 5*time.Second); err != nil {
+		t.Fatalf("expected spawned pid %d to appear: %v", pid, err)
+	}
+
+	// AC7 step 6: kill the subprocess.
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill sleep subprocess: %v", err)
+	}
+	_, _ = cmd.Process.Wait()
+
+	// AC7 step 7-8: after the next poll cycle the provider must drop the
+	// dead pid. The provider polls every 150ms, so a 5s budget is comfortable.
+	if err := waitForProcessAbsent(t, ctx, graphqlURL, pid, 5*time.Second); err != nil {
+		t.Fatalf("expected pid %d to disappear after kill: %v", pid, err)
+	}
+}
+
+// processesByPidResponse mirrors the GraphQL envelope for the pidIn query.
+type processesByPidResponse struct {
+	Data struct {
+		Host struct {
+			Processes []struct {
+				ID      string  `json:"id"`
+				Pid     int     `json:"pid"`
+				Command string  `json:"command"`
+				Cwd     *string `json:"cwd"`
+			} `json:"processes"`
+		} `json:"host"`
+	} `json:"data"`
+	Errors []json.RawMessage `json:"errors"`
+}
+
+// queryByPid hits the test daemon and returns whatever processes the
+// resolver matched against the given pid filter.
+func queryByPid(ctx context.Context, graphqlURL string, pid int) (processesByPidResponse, error) {
+	const query = `query($pids:[Int!]) {
+	  host { processes(filter: {pidIn: $pids}) { id pid command cwd } }
+	}`
+	body, err := json.Marshal(map[string]any{
+		"query":     query,
+		"variables": map[string]any{"pids": []int{pid}},
+	})
+	if err != nil {
+		return processesByPidResponse{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, graphqlURL, bytes.NewReader(body))
+	if err != nil {
+		return processesByPidResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return processesByPidResponse{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return processesByPidResponse{}, err
+	}
+	var out processesByPidResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return processesByPidResponse{}, err
+	}
+	return out, nil
+}
+
+// waitForProcessVisible polls the daemon until the spawned pid shows up
+// (or the deadline elapses). The watcher tick is 150ms; we poll every
+// 100ms which is fast enough not to miss the transition.
+func waitForProcessVisible(t *testing.T, ctx context.Context, graphqlURL string, pid int, wantCommand string, budget time.Duration) error {
+	t.Helper()
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		got, err := queryByPid(ctx, graphqlURL, pid)
+		if err != nil {
+			return err
+		}
+		for _, p := range got.Data.Host.Processes {
+			if p.Pid == pid && p.Command == wantCommand {
+				return nil
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("pid %d / command %q never appeared in graphql results within %s", pid, wantCommand, budget)
+}
+
+// waitForProcessAbsent polls until the pid is no longer in the resolver's
+// list. After cmd.Process.Kill the provider's next tick should evict it.
+func waitForProcessAbsent(t *testing.T, ctx context.Context, graphqlURL string, pid int, budget time.Duration) error {
+	t.Helper()
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		got, err := queryByPid(ctx, graphqlURL, pid)
+		if err != nil {
+			return err
+		}
+		present := false
+		for _, p := range got.Data.Host.Processes {
+			if p.Pid == pid {
+				present = true
+				break
+			}
+		}
+		if !present {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("pid %d still visible after kill within %s", pid, budget)
+}

--- a/internal/server/providers/ps/types.go
+++ b/internal/server/providers/ps/types.go
@@ -1,0 +1,52 @@
+package ps
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ProcessID is the provider's key type. macOS pids are int32, but Linux
+// allows the full 32-bit range, so we use int. Composed with HostID for
+// the GraphQL Node identity (`<host>:<pid>`).
+type ProcessID struct {
+	Host string
+	PID  int
+}
+
+// String returns the wire-format Node id (`<host>:<pid>`).
+func (p ProcessID) String() string {
+	return fmt.Sprintf("%s:%d", p.Host, p.PID)
+}
+
+// ParseProcessID parses the wire-format Node id. Returns an error if the
+// shape is malformed; callers can use this to resolve `node(id:)` lookups
+// once that resolver lands.
+func ParseProcessID(s string) (ProcessID, error) {
+	idx := strings.LastIndexByte(s, ':')
+	if idx <= 0 || idx == len(s)-1 {
+		return ProcessID{}, fmt.Errorf("ps: malformed process id %q (want <host>:<pid>)", s)
+	}
+	pid, err := strconv.Atoi(s[idx+1:])
+	if err != nil {
+		return ProcessID{}, fmt.Errorf("ps: malformed pid in %q: %w", s, err)
+	}
+	return ProcessID{Host: s[:idx], PID: pid}, nil
+}
+
+// Process is the domain type the provider stores in its cache. Resolvers
+// project this onto the gqlgen wire type (graphql.Process) and lazily
+// fetch slow-path fields (args, cwd) only when requested.
+type Process struct {
+	ID         ProcessID
+	PPID       int
+	User       string
+	TTY        string  // empty when ps reports "??"
+	CPUPercent float64
+	MemBytes   int64   // RSS (1024-byte pages on macOS; bytes after multiplication)
+	StartedAt  time.Time
+	StartedRaw string  // original lstart string, kept for cases where parsing failed
+	Command    string  // basename (e.g. "sleep") — stripped path + argv
+	CommandRaw string  // full path-and-argv as ps emitted it (used for command-line searches)
+}

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -1,3 +1,7 @@
+// Package resolvers wires the gqlgen-generated GraphQL surface to the
+// providers under internal/server/providers. One file per node type
+// hangs off this Resolver root; the root holds dependencies the field
+// resolvers need.
 package resolvers
 
 import (
@@ -7,6 +11,7 @@ import (
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 )
 
 // ProjectsLister is the narrow read-side contract the project resolver
@@ -30,6 +35,7 @@ type Resolver struct {
 	HostProvider     *host.Provider
 	ProjectsProvider ProjectsLister
 	Git              *gitprovider.Provider
+	PS               *ps.Provider
 }
 
 // New constructs a Resolver with the daemon's start time captured. The
@@ -56,5 +62,12 @@ func (r *Resolver) WithProjects(p ProjectsLister) *Resolver {
 // Worktree.* resolvers.
 func (r *Resolver) WithGit(g *gitprovider.Provider) *Resolver {
 	r.Git = g
+	return r
+}
+
+// WithPS wires the ps provider that backs Host.processes and Process
+// node resolution.
+func (r *Resolver) WithPS(p *ps.Provider) *Resolver {
+	r.PS = p
 	return r
 }

--- a/internal/server/resolvers/resolver_filter_test.go
+++ b/internal/server/resolvers/resolver_filter_test.go
@@ -1,0 +1,68 @@
+package resolvers
+
+import (
+	"context"
+	"testing"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+)
+
+// TestApplyProcessFilter_PidIn confirms pidIn filters are applied at the
+// resolver layer over the cached process snapshot.
+func TestApplyProcessFilter_PidIn(t *testing.T) {
+	all := []ps.Process{
+		{ID: ps.ProcessID{Host: "local", PID: 1}, Command: "launchd"},
+		{ID: ps.ProcessID{Host: "local", PID: 2}, Command: "init"},
+		{ID: ps.ProcessID{Host: "local", PID: 17729}, Command: "zsh"},
+	}
+	want := int64(17729)
+	filter := &graphql1.ProcessFilter{PidIn: []int64{want}}
+	got := applyProcessFilter(context.Background(), nil, all, filter)
+	if len(got) != 1 || got[0].ID.PID != int(want) {
+		t.Fatalf("got %+v, want pid %d", got, want)
+	}
+}
+
+// TestApplyProcessFilter_CommandIn confirms commandIn matches by basename.
+func TestApplyProcessFilter_CommandIn(t *testing.T) {
+	all := []ps.Process{
+		{ID: ps.ProcessID{Host: "local", PID: 1}, Command: "launchd"},
+		{ID: ps.ProcessID{Host: "local", PID: 2}, Command: "claude"},
+		{ID: ps.ProcessID{Host: "local", PID: 3}, Command: "claude"},
+		{ID: ps.ProcessID{Host: "local", PID: 4}, Command: "zsh"},
+	}
+	filter := &graphql1.ProcessFilter{CommandIn: []string{"claude"}}
+	got := applyProcessFilter(context.Background(), nil, all, filter)
+	if len(got) != 2 {
+		t.Fatalf("got len %d, want 2", len(got))
+	}
+	for _, p := range got {
+		if p.Command != "claude" {
+			t.Errorf("unexpected command %q", p.Command)
+		}
+	}
+}
+
+// TestApplyProcessFilter_NilReturnsAll confirms a nil filter passes through.
+func TestApplyProcessFilter_NilReturnsAll(t *testing.T) {
+	all := []ps.Process{{ID: ps.ProcessID{PID: 1}}, {ID: ps.ProcessID{PID: 2}}}
+	got := applyProcessFilter(context.Background(), nil, all, nil)
+	if len(got) != len(all) {
+		t.Fatalf("nil filter should pass-through, got %d, want %d", len(got), len(all))
+	}
+}
+
+// TestProjectProcess_TimeFormatting verifies a parseable startedAt is
+// emitted in RFC3339, and an unparseable one falls back to the raw string.
+func TestProjectProcess_TimeFormatting(t *testing.T) {
+	zero := ps.Process{
+		ID:         ps.ProcessID{Host: "local", PID: 1},
+		Command:    "launchd",
+		StartedRaw: "Sun May  3 15:38:46 2026",
+	}
+	got := projectProcess(&zero, "local")
+	if got.StartedAt != "Sun May  3 15:38:46 2026" {
+		t.Errorf("zero StartedAt should fall back to raw, got %q", got.StartedAt)
+	}
+}

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -100,16 +100,22 @@ func (r *queryResolver) Health(ctx context.Context) (*graphql1.Health, error) {
 	}, nil
 }
 
-// Host is the resolver for the host field.
+// Host is the resolver for the host field. When HostProvider is wired,
+// returns the real local Host node. Otherwise (e.g. test harnesses that
+// only wire the ps provider) returns a stub Host carrying the ps
+// provider's host id so Host.processes still resolves.
 func (r *queryResolver) Host(ctx context.Context) (*graphql1.Host, error) {
-	if r.HostProvider == nil {
-		return nil, fmt.Errorf("host provider not initialised")
+	if r.HostProvider != nil {
+		h, _, err := r.HostProvider.Get(ctx, r.HostProvider.LocalID())
+		if err != nil {
+			return nil, fmt.Errorf("host: %w", err)
+		}
+		return h, nil
 	}
-	h, _, err := r.HostProvider.Get(ctx, r.HostProvider.LocalID())
-	if err != nil {
-		return nil, fmt.Errorf("host: %w", err)
+	if r.PS != nil {
+		return &graphql1.Host{ID: r.PS.HostID()}, nil
 	}
-	return h, nil
+	return nil, fmt.Errorf("host provider not initialised")
 }
 
 // Hosts is the resolver for the hosts field.

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -8,16 +8,15 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 )
 
-// Worktrees is the resolver for the worktrees field. Lists the git
-// worktrees backing this project — the main checkout plus everything
-// under `.git/worktrees/`. Returns an empty list when the git provider
-// has no records yet for this project (e.g. fresh boot before scan).
+// Worktrees is the resolver for the project.worktrees field.
 func (r *projectResolver) Worktrees(ctx context.Context, obj *graphql1.Project) ([]*graphql1.Worktree, error) {
 	if r.Git == nil {
 		return nil, fmt.Errorf("git provider not configured")
@@ -31,6 +30,65 @@ func (r *projectResolver) Worktrees(ctx context.Context, obj *graphql1.Project) 
 		out = append(out, toGraphQLWorktree(w))
 	}
 	return out, nil
+}
+
+// Processes is the resolver for the host.processes field.
+func (r *hostResolver) Processes(ctx context.Context, obj *graphql1.Host, filter *graphql1.ProcessFilter) ([]*graphql1.Process, error) {
+	if r.PS == nil {
+		return nil, fmt.Errorf("ps provider not wired")
+	}
+	all := r.PS.List()
+	filtered := applyProcessFilter(ctx, r.PS, all, filter)
+	hostID := r.PS.HostID()
+	out := make([]*graphql1.Process, 0, len(filtered))
+	for i := range filtered {
+		out = append(out, projectProcess(&filtered[i], hostID))
+	}
+	return out, nil
+}
+
+// Host is the resolver for the process.host field.
+func (r *processResolver) Host(_ context.Context, obj *graphql1.Process) (*graphql1.Host, error) {
+	hostID, _ := splitProcessNodeID(obj.ID)
+	return &graphql1.Host{ID: hostID}, nil
+}
+
+// Args is the resolver for the process.args field.
+func (r *processResolver) Args(ctx context.Context, obj *graphql1.Process) ([]string, error) {
+	if r.PS == nil {
+		return nil, nil
+	}
+	pid := int(obj.Pid)
+	got, err := r.PS.LoadArgs(ctx, []int{pid})
+	if err != nil {
+		return nil, err
+	}
+	return got[pid], nil
+}
+
+// Cwd is the resolver for the process.cwd field.
+func (r *processResolver) Cwd(ctx context.Context, obj *graphql1.Process) (*string, error) {
+	if r.PS == nil {
+		return nil, nil
+	}
+	cwd, err := r.PS.LoadCwd(ctx, int(obj.Pid))
+	if err != nil {
+		return nil, err
+	}
+	if cwd == "" {
+		return nil, nil
+	}
+	return &cwd, nil
+}
+
+// Worktree is the resolver for the process.worktree field. Placeholder until ws-b-git wires the cwd lookup.
+func (r *processResolver) Worktree(_ context.Context, _ *graphql1.Process) (*graphql1.Worktree, error) {
+	return nil, nil
+}
+
+// ClaudeInstance is the resolver for the process.claudeInstance field. Placeholder until ws-b-claudeinstance lands.
+func (r *processResolver) ClaudeInstance(_ context.Context, _ *graphql1.Process) (*graphql1.ClaudeInstance, error) {
+	return nil, nil
 }
 
 // Health is the resolver for the health field.
@@ -63,9 +121,7 @@ func (r *queryResolver) Hosts(ctx context.Context) ([]*graphql1.Host, error) {
 	return []*graphql1.Host{h}, nil
 }
 
-// Projects is the resolver for the projects field. It returns the
-// in-memory cached snapshot from the config provider. Order is stable
-// (by id) so consumers get reproducible output.
+// Projects is the resolver for the projects field.
 func (r *queryResolver) Projects(ctx context.Context) ([]*graphql1.Project, error) {
 	if r.ProjectsProvider == nil {
 		return nil, fmt.Errorf("projects provider not wired: daemon misconfigured")
@@ -86,14 +142,16 @@ func (r *queryResolver) Projects(ctx context.Context) ([]*graphql1.Project, erro
 	return out, nil
 }
 
-// Processes is the resolver for the processes field.
-//
-// Placeholder until Workstream B-ps lands the ps provider. Returning
-// an empty slice satisfies the non-null `[Process!]!` schema contract
-// and keeps the rest of the graph queryable.
+// Processes is the resolver for the worktree.processes field. Placeholder until cwd-to-worktree join lands.
 func (r *worktreeResolver) Processes(_ context.Context, _ *graphql1.Worktree) ([]*graphql1.Process, error) {
 	return []*graphql1.Process{}, nil
 }
+
+// Host returns graphql1.HostResolver implementation.
+func (r *Resolver) Host() graphql1.HostResolver { return &hostResolver{r} }
+
+// Process returns graphql1.ProcessResolver implementation.
+func (r *Resolver) Process() graphql1.ProcessResolver { return &processResolver{r} }
 
 // Project returns graphql1.ProjectResolver implementation.
 func (r *Resolver) Project() graphql1.ProjectResolver { return &projectResolver{r} }
@@ -104,13 +162,13 @@ func (r *Resolver) Query() graphql1.QueryResolver { return &queryResolver{r} }
 // Worktree returns graphql1.WorktreeResolver implementation.
 func (r *Resolver) Worktree() graphql1.WorktreeResolver { return &worktreeResolver{r} }
 
+type hostResolver struct{ *Resolver }
+type processResolver struct{ *Resolver }
 type projectResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type worktreeResolver struct{ *Resolver }
 
-// toGraphQLWorktree projects a git provider Worktree into the GraphQL
-// model. Kept as a free function so the projection logic is testable
-// without a full resolver harness.
+// toGraphQLWorktree projects a git provider Worktree into the GraphQL model.
 func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
 	return &graphql1.Worktree{
 		ID:     string(w.ID),
@@ -119,4 +177,95 @@ func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
 		Head:   w.Head,
 		Bare:   w.Bare,
 	}
+}
+
+// projectProcess maps the provider's domain Process onto the gqlgen wire type.
+func projectProcess(p *ps.Process, hostID string) *graphql1.Process {
+	tty := p.TTY
+	startedAt := p.StartedRaw
+	if !p.StartedAt.IsZero() {
+		startedAt = p.StartedAt.Format(time.RFC3339)
+	}
+	out := &graphql1.Process{
+		ID:         p.ID.String(),
+		Host:       &graphql1.Host{ID: hostID},
+		Pid:        int64(p.ID.PID),
+		Ppid:       int64(p.PPID),
+		Command:    p.Command,
+		StartedAt:  startedAt,
+		CPUPercent: p.CPUPercent,
+		MemBytes:   p.MemBytes,
+	}
+	if tty != "" {
+		out.Tty = &tty
+	}
+	return out
+}
+
+// applyProcessFilter applies the resolver-layer filter.
+// Cheap filters (pidIn, commandIn) run first; cwdPrefix forces a slow lsof batch.
+func applyProcessFilter(ctx context.Context, p *ps.Provider, in []ps.Process, filter *graphql1.ProcessFilter) []ps.Process {
+	if filter == nil {
+		return in
+	}
+	out := make([]ps.Process, len(in))
+	copy(out, in)
+
+	if pids := filter.PidIn; len(pids) > 0 {
+		want := make(map[int]struct{}, len(pids))
+		for _, pid := range pids {
+			want[int(pid)] = struct{}{}
+		}
+		next := out[:0]
+		for _, proc := range out {
+			if _, ok := want[proc.ID.PID]; ok {
+				next = append(next, proc)
+			}
+		}
+		out = next
+	}
+
+	if cmds := filter.CommandIn; len(cmds) > 0 {
+		want := make(map[string]struct{}, len(cmds))
+		for _, c := range cmds {
+			want[c] = struct{}{}
+		}
+		next := out[:0]
+		for _, proc := range out {
+			if _, ok := want[proc.Command]; ok {
+				next = append(next, proc)
+			}
+		}
+		out = next
+	}
+
+	if filter.CwdPrefix != nil && *filter.CwdPrefix != "" {
+		prefix := *filter.CwdPrefix
+		pids := make([]int, 0, len(out))
+		for _, proc := range out {
+			pids = append(pids, proc.ID.PID)
+		}
+		cwds, err := p.LoadCwds(ctx, pids)
+		if err != nil {
+			return nil
+		}
+		next := out[:0]
+		for _, proc := range out {
+			if cwd, ok := cwds[proc.ID.PID]; ok && strings.HasPrefix(cwd, prefix) {
+				next = append(next, proc)
+			}
+		}
+		out = next
+	}
+
+	return out
+}
+
+// splitProcessNodeID extracts (host, pid) from a Process node id of the form host:pid.
+func splitProcessNodeID(s string) (string, string) {
+	idx := strings.LastIndexByte(s, ':')
+	if idx <= 0 {
+		return "local", s
+	}
+	return s[:idx], s[idx+1:]
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,12 @@
 //
 // Workstream B-git: WithGit wires the git provider that backs
 // Project.worktrees and Worktree.* resolvers.
+//
+// Workstream B-ps: WithPS attaches a ps provider so resolvers can serve
+// `host.processes` and the Process node fields. The server takes
+// responsibility for the provider's lifecycle: Run() calls Start()
+// before opening the listener and (implicitly) tears it down by
+// cancelling its context on shutdown.
 package server
 
 import (
@@ -35,6 +41,7 @@ import (
 	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
 )
 
@@ -51,6 +58,7 @@ type Server struct {
 	httpSrv   *http.Server
 	host      *host.Provider
 	resolver  *resolvers.Resolver
+	psProv    *ps.Provider
 }
 
 // Option mutates a Server during construction. Used for wiring optional
@@ -65,6 +73,16 @@ func WithProjects(p resolvers.ProjectsLister) Option {
 // WithGit wires a git provider into the resolver.
 func WithGit(g *gitprovider.Provider) Option {
 	return func(_ *Server, r *resolvers.Resolver) { r.WithGit(g) }
+}
+
+// WithPS attaches a ps provider to the server's resolver root. The
+// server takes responsibility for the provider's lifecycle: Run()
+// calls Start() before opening the listener.
+func WithPS(p *ps.Provider) Option {
+	return func(s *Server, r *resolvers.Resolver) {
+		s.psProv = p
+		r.WithPS(p)
+	}
 }
 
 // New constructs a Server bound to addr. The host provider is constructed
@@ -135,6 +153,11 @@ func (s *Server) Run(ctx context.Context) error {
 		// Identity is load-bearing — fail fast so the operator sees it
 		// rather than getting half-populated GraphQL responses.
 		return fmt.Errorf("start host provider: %w", err)
+	}
+	if s.psProv != nil {
+		if err := s.psProv.Start(ctx); err != nil {
+			return fmt.Errorf("ps provider start: %w", err)
+		}
 	}
 
 	errCh := make(chan error, 1)

--- a/internal/server/store/store.go
+++ b/internal/server/store/store.go
@@ -1,0 +1,115 @@
+// Package store provides the per-provider in-memory cache. Per ADR-011
+// §4, every provider owns one Store[K, V]: a map plus per-entry
+// freshness metadata. Hydrated by the watcher; expired by TTL backstop
+// in the provider, not here.
+//
+// **No SQLite. No event log. No persistence here.** Snapshot persistence
+// is opt-in per provider via the snapshot package (not in this PR).
+package store
+
+import (
+	"sync"
+	"time"
+
+	provider "github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
+)
+
+// Store is a generic in-memory map of K → V plus per-entry freshness.
+// Safe for concurrent use.
+type Store[K provider.Key, V any] struct {
+	mu      sync.RWMutex
+	entries map[K]entry[V]
+}
+
+type entry[V any] struct {
+	value     V
+	freshness provider.Freshness
+}
+
+// New returns an empty store ready for use.
+func New[K provider.Key, V any]() *Store[K, V] {
+	return &Store[K, V]{entries: make(map[K]entry[V])}
+}
+
+// Put writes a value with freshness metadata.
+func (s *Store[K, V]) Put(key K, value V, source provider.FreshnessSource) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries[key] = entry[V]{
+		value: value,
+		freshness: provider.Freshness{
+			LastFetchedAt: time.Now(),
+			Source:        source,
+		},
+	}
+}
+
+// Get reads a value plus freshness. The boolean is false if the key is
+// not present (callers distinguish miss from "value is the zero value").
+func (s *Store[K, V]) Get(key K) (V, provider.Freshness, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	e, ok := s.entries[key]
+	if !ok {
+		var zero V
+		return zero, provider.Freshness{}, false
+	}
+	return e.value, e.freshness, true
+}
+
+// Keys returns every key currently in the store. Order is unspecified.
+func (s *Store[K, V]) Keys() []K {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]K, 0, len(s.entries))
+	for k := range s.entries {
+		out = append(out, k)
+	}
+	return out
+}
+
+// Snapshot returns a copy of every entry. Callers can iterate without
+// holding the store lock. Order is unspecified.
+func (s *Store[K, V]) Snapshot() map[K]V {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[K]V, len(s.entries))
+	for k, e := range s.entries {
+		out[k] = e.value
+	}
+	return out
+}
+
+// ReplaceAll atomically swaps the entire population to `next`, marking
+// every entry with the given source. Keys present in the prior
+// population but absent from `next` are evicted. Returns the set of
+// keys that changed (added, removed, or value-modified per the
+// `equals` predicate). Callers fan these out as InvalidationEvents.
+func (s *Store[K, V]) ReplaceAll(next map[K]V, source provider.FreshnessSource, equals func(a, b V) bool) []K {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := time.Now()
+	changed := make([]K, 0)
+	// Additions and modifications.
+	for k, v := range next {
+		prior, ok := s.entries[k]
+		if !ok || !equals(prior.value, v) {
+			changed = append(changed, k)
+		}
+		s.entries[k] = entry[V]{
+			value: v,
+			freshness: provider.Freshness{
+				LastFetchedAt: now,
+				Source:        source,
+			},
+		}
+	}
+	// Removals.
+	for k := range s.entries {
+		if _, ok := next[k]; !ok {
+			delete(s.entries, k)
+			changed = append(changed, k)
+		}
+	}
+	return changed
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -18,6 +18,10 @@
 # Workstream B-git: Worktree node + Project.worktrees back-edge. Process
 # is forward-declared so Worktree.processes can reference it; ws-b-ps
 # fills in the rest.
+#
+# Workstream B-ps: full Process node + Host.processes(filter). Edges
+# to Worktree (via cwd) and ClaudeInstance (via foreground claude pid)
+# stay placeholder until their owning workstreams land.
 
 """
 A node in the orchard graph. Every node has a globally-unique id so
@@ -29,12 +33,74 @@ interface Node {
   id: ID!
 }
 
-# Process is forward-declared here so Worktree.processes can reference
-# it; the ps provider in ws-b-ps fills in the rest of the type.
-# Until that lands, Worktree.processes resolves to `[]`.
+# Process is an OS-level process surfaced via the `ps` adapter.
+# Identity: (host_id, pid). Lifetime: alive AND visible to ps.
+# Not enumerable from root — reach via `host.processes` etc.
+# See ADR-011 §5.1.
 type Process implements Node {
   "Stable id formatted as `<host>:<pid>`."
   id: ID!
+
+  "Host this process is running on."
+  host: Host!
+
+  "Process id."
+  pid: Int!
+
+  "Parent process id (0 for kernel/launchd-rooted processes)."
+  ppid: Int!
+
+  "Command basename (e.g. 'sleep', 'claude'). Cheap, always populated."
+  command: String!
+
+  "Full argv. Slow path — opt-in (separate `ps -wwax -o pid,args` lookup)."
+  args: [String!]
+
+  "Current working directory. Slow path — opt-in (lsof on macOS, /proc on Linux)."
+  cwd: String
+
+  "Process start time (RFC3339 if parseable, otherwise the raw `lstart` field)."
+  startedAt: String!
+
+  "CPU percent as reported by ps."
+  cpuPercent: Float!
+
+  "Resident memory in bytes (RSS * 1024 from ps)."
+  memBytes: Int!
+
+  "Controlling terminal, or null if none."
+  tty: String
+
+  # Cross-provider edges — placeholders until their owning workstreams land.
+  # ws-b-git wires `worktree` via cwd → git worktree lookup;
+  # ws-b-claudeinstance (Wave 3) wires `claudeInstance` as the back-edge
+  # from a Claude pid.
+
+  "Worktree this process is running inside, derived from cwd. Null until ws-b-git wires the lookup."
+  worktree: Worktree
+
+  "Claude instance back-edge — populated when this pid is the foreground claude pid. Null until ws-b-claudeinstance lands."
+  claudeInstance: ClaudeInstance
+}
+
+# Forward-declared placeholder. ws-b-claudeinstance replaces this with the
+# real ClaudeInstance node (pane, process, account, state, …).
+type ClaudeInstance {
+  "Stable id; ws-b-claudeinstance formalises (host_id, claudePid)."
+  id: ID!
+}
+
+# ProcessFilter is applied at the resolver layer over the cached process
+# list. Multiple filters are AND-combined.
+input ProcessFilter {
+  "Match processes whose command basename is in this list."
+  commandIn: [String!]
+
+  "Match processes whose cwd starts with this prefix. Forces cwd resolution."
+  cwdPrefix: String
+
+  "Match processes by pid."
+  pidIn: [Int!]
 }
 
 type Query {
@@ -94,6 +160,9 @@ type Host implements Node {
 
   "Peer hosts this daemon federates with. v1: always empty; Workstream F populates."
   peers: [Host!]!
+
+  "Processes visible to this host's `ps` adapter, optionally filtered."
+  processes(filter: ProcessFilter): [Process!]!
 }
 
 """


### PR DESCRIPTION
## Summary

Implements the **ps provider** and the **Process node** end-to-end:
schema → adapter → provider → resolver → CLI → E2E test. Surfaces
running processes via `host.processes(filter:)` and `orchard query
processes`. macOS-first; Linux is best-effort (parser is OS-agnostic;
`cwd` resolution stubbed pending `/proc` fallback).

Bases on `ws-a-scaffold` to match the parallel ws-b PRs (#381, #382,
#383).

## ACs

- [x] **AC1 — schema additions** (commit `0387816`)
  `Process implements Node`, `Host.processes(filter: ProcessFilter)`,
  `ProcessFilter { commandIn, cwdPrefix, pidIn }`, plus forward-declared
  `Worktree` / `ClaudeInstance` stubs so ws-b-git and ws-b-claudeinstance
  can fill them in without schema churn. `make generate` re-run; `gqlgen.yml`
  configures field resolvers for `Host.processes` and the cross-provider
  `Process.{worktree,claudeInstance}`.

- [x] **AC2 — provider implementation** (commit `0387816`)
  `internal/server/providers/ps/`: `PsAdapter` shells `ps -ax -o
  pid,ppid,user,tty,%cpu,rss,lstart,command`, separate `ps -wwax -o
  pid,args` for the slow `args` path, `lsof -a -d cwd -p <pid> -F n`
  per pid for `cwd` (macOS). Watcher polls at 3s default; `WithPollInterval`
  exposed for tests. `processEqualsHotPath` ignores CPU/RSS so the watcher
  doesn't emit one event per pid per tick. Tiny ps-local DataLoader
  stand-in (`batchloader.go`) — Workstream C swaps to `dataloader/v7`.

- [x] **AC3 — resolver wiring** (commit `0387816`)
  `Host.processes` populates from the cache; filter applied at the
  resolver layer, ordered cheap → expensive (`pidIn` → `commandIn` →
  `cwdPrefix`). `cwdPrefix` forces an `lsof` batch over the
  already-narrowed pids. Filter unit tests in
  `internal/server/resolvers/resolver_filter_test.go`.

- [x] **AC4 — `Process.worktree` placeholder** (commit `0387816`)
  Returns `nil`. Comment points to ws-b-git. Schema has a
  forward-declared `Worktree { id: ID! }` stub.

- [x] **AC5 — `Process.claudeInstance` placeholder** (commit `0387816`)
  Returns `nil`. Comment points to ws-b-claudeinstance.

- [x] **AC6 — `orchard query processes [--by-cwd PATH] [--command CMD]`** (commit `0387816`)
  `internal/cli/query/processes.go`. JSON output by default. Smoke-tested:
  ```
  XDG_STATE_HOME=/tmp/orchard-smoke ./bin/orchard daemon start &
  ./bin/orchard query processes --command sleep
  ```
  → returns the spawned `sleep` with id, pid, ppid, command, args, cwd,
  startedAt, cpuPercent, memBytes.

- [x] **AC7 — E2E test** (commit `ec40ad3`)
  `internal/server/providers/ps/ps_e2e_test.go` (`package ps_test`):
  boots `httptest.Server` with the real gqlgen handler wired through a
  real `PsAdapter` (`WithPollInterval(150ms)`), spawns `sleep 30`,
  GraphQL-POSTs `query { host { processes(filter:{pidIn:[<pid>]}) { id
  pid command cwd } } }`, asserts presence; kills the subprocess; asserts
  disappearance after the next watcher tick. Real ps, real subprocess,
  real http transport. **No mocks.** Runs in ~1s.

- [x] **AC8 — `go test ./internal/server/providers/ps/...`** green on macOS.
  9 tests in this package: parser fixtures, real-ps adapter, real-lsof
  cwd, real-args, watcher spawn-detection, provider invalidation, and
  the new E2E. Plus 4 resolver-filter tests in
  `internal/server/resolvers/`.

- [x] **AC9 — `golangci-lint run` clean for ps scope** (commit `32788c4`)
  `internal/server/{provider,adapter,store,providers/ps,resolvers}` +
  `internal/cli/query` report 0 issues. Pre-existing errcheck nits in
  `internal/cli/{config,daemon}` are ws-a's and out of scope.

- [x] **AC10 — draft PR open** (this PR)

## Decisions worth flagging

1. **External test package (`ps_test`)** — the resolver layer imports
   the ps provider, so an internal `package ps` test couldn't import
   `resolvers` without an import cycle. `ps_test` is the standard Go
   solution and matches how the briefing's AC7 query exercises the
   resolver path (the very thing under test).

2. **`processEqualsHotPath` ignores CPU/RSS** — those fields shift
   every tick for every running process; including them would emit one
   InvalidationEvent per pid per tick. Subscribers re-fetch on demand
   if they care about live numbers.

3. **`Host.id` hardcoded `"local"`** — Workstream G replaces with a
   real `machineId` once the Host provider lands. The resolver's
   `splitProcessNodeID` already uses `LastIndexByte` so it tolerates
   colons in host names.

4. **Forward-declared schema stubs for `Worktree` / `ClaudeInstance`** —
   AC4/AC5 say "return null and document"; the cleanest seam is a
   `type X { id: ID! }` stub that the cross-workstream PRs can enrich
   without schema churn.

## Test plan

- [x] `go test ./internal/server/providers/ps/... ./internal/server/resolvers/... -v`
  → 13/13 PASS in ~6s on macOS.
- [x] `~/go/bin/golangci-lint run ./internal/server/... ./internal/cli/query/...`
  → 0 issues.
- [x] Smoke: spawn `sleep 30`, run `orchard query processes --command sleep`,
  observe spawned pid in JSON output. Kill → next query no longer lists it.

## Out of scope (per briefing)

- Linux-specific cwd path (`/proc/<pid>/cwd`) — adapter degrades to
  empty-map on Linux so resolvers serve `cwd: null` rather than error.
- `Process.worktree` real wiring — ws-b-git follows up.
- `Process.claudeInstance` real wiring — ws-b-claudeinstance (Wave 3) follows up.
- Process subscription (live updates) — Workstream C lights subscriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Added a new `orchard query processes` CLI command to list and filter running processes by command name, current working directory, or process ID
* Extended GraphQL schema to expose detailed process information including process ID, parent process ID, command, arguments, working directory, CPU usage, memory consumption, and TTY assignment
* Processes are now queryable through the daemon with filtering capabilities via the GraphQL API
<!-- end of auto-generated comment: release notes by coderabbit.ai -->