### PR TITLE
Workstream B-tmux: tmux provider → TmuxServer/Session/Window/Pane/Client

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -68,3 +68,99 @@ models:
         resolver: true
       claudeInstance:
         resolver: true
+
+  # Tmux fields that require provider lookups (relationship traversals,
+  # on-demand content captures) are resolved by per-field resolvers, not
+  # by reading the struct. The lightweight identifier-only fields stay on
+  # the generated struct so callers paying for `id` alone don't pay for a
+  # provider hit.
+  TmuxServer:
+    fields:
+      sessions:
+        resolver: true
+      clients:
+        resolver: true
+      pid:
+        resolver: true
+      alive:
+        resolver: true
+  TmuxSession:
+    fields:
+      server:
+        resolver: true
+      attached:
+        resolver: true
+      activeAttached:
+        resolver: true
+      attachedClients:
+        resolver: true
+      lastActivityAt:
+        resolver: true
+      windows:
+        resolver: true
+      currentWindow:
+        resolver: true
+      createdAt:
+        resolver: true
+  TmuxWindow:
+    fields:
+      session:
+        resolver: true
+      panes:
+        resolver: true
+      currentPane:
+        resolver: true
+      active:
+        resolver: true
+      name:
+        resolver: true
+  TmuxPane:
+    fields:
+      window:
+        resolver: true
+      title:
+        resolver: true
+      currentCommand:
+        resolver: true
+      currentPid:
+        resolver: true
+      width:
+        resolver: true
+      height:
+        resolver: true
+      dead:
+        resolver: true
+      watchingClients:
+        resolver: true
+      process:
+        resolver: true
+      claudeInstance:
+        resolver: true
+      content:
+        resolver: true
+      contentRange:
+        resolver: true
+      contentFull:
+        resolver: true
+  TmuxClient:
+    fields:
+      server:
+        resolver: true
+      session:
+        resolver: true
+      tty:
+        resolver: true
+      hostname:
+        resolver: true
+      termName:
+        resolver: true
+      attachedAt:
+        resolver: true
+      lastActivityAt:
+        resolver: true
+      readonly:
+        resolver: true
+      currentWindow:
+        resolver: true
+      currentPane:
+        resolver: true

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -34,6 +34,7 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server"
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 )
 
 // Command returns the `daemon` subcommand group rooted with three leaves.
@@ -120,12 +121,22 @@ func runStart(parentCtx context.Context, addr string) error {
 	// for v1 — the host provider (Workstream G) replaces this with a
 	// real machine id once it lands.
 	psProvider := ps.New(ps.NewAdapter("local"), logger)
+	tmuxProvider := tmux.New(tmux.NewAdapter(localHostID()), logger)
 
 	srv := server.New(addr, logger,
 		server.WithProjects(configProvider),
 		server.WithPS(psProvider),
+		server.WithTmux(tmuxProvider),
 	)
 	return srv.Run(ctx)
+}
+
+// localHostID returns the host id every tmux node carries. v1 stays
+// neutral (`local`); ws-b-host promotes this to the OS-issued machine
+// id, but until that adapter lands on this branch a fixed string is
+// fine — node ids are still per-host stable within one orchard process.
+func localHostID() tmux.HostID {
+	return tmux.HostID("local")
 }
 
 // runStop reads the pidfile and signals the running daemon.

--- a/internal/cli/query/panes.go
+++ b/internal/cli/query/panes.go
@@ -1,0 +1,201 @@
+// `orchard query panes` — list tmux panes from the local daemon.
+//
+// Usage:
+//
+//	orchard query panes
+//	orchard query panes --where currentCommand=claude
+//	orchard query panes --where session=main --where currentCommand=zsh
+//
+// `--where KEY=VALUE` is repeatable; multiple filters AND-combine.
+// Recognised keys (mirror `TmuxPaneFilter`):
+//
+//	currentCommand    foreground command basename
+//	paneId            tmux pane id (e.g. %26)
+//	session           session name
+//	titleContains     case-sensitive substring of pane_title
+//	dead              true / false
+//
+// Output is JSON for downstream tooling.
+
+package query
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func panesCmd() *cobra.Command {
+	var where []string
+	c := &cobra.Command{
+		Use:   "panes",
+		Short: "List tmux panes visible to the local daemon (JSON)",
+		Long: "Query the running orchard daemon for tmux panes. " +
+			"Use --where KEY=VALUE (repeatable) to filter; multiple " +
+			"filters AND-combine.\n\n" +
+			"Recognised keys: currentCommand, paneId, session, " +
+			"titleContains, dead.",
+		Example: "  orchard query panes\n" +
+			"  orchard query panes --where currentCommand=claude\n" +
+			"  orchard query panes --where session=main --where currentCommand=zsh",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPanes(cmd.Context(), cmd.OutOrStdout(), where)
+		},
+	}
+	c.Flags().StringSliceVar(&where, "where", nil, "filter expression KEY=VALUE (repeat for AND)")
+	return c
+}
+
+const panesQuery = `query Panes($filter: TmuxPaneFilter) {
+  tmuxPanes(filter: $filter) {
+    id
+    paneId
+    title
+    currentCommand
+    currentPid
+    width
+    height
+    dead
+  }
+}`
+
+type panesEntry struct {
+	ID             string `json:"id"`
+	PaneID         string `json:"paneId"`
+	Title          string `json:"title"`
+	CurrentCommand string `json:"currentCommand"`
+	CurrentPid     *int64 `json:"currentPid,omitempty"`
+	Width          int64  `json:"width"`
+	Height         int64  `json:"height"`
+	Dead           bool   `json:"dead"`
+}
+
+type panesResponse struct {
+	Panes  []panesEntry      `json:"panes"`
+	Errors []json.RawMessage `json:"errors,omitempty"`
+}
+
+func runPanes(ctx context.Context, w io.Writer, where []string) error {
+	filter, err := parsePaneWhere(where)
+	if err != nil {
+		return err
+	}
+
+	var variables map[string]any
+	if len(filter) > 0 {
+		variables = map[string]any{"filter": filter}
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"query":     panesQuery,
+		"variables": variables,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, resolveDaemonURL()+"/graphql", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("daemon not running, start with `orchard daemon start` (%w)", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var envelope struct {
+		Data struct {
+			TmuxPanes []panesEntry `json:"tmuxPanes"`
+		} `json:"data"`
+		Errors []json.RawMessage `json:"errors"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	out := panesResponse{
+		Panes:  envelope.Data.TmuxPanes,
+		Errors: envelope.Errors,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		return fmt.Errorf("encode output: %w", err)
+	}
+	return nil
+}
+
+// parsePaneWhere converts `--where KEY=VALUE` flags into the GraphQL
+// TmuxPaneFilter shape. Unknown keys are an error so users notice typos
+// instead of silently getting the unfiltered set.
+func parsePaneWhere(exprs []string) (map[string]any, error) {
+	out := map[string]any{}
+	for _, raw := range exprs {
+		eq := strings.IndexByte(raw, '=')
+		if eq <= 0 {
+			return nil, fmt.Errorf("--where %q: expected KEY=VALUE", raw)
+		}
+		key := strings.TrimSpace(raw[:eq])
+		value := strings.TrimSpace(raw[eq+1:])
+		if value == "" {
+			return nil, fmt.Errorf("--where %q: empty value", raw)
+		}
+		switch key {
+		case "currentCommand":
+			out["currentCommandIn"] = appendStringList(out["currentCommandIn"], value)
+		case "paneId":
+			out["paneIdIn"] = appendStringList(out["paneIdIn"], value)
+		case "session":
+			out["sessionIn"] = appendStringList(out["sessionIn"], value)
+		case "titleContains":
+			out["titleContains"] = value
+		case "dead":
+			b, err := parseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("--where dead=%q: %w", value, err)
+			}
+			out["dead"] = b
+		default:
+			return nil, fmt.Errorf("--where %q: unknown key (allowed: currentCommand, paneId, session, titleContains, dead)", key)
+		}
+	}
+	return out, nil
+}
+
+func appendStringList(prev any, value string) []string {
+	if prev == nil {
+		return []string{value}
+	}
+	if list, ok := prev.([]string); ok {
+		return append(list, value)
+	}
+	return []string{value}
+}
+
+func parseBool(s string) (bool, error) {
+	switch strings.ToLower(s) {
+	case "true", "1", "yes", "y":
+		return true, nil
+	case "false", "0", "no", "n":
+		return false, nil
+	}
+	return false, fmt.Errorf("expected true|false")
+}

--- a/internal/cli/query/query.go
+++ b/internal/cli/query/query.go
@@ -54,24 +54,26 @@ func Command() *cobra.Command {
 		Aliases: []string{"q"},
 		Short:   "Query the running orchard daemon via GraphQL",
 		Long: "Dispatch GraphQL queries against the running daemon at " + server.DefaultAddr + ".\n\n" +
-			"Use a named verb (e.g. `host`, `projects`, `processes`) for high-level reads,\n" +
+			"Use a named verb (e.g. `host`, `projects`, `processes`, `panes`) for high-level reads,\n" +
 			"or `--raw '<gql>'` as the escape hatch when you need a custom GraphQL query.",
 		Example: "  orchard query host\n" +
 			"  orchard query projects\n" +
 			"  orchard query processes\n" +
+			"  orchard query panes\n" +
 			"  orchard query --raw 'query { health { status } }'",
 	}
 	var raw string
 	cmd.Flags().StringVar(&raw, "raw", "", "raw GraphQL query string")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		if raw == "" {
-			return fmt.Errorf("provide a verb (e.g. `host`, `projects`, `processes`) or --raw '<graphql>'")
+			return fmt.Errorf("provide a verb (e.g. `host`, `projects`, `processes`, `panes`) or --raw '<graphql>'")
 		}
 		return runRaw(cmd.Context(), cmd.OutOrStdout(), raw)
 	}
 	cmd.AddCommand(hostCmd())
 	cmd.AddCommand(projectsCmd())
 	cmd.AddCommand(processesCmd())
+	cmd.AddCommand(panesCmd())
 	return cmd
 }
 

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -41,6 +41,11 @@ type ResolverRoot interface {
 	Process() ProcessResolver
 	Project() ProjectResolver
 	Query() QueryResolver
+	TmuxClient() TmuxClientResolver
+	TmuxPane() TmuxPaneResolver
+	TmuxServer() TmuxServerResolver
+	TmuxSession() TmuxSessionResolver
+	TmuxWindow() TmuxWindowResolver
 	Worktree() WorktreeResolver
 }
 
@@ -95,10 +100,13 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Health   func(childComplexity int) int
-		Host     func(childComplexity int) int
-		Hosts    func(childComplexity int) int
-		Projects func(childComplexity int) int
+		Health       func(childComplexity int) int
+		Host         func(childComplexity int) int
+		Hosts        func(childComplexity int) int
+		Projects     func(childComplexity int) int
+		TmuxPanes    func(childComplexity int, filter *TmuxPaneFilter) int
+		TmuxServer   func(childComplexity int) int
+		TmuxSessions func(childComplexity int, filter *TmuxSessionFilter) int
 	}
 
 	ResourceLoad struct {
@@ -108,6 +116,70 @@ type ComplexityRoot struct {
 		LoadAvg1m   func(childComplexity int) int
 		LoadAvg5m   func(childComplexity int) int
 		MemPercent  func(childComplexity int) int
+	}
+
+	TmuxClient struct {
+		AttachedAt     func(childComplexity int) int
+		CurrentPane    func(childComplexity int) int
+		CurrentWindow  func(childComplexity int) int
+		Hostname       func(childComplexity int) int
+		ID             func(childComplexity int) int
+		LastActivityAt func(childComplexity int) int
+		Readonly       func(childComplexity int) int
+		Server         func(childComplexity int) int
+		Session        func(childComplexity int) int
+		TermName       func(childComplexity int) int
+		Tty            func(childComplexity int) int
+	}
+
+	TmuxPane struct {
+		ClaudeInstance  func(childComplexity int) int
+		Content         func(childComplexity int, lines *int64, stripAnsi *bool) int
+		ContentFull     func(childComplexity int, stripAnsi *bool) int
+		ContentRange    func(childComplexity int, startLine int64, endLine int64, stripAnsi *bool) int
+		CurrentCommand  func(childComplexity int) int
+		CurrentPid      func(childComplexity int) int
+		Dead            func(childComplexity int) int
+		Height          func(childComplexity int) int
+		ID              func(childComplexity int) int
+		PaneID          func(childComplexity int) int
+		Process         func(childComplexity int) int
+		Title           func(childComplexity int) int
+		WatchingClients func(childComplexity int) int
+		Width           func(childComplexity int) int
+		Window          func(childComplexity int) int
+	}
+
+	TmuxServer struct {
+		Alive      func(childComplexity int) int
+		Clients    func(childComplexity int) int
+		ID         func(childComplexity int) int
+		Pid        func(childComplexity int) int
+		Sessions   func(childComplexity int) int
+		SocketPath func(childComplexity int) int
+	}
+
+	TmuxSession struct {
+		ActiveAttached  func(childComplexity int) int
+		Attached        func(childComplexity int) int
+		AttachedClients func(childComplexity int) int
+		CreatedAt       func(childComplexity int) int
+		CurrentWindow   func(childComplexity int) int
+		ID              func(childComplexity int) int
+		LastActivityAt  func(childComplexity int) int
+		Name            func(childComplexity int) int
+		Server          func(childComplexity int) int
+		Windows         func(childComplexity int) int
+	}
+
+	TmuxWindow struct {
+		Active      func(childComplexity int) int
+		CurrentPane func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Index       func(childComplexity int) int
+		Name        func(childComplexity int) int
+		Panes       func(childComplexity int) int
+		Session     func(childComplexity int) int
 	}
 
 	Worktree struct {
@@ -140,6 +212,62 @@ type QueryResolver interface {
 	Host(ctx context.Context) (*Host, error)
 	Hosts(ctx context.Context) ([]*Host, error)
 	Projects(ctx context.Context) ([]*Project, error)
+	TmuxServer(ctx context.Context) (*TmuxServer, error)
+	TmuxSessions(ctx context.Context, filter *TmuxSessionFilter) ([]*TmuxSession, error)
+	TmuxPanes(ctx context.Context, filter *TmuxPaneFilter) ([]*TmuxPane, error)
+}
+type TmuxClientResolver interface {
+	Server(ctx context.Context, obj *TmuxClient) (*TmuxServer, error)
+	Session(ctx context.Context, obj *TmuxClient) (*TmuxSession, error)
+	Tty(ctx context.Context, obj *TmuxClient) (string, error)
+	Hostname(ctx context.Context, obj *TmuxClient) (string, error)
+	TermName(ctx context.Context, obj *TmuxClient) (string, error)
+	AttachedAt(ctx context.Context, obj *TmuxClient) (string, error)
+	LastActivityAt(ctx context.Context, obj *TmuxClient) (*string, error)
+	Readonly(ctx context.Context, obj *TmuxClient) (bool, error)
+	CurrentWindow(ctx context.Context, obj *TmuxClient) (*TmuxWindow, error)
+	CurrentPane(ctx context.Context, obj *TmuxClient) (*TmuxPane, error)
+}
+type TmuxPaneResolver interface {
+	Window(ctx context.Context, obj *TmuxPane) (*TmuxWindow, error)
+
+	Title(ctx context.Context, obj *TmuxPane) (string, error)
+	CurrentCommand(ctx context.Context, obj *TmuxPane) (string, error)
+	CurrentPid(ctx context.Context, obj *TmuxPane) (*int64, error)
+	Width(ctx context.Context, obj *TmuxPane) (int64, error)
+	Height(ctx context.Context, obj *TmuxPane) (int64, error)
+	Dead(ctx context.Context, obj *TmuxPane) (bool, error)
+	WatchingClients(ctx context.Context, obj *TmuxPane) ([]*TmuxClient, error)
+	Process(ctx context.Context, obj *TmuxPane) (*Process, error)
+	ClaudeInstance(ctx context.Context, obj *TmuxPane) (*ClaudeInstance, error)
+	Content(ctx context.Context, obj *TmuxPane, lines *int64, stripAnsi *bool) (string, error)
+	ContentRange(ctx context.Context, obj *TmuxPane, startLine int64, endLine int64, stripAnsi *bool) (string, error)
+	ContentFull(ctx context.Context, obj *TmuxPane, stripAnsi *bool) (string, error)
+}
+type TmuxServerResolver interface {
+	Pid(ctx context.Context, obj *TmuxServer) (*int64, error)
+	Alive(ctx context.Context, obj *TmuxServer) (bool, error)
+	Sessions(ctx context.Context, obj *TmuxServer) ([]*TmuxSession, error)
+	Clients(ctx context.Context, obj *TmuxServer) ([]*TmuxClient, error)
+}
+type TmuxSessionResolver interface {
+	Server(ctx context.Context, obj *TmuxSession) (*TmuxServer, error)
+
+	CreatedAt(ctx context.Context, obj *TmuxSession) (string, error)
+	Attached(ctx context.Context, obj *TmuxSession) (bool, error)
+	ActiveAttached(ctx context.Context, obj *TmuxSession) (bool, error)
+	AttachedClients(ctx context.Context, obj *TmuxSession) ([]*TmuxClient, error)
+	LastActivityAt(ctx context.Context, obj *TmuxSession) (*string, error)
+	Windows(ctx context.Context, obj *TmuxSession) ([]*TmuxWindow, error)
+	CurrentWindow(ctx context.Context, obj *TmuxSession) (*TmuxWindow, error)
+}
+type TmuxWindowResolver interface {
+	Session(ctx context.Context, obj *TmuxWindow) (*TmuxSession, error)
+
+	Name(ctx context.Context, obj *TmuxWindow) (string, error)
+	Active(ctx context.Context, obj *TmuxWindow) (bool, error)
+	Panes(ctx context.Context, obj *TmuxWindow) ([]*TmuxPane, error)
+	CurrentPane(ctx context.Context, obj *TmuxWindow) (*TmuxPane, error)
 }
 type WorktreeResolver interface {
 	Processes(ctx context.Context, obj *Worktree) ([]*Process, error)
@@ -414,6 +542,37 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Projects(childComplexity), true
 
+	case "Query.tmuxPanes":
+		if e.complexity.Query.TmuxPanes == nil {
+			break
+		}
+
+		args, err := ec.field_Query_tmuxPanes_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.TmuxPanes(childComplexity, args["filter"].(*TmuxPaneFilter)), true
+
+	case "Query.tmuxServer":
+		if e.complexity.Query.TmuxServer == nil {
+			break
+		}
+
+		return e.complexity.Query.TmuxServer(childComplexity), true
+
+	case "Query.tmuxSessions":
+		if e.complexity.Query.TmuxSessions == nil {
+			break
+		}
+
+		args, err := ec.field_Query_tmuxSessions_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.TmuxSessions(childComplexity, args["filter"].(*TmuxSessionFilter)), true
+
 	case "ResourceLoad.cpuPercent":
 		if e.complexity.ResourceLoad.CPUPercent == nil {
 			break
@@ -455,6 +614,364 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ResourceLoad.MemPercent(childComplexity), true
+
+	case "TmuxClient.attachedAt":
+		if e.complexity.TmuxClient.AttachedAt == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.AttachedAt(childComplexity), true
+
+	case "TmuxClient.currentPane":
+		if e.complexity.TmuxClient.CurrentPane == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.CurrentPane(childComplexity), true
+
+	case "TmuxClient.currentWindow":
+		if e.complexity.TmuxClient.CurrentWindow == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.CurrentWindow(childComplexity), true
+
+	case "TmuxClient.hostname":
+		if e.complexity.TmuxClient.Hostname == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.Hostname(childComplexity), true
+
+	case "TmuxClient.id":
+		if e.complexity.TmuxClient.ID == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.ID(childComplexity), true
+
+	case "TmuxClient.lastActivityAt":
+		if e.complexity.TmuxClient.LastActivityAt == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.LastActivityAt(childComplexity), true
+
+	case "TmuxClient.readonly":
+		if e.complexity.TmuxClient.Readonly == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.Readonly(childComplexity), true
+
+	case "TmuxClient.server":
+		if e.complexity.TmuxClient.Server == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.Server(childComplexity), true
+
+	case "TmuxClient.session":
+		if e.complexity.TmuxClient.Session == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.Session(childComplexity), true
+
+	case "TmuxClient.termName":
+		if e.complexity.TmuxClient.TermName == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.TermName(childComplexity), true
+
+	case "TmuxClient.tty":
+		if e.complexity.TmuxClient.Tty == nil {
+			break
+		}
+
+		return e.complexity.TmuxClient.Tty(childComplexity), true
+
+	case "TmuxPane.claudeInstance":
+		if e.complexity.TmuxPane.ClaudeInstance == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.ClaudeInstance(childComplexity), true
+
+	case "TmuxPane.content":
+		if e.complexity.TmuxPane.Content == nil {
+			break
+		}
+
+		args, err := ec.field_TmuxPane_content_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.TmuxPane.Content(childComplexity, args["lines"].(*int64), args["stripAnsi"].(*bool)), true
+
+	case "TmuxPane.contentFull":
+		if e.complexity.TmuxPane.ContentFull == nil {
+			break
+		}
+
+		args, err := ec.field_TmuxPane_contentFull_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.TmuxPane.ContentFull(childComplexity, args["stripAnsi"].(*bool)), true
+
+	case "TmuxPane.contentRange":
+		if e.complexity.TmuxPane.ContentRange == nil {
+			break
+		}
+
+		args, err := ec.field_TmuxPane_contentRange_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.TmuxPane.ContentRange(childComplexity, args["startLine"].(int64), args["endLine"].(int64), args["stripAnsi"].(*bool)), true
+
+	case "TmuxPane.currentCommand":
+		if e.complexity.TmuxPane.CurrentCommand == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.CurrentCommand(childComplexity), true
+
+	case "TmuxPane.currentPid":
+		if e.complexity.TmuxPane.CurrentPid == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.CurrentPid(childComplexity), true
+
+	case "TmuxPane.dead":
+		if e.complexity.TmuxPane.Dead == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.Dead(childComplexity), true
+
+	case "TmuxPane.height":
+		if e.complexity.TmuxPane.Height == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.Height(childComplexity), true
+
+	case "TmuxPane.id":
+		if e.complexity.TmuxPane.ID == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.ID(childComplexity), true
+
+	case "TmuxPane.paneId":
+		if e.complexity.TmuxPane.PaneID == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.PaneID(childComplexity), true
+
+	case "TmuxPane.process":
+		if e.complexity.TmuxPane.Process == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.Process(childComplexity), true
+
+	case "TmuxPane.title":
+		if e.complexity.TmuxPane.Title == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.Title(childComplexity), true
+
+	case "TmuxPane.watchingClients":
+		if e.complexity.TmuxPane.WatchingClients == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.WatchingClients(childComplexity), true
+
+	case "TmuxPane.width":
+		if e.complexity.TmuxPane.Width == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.Width(childComplexity), true
+
+	case "TmuxPane.window":
+		if e.complexity.TmuxPane.Window == nil {
+			break
+		}
+
+		return e.complexity.TmuxPane.Window(childComplexity), true
+
+	case "TmuxServer.alive":
+		if e.complexity.TmuxServer.Alive == nil {
+			break
+		}
+
+		return e.complexity.TmuxServer.Alive(childComplexity), true
+
+	case "TmuxServer.clients":
+		if e.complexity.TmuxServer.Clients == nil {
+			break
+		}
+
+		return e.complexity.TmuxServer.Clients(childComplexity), true
+
+	case "TmuxServer.id":
+		if e.complexity.TmuxServer.ID == nil {
+			break
+		}
+
+		return e.complexity.TmuxServer.ID(childComplexity), true
+
+	case "TmuxServer.pid":
+		if e.complexity.TmuxServer.Pid == nil {
+			break
+		}
+
+		return e.complexity.TmuxServer.Pid(childComplexity), true
+
+	case "TmuxServer.sessions":
+		if e.complexity.TmuxServer.Sessions == nil {
+			break
+		}
+
+		return e.complexity.TmuxServer.Sessions(childComplexity), true
+
+	case "TmuxServer.socketPath":
+		if e.complexity.TmuxServer.SocketPath == nil {
+			break
+		}
+
+		return e.complexity.TmuxServer.SocketPath(childComplexity), true
+
+	case "TmuxSession.activeAttached":
+		if e.complexity.TmuxSession.ActiveAttached == nil {
+			break
+		}
+
+		return e.complexity.TmuxSession.ActiveAttached(childComplexity), true
+
+	case "TmuxSession.attached":
+		if e.complexity.TmuxSession.Attached == nil {
+			break
+		}
+
+		return e.complexity.TmuxSession.Attached(childComplexity), true
+
+	case "TmuxSession.attachedClients":
+		if e.complexity.TmuxSession.AttachedClients == nil {
+			break
+		}
+
+		return e.complexity.TmuxSession.AttachedClients(childComplexity), true
+
+	case "TmuxSession.createdAt":
+		if e.complexity.TmuxSession.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.TmuxSession.CreatedAt(childComplexity), true
+
+	case "TmuxSession.currentWindow":
+		if e.complexity.TmuxSession.CurrentWindow == nil {
+			break
+		}
+
+		return e.complexity.TmuxSession.CurrentWindow(childComplexity), true
+
+	case "TmuxSession.id":
+		if e.complexity.TmuxSession.ID == nil {
+			break
+		}
+
+		return e.complexity.TmuxSession.ID(childComplexity), true
+
+	case "TmuxSession.lastActivityAt":
+		if e.complexity.TmuxSession.LastActivityAt == nil {
+			break
+		}
+
+		return e.complexity.TmuxSession.LastActivityAt(childComplexity), true
+
+	case "TmuxSession.name":
+		if e.complexity.TmuxSession.Name == nil {
+			break
+		}
+
+		return e.complexity.TmuxSession.Name(childComplexity), true
+
+	case "TmuxSession.server":
+		if e.complexity.TmuxSession.Server == nil {
+			break
+		}
+
+		return e.complexity.TmuxSession.Server(childComplexity), true
+
+	case "TmuxSession.windows":
+		if e.complexity.TmuxSession.Windows == nil {
+			break
+		}
+
+		return e.complexity.TmuxSession.Windows(childComplexity), true
+
+	case "TmuxWindow.active":
+		if e.complexity.TmuxWindow.Active == nil {
+			break
+		}
+
+		return e.complexity.TmuxWindow.Active(childComplexity), true
+
+	case "TmuxWindow.currentPane":
+		if e.complexity.TmuxWindow.CurrentPane == nil {
+			break
+		}
+
+		return e.complexity.TmuxWindow.CurrentPane(childComplexity), true
+
+	case "TmuxWindow.id":
+		if e.complexity.TmuxWindow.ID == nil {
+			break
+		}
+
+		return e.complexity.TmuxWindow.ID(childComplexity), true
+
+	case "TmuxWindow.index":
+		if e.complexity.TmuxWindow.Index == nil {
+			break
+		}
+
+		return e.complexity.TmuxWindow.Index(childComplexity), true
+
+	case "TmuxWindow.name":
+		if e.complexity.TmuxWindow.Name == nil {
+			break
+		}
+
+		return e.complexity.TmuxWindow.Name(childComplexity), true
+
+	case "TmuxWindow.panes":
+		if e.complexity.TmuxWindow.Panes == nil {
+			break
+		}
+
+		return e.complexity.TmuxWindow.Panes(childComplexity), true
+
+	case "TmuxWindow.session":
+		if e.complexity.TmuxWindow.Session == nil {
+			break
+		}
+
+		return e.complexity.TmuxWindow.Session(childComplexity), true
 
 	case "Worktree.bare":
 		if e.complexity.Worktree.Bare == nil {
@@ -507,6 +1024,8 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	ec := executionContext{rc, e, 0, 0, make(chan graphql.DeferredResult)}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputProcessFilter,
+		ec.unmarshalInputTmuxPaneFilter,
+		ec.unmarshalInputTmuxSessionFilter,
 	)
 	first := true
 
@@ -595,24 +1114,12 @@ var sources = []*ast.Source{
 # under internal/server/graphql/. The Rust TUI codegens its client from
 # the same file. Schema-first is intentional; see ADR-011.
 #
-# Workstream A scope: only the ` + "`" + `health` + "`" + ` field. Real node types come in
-# later workstreams.
-#
-# Workstream B-host: Host node + ResourceLoad. Identity surfaces machine
-# id, hostname, OS, kernel; resourceLoad surfaces live CPU/mem/disk/load
-# averages. peers ships empty until Workstream F federates orchard
-# instances together. Other providers add their own back-edges.
-#
-# Workstream B-config: Project node — projects declared in the orchard
-# config. Read-only; mutations go through ` + "`" + `orchard config add-repo` + "`" + `.
-#
-# Workstream B-git: Worktree node + Project.worktrees back-edge. Process
-# is forward-declared so Worktree.processes can reference it; ws-b-ps
-# fills in the rest.
-#
-# Workstream B-ps: full Process node + Host.processes(filter). Edges
-# to Worktree (via cwd) and ClaudeInstance (via foreground claude pid)
-# stay placeholder until their owning workstreams land.
+# Workstream A: only the ` + "`" + `health` + "`" + ` field.
+# Workstream B-host: Host node + ResourceLoad.
+# Workstream B-config: Project node — projects declared in orchard config.
+# Workstream B-git: Worktree node + Project.worktrees back-edge.
+# Workstream B-ps: full Process node + Host.processes(filter).
+# Workstream B-tmux: TmuxServer/Session/Window/Pane/Client + filtered queries.
 
 """
 A node in the orchard graph. Every node has a globally-unique id so
@@ -625,9 +1132,6 @@ interface Node {
 }
 
 # Process is an OS-level process surfaced via the ` + "`" + `ps` + "`" + ` adapter.
-# Identity: (host_id, pid). Lifetime: alive AND visible to ps.
-# Not enumerable from root — reach via ` + "`" + `host.processes` + "`" + ` etc.
-# See ADR-011 §5.1.
 type Process implements Node {
   "Stable id formatted as ` + "`" + `<host>:<pid>` + "`" + `."
   id: ID!
@@ -661,11 +1165,6 @@ type Process implements Node {
 
   "Controlling terminal, or null if none."
   tty: String
-
-  # Cross-provider edges — placeholders until their owning workstreams land.
-  # ws-b-git wires ` + "`" + `worktree` + "`" + ` via cwd → git worktree lookup;
-  # ws-b-claudeinstance (Wave 3) wires ` + "`" + `claudeInstance` + "`" + ` as the back-edge
-  # from a Claude pid.
 
   "Worktree this process is running inside, derived from cwd. Null until ws-b-git wires the lookup."
   worktree: Worktree
@@ -706,6 +1205,15 @@ type Query {
 
   "All projects declared in ~/.config/orchard/config.json. Read-only — projects are added with ` + "`" + `orchard config add-repo` + "`" + `."
   projects: [Project!]!
+
+  "The tmux server running on the local host. Null when no tmux daemon is reachable."
+  tmuxServer: TmuxServer
+
+  "Tmux sessions on the local host, optionally filtered. Empty when no tmux daemon is reachable."
+  tmuxSessions(filter: TmuxSessionFilter): [TmuxSession!]!
+
+  "Tmux panes on the local host, optionally filtered. Cheaper than walking the tree per-pane."
+  tmuxPanes(filter: TmuxPaneFilter): [TmuxPane!]!
 }
 
 type Health {
@@ -815,6 +1323,232 @@ type Worktree implements Node {
   "Processes whose cwd lies under ` + "`" + `path` + "`" + `. Resolved by the ps provider (ws-b-ps); returns ` + "`" + `[]` + "`" + ` until that provider lands."
   processes: [Process!]!
 }
+
+# ---------------------------------------------------------------------
+# Tmux node hierarchy — see ADR-011 §5.1.
+#
+# Identity scheme:
+#   TmuxServer:   ` + "`" + `TmuxServer:<host>:<socketPath>` + "`" + `
+#   TmuxSession:  ` + "`" + `TmuxSession:<host>:<sessionName>` + "`" + `
+#   TmuxWindow:   ` + "`" + `TmuxWindow:<host>:<sessionName>:<windowIndex>` + "`" + `
+#   TmuxPane:     ` + "`" + `TmuxPane:<host>:<paneId>` + "`" + `            (e.g. ` + "`" + `%26` + "`" + `)
+#   TmuxClient:   ` + "`" + `TmuxClient:<host>:<clientName>` + "`" + `
+# ---------------------------------------------------------------------
+
+"""
+The tmux daemon process on a host. v1 surfaces the local tmux only;
+multi-server setups (custom -L socket names) are reachable via socketPath.
+"""
+type TmuxServer implements Node {
+  "Stable id ` + "`" + `TmuxServer:<host>:<socketPath>` + "`" + `."
+  id: ID!
+
+  "Filesystem path of the tmux socket the daemon is listening on."
+  socketPath: String!
+
+  "Pid of the tmux daemon process. Null if not currently determinable."
+  pid: Int
+
+  "True while the tmux daemon answers a heartbeat command."
+  alive: Boolean!
+
+  "Sessions hosted on this server."
+  sessions: [TmuxSession!]!
+
+  "Clients currently connected to this server."
+  clients: [TmuxClient!]!
+}
+
+"""
+A named tmux session. Stable across detach/reattach. Identity is the
+session name within its server.
+"""
+type TmuxSession implements Node {
+  "Stable id ` + "`" + `TmuxSession:<host>:<sessionName>` + "`" + `."
+  id: ID!
+
+  "Server hosting this session."
+  server: TmuxServer!
+
+  "Session name."
+  name: String!
+
+  "RFC3339 timestamp of when the session was created."
+  createdAt: String!
+
+  "True when at least one client is attached to this session."
+  attached: Boolean!
+
+  "True when at least one attached client has had activity within the freshness window (default 5m)."
+  activeAttached: Boolean!
+
+  "Clients currently attached to this session."
+  attachedClients: [TmuxClient!]!
+
+  "Most recent activity timestamp across all panes/windows. RFC3339; null if never observed."
+  lastActivityAt: String
+
+  "Windows in this session."
+  windows: [TmuxWindow!]!
+
+  "The currently-focused window in this session."
+  currentWindow: TmuxWindow
+}
+
+"""
+A window inside a tmux session. Identity is the window index within its
+session.
+"""
+type TmuxWindow implements Node {
+  "Stable id ` + "`" + `TmuxWindow:<host>:<sessionName>:<windowIndex>` + "`" + `."
+  id: ID!
+
+  "Session this window belongs to."
+  session: TmuxSession!
+
+  "Window index, zero-based as tmux numbers them when -base-index is 0."
+  index: Int!
+
+  "Window name (tmux's ` + "`" + `window_name` + "`" + `)."
+  name: String!
+
+  "True when this window is the currently-focused window in its session."
+  active: Boolean!
+
+  "Panes in this window."
+  panes: [TmuxPane!]!
+
+  "The currently-focused pane in this window."
+  currentPane: TmuxPane
+}
+
+"""
+A pane inside a window — the leaf where commands actually run. Identity
+is the global tmux pane id (e.g. ` + "`" + `%26` + "`" + `) within a host.
+
+Content fields (` + "`" + `content` + "`" + `, ` + "`" + `contentRange` + "`" + `, ` + "`" + `contentFull` + "`" + `) shell out to
+` + "`" + `tmux capture-pane` + "`" + `. They are not poll-cached; queries that ask for them
+pay the per-call cost.
+"""
+type TmuxPane implements Node {
+  "Stable id ` + "`" + `TmuxPane:<host>:<paneId>` + "`" + `."
+  id: ID!
+
+  "Window this pane belongs to."
+  window: TmuxWindow!
+
+  "tmux pane id, including the leading ` + "`" + `%` + "`" + ` (e.g. ` + "`" + `%26` + "`" + `)."
+  paneId: String!
+
+  "Pane title (tmux ` + "`" + `pane_title` + "`" + `)."
+  title: String!
+
+  "Foreground command basename (tmux ` + "`" + `pane_current_command` + "`" + `, e.g. 'claude', 'zsh')."
+  currentCommand: String!
+
+  "Pid of the foreground process. Null when tmux reports no current pid."
+  currentPid: Int
+
+  "Pane width in cells."
+  width: Int!
+
+  "Pane height in cells."
+  height: Int!
+
+  "True when tmux marks the pane as dead (process exited, awaiting reuse/close)."
+  dead: Boolean!
+
+  "Clients with their cursor on this pane."
+  watchingClients: [TmuxClient!]!
+
+  "OS-level Process for the foreground pid. Null until ws-b-ps wires it."
+  process: Process
+
+  "Claude instance running in this pane, if the foreground command is claude. Null until ws-b-claudeinstance wires it."
+  claudeInstance: ClaudeInstance
+
+  "Last N lines of pane output, default 50. Strips ANSI escapes by default."
+  content(lines: Int = 50, stripAnsi: Boolean = true): String!
+
+  "Output between two history line numbers (tmux's -S/-E semantics)."
+  contentRange(startLine: Int!, endLine: Int!, stripAnsi: Boolean = true): String!
+
+  "Full visible-history pane buffer."
+  contentFull(stripAnsi: Boolean = true): String!
+}
+
+"""
+A client (terminal) attached to a tmux server. Multiple clients may share
+the same session/window/pane.
+"""
+type TmuxClient implements Node {
+  "Stable id ` + "`" + `TmuxClient:<host>:<clientName>` + "`" + `."
+  id: ID!
+
+  "Server this client connects to."
+  server: TmuxServer!
+
+  "Session this client is attached to."
+  session: TmuxSession!
+
+  "Client tty path (e.g. ` + "`" + `/dev/ttys003` + "`" + `)."
+  tty: String!
+
+  "Hostname the client originated from. Empty for local clients."
+  hostname: String!
+
+  "TERM value the client advertises (e.g. ` + "`" + `xterm-256color` + "`" + `)."
+  termName: String!
+
+  "RFC3339 attach time."
+  attachedAt: String!
+
+  "RFC3339 last activity time. Null if tmux returned no value."
+  lastActivityAt: String
+
+  "True when the client is in read-only mode."
+  readonly: Boolean!
+
+  "Window the client is currently looking at."
+  currentWindow: TmuxWindow
+
+  "Pane the client is currently looking at."
+  currentPane: TmuxPane
+}
+
+# ---------------------------------------------------------------------
+# Filter inputs — applied at the resolver layer per ADR-011 §6.
+# ---------------------------------------------------------------------
+
+"Filter for ` + "`" + `Query.tmuxSessions` + "`" + `. AND-combined when multiple are set."
+input TmuxSessionFilter {
+  "Session names to include."
+  nameIn: [String!]
+
+  "Only include sessions with at least one attached client."
+  attachedOnly: Boolean
+
+  "Only include sessions with active-attached clients within the freshness window."
+  activeAttachedOnly: Boolean
+}
+
+"Filter for ` + "`" + `Query.tmuxPanes` + "`" + `. AND-combined when multiple are set."
+input TmuxPaneFilter {
+  "Pane ids (e.g. ` + "`" + `%26` + "`" + `) to include."
+  paneIdIn: [String!]
+
+  "Only include panes whose ` + "`" + `currentCommand` + "`" + ` is in this list."
+  currentCommandIn: [String!]
+
+  "Only include panes in these session names."
+  sessionIn: [String!]
+
+  "Only include panes whose ` + "`" + `pane_title` + "`" + ` matches the substring (case-sensitive)."
+  titleContains: String
+
+  "Only include dead (or non-dead) panes."
+  dead: Boolean
+}
 `, BuiltIn: false},
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)
@@ -850,6 +1584,108 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 		}
 	}
 	args["name"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_tmuxPanes_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *TmuxPaneFilter
+	if tmp, ok := rawArgs["filter"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+		arg0, err = ec.unmarshalOTmuxPaneFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPaneFilter(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["filter"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_tmuxSessions_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *TmuxSessionFilter
+	if tmp, ok := rawArgs["filter"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+		arg0, err = ec.unmarshalOTmuxSessionFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSessionFilter(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["filter"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_TmuxPane_contentFull_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *bool
+	if tmp, ok := rawArgs["stripAnsi"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("stripAnsi"))
+		arg0, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["stripAnsi"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_TmuxPane_contentRange_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 int64
+	if tmp, ok := rawArgs["startLine"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("startLine"))
+		arg0, err = ec.unmarshalNInt2int64(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["startLine"] = arg0
+	var arg1 int64
+	if tmp, ok := rawArgs["endLine"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("endLine"))
+		arg1, err = ec.unmarshalNInt2int64(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["endLine"] = arg1
+	var arg2 *bool
+	if tmp, ok := rawArgs["stripAnsi"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("stripAnsi"))
+		arg2, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["stripAnsi"] = arg2
+	return args, nil
+}
+
+func (ec *executionContext) field_TmuxPane_content_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *int64
+	if tmp, ok := rawArgs["lines"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("lines"))
+		arg0, err = ec.unmarshalOInt2ᚖint64(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["lines"] = arg0
+	var arg1 *bool
+	if tmp, ok := rawArgs["stripAnsi"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("stripAnsi"))
+		arg1, err = ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["stripAnsi"] = arg1
 	return args, nil
 }
 
@@ -2604,6 +3440,225 @@ func (ec *executionContext) fieldContext_Query_projects(ctx context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_tmuxServer(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_tmuxServer(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().TmuxServer(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxServer)
+	fc.Result = res
+	return ec.marshalOTmuxServer2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxServer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_tmuxServer(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxServer_id(ctx, field)
+			case "socketPath":
+				return ec.fieldContext_TmuxServer_socketPath(ctx, field)
+			case "pid":
+				return ec.fieldContext_TmuxServer_pid(ctx, field)
+			case "alive":
+				return ec.fieldContext_TmuxServer_alive(ctx, field)
+			case "sessions":
+				return ec.fieldContext_TmuxServer_sessions(ctx, field)
+			case "clients":
+				return ec.fieldContext_TmuxServer_clients(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxServer", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_tmuxSessions(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_tmuxSessions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().TmuxSessions(rctx, fc.Args["filter"].(*TmuxSessionFilter))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*TmuxSession)
+	fc.Result = res
+	return ec.marshalNTmuxSession2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSessionᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_tmuxSessions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxSession_id(ctx, field)
+			case "server":
+				return ec.fieldContext_TmuxSession_server(ctx, field)
+			case "name":
+				return ec.fieldContext_TmuxSession_name(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TmuxSession_createdAt(ctx, field)
+			case "attached":
+				return ec.fieldContext_TmuxSession_attached(ctx, field)
+			case "activeAttached":
+				return ec.fieldContext_TmuxSession_activeAttached(ctx, field)
+			case "attachedClients":
+				return ec.fieldContext_TmuxSession_attachedClients(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_TmuxSession_lastActivityAt(ctx, field)
+			case "windows":
+				return ec.fieldContext_TmuxSession_windows(ctx, field)
+			case "currentWindow":
+				return ec.fieldContext_TmuxSession_currentWindow(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxSession", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_tmuxSessions_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_tmuxPanes(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_tmuxPanes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().TmuxPanes(rctx, fc.Args["filter"].(*TmuxPaneFilter))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*TmuxPane)
+	fc.Result = res
+	return ec.marshalNTmuxPane2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPaneᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_tmuxPanes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxPane_id(ctx, field)
+			case "window":
+				return ec.fieldContext_TmuxPane_window(ctx, field)
+			case "paneId":
+				return ec.fieldContext_TmuxPane_paneId(ctx, field)
+			case "title":
+				return ec.fieldContext_TmuxPane_title(ctx, field)
+			case "currentCommand":
+				return ec.fieldContext_TmuxPane_currentCommand(ctx, field)
+			case "currentPid":
+				return ec.fieldContext_TmuxPane_currentPid(ctx, field)
+			case "width":
+				return ec.fieldContext_TmuxPane_width(ctx, field)
+			case "height":
+				return ec.fieldContext_TmuxPane_height(ctx, field)
+			case "dead":
+				return ec.fieldContext_TmuxPane_dead(ctx, field)
+			case "watchingClients":
+				return ec.fieldContext_TmuxPane_watchingClients(ctx, field)
+			case "process":
+				return ec.fieldContext_TmuxPane_process(ctx, field)
+			case "claudeInstance":
+				return ec.fieldContext_TmuxPane_claudeInstance(ctx, field)
+			case "content":
+				return ec.fieldContext_TmuxPane_content(ctx, field)
+			case "contentRange":
+				return ec.fieldContext_TmuxPane_contentRange(ctx, field)
+			case "contentFull":
+				return ec.fieldContext_TmuxPane_contentFull(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxPane", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_tmuxPanes_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -2992,6 +4047,2523 @@ func (ec *executionContext) fieldContext_ResourceLoad_loadAvg15m(ctx context.Con
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_id(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_server(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_server(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxClient().Server(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxServer)
+	fc.Result = res
+	return ec.marshalNTmuxServer2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxServer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_server(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxServer_id(ctx, field)
+			case "socketPath":
+				return ec.fieldContext_TmuxServer_socketPath(ctx, field)
+			case "pid":
+				return ec.fieldContext_TmuxServer_pid(ctx, field)
+			case "alive":
+				return ec.fieldContext_TmuxServer_alive(ctx, field)
+			case "sessions":
+				return ec.fieldContext_TmuxServer_sessions(ctx, field)
+			case "clients":
+				return ec.fieldContext_TmuxServer_clients(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxServer", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_session(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_session(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxClient().Session(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxSession)
+	fc.Result = res
+	return ec.marshalNTmuxSession2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSession(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_session(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxSession_id(ctx, field)
+			case "server":
+				return ec.fieldContext_TmuxSession_server(ctx, field)
+			case "name":
+				return ec.fieldContext_TmuxSession_name(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TmuxSession_createdAt(ctx, field)
+			case "attached":
+				return ec.fieldContext_TmuxSession_attached(ctx, field)
+			case "activeAttached":
+				return ec.fieldContext_TmuxSession_activeAttached(ctx, field)
+			case "attachedClients":
+				return ec.fieldContext_TmuxSession_attachedClients(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_TmuxSession_lastActivityAt(ctx, field)
+			case "windows":
+				return ec.fieldContext_TmuxSession_windows(ctx, field)
+			case "currentWindow":
+				return ec.fieldContext_TmuxSession_currentWindow(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxSession", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_tty(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_tty(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxClient().Tty(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_tty(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_hostname(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_hostname(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxClient().Hostname(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_hostname(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_termName(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_termName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxClient().TermName(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_termName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_attachedAt(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_attachedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxClient().AttachedAt(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_attachedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_lastActivityAt(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_lastActivityAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxClient().LastActivityAt(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_lastActivityAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_readonly(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_readonly(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxClient().Readonly(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_readonly(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_currentWindow(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_currentWindow(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxClient().CurrentWindow(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxWindow)
+	fc.Result = res
+	return ec.marshalOTmuxWindow2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxWindow(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_currentWindow(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxWindow_id(ctx, field)
+			case "session":
+				return ec.fieldContext_TmuxWindow_session(ctx, field)
+			case "index":
+				return ec.fieldContext_TmuxWindow_index(ctx, field)
+			case "name":
+				return ec.fieldContext_TmuxWindow_name(ctx, field)
+			case "active":
+				return ec.fieldContext_TmuxWindow_active(ctx, field)
+			case "panes":
+				return ec.fieldContext_TmuxWindow_panes(ctx, field)
+			case "currentPane":
+				return ec.fieldContext_TmuxWindow_currentPane(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxWindow", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxClient_currentPane(ctx context.Context, field graphql.CollectedField, obj *TmuxClient) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxClient_currentPane(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxClient().CurrentPane(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxPane)
+	fc.Result = res
+	return ec.marshalOTmuxPane2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPane(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxClient_currentPane(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxClient",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxPane_id(ctx, field)
+			case "window":
+				return ec.fieldContext_TmuxPane_window(ctx, field)
+			case "paneId":
+				return ec.fieldContext_TmuxPane_paneId(ctx, field)
+			case "title":
+				return ec.fieldContext_TmuxPane_title(ctx, field)
+			case "currentCommand":
+				return ec.fieldContext_TmuxPane_currentCommand(ctx, field)
+			case "currentPid":
+				return ec.fieldContext_TmuxPane_currentPid(ctx, field)
+			case "width":
+				return ec.fieldContext_TmuxPane_width(ctx, field)
+			case "height":
+				return ec.fieldContext_TmuxPane_height(ctx, field)
+			case "dead":
+				return ec.fieldContext_TmuxPane_dead(ctx, field)
+			case "watchingClients":
+				return ec.fieldContext_TmuxPane_watchingClients(ctx, field)
+			case "process":
+				return ec.fieldContext_TmuxPane_process(ctx, field)
+			case "claudeInstance":
+				return ec.fieldContext_TmuxPane_claudeInstance(ctx, field)
+			case "content":
+				return ec.fieldContext_TmuxPane_content(ctx, field)
+			case "contentRange":
+				return ec.fieldContext_TmuxPane_contentRange(ctx, field)
+			case "contentFull":
+				return ec.fieldContext_TmuxPane_contentFull(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxPane", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_id(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_window(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_window(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().Window(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxWindow)
+	fc.Result = res
+	return ec.marshalNTmuxWindow2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxWindow(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_window(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxWindow_id(ctx, field)
+			case "session":
+				return ec.fieldContext_TmuxWindow_session(ctx, field)
+			case "index":
+				return ec.fieldContext_TmuxWindow_index(ctx, field)
+			case "name":
+				return ec.fieldContext_TmuxWindow_name(ctx, field)
+			case "active":
+				return ec.fieldContext_TmuxWindow_active(ctx, field)
+			case "panes":
+				return ec.fieldContext_TmuxWindow_panes(ctx, field)
+			case "currentPane":
+				return ec.fieldContext_TmuxWindow_currentPane(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxWindow", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_paneId(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_paneId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PaneID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_paneId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_title(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_title(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().Title(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_title(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_currentCommand(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_currentCommand(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().CurrentCommand(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_currentCommand(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_currentPid(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_currentPid(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().CurrentPid(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_currentPid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_width(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_width(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().Width(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_width(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_height(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_height(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().Height(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_height(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_dead(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_dead(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().Dead(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_dead(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_watchingClients(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_watchingClients(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().WatchingClients(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*TmuxClient)
+	fc.Result = res
+	return ec.marshalNTmuxClient2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxClientᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_watchingClients(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxClient_id(ctx, field)
+			case "server":
+				return ec.fieldContext_TmuxClient_server(ctx, field)
+			case "session":
+				return ec.fieldContext_TmuxClient_session(ctx, field)
+			case "tty":
+				return ec.fieldContext_TmuxClient_tty(ctx, field)
+			case "hostname":
+				return ec.fieldContext_TmuxClient_hostname(ctx, field)
+			case "termName":
+				return ec.fieldContext_TmuxClient_termName(ctx, field)
+			case "attachedAt":
+				return ec.fieldContext_TmuxClient_attachedAt(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_TmuxClient_lastActivityAt(ctx, field)
+			case "readonly":
+				return ec.fieldContext_TmuxClient_readonly(ctx, field)
+			case "currentWindow":
+				return ec.fieldContext_TmuxClient_currentWindow(ctx, field)
+			case "currentPane":
+				return ec.fieldContext_TmuxClient_currentPane(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxClient", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_process(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_process(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().Process(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*Process)
+	fc.Result = res
+	return ec.marshalOProcess2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcess(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_process(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Process_id(ctx, field)
+			case "host":
+				return ec.fieldContext_Process_host(ctx, field)
+			case "pid":
+				return ec.fieldContext_Process_pid(ctx, field)
+			case "ppid":
+				return ec.fieldContext_Process_ppid(ctx, field)
+			case "command":
+				return ec.fieldContext_Process_command(ctx, field)
+			case "args":
+				return ec.fieldContext_Process_args(ctx, field)
+			case "cwd":
+				return ec.fieldContext_Process_cwd(ctx, field)
+			case "startedAt":
+				return ec.fieldContext_Process_startedAt(ctx, field)
+			case "cpuPercent":
+				return ec.fieldContext_Process_cpuPercent(ctx, field)
+			case "memBytes":
+				return ec.fieldContext_Process_memBytes(ctx, field)
+			case "tty":
+				return ec.fieldContext_Process_tty(ctx, field)
+			case "worktree":
+				return ec.fieldContext_Process_worktree(ctx, field)
+			case "claudeInstance":
+				return ec.fieldContext_Process_claudeInstance(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Process", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_claudeInstance(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_claudeInstance(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().ClaudeInstance(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*ClaudeInstance)
+	fc.Result = res
+	return ec.marshalOClaudeInstance2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐClaudeInstance(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_claudeInstance(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ClaudeInstance_id(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_content(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_content(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().Content(rctx, obj, fc.Args["lines"].(*int64), fc.Args["stripAnsi"].(*bool))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_content(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_TmuxPane_content_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_contentRange(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_contentRange(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().ContentRange(rctx, obj, fc.Args["startLine"].(int64), fc.Args["endLine"].(int64), fc.Args["stripAnsi"].(*bool))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_contentRange(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_TmuxPane_contentRange_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxPane_contentFull(ctx context.Context, field graphql.CollectedField, obj *TmuxPane) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxPane_contentFull(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxPane().ContentFull(rctx, obj, fc.Args["stripAnsi"].(*bool))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxPane_contentFull(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxPane",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_TmuxPane_contentFull_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxServer_id(ctx context.Context, field graphql.CollectedField, obj *TmuxServer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxServer_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxServer_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxServer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxServer_socketPath(ctx context.Context, field graphql.CollectedField, obj *TmuxServer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxServer_socketPath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SocketPath, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxServer_socketPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxServer",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxServer_pid(ctx context.Context, field graphql.CollectedField, obj *TmuxServer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxServer_pid(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxServer().Pid(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxServer_pid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxServer",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxServer_alive(ctx context.Context, field graphql.CollectedField, obj *TmuxServer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxServer_alive(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxServer().Alive(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxServer_alive(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxServer",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxServer_sessions(ctx context.Context, field graphql.CollectedField, obj *TmuxServer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxServer_sessions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxServer().Sessions(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*TmuxSession)
+	fc.Result = res
+	return ec.marshalNTmuxSession2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSessionᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxServer_sessions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxServer",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxSession_id(ctx, field)
+			case "server":
+				return ec.fieldContext_TmuxSession_server(ctx, field)
+			case "name":
+				return ec.fieldContext_TmuxSession_name(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TmuxSession_createdAt(ctx, field)
+			case "attached":
+				return ec.fieldContext_TmuxSession_attached(ctx, field)
+			case "activeAttached":
+				return ec.fieldContext_TmuxSession_activeAttached(ctx, field)
+			case "attachedClients":
+				return ec.fieldContext_TmuxSession_attachedClients(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_TmuxSession_lastActivityAt(ctx, field)
+			case "windows":
+				return ec.fieldContext_TmuxSession_windows(ctx, field)
+			case "currentWindow":
+				return ec.fieldContext_TmuxSession_currentWindow(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxSession", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxServer_clients(ctx context.Context, field graphql.CollectedField, obj *TmuxServer) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxServer_clients(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxServer().Clients(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*TmuxClient)
+	fc.Result = res
+	return ec.marshalNTmuxClient2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxClientᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxServer_clients(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxServer",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxClient_id(ctx, field)
+			case "server":
+				return ec.fieldContext_TmuxClient_server(ctx, field)
+			case "session":
+				return ec.fieldContext_TmuxClient_session(ctx, field)
+			case "tty":
+				return ec.fieldContext_TmuxClient_tty(ctx, field)
+			case "hostname":
+				return ec.fieldContext_TmuxClient_hostname(ctx, field)
+			case "termName":
+				return ec.fieldContext_TmuxClient_termName(ctx, field)
+			case "attachedAt":
+				return ec.fieldContext_TmuxClient_attachedAt(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_TmuxClient_lastActivityAt(ctx, field)
+			case "readonly":
+				return ec.fieldContext_TmuxClient_readonly(ctx, field)
+			case "currentWindow":
+				return ec.fieldContext_TmuxClient_currentWindow(ctx, field)
+			case "currentPane":
+				return ec.fieldContext_TmuxClient_currentPane(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxClient", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxSession_id(ctx context.Context, field graphql.CollectedField, obj *TmuxSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxSession_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxSession_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxSession_server(ctx context.Context, field graphql.CollectedField, obj *TmuxSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxSession_server(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxSession().Server(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxServer)
+	fc.Result = res
+	return ec.marshalNTmuxServer2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxServer(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxSession_server(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxSession",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxServer_id(ctx, field)
+			case "socketPath":
+				return ec.fieldContext_TmuxServer_socketPath(ctx, field)
+			case "pid":
+				return ec.fieldContext_TmuxServer_pid(ctx, field)
+			case "alive":
+				return ec.fieldContext_TmuxServer_alive(ctx, field)
+			case "sessions":
+				return ec.fieldContext_TmuxServer_sessions(ctx, field)
+			case "clients":
+				return ec.fieldContext_TmuxServer_clients(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxServer", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxSession_name(ctx context.Context, field graphql.CollectedField, obj *TmuxSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxSession_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxSession_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxSession",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxSession_createdAt(ctx context.Context, field graphql.CollectedField, obj *TmuxSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxSession_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxSession().CreatedAt(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxSession_createdAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxSession",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxSession_attached(ctx context.Context, field graphql.CollectedField, obj *TmuxSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxSession_attached(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxSession().Attached(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxSession_attached(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxSession",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxSession_activeAttached(ctx context.Context, field graphql.CollectedField, obj *TmuxSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxSession_activeAttached(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxSession().ActiveAttached(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxSession_activeAttached(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxSession",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxSession_attachedClients(ctx context.Context, field graphql.CollectedField, obj *TmuxSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxSession_attachedClients(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxSession().AttachedClients(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*TmuxClient)
+	fc.Result = res
+	return ec.marshalNTmuxClient2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxClientᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxSession_attachedClients(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxSession",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxClient_id(ctx, field)
+			case "server":
+				return ec.fieldContext_TmuxClient_server(ctx, field)
+			case "session":
+				return ec.fieldContext_TmuxClient_session(ctx, field)
+			case "tty":
+				return ec.fieldContext_TmuxClient_tty(ctx, field)
+			case "hostname":
+				return ec.fieldContext_TmuxClient_hostname(ctx, field)
+			case "termName":
+				return ec.fieldContext_TmuxClient_termName(ctx, field)
+			case "attachedAt":
+				return ec.fieldContext_TmuxClient_attachedAt(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_TmuxClient_lastActivityAt(ctx, field)
+			case "readonly":
+				return ec.fieldContext_TmuxClient_readonly(ctx, field)
+			case "currentWindow":
+				return ec.fieldContext_TmuxClient_currentWindow(ctx, field)
+			case "currentPane":
+				return ec.fieldContext_TmuxClient_currentPane(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxClient", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxSession_lastActivityAt(ctx context.Context, field graphql.CollectedField, obj *TmuxSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxSession_lastActivityAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxSession().LastActivityAt(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxSession_lastActivityAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxSession",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxSession_windows(ctx context.Context, field graphql.CollectedField, obj *TmuxSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxSession_windows(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxSession().Windows(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*TmuxWindow)
+	fc.Result = res
+	return ec.marshalNTmuxWindow2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxWindowᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxSession_windows(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxSession",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxWindow_id(ctx, field)
+			case "session":
+				return ec.fieldContext_TmuxWindow_session(ctx, field)
+			case "index":
+				return ec.fieldContext_TmuxWindow_index(ctx, field)
+			case "name":
+				return ec.fieldContext_TmuxWindow_name(ctx, field)
+			case "active":
+				return ec.fieldContext_TmuxWindow_active(ctx, field)
+			case "panes":
+				return ec.fieldContext_TmuxWindow_panes(ctx, field)
+			case "currentPane":
+				return ec.fieldContext_TmuxWindow_currentPane(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxWindow", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxSession_currentWindow(ctx context.Context, field graphql.CollectedField, obj *TmuxSession) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxSession_currentWindow(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxSession().CurrentWindow(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxWindow)
+	fc.Result = res
+	return ec.marshalOTmuxWindow2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxWindow(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxSession_currentWindow(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxSession",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxWindow_id(ctx, field)
+			case "session":
+				return ec.fieldContext_TmuxWindow_session(ctx, field)
+			case "index":
+				return ec.fieldContext_TmuxWindow_index(ctx, field)
+			case "name":
+				return ec.fieldContext_TmuxWindow_name(ctx, field)
+			case "active":
+				return ec.fieldContext_TmuxWindow_active(ctx, field)
+			case "panes":
+				return ec.fieldContext_TmuxWindow_panes(ctx, field)
+			case "currentPane":
+				return ec.fieldContext_TmuxWindow_currentPane(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxWindow", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxWindow_id(ctx context.Context, field graphql.CollectedField, obj *TmuxWindow) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxWindow_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxWindow_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxWindow",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxWindow_session(ctx context.Context, field graphql.CollectedField, obj *TmuxWindow) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxWindow_session(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxWindow().Session(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxSession)
+	fc.Result = res
+	return ec.marshalNTmuxSession2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSession(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxWindow_session(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxWindow",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxSession_id(ctx, field)
+			case "server":
+				return ec.fieldContext_TmuxSession_server(ctx, field)
+			case "name":
+				return ec.fieldContext_TmuxSession_name(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TmuxSession_createdAt(ctx, field)
+			case "attached":
+				return ec.fieldContext_TmuxSession_attached(ctx, field)
+			case "activeAttached":
+				return ec.fieldContext_TmuxSession_activeAttached(ctx, field)
+			case "attachedClients":
+				return ec.fieldContext_TmuxSession_attachedClients(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_TmuxSession_lastActivityAt(ctx, field)
+			case "windows":
+				return ec.fieldContext_TmuxSession_windows(ctx, field)
+			case "currentWindow":
+				return ec.fieldContext_TmuxSession_currentWindow(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxSession", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxWindow_index(ctx context.Context, field graphql.CollectedField, obj *TmuxWindow) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxWindow_index(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Index, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxWindow_index(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxWindow",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxWindow_name(ctx context.Context, field graphql.CollectedField, obj *TmuxWindow) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxWindow_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxWindow().Name(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxWindow_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxWindow",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxWindow_active(ctx context.Context, field graphql.CollectedField, obj *TmuxWindow) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxWindow_active(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxWindow().Active(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxWindow_active(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxWindow",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxWindow_panes(ctx context.Context, field graphql.CollectedField, obj *TmuxWindow) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxWindow_panes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxWindow().Panes(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*TmuxPane)
+	fc.Result = res
+	return ec.marshalNTmuxPane2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPaneᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxWindow_panes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxWindow",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxPane_id(ctx, field)
+			case "window":
+				return ec.fieldContext_TmuxPane_window(ctx, field)
+			case "paneId":
+				return ec.fieldContext_TmuxPane_paneId(ctx, field)
+			case "title":
+				return ec.fieldContext_TmuxPane_title(ctx, field)
+			case "currentCommand":
+				return ec.fieldContext_TmuxPane_currentCommand(ctx, field)
+			case "currentPid":
+				return ec.fieldContext_TmuxPane_currentPid(ctx, field)
+			case "width":
+				return ec.fieldContext_TmuxPane_width(ctx, field)
+			case "height":
+				return ec.fieldContext_TmuxPane_height(ctx, field)
+			case "dead":
+				return ec.fieldContext_TmuxPane_dead(ctx, field)
+			case "watchingClients":
+				return ec.fieldContext_TmuxPane_watchingClients(ctx, field)
+			case "process":
+				return ec.fieldContext_TmuxPane_process(ctx, field)
+			case "claudeInstance":
+				return ec.fieldContext_TmuxPane_claudeInstance(ctx, field)
+			case "content":
+				return ec.fieldContext_TmuxPane_content(ctx, field)
+			case "contentRange":
+				return ec.fieldContext_TmuxPane_contentRange(ctx, field)
+			case "contentFull":
+				return ec.fieldContext_TmuxPane_contentFull(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxPane", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TmuxWindow_currentPane(ctx context.Context, field graphql.CollectedField, obj *TmuxWindow) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_TmuxWindow_currentPane(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.TmuxWindow().CurrentPane(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxPane)
+	fc.Result = res
+	return ec.marshalOTmuxPane2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPane(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_TmuxWindow_currentPane(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TmuxWindow",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxPane_id(ctx, field)
+			case "window":
+				return ec.fieldContext_TmuxPane_window(ctx, field)
+			case "paneId":
+				return ec.fieldContext_TmuxPane_paneId(ctx, field)
+			case "title":
+				return ec.fieldContext_TmuxPane_title(ctx, field)
+			case "currentCommand":
+				return ec.fieldContext_TmuxPane_currentCommand(ctx, field)
+			case "currentPid":
+				return ec.fieldContext_TmuxPane_currentPid(ctx, field)
+			case "width":
+				return ec.fieldContext_TmuxPane_width(ctx, field)
+			case "height":
+				return ec.fieldContext_TmuxPane_height(ctx, field)
+			case "dead":
+				return ec.fieldContext_TmuxPane_dead(ctx, field)
+			case "watchingClients":
+				return ec.fieldContext_TmuxPane_watchingClients(ctx, field)
+			case "process":
+				return ec.fieldContext_TmuxPane_process(ctx, field)
+			case "claudeInstance":
+				return ec.fieldContext_TmuxPane_claudeInstance(ctx, field)
+			case "content":
+				return ec.fieldContext_TmuxPane_content(ctx, field)
+			case "contentRange":
+				return ec.fieldContext_TmuxPane_contentRange(ctx, field)
+			case "contentFull":
+				return ec.fieldContext_TmuxPane_contentFull(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxPane", field.Name)
 		},
 	}
 	return fc, nil
@@ -5103,6 +8675,102 @@ func (ec *executionContext) unmarshalInputProcessFilter(ctx context.Context, obj
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputTmuxPaneFilter(ctx context.Context, obj interface{}) (TmuxPaneFilter, error) {
+	var it TmuxPaneFilter
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"paneIdIn", "currentCommandIn", "sessionIn", "titleContains", "dead"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "paneIdIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("paneIdIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.PaneIDIn = data
+		case "currentCommandIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("currentCommandIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.CurrentCommandIn = data
+		case "sessionIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sessionIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SessionIn = data
+		case "titleContains":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("titleContains"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TitleContains = data
+		case "dead":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("dead"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Dead = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputTmuxSessionFilter(ctx context.Context, obj interface{}) (TmuxSessionFilter, error) {
+	var it TmuxSessionFilter
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"nameIn", "attachedOnly", "activeAttachedOnly"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "nameIn":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("nameIn"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.NameIn = data
+		case "attachedOnly":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("attachedOnly"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.AttachedOnly = data
+		case "activeAttachedOnly":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("activeAttachedOnly"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ActiveAttachedOnly = data
+		}
+	}
+
+	return it, nil
+}
+
 // endregion **************************** input.gotpl *****************************
 
 // region    ************************** interface.gotpl ***************************
@@ -5139,6 +8807,41 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Worktree(ctx, sel, obj)
+	case TmuxServer:
+		return ec._TmuxServer(ctx, sel, &obj)
+	case *TmuxServer:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._TmuxServer(ctx, sel, obj)
+	case TmuxSession:
+		return ec._TmuxSession(ctx, sel, &obj)
+	case *TmuxSession:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._TmuxSession(ctx, sel, obj)
+	case TmuxWindow:
+		return ec._TmuxWindow(ctx, sel, &obj)
+	case *TmuxWindow:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._TmuxWindow(ctx, sel, obj)
+	case TmuxPane:
+		return ec._TmuxPane(ctx, sel, &obj)
+	case *TmuxPane:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._TmuxPane(ctx, sel, obj)
+	case TmuxClient:
+		return ec._TmuxClient(ctx, sel, &obj)
+	case *TmuxClient:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._TmuxClient(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -5773,6 +9476,69 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "tmuxServer":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_tmuxServer(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "tmuxSessions":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_tmuxSessions(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "tmuxPanes":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_tmuxPanes(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "__type":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___type(ctx, field)
@@ -5845,6 +9611,1631 @@ func (ec *executionContext) _ResourceLoad(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var tmuxClientImplementors = []string{"TmuxClient", "Node"}
+
+func (ec *executionContext) _TmuxClient(ctx context.Context, sel ast.SelectionSet, obj *TmuxClient) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tmuxClientImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TmuxClient")
+		case "id":
+			out.Values[i] = ec._TmuxClient_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "server":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxClient_server(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "session":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxClient_session(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "tty":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxClient_tty(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "hostname":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxClient_hostname(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "termName":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxClient_termName(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "attachedAt":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxClient_attachedAt(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "lastActivityAt":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxClient_lastActivityAt(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "readonly":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxClient_readonly(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "currentWindow":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxClient_currentWindow(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "currentPane":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxClient_currentPane(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var tmuxPaneImplementors = []string{"TmuxPane", "Node"}
+
+func (ec *executionContext) _TmuxPane(ctx context.Context, sel ast.SelectionSet, obj *TmuxPane) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tmuxPaneImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TmuxPane")
+		case "id":
+			out.Values[i] = ec._TmuxPane_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "window":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_window(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "paneId":
+			out.Values[i] = ec._TmuxPane_paneId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "title":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_title(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "currentCommand":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_currentCommand(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "currentPid":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_currentPid(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "width":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_width(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "height":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_height(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "dead":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_dead(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "watchingClients":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_watchingClients(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "process":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_process(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "claudeInstance":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_claudeInstance(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "content":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_content(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "contentRange":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_contentRange(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "contentFull":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxPane_contentFull(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var tmuxServerImplementors = []string{"TmuxServer", "Node"}
+
+func (ec *executionContext) _TmuxServer(ctx context.Context, sel ast.SelectionSet, obj *TmuxServer) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tmuxServerImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TmuxServer")
+		case "id":
+			out.Values[i] = ec._TmuxServer_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "socketPath":
+			out.Values[i] = ec._TmuxServer_socketPath(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "pid":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxServer_pid(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "alive":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxServer_alive(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "sessions":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxServer_sessions(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "clients":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxServer_clients(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var tmuxSessionImplementors = []string{"TmuxSession", "Node"}
+
+func (ec *executionContext) _TmuxSession(ctx context.Context, sel ast.SelectionSet, obj *TmuxSession) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tmuxSessionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TmuxSession")
+		case "id":
+			out.Values[i] = ec._TmuxSession_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "server":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxSession_server(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "name":
+			out.Values[i] = ec._TmuxSession_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "createdAt":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxSession_createdAt(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "attached":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxSession_attached(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "activeAttached":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxSession_activeAttached(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "attachedClients":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxSession_attachedClients(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "lastActivityAt":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxSession_lastActivityAt(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "windows":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxSession_windows(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "currentWindow":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxSession_currentWindow(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var tmuxWindowImplementors = []string{"TmuxWindow", "Node"}
+
+func (ec *executionContext) _TmuxWindow(ctx context.Context, sel ast.SelectionSet, obj *TmuxWindow) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tmuxWindowImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TmuxWindow")
+		case "id":
+			out.Values[i] = ec._TmuxWindow_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "session":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxWindow_session(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "index":
+			out.Values[i] = ec._TmuxWindow_index(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "name":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxWindow_name(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "active":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxWindow_active(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "panes":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxWindow_panes(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "currentPane":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TmuxWindow_currentPane(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -6544,6 +11935,244 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 	return res
 }
 
+func (ec *executionContext) marshalNTmuxClient2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxClientᚄ(ctx context.Context, sel ast.SelectionSet, v []*TmuxClient) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTmuxClient2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxClient(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTmuxClient2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxClient(ctx context.Context, sel ast.SelectionSet, v *TmuxClient) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TmuxClient(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTmuxPane2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPaneᚄ(ctx context.Context, sel ast.SelectionSet, v []*TmuxPane) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTmuxPane2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPane(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTmuxPane2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPane(ctx context.Context, sel ast.SelectionSet, v *TmuxPane) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TmuxPane(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTmuxServer2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxServer(ctx context.Context, sel ast.SelectionSet, v TmuxServer) graphql.Marshaler {
+	return ec._TmuxServer(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTmuxServer2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxServer(ctx context.Context, sel ast.SelectionSet, v *TmuxServer) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TmuxServer(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTmuxSession2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSession(ctx context.Context, sel ast.SelectionSet, v TmuxSession) graphql.Marshaler {
+	return ec._TmuxSession(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTmuxSession2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSessionᚄ(ctx context.Context, sel ast.SelectionSet, v []*TmuxSession) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTmuxSession2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSession(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTmuxSession2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSession(ctx context.Context, sel ast.SelectionSet, v *TmuxSession) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TmuxSession(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNTmuxWindow2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxWindow(ctx context.Context, sel ast.SelectionSet, v TmuxWindow) graphql.Marshaler {
+	return ec._TmuxWindow(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNTmuxWindow2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxWindowᚄ(ctx context.Context, sel ast.SelectionSet, v []*TmuxWindow) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTmuxWindow2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxWindow(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNTmuxWindow2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxWindow(ctx context.Context, sel ast.SelectionSet, v *TmuxWindow) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._TmuxWindow(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNWorktree2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐWorktreeᚄ(ctx context.Context, sel ast.SelectionSet, v []*Worktree) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -6922,6 +12551,29 @@ func (ec *executionContext) marshalOInt2ᚕint64ᚄ(ctx context.Context, sel ast
 	return ret
 }
 
+func (ec *executionContext) unmarshalOInt2ᚖint64(ctx context.Context, v interface{}) (*int64, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalInt64(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOInt2ᚖint64(ctx context.Context, sel ast.SelectionSet, v *int64) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalInt64(*v)
+	return res
+}
+
+func (ec *executionContext) marshalOProcess2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcess(ctx context.Context, sel ast.SelectionSet, v *Process) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Process(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalOProcessFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcessFilter(ctx context.Context, v interface{}) (*ProcessFilter, error) {
 	if v == nil {
 		return nil, nil
@@ -6989,6 +12641,43 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 	}
 	res := graphql.MarshalString(*v)
 	return res
+}
+
+func (ec *executionContext) marshalOTmuxPane2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPane(ctx context.Context, sel ast.SelectionSet, v *TmuxPane) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TmuxPane(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOTmuxPaneFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPaneFilter(ctx context.Context, v interface{}) (*TmuxPaneFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputTmuxPaneFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTmuxServer2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxServer(ctx context.Context, sel ast.SelectionSet, v *TmuxServer) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TmuxServer(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOTmuxSessionFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSessionFilter(ctx context.Context, v interface{}) (*TmuxSessionFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputTmuxSessionFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTmuxWindow2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxWindow(ctx context.Context, sel ast.SelectionSet, v *TmuxWindow) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TmuxWindow(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOWorktree2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐWorktree(ctx context.Context, sel ast.SelectionSet, v *Worktree) graphql.Marshaler {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -136,6 +136,182 @@ type ResourceLoad struct {
 	LoadAvg15m float64 `json:"loadAvg15m"`
 }
 
+// A client (terminal) attached to a tmux server. Multiple clients may share
+// the same session/window/pane.
+type TmuxClient struct {
+	// Stable id `TmuxClient:<host>:<clientName>`.
+	ID string `json:"id"`
+	// Server this client connects to.
+	Server *TmuxServer `json:"server"`
+	// Session this client is attached to.
+	Session *TmuxSession `json:"session"`
+	// Client tty path (e.g. `/dev/ttys003`).
+	Tty string `json:"tty"`
+	// Hostname the client originated from. Empty for local clients.
+	Hostname string `json:"hostname"`
+	// TERM value the client advertises (e.g. `xterm-256color`).
+	TermName string `json:"termName"`
+	// RFC3339 attach time.
+	AttachedAt string `json:"attachedAt"`
+	// RFC3339 last activity time. Null if tmux returned no value.
+	LastActivityAt *string `json:"lastActivityAt,omitempty"`
+	// True when the client is in read-only mode.
+	Readonly bool `json:"readonly"`
+	// Window the client is currently looking at.
+	CurrentWindow *TmuxWindow `json:"currentWindow,omitempty"`
+	// Pane the client is currently looking at.
+	CurrentPane *TmuxPane `json:"currentPane,omitempty"`
+}
+
+func (TmuxClient) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this TmuxClient) GetID() string { return this.ID }
+
+// A pane inside a window — the leaf where commands actually run. Identity
+// is the global tmux pane id (e.g. `%26`) within a host.
+//
+// Content fields (`content`, `contentRange`, `contentFull`) shell out to
+// `tmux capture-pane`. They are not poll-cached; queries that ask for them
+// pay the per-call cost.
+type TmuxPane struct {
+	// Stable id `TmuxPane:<host>:<paneId>`.
+	ID string `json:"id"`
+	// Window this pane belongs to.
+	Window *TmuxWindow `json:"window"`
+	// tmux pane id, including the leading `%` (e.g. `%26`).
+	PaneID string `json:"paneId"`
+	// Pane title (tmux `pane_title`).
+	Title string `json:"title"`
+	// Foreground command basename (tmux `pane_current_command`, e.g. 'claude', 'zsh').
+	CurrentCommand string `json:"currentCommand"`
+	// Pid of the foreground process. Null when tmux reports no current pid.
+	CurrentPid *int64 `json:"currentPid,omitempty"`
+	// Pane width in cells.
+	Width int64 `json:"width"`
+	// Pane height in cells.
+	Height int64 `json:"height"`
+	// True when tmux marks the pane as dead (process exited, awaiting reuse/close).
+	Dead bool `json:"dead"`
+	// Clients with their cursor on this pane.
+	WatchingClients []*TmuxClient `json:"watchingClients"`
+	// OS-level Process for the foreground pid. Null until ws-b-ps wires it.
+	Process *Process `json:"process,omitempty"`
+	// Claude instance running in this pane, if the foreground command is claude. Null until ws-b-claudeinstance wires it.
+	ClaudeInstance *ClaudeInstance `json:"claudeInstance,omitempty"`
+	// Last N lines of pane output, default 50. Strips ANSI escapes by default.
+	Content string `json:"content"`
+	// Output between two history line numbers (tmux's -S/-E semantics).
+	ContentRange string `json:"contentRange"`
+	// Full visible-history pane buffer.
+	ContentFull string `json:"contentFull"`
+}
+
+func (TmuxPane) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this TmuxPane) GetID() string { return this.ID }
+
+// Filter for `Query.tmuxPanes`. AND-combined when multiple are set.
+type TmuxPaneFilter struct {
+	// Pane ids (e.g. `%26`) to include.
+	PaneIDIn []string `json:"paneIdIn,omitempty"`
+	// Only include panes whose `currentCommand` is in this list.
+	CurrentCommandIn []string `json:"currentCommandIn,omitempty"`
+	// Only include panes in these session names.
+	SessionIn []string `json:"sessionIn,omitempty"`
+	// Only include panes whose `pane_title` matches the substring (case-sensitive).
+	TitleContains *string `json:"titleContains,omitempty"`
+	// Only include dead (or non-dead) panes.
+	Dead *bool `json:"dead,omitempty"`
+}
+
+// The tmux daemon process on a host. v1 surfaces the local tmux only;
+// multi-server setups (custom -L socket names) are reachable via socketPath.
+type TmuxServer struct {
+	// Stable id `TmuxServer:<host>:<socketPath>`.
+	ID string `json:"id"`
+	// Filesystem path of the tmux socket the daemon is listening on.
+	SocketPath string `json:"socketPath"`
+	// Pid of the tmux daemon process. Null if not currently determinable.
+	Pid *int64 `json:"pid,omitempty"`
+	// True while the tmux daemon answers a heartbeat command.
+	Alive bool `json:"alive"`
+	// Sessions hosted on this server.
+	Sessions []*TmuxSession `json:"sessions"`
+	// Clients currently connected to this server.
+	Clients []*TmuxClient `json:"clients"`
+}
+
+func (TmuxServer) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this TmuxServer) GetID() string { return this.ID }
+
+// A named tmux session. Stable across detach/reattach. Identity is the
+// session name within its server.
+type TmuxSession struct {
+	// Stable id `TmuxSession:<host>:<sessionName>`.
+	ID string `json:"id"`
+	// Server hosting this session.
+	Server *TmuxServer `json:"server"`
+	// Session name.
+	Name string `json:"name"`
+	// RFC3339 timestamp of when the session was created.
+	CreatedAt string `json:"createdAt"`
+	// True when at least one client is attached to this session.
+	Attached bool `json:"attached"`
+	// True when at least one attached client has had activity within the freshness window (default 5m).
+	ActiveAttached bool `json:"activeAttached"`
+	// Clients currently attached to this session.
+	AttachedClients []*TmuxClient `json:"attachedClients"`
+	// Most recent activity timestamp across all panes/windows. RFC3339; null if never observed.
+	LastActivityAt *string `json:"lastActivityAt,omitempty"`
+	// Windows in this session.
+	Windows []*TmuxWindow `json:"windows"`
+	// The currently-focused window in this session.
+	CurrentWindow *TmuxWindow `json:"currentWindow,omitempty"`
+}
+
+func (TmuxSession) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this TmuxSession) GetID() string { return this.ID }
+
+// Filter for `Query.tmuxSessions`. AND-combined when multiple are set.
+type TmuxSessionFilter struct {
+	// Session names to include.
+	NameIn []string `json:"nameIn,omitempty"`
+	// Only include sessions with at least one attached client.
+	AttachedOnly *bool `json:"attachedOnly,omitempty"`
+	// Only include sessions with active-attached clients within the freshness window.
+	ActiveAttachedOnly *bool `json:"activeAttachedOnly,omitempty"`
+}
+
+// A window inside a tmux session. Identity is the window index within its
+// session.
+type TmuxWindow struct {
+	// Stable id `TmuxWindow:<host>:<sessionName>:<windowIndex>`.
+	ID string `json:"id"`
+	// Session this window belongs to.
+	Session *TmuxSession `json:"session"`
+	// Window index, zero-based as tmux numbers them when -base-index is 0.
+	Index int64 `json:"index"`
+	// Window name (tmux's `window_name`).
+	Name string `json:"name"`
+	// True when this window is the currently-focused window in its session.
+	Active bool `json:"active"`
+	// Panes in this window.
+	Panes []*TmuxPane `json:"panes"`
+	// The currently-focused pane in this window.
+	CurrentPane *TmuxPane `json:"currentPane,omitempty"`
+}
+
+func (TmuxWindow) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this TmuxWindow) GetID() string { return this.ID }
+
 // A git worktree — either the project's main checkout or one created with `git worktree add`. See ADR-011 §5.1.
 type Worktree struct {
 	// Stable identifier formatted as `<project_id>:<worktree_name>`. The main checkout uses the worktree name `main`.

--- a/internal/server/providers/tmux/adapter.go
+++ b/internal/server/providers/tmux/adapter.go
@@ -1,0 +1,436 @@
+// Adapter wraps the tmux CLI. Per ADR-011 §3 it is stateless: cache,
+// watcher, and invalidation live in the surrounding Provider.
+//
+// All field separation in -F format strings uses U+0001 (`\x01`) — tmux
+// never emits that byte for the format-variables we read, so the parser
+// never needs to consider quoting or escaping.
+
+package tmux
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Field separator in -F format strings. tmux format-variables we read
+// (names, indexes, integers, paths, terminal names) never contain this
+// byte, so splitting on it round-trips losslessly.
+const fieldSep = "\x01"
+
+// CommandRunner is the test seam — production wires execRunner.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return stdout.Bytes(), fmt.Errorf("%s %v: %w (stderr: %q)", name, args, err, strings.TrimSpace(stderr.String()))
+		}
+		return stdout.Bytes(), fmt.Errorf("%s %v: %w", name, args, err)
+	}
+	return stdout.Bytes(), nil
+}
+
+// Adapter is the stateless tmux CLI client.
+type Adapter struct {
+	host   HostID
+	socket string // empty = default socket
+	runner CommandRunner
+}
+
+// NewAdapter constructs an Adapter targeting the default tmux socket on
+// the given host. Use WithSocket for tests / non-default sockets.
+func NewAdapter(host HostID) *Adapter {
+	return &Adapter{host: host, runner: execRunner{}}
+}
+
+// WithSocket returns a copy of a addressing the given tmux socket via
+// `-S <path>`. Lets E2E tests run against a sandbox tmux server.
+func (a *Adapter) WithSocket(path string) *Adapter {
+	cp := *a
+	cp.socket = path
+	return &cp
+}
+
+// WithRunner returns a copy of a using the given runner — for tests.
+func (a *Adapter) WithRunner(r CommandRunner) *Adapter {
+	cp := *a
+	cp.runner = r
+	return &cp
+}
+
+// Host returns the host id baked into every key the adapter emits.
+func (a *Adapter) Host() HostID { return a.host }
+
+// Socket exposes the configured socket path (empty = tmux default).
+func (a *Adapter) Socket() string { return a.socket }
+
+// tmuxArgs returns the global flags every tmux invocation gets.
+// `-L`/`-S` come first per `man 1 tmux`.
+func (a *Adapter) tmuxArgs(rest ...string) []string {
+	out := make([]string, 0, len(rest)+2)
+	if a.socket != "" {
+		out = append(out, "-S", a.socket)
+	}
+	out = append(out, rest...)
+	return out
+}
+
+// IsAlive shells out the cheapest possible command to detect a live
+// tmux server. Used by both the adapter (to short-circuit on dead
+// daemons) and the resolver (TmuxServer.alive).
+func (a *Adapter) IsAlive(ctx context.Context) bool {
+	_, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("info")...)
+	return err == nil
+}
+
+// FetchAll runs the four list-* commands and folds them into a single
+// Snapshot. When the daemon is dead, FetchAll returns an EmptySnapshot
+// without an error — callers see "no sessions" instead of an error.
+func (a *Adapter) FetchAll(ctx context.Context) (Snapshot, error) {
+	if !a.IsAlive(ctx) {
+		snap := EmptySnapshot()
+		snap.Server = ServerInfo{SocketPath: a.socketOrDefault(), Alive: false}
+		return snap, nil
+	}
+
+	sessions, err := a.listSessions(ctx)
+	if err != nil {
+		return EmptySnapshot(), fmt.Errorf("list-sessions: %w", err)
+	}
+	windows, err := a.listWindows(ctx)
+	if err != nil {
+		return EmptySnapshot(), fmt.Errorf("list-windows: %w", err)
+	}
+	panes, err := a.listPanes(ctx)
+	if err != nil {
+		return EmptySnapshot(), fmt.Errorf("list-panes: %w", err)
+	}
+	clients, err := a.listClients(ctx)
+	if err != nil {
+		return EmptySnapshot(), fmt.Errorf("list-clients: %w", err)
+	}
+	server := a.serverInfo(ctx)
+
+	return Snapshot{
+		Server:   server,
+		Sessions: sessions,
+		Windows:  windows,
+		Panes:    panes,
+		Clients:  clients,
+	}, nil
+}
+
+// CapturePane runs `tmux capture-pane -p` against a single pane. start
+// and end are line numbers in tmux's history coordinate (negative
+// values walk backwards into history, 0 is the top of the screen, etc.
+// — see `man 1 tmux` "WINDOWS AND PANES").
+//
+// Pass startLine=0, endLine=0 with full=true to capture the entire
+// visible+history buffer (`-S -`, `-E -`).
+func (a *Adapter) CapturePane(ctx context.Context, pane PaneKey, start, end int, full bool, stripAnsi bool) (string, error) {
+	args := []string{"capture-pane", "-p", "-t", pane.PaneID}
+	if !stripAnsi {
+		// `-e` keeps escape sequences. By default capture-pane strips
+		// them, which matches `stripAnsi: true` in the schema.
+		args = append(args, "-e")
+	}
+	if full {
+		args = append(args, "-S", "-", "-E", "-")
+	} else {
+		if start != 0 {
+			args = append(args, "-S", strconv.Itoa(start))
+		}
+		if end != 0 {
+			args = append(args, "-E", strconv.Itoa(end))
+		}
+	}
+
+	out, err := a.runner.Run(ctx, "tmux", a.tmuxArgs(args...)...)
+	if err != nil {
+		return "", fmt.Errorf("capture-pane %s: %w", pane.PaneID, err)
+	}
+	return string(out), nil
+}
+
+// CapturePaneTail captures the last `lines` rows. Implemented as
+// `-S -<lines>` per tmux convention (negative starts walk into history).
+func (a *Adapter) CapturePaneTail(ctx context.Context, pane PaneKey, lines int, stripAnsi bool) (string, error) {
+	if lines <= 0 {
+		lines = 50
+	}
+	args := []string{"capture-pane", "-p", "-t", pane.PaneID, "-S", strconv.Itoa(-lines)}
+	if !stripAnsi {
+		args = append(args, "-e")
+	}
+	out, err := a.runner.Run(ctx, "tmux", a.tmuxArgs(args...)...)
+	if err != nil {
+		return "", fmt.Errorf("capture-pane tail %s: %w", pane.PaneID, err)
+	}
+	return string(out), nil
+}
+
+// ----------------------------------------------------------------------
+// list-* parsers. Each format string lists the variables in a known
+// order separated by U+0001; the parser splits and converts.
+// ----------------------------------------------------------------------
+
+const sessionFormat = "" +
+	"#{session_name}" + fieldSep +
+	"#{session_created}" + fieldSep +
+	"#{session_attached}" + fieldSep +
+	"#{session_activity}" + fieldSep +
+	"#{session_windows}" + fieldSep +
+	"#{session_window_index}"
+
+func (a *Adapter) listSessions(ctx context.Context) (map[SessionKey]Session, error) {
+	out, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("list-sessions", "-F", sessionFormat)...)
+	if err != nil {
+		// `no server running` is a valid (empty) state for newer tmux;
+		// the IsAlive check above usually catches it. Defensive return.
+		if strings.Contains(err.Error(), "no server running") {
+			return map[SessionKey]Session{}, nil
+		}
+		return nil, err
+	}
+	out = bytes.TrimRight(out, "\n")
+	if len(out) == 0 {
+		return map[SessionKey]Session{}, nil
+	}
+	sessions := make(map[SessionKey]Session)
+	for _, line := range bytes.Split(out, []byte{'\n'}) {
+		fields := strings.Split(string(line), fieldSep)
+		if len(fields) != 6 {
+			continue
+		}
+		key := SessionKey{Host: a.host, Name: fields[0]}
+		sessions[key] = Session{
+			Key:            key,
+			CreatedAt:      parseUnix(fields[1]),
+			Attached:       fields[2] != "" && fields[2] != "0",
+			AttachedCount:  parseInt(fields[2]),
+			LastActivityAt: parseUnix(fields[3]),
+			WindowCount:    parseInt(fields[4]),
+			CurrentWindow:  parseInt(fields[5]),
+		}
+	}
+	return sessions, nil
+}
+
+const windowFormat = "" +
+	"#{session_name}" + fieldSep +
+	"#{window_index}" + fieldSep +
+	"#{window_name}" + fieldSep +
+	"#{window_active}" + fieldSep +
+	"#{window_panes}" + fieldSep +
+	"#{window_active_pane}"
+
+func (a *Adapter) listWindows(ctx context.Context) (map[WindowKey]Window, error) {
+	out, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("list-windows", "-a", "-F", windowFormat)...)
+	if err != nil {
+		if strings.Contains(err.Error(), "no server running") {
+			return map[WindowKey]Window{}, nil
+		}
+		return nil, err
+	}
+	out = bytes.TrimRight(out, "\n")
+	if len(out) == 0 {
+		return map[WindowKey]Window{}, nil
+	}
+	windows := make(map[WindowKey]Window)
+	for _, line := range bytes.Split(out, []byte{'\n'}) {
+		fields := strings.Split(string(line), fieldSep)
+		if len(fields) != 6 {
+			continue
+		}
+		key := WindowKey{
+			Host:    a.host,
+			Session: fields[0],
+			Index:   parseInt(fields[1]),
+		}
+		windows[key] = Window{
+			Key:         key,
+			Name:        fields[2],
+			Active:      fields[3] == "1",
+			PaneCount:   parseInt(fields[4]),
+			CurrentPane: fields[5],
+		}
+	}
+	return windows, nil
+}
+
+const paneFormat = "" +
+	"#{session_name}" + fieldSep +
+	"#{window_index}" + fieldSep +
+	"#{pane_id}" + fieldSep +
+	"#{pane_title}" + fieldSep +
+	"#{pane_current_command}" + fieldSep +
+	"#{pane_pid}" + fieldSep +
+	"#{pane_width}" + fieldSep +
+	"#{pane_height}" + fieldSep +
+	"#{pane_dead}"
+
+func (a *Adapter) listPanes(ctx context.Context) (map[PaneKey]Pane, error) {
+	out, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("list-panes", "-a", "-F", paneFormat)...)
+	if err != nil {
+		if strings.Contains(err.Error(), "no server running") {
+			return map[PaneKey]Pane{}, nil
+		}
+		return nil, err
+	}
+	out = bytes.TrimRight(out, "\n")
+	if len(out) == 0 {
+		return map[PaneKey]Pane{}, nil
+	}
+	panes := make(map[PaneKey]Pane)
+	for _, line := range bytes.Split(out, []byte{'\n'}) {
+		fields := strings.Split(string(line), fieldSep)
+		if len(fields) != 9 {
+			continue
+		}
+		paneKey := PaneKey{Host: a.host, PaneID: fields[2]}
+		panes[paneKey] = Pane{
+			Key: paneKey,
+			WindowKey: WindowKey{
+				Host:    a.host,
+				Session: fields[0],
+				Index:   parseInt(fields[1]),
+			},
+			Title:          fields[3],
+			CurrentCommand: fields[4],
+			CurrentPid:     parseInt(fields[5]),
+			Width:          parseInt(fields[6]),
+			Height:         parseInt(fields[7]),
+			Dead:           fields[8] == "1",
+		}
+	}
+	return panes, nil
+}
+
+const clientFormat = "" +
+	"#{client_name}" + fieldSep +
+	"#{client_session}" + fieldSep +
+	"#{client_tty}" + fieldSep +
+	"#{client_termname}" + fieldSep +
+	"#{client_created}" + fieldSep +
+	"#{client_activity}" + fieldSep +
+	"#{client_readonly}" + fieldSep +
+	"#{client_window_index}" + fieldSep +
+	"#{client_active_pane}"
+
+func (a *Adapter) listClients(ctx context.Context) (map[ClientKey]Client, error) {
+	out, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("list-clients", "-F", clientFormat)...)
+	if err != nil {
+		if strings.Contains(err.Error(), "no server running") {
+			return map[ClientKey]Client{}, nil
+		}
+		return nil, err
+	}
+	out = bytes.TrimRight(out, "\n")
+	if len(out) == 0 {
+		return map[ClientKey]Client{}, nil
+	}
+	clients := make(map[ClientKey]Client)
+	for _, line := range bytes.Split(out, []byte{'\n'}) {
+		fields := strings.Split(string(line), fieldSep)
+		if len(fields) != 9 {
+			continue
+		}
+		// tmux historically used the tty path as `client_name`; newer
+		// tmux releases honour the client name passed to `attach -t`.
+		// Either way the value is unique within a server.
+		name := fields[0]
+		if name == "" {
+			name = fields[2]
+		}
+		key := ClientKey{Host: a.host, ClientName: name}
+		clients[key] = Client{
+			Key:            key,
+			Session:        fields[1],
+			TTY:            fields[2],
+			TermName:       fields[3],
+			AttachedAt:     parseUnix(fields[4]),
+			LastActivityAt: parseUnix(fields[5]),
+			Readonly:       fields[6] == "1",
+			CurrentWindow:  parseIntOrNeg1(fields[7]),
+			CurrentPane:    fields[8],
+		}
+	}
+	return clients, nil
+}
+
+// serverInfo gathers `display-message`-driven facts about the running
+// tmux server. Best-effort; non-fatal failures collapse to zero values.
+func (a *Adapter) serverInfo(ctx context.Context) ServerInfo {
+	info := ServerInfo{SocketPath: a.socketOrDefault(), Alive: true}
+	pidOut, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("display-message", "-p", "#{pid}")...)
+	if err == nil {
+		info.Pid = parseInt(strings.TrimSpace(string(pidOut)))
+	}
+	return info
+}
+
+// socketOrDefault returns the configured socket path, falling back to a
+// stable string for the daemon's default. tmux's actual default lives
+// in $TMPDIR (e.g. /private/tmp/tmux-501/default on macOS); for callers
+// that need a stable identifier the symbolic name is fine.
+func (a *Adapter) socketOrDefault() string {
+	if a.socket != "" {
+		return a.socket
+	}
+	return "default"
+}
+
+// ----------------------------------------------------------------------
+// Helpers. Tiny, intentionally — keep parsing locality high.
+// ----------------------------------------------------------------------
+
+func parseInt(s string) int {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func parseIntOrNeg1(s string) int {
+	if s == "" {
+		return -1
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return -1
+	}
+	return n
+}
+
+// parseUnix accepts tmux's epoch-second timestamps (e.g. session_created).
+// Empty / unparseable values yield the zero time, which downstream maps
+// to a null GraphQL value.
+func parseUnix(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || n <= 0 {
+		return time.Time{}
+	}
+	return time.Unix(n, 0).UTC()
+}

--- a/internal/server/providers/tmux/adapter_test.go
+++ b/internal/server/providers/tmux/adapter_test.go
@@ -1,0 +1,155 @@
+// Adapter tests — focused on the deterministic format-string parsers.
+// The E2E suite covers behaviour against a real tmux daemon; this file
+// pins parsing rules so a tmux output regression fails locally instead
+// of in production.
+
+package tmux
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeRunner returns canned bytes per command so parser tests can run
+// without a tmux daemon.
+type fakeRunner struct {
+	out  map[string][]byte
+	errs map[string]error
+}
+
+func (f fakeRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	key := strings.Join(append([]string{name}, args...), " ")
+	if err, ok := f.errs[key]; ok {
+		return f.out[key], err
+	}
+	if out, ok := f.out[key]; ok {
+		return out, nil
+	}
+	// Match by leading verb when the caller supplies a partial key —
+	// keeps test data short.
+	for prefix, out := range f.out {
+		if strings.HasPrefix(key, prefix) {
+			return out, nil
+		}
+	}
+	return nil, nil
+}
+
+func TestListSessions_Parses(t *testing.T) {
+	const sep = "\x01"
+	out := strings.Join([]string{
+		strings.Join([]string{"alpha", "1700000000", "1", "1700001000", "2", "0"}, sep),
+		strings.Join([]string{"beta", "1700000100", "0", "0", "1", "0"}, sep),
+	}, "\n")
+
+	a := NewAdapter("h").WithRunner(fakeRunner{out: map[string][]byte{
+		"tmux info":          []byte("alive"),
+		"tmux list-sessions": []byte(out),
+	}})
+
+	sessions, err := a.listSessions(context.Background())
+	if err != nil {
+		t.Fatalf("listSessions: %v", err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("want 2 sessions, got %d (%v)", len(sessions), sessions)
+	}
+
+	alpha := sessions[SessionKey{Host: "h", Name: "alpha"}]
+	if !alpha.Attached {
+		t.Errorf("alpha should be attached")
+	}
+	if alpha.AttachedCount != 1 {
+		t.Errorf("alpha attached count: want 1, got %d", alpha.AttachedCount)
+	}
+	if alpha.WindowCount != 2 {
+		t.Errorf("alpha window count: want 2, got %d", alpha.WindowCount)
+	}
+	if alpha.CreatedAt.Equal(time.Time{}) {
+		t.Errorf("alpha createdAt: want non-zero")
+	}
+
+	beta := sessions[SessionKey{Host: "h", Name: "beta"}]
+	if beta.Attached {
+		t.Errorf("beta should not be attached")
+	}
+	if !beta.LastActivityAt.IsZero() {
+		t.Errorf("beta lastActivity: want zero (raw '0' input), got %v", beta.LastActivityAt)
+	}
+}
+
+func TestListPanes_Parses(t *testing.T) {
+	const sep = "\x01"
+	out := strings.Join([]string{
+		strings.Join([]string{"alpha", "0", "%26", "Editor", "vim", "12345", "120", "30", "0"}, sep),
+		strings.Join([]string{"alpha", "0", "%27", "Shell", "zsh", "12346", "120", "30", "0"}, sep),
+	}, "\n")
+
+	a := NewAdapter("h").WithRunner(fakeRunner{out: map[string][]byte{
+		"tmux info":       []byte("alive"),
+		"tmux list-panes": []byte(out),
+	}})
+
+	panes, err := a.listPanes(context.Background())
+	if err != nil {
+		t.Fatalf("listPanes: %v", err)
+	}
+	if len(panes) != 2 {
+		t.Fatalf("want 2 panes, got %d", len(panes))
+	}
+
+	p := panes[PaneKey{Host: "h", PaneID: "%26"}]
+	if p.CurrentCommand != "vim" {
+		t.Errorf("currentCommand: want vim, got %q", p.CurrentCommand)
+	}
+	if p.WindowKey.Index != 0 {
+		t.Errorf("windowIndex: want 0, got %d", p.WindowKey.Index)
+	}
+	if p.Width != 120 || p.Height != 30 {
+		t.Errorf("dims: want 120x30, got %dx%d", p.Width, p.Height)
+	}
+}
+
+func TestListPanes_EmptyOnNoServer(t *testing.T) {
+	a := NewAdapter("h").WithRunner(fakeRunner{out: map[string][]byte{
+		"tmux info": nil,
+	}, errs: map[string]error{
+		"tmux info": errFake("no server running"),
+	}})
+
+	snap, err := a.FetchAll(context.Background())
+	if err != nil {
+		t.Fatalf("FetchAll: %v", err)
+	}
+	if snap.Server.Alive {
+		t.Errorf("Server.Alive should be false when daemon is dead")
+	}
+	if len(snap.Sessions) != 0 || len(snap.Panes) != 0 {
+		t.Errorf("expected empty maps, got sessions=%d panes=%d", len(snap.Sessions), len(snap.Panes))
+	}
+}
+
+// errFake is a tiny error type so tests can stage an "exit 1" response
+// without dragging in os/exec.
+type errFakeT string
+
+func (e errFakeT) Error() string { return string(e) }
+
+func errFake(msg string) error { return errFakeT(msg) }
+
+func TestParseUnix(t *testing.T) {
+	cases := map[string]bool{
+		"":           true,  // zero
+		"0":          true,  // zero
+		"1700000000": false, // valid
+		"abc":        true,  // invalid → zero
+	}
+	for in, wantZero := range cases {
+		got := parseUnix(in)
+		if got.IsZero() != wantZero {
+			t.Errorf("parseUnix(%q): zero=%t (want %t)", in, got.IsZero(), wantZero)
+		}
+	}
+}

--- a/internal/server/providers/tmux/provider.go
+++ b/internal/server/providers/tmux/provider.go
@@ -1,0 +1,523 @@
+// Provider wires the tmux Adapter, an in-memory Store, and the watcher
+// loop into the Provider[K, V] surface. Per ADR-011 the resolver layer
+// depends on this provider through its node-typed Provider interfaces;
+// the adapter is private to this package.
+
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/provider"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/store"
+)
+
+// DefaultPollInterval is the watcher tick rate per ADR-011 §12 line 413.
+// Tunable via WithPollInterval — the E2E test runs faster.
+const DefaultPollInterval = 1 * time.Second
+
+// ActiveAttachedWindow is how recent a client's last_activity must be
+// for TmuxSession.activeAttached to be true. ADR §5.1 spec.
+const ActiveAttachedWindow = 5 * time.Minute
+
+// Provider is the orchard-side facade over the tmux Adapter. It owns
+// the in-memory cache (one Store per node type), the poll/watch loop,
+// and invalidation fanout. Resolvers reach through Snapshot() to read
+// joined state; the four typed Provider[K, V] facets satisfy the
+// generic Provider contract for each node type.
+type Provider struct {
+	adapter      *Adapter
+	pollInterval time.Duration
+	logger       *slog.Logger
+
+	sessions *store.Store[SessionKey, Session]
+	windows  *store.Store[WindowKey, Window]
+	panes    *store.Store[PaneKey, Pane]
+	clients  *store.Store[ClientKey, Client]
+
+	mu     sync.RWMutex
+	server ServerInfo
+
+	subsMu       sync.Mutex
+	sessionSubs  []chan provider.InvalidationEvent[SessionKey]
+	windowSubs   []chan provider.InvalidationEvent[WindowKey]
+	paneSubs     []chan provider.InvalidationEvent[PaneKey]
+	clientSubs   []chan provider.InvalidationEvent[ClientKey]
+	tickerSignal chan struct{} // tests pulse this to force a refresh
+}
+
+// New constructs a Provider for the given adapter. The watcher does not
+// start until Start is called.
+func New(a *Adapter, logger *slog.Logger) *Provider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Provider{
+		adapter:      a,
+		pollInterval: DefaultPollInterval,
+		logger:       logger,
+		sessions:     store.New[SessionKey, Session](),
+		windows:      store.New[WindowKey, Window](),
+		panes:        store.New[PaneKey, Pane](),
+		clients:      store.New[ClientKey, Client](),
+		tickerSignal: make(chan struct{}, 1),
+	}
+}
+
+// WithPollInterval lets tests bypass the 1s default — passing 50ms gives
+// E2E tests a sub-second roundtrip without burning CPU in production.
+func (p *Provider) WithPollInterval(d time.Duration) *Provider {
+	if d > 0 {
+		p.pollInterval = d
+	}
+	return p
+}
+
+// Adapter exposes the wrapped adapter for tests / introspection.
+func (p *Provider) Adapter() *Adapter { return p.adapter }
+
+// Host returns the host id every key carries.
+func (p *Provider) Host() HostID { return p.adapter.Host() }
+
+// Start performs an initial fetch and kicks off the poll loop. Returns
+// the first-fetch error so the caller (the daemon entry point) sees a
+// fundamentally broken environment at boot rather than later.
+func (p *Provider) Start(ctx context.Context) error {
+	if err := p.refresh(ctx); err != nil {
+		return fmt.Errorf("tmux provider: initial fetch: %w", err)
+	}
+	go p.pollLoop(ctx)
+	return nil
+}
+
+// Refresh runs an immediate fetch — useful in tests that want to skip
+// the poll wait.
+func (p *Provider) Refresh(ctx context.Context) error { return p.refresh(ctx) }
+
+func (p *Provider) refresh(ctx context.Context) error {
+	snap, err := p.adapter.FetchAll(ctx)
+	if err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+	p.server = snap.Server
+	p.mu.Unlock()
+
+	now := time.Now()
+	sessChanged := p.sessions.ReplaceAll(snap.Sessions, provider.SourcePoll, sessionsEqual)
+	winChanged := p.windows.ReplaceAll(snap.Windows, provider.SourcePoll, windowsEqual)
+	paneChanged := p.panes.ReplaceAll(snap.Panes, provider.SourcePoll, panesEqual)
+	clientChanged := p.clients.ReplaceAll(snap.Clients, provider.SourcePoll, clientsEqual)
+
+	for _, k := range sessChanged {
+		p.fanoutSession(provider.InvalidationEvent[SessionKey]{Key: k, Reason: "poll", At: now})
+	}
+	for _, k := range winChanged {
+		p.fanoutWindow(provider.InvalidationEvent[WindowKey]{Key: k, Reason: "poll", At: now})
+	}
+	for _, k := range paneChanged {
+		p.fanoutPane(provider.InvalidationEvent[PaneKey]{Key: k, Reason: "poll", At: now})
+	}
+	for _, k := range clientChanged {
+		p.fanoutClient(provider.InvalidationEvent[ClientKey]{Key: k, Reason: "poll", At: now})
+	}
+	return nil
+}
+
+func (p *Provider) pollLoop(ctx context.Context) {
+	t := time.NewTicker(p.pollInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := p.refresh(ctx); err != nil {
+				p.logger.Warn("tmux provider: refresh failed", "err", err)
+			}
+		case <-p.tickerSignal:
+			if err := p.refresh(ctx); err != nil {
+				p.logger.Warn("tmux provider: forced refresh failed", "err", err)
+			}
+		}
+	}
+}
+
+// PokeRefresh forces the poll loop to refresh outside its tick. The
+// fsnotify watcher hooks into this so socket-directory events translate
+// into immediate fetches.
+func (p *Provider) PokeRefresh() {
+	select {
+	case p.tickerSignal <- struct{}{}:
+	default:
+	}
+}
+
+// ----------------------------------------------------------------------
+// Snapshot — resolver-friendly read of the entire cached graph.
+// ----------------------------------------------------------------------
+
+// Snapshot is a pointer-free view of the provider's cache, taken under
+// each store's read lock independently — callers should treat the
+// snapshot as a single point in time even though the four reads are
+// not transactional. Mutations after the call do not bleed into the
+// returned maps.
+type RuntimeSnapshot struct {
+	Server   ServerInfo
+	Sessions map[SessionKey]Session
+	Windows  map[WindowKey]Window
+	Panes    map[PaneKey]Pane
+	Clients  map[ClientKey]Client
+}
+
+// Snapshot returns the cached graph. Empty when no tmux daemon is
+// running (poll loop puts EmptySnapshot through the stores in that case).
+func (p *Provider) Snapshot() RuntimeSnapshot {
+	p.mu.RLock()
+	server := p.server
+	p.mu.RUnlock()
+	return RuntimeSnapshot{
+		Server:   server,
+		Sessions: p.sessions.Snapshot(),
+		Windows:  p.windows.Snapshot(),
+		Panes:    p.panes.Snapshot(),
+		Clients:  p.clients.Snapshot(),
+	}
+}
+
+// Server returns the cached ServerInfo. Provided separately so resolvers
+// for TmuxServer.alive / .pid don't pay the snapshot copy cost.
+func (p *Provider) Server() ServerInfo {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.server
+}
+
+// CapturePane shells out via the adapter; not cached. The schema docs
+// the on-demand cost.
+func (p *Provider) CapturePane(ctx context.Context, key PaneKey, start, end int, full, stripAnsi bool) (string, error) {
+	return p.adapter.CapturePane(ctx, key, start, end, full, stripAnsi)
+}
+
+// CapturePaneTail wraps the adapter's tail-capture for the schema
+// `content(lines:)` field.
+func (p *Provider) CapturePaneTail(ctx context.Context, key PaneKey, lines int, stripAnsi bool) (string, error) {
+	return p.adapter.CapturePaneTail(ctx, key, lines, stripAnsi)
+}
+
+// ----------------------------------------------------------------------
+// Provider[K,V] facets — one per node type. Resolvers depend on these
+// generic interfaces, not on *Provider directly.
+// ----------------------------------------------------------------------
+
+// Sessions returns a Provider facet over SessionKey/Session.
+func (p *Provider) Sessions() provider.Provider[SessionKey, Session] {
+	return sessionsFacet{p}
+}
+
+// Windows returns a Provider facet over WindowKey/Window.
+func (p *Provider) Windows() provider.Provider[WindowKey, Window] { return windowsFacet{p} }
+
+// Panes returns a Provider facet over PaneKey/Pane.
+func (p *Provider) Panes() provider.Provider[PaneKey, Pane] { return panesFacet{p} }
+
+// Clients returns a Provider facet over ClientKey/Client.
+func (p *Provider) Clients() provider.Provider[ClientKey, Client] { return clientsFacet{p} }
+
+type sessionsFacet struct{ p *Provider }
+
+func (f sessionsFacet) Get(_ context.Context, k SessionKey) (Session, provider.Freshness, error) {
+	v, fr, ok := f.p.sessions.Get(k)
+	if !ok {
+		return Session{}, provider.Freshness{}, fmt.Errorf("tmux session %q not found", k.Name)
+	}
+	return v, fr, nil
+}
+
+func (f sessionsFacet) GetMany(_ context.Context, keys []SessionKey) (map[SessionKey]Session, map[SessionKey]provider.Freshness, error) {
+	values := make(map[SessionKey]Session, len(keys))
+	freshness := make(map[SessionKey]provider.Freshness, len(keys))
+	for _, k := range keys {
+		if v, fr, ok := f.p.sessions.Get(k); ok {
+			values[k] = v
+			freshness[k] = fr
+		}
+	}
+	return values, freshness, nil
+}
+
+func (f sessionsFacet) Keys(_ context.Context) ([]SessionKey, error) {
+	return f.p.sessions.Keys(), nil
+}
+
+func (f sessionsFacet) Subscribe(ctx context.Context) <-chan provider.InvalidationEvent[SessionKey] {
+	ch := make(chan provider.InvalidationEvent[SessionKey], 8)
+	f.p.subsMu.Lock()
+	f.p.sessionSubs = append(f.p.sessionSubs, ch)
+	f.p.subsMu.Unlock()
+	go func() {
+		<-ctx.Done()
+		f.p.subsMu.Lock()
+		defer f.p.subsMu.Unlock()
+		for i, c := range f.p.sessionSubs {
+			if c == ch {
+				f.p.sessionSubs = append(f.p.sessionSubs[:i], f.p.sessionSubs[i+1:]...)
+				close(ch)
+				return
+			}
+		}
+	}()
+	return ch
+}
+
+type windowsFacet struct{ p *Provider }
+
+func (f windowsFacet) Get(_ context.Context, k WindowKey) (Window, provider.Freshness, error) {
+	v, fr, ok := f.p.windows.Get(k)
+	if !ok {
+		return Window{}, provider.Freshness{}, fmt.Errorf("tmux window %s:%d not found", k.Session, k.Index)
+	}
+	return v, fr, nil
+}
+
+func (f windowsFacet) GetMany(_ context.Context, keys []WindowKey) (map[WindowKey]Window, map[WindowKey]provider.Freshness, error) {
+	values := make(map[WindowKey]Window, len(keys))
+	freshness := make(map[WindowKey]provider.Freshness, len(keys))
+	for _, k := range keys {
+		if v, fr, ok := f.p.windows.Get(k); ok {
+			values[k] = v
+			freshness[k] = fr
+		}
+	}
+	return values, freshness, nil
+}
+
+func (f windowsFacet) Keys(_ context.Context) ([]WindowKey, error) { return f.p.windows.Keys(), nil }
+
+func (f windowsFacet) Subscribe(ctx context.Context) <-chan provider.InvalidationEvent[WindowKey] {
+	ch := make(chan provider.InvalidationEvent[WindowKey], 8)
+	f.p.subsMu.Lock()
+	f.p.windowSubs = append(f.p.windowSubs, ch)
+	f.p.subsMu.Unlock()
+	go func() {
+		<-ctx.Done()
+		f.p.subsMu.Lock()
+		defer f.p.subsMu.Unlock()
+		for i, c := range f.p.windowSubs {
+			if c == ch {
+				f.p.windowSubs = append(f.p.windowSubs[:i], f.p.windowSubs[i+1:]...)
+				close(ch)
+				return
+			}
+		}
+	}()
+	return ch
+}
+
+type panesFacet struct{ p *Provider }
+
+func (f panesFacet) Get(_ context.Context, k PaneKey) (Pane, provider.Freshness, error) {
+	v, fr, ok := f.p.panes.Get(k)
+	if !ok {
+		return Pane{}, provider.Freshness{}, fmt.Errorf("tmux pane %s not found", k.PaneID)
+	}
+	return v, fr, nil
+}
+
+func (f panesFacet) GetMany(_ context.Context, keys []PaneKey) (map[PaneKey]Pane, map[PaneKey]provider.Freshness, error) {
+	values := make(map[PaneKey]Pane, len(keys))
+	freshness := make(map[PaneKey]provider.Freshness, len(keys))
+	for _, k := range keys {
+		if v, fr, ok := f.p.panes.Get(k); ok {
+			values[k] = v
+			freshness[k] = fr
+		}
+	}
+	return values, freshness, nil
+}
+
+func (f panesFacet) Keys(_ context.Context) ([]PaneKey, error) { return f.p.panes.Keys(), nil }
+
+func (f panesFacet) Subscribe(ctx context.Context) <-chan provider.InvalidationEvent[PaneKey] {
+	ch := make(chan provider.InvalidationEvent[PaneKey], 8)
+	f.p.subsMu.Lock()
+	f.p.paneSubs = append(f.p.paneSubs, ch)
+	f.p.subsMu.Unlock()
+	go func() {
+		<-ctx.Done()
+		f.p.subsMu.Lock()
+		defer f.p.subsMu.Unlock()
+		for i, c := range f.p.paneSubs {
+			if c == ch {
+				f.p.paneSubs = append(f.p.paneSubs[:i], f.p.paneSubs[i+1:]...)
+				close(ch)
+				return
+			}
+		}
+	}()
+	return ch
+}
+
+type clientsFacet struct{ p *Provider }
+
+func (f clientsFacet) Get(_ context.Context, k ClientKey) (Client, provider.Freshness, error) {
+	v, fr, ok := f.p.clients.Get(k)
+	if !ok {
+		return Client{}, provider.Freshness{}, fmt.Errorf("tmux client %q not found", k.ClientName)
+	}
+	return v, fr, nil
+}
+
+func (f clientsFacet) GetMany(_ context.Context, keys []ClientKey) (map[ClientKey]Client, map[ClientKey]provider.Freshness, error) {
+	values := make(map[ClientKey]Client, len(keys))
+	freshness := make(map[ClientKey]provider.Freshness, len(keys))
+	for _, k := range keys {
+		if v, fr, ok := f.p.clients.Get(k); ok {
+			values[k] = v
+			freshness[k] = fr
+		}
+	}
+	return values, freshness, nil
+}
+
+func (f clientsFacet) Keys(_ context.Context) ([]ClientKey, error) { return f.p.clients.Keys(), nil }
+
+func (f clientsFacet) Subscribe(ctx context.Context) <-chan provider.InvalidationEvent[ClientKey] {
+	ch := make(chan provider.InvalidationEvent[ClientKey], 8)
+	f.p.subsMu.Lock()
+	f.p.clientSubs = append(f.p.clientSubs, ch)
+	f.p.subsMu.Unlock()
+	go func() {
+		<-ctx.Done()
+		f.p.subsMu.Lock()
+		defer f.p.subsMu.Unlock()
+		for i, c := range f.p.clientSubs {
+			if c == ch {
+				f.p.clientSubs = append(f.p.clientSubs[:i], f.p.clientSubs[i+1:]...)
+				close(ch)
+				return
+			}
+		}
+	}()
+	return ch
+}
+
+// ----------------------------------------------------------------------
+// Compile-time assertions — fast feedback when a Provider[K, V]
+// signature drifts.
+// ----------------------------------------------------------------------
+
+var (
+	_ provider.Provider[SessionKey, Session] = sessionsFacet{}
+	_ provider.Provider[WindowKey, Window]   = windowsFacet{}
+	_ provider.Provider[PaneKey, Pane]       = panesFacet{}
+	_ provider.Provider[ClientKey, Client]   = clientsFacet{}
+)
+
+// ----------------------------------------------------------------------
+// Subscribe fanout. Caller MUST NOT hold a store lock — the send is
+// best-effort but the goroutine still races other producers, so we want
+// minimum critical sections.
+// ----------------------------------------------------------------------
+
+func (p *Provider) fanoutSession(ev provider.InvalidationEvent[SessionKey]) {
+	p.subsMu.Lock()
+	subs := append([]chan provider.InvalidationEvent[SessionKey](nil), p.sessionSubs...)
+	p.subsMu.Unlock()
+	for _, c := range subs {
+		select {
+		case c <- ev:
+		default:
+		}
+	}
+}
+
+func (p *Provider) fanoutWindow(ev provider.InvalidationEvent[WindowKey]) {
+	p.subsMu.Lock()
+	subs := append([]chan provider.InvalidationEvent[WindowKey](nil), p.windowSubs...)
+	p.subsMu.Unlock()
+	for _, c := range subs {
+		select {
+		case c <- ev:
+		default:
+		}
+	}
+}
+
+func (p *Provider) fanoutPane(ev provider.InvalidationEvent[PaneKey]) {
+	p.subsMu.Lock()
+	subs := append([]chan provider.InvalidationEvent[PaneKey](nil), p.paneSubs...)
+	p.subsMu.Unlock()
+	for _, c := range subs {
+		select {
+		case c <- ev:
+		default:
+		}
+	}
+}
+
+func (p *Provider) fanoutClient(ev provider.InvalidationEvent[ClientKey]) {
+	p.subsMu.Lock()
+	subs := append([]chan provider.InvalidationEvent[ClientKey](nil), p.clientSubs...)
+	p.subsMu.Unlock()
+	for _, c := range subs {
+		select {
+		case c <- ev:
+		default:
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+// Equality helpers used by Store.ReplaceAll to compute the "changed"
+// set per tick. Comparing every field would force the watcher to fan
+// out a no-op on every poll; comparing the fields a client cares about
+// (state + activity timestamps) keeps fanout proportional to real change.
+// ----------------------------------------------------------------------
+
+func sessionsEqual(a, b Session) bool {
+	return a.Key == b.Key &&
+		a.Attached == b.Attached &&
+		a.AttachedCount == b.AttachedCount &&
+		a.WindowCount == b.WindowCount &&
+		a.CurrentWindow == b.CurrentWindow &&
+		a.LastActivityAt.Equal(b.LastActivityAt) &&
+		a.CreatedAt.Equal(b.CreatedAt)
+}
+
+func windowsEqual(a, b Window) bool {
+	return a.Key == b.Key &&
+		a.Name == b.Name &&
+		a.Active == b.Active &&
+		a.PaneCount == b.PaneCount &&
+		a.CurrentPane == b.CurrentPane
+}
+
+func panesEqual(a, b Pane) bool {
+	return a.Key == b.Key &&
+		a.WindowKey == b.WindowKey &&
+		a.Title == b.Title &&
+		a.CurrentCommand == b.CurrentCommand &&
+		a.CurrentPid == b.CurrentPid &&
+		a.Width == b.Width &&
+		a.Height == b.Height &&
+		a.Dead == b.Dead
+}
+
+func clientsEqual(a, b Client) bool {
+	return a.Key == b.Key &&
+		a.Session == b.Session &&
+		a.TTY == b.TTY &&
+		a.Hostname == b.Hostname &&
+		a.TermName == b.TermName &&
+		a.Readonly == b.Readonly &&
+		a.CurrentWindow == b.CurrentWindow &&
+		a.CurrentPane == b.CurrentPane &&
+		a.AttachedAt.Equal(b.AttachedAt) &&
+		a.LastActivityAt.Equal(b.LastActivityAt)
+}

--- a/internal/server/providers/tmux/provider.go
+++ b/internal/server/providers/tmux/provider.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/drewdrewthis/git-orchard-rs/internal/server/provider"
+	provider "github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/store"
 )
 

--- a/internal/server/providers/tmux/tmux_e2e_test.go
+++ b/internal/server/providers/tmux/tmux_e2e_test.go
@@ -154,7 +154,7 @@ func TestEndToEnd_SessionAppearsAndDisappears(t *testing.T) {
 		t.Fatalf("provider start: %v", err)
 	}
 
-	srv := server.New("", nil, server.WithTmuxProvider(provider))
+	srv := server.New("", nil, server.WithTmux(provider))
 	httpSrv := httptest.NewServer(srv.GraphQLHandler())
 	t.Cleanup(httpSrv.Close)
 
@@ -235,7 +235,7 @@ func TestProvider_NoTmux(t *testing.T) {
 		t.Fatalf("provider start: %v", err)
 	}
 
-	srv := server.New("", nil, server.WithTmuxProvider(provider))
+	srv := server.New("", nil, server.WithTmux(provider))
 	httpSrv := httptest.NewServer(srv.GraphQLHandler())
 	t.Cleanup(httpSrv.Close)
 

--- a/internal/server/providers/tmux/tmux_e2e_test.go
+++ b/internal/server/providers/tmux/tmux_e2e_test.go
@@ -1,0 +1,315 @@
+// E2E coverage for the tmux provider — spins a real tmux server in a
+// throwaway socket, drives it through the standard Adapter / Provider
+// pipeline, and asserts the GraphQL surface returns what the user
+// would expect.
+//
+// macOS-only assumptions: `tmux` is on PATH (CI installs it) and the
+// `bash` interpreter is available for the dummy pane process. Linux
+// CI satisfies both.
+
+package tmux_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
+)
+
+// pollInterval is the test-time tick rate. Snappier than the 1s
+// production default so the kill/disappear assertion does not push the
+// total runtime past `go test -timeout` defaults.
+const testPollInterval = 100 * time.Millisecond
+
+// waitFor polls fn until it returns true or the context fires. Returns
+// the last (false) value when the context dies. Used for the
+// "session disappears after one poll cycle" assertion.
+func waitFor(ctx context.Context, fn func() bool) bool {
+	deadline, _ := ctx.Deadline()
+	for {
+		if fn() {
+			return true
+		}
+		if !deadline.IsZero() && time.Now().After(deadline) {
+			return false
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// tmuxAvailable returns nil when `tmux` is on PATH; the test skips
+// otherwise so a sandbox without tmux doesn't fail the suite.
+func tmuxAvailable(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skipf("tmux not on PATH; skipping E2E: %v", err)
+	}
+}
+
+// startSandboxTmux launches a tmux server on a temporary socket so it
+// cannot collide with the developer's primary tmux. Cleanup kills the
+// server and removes the socket.
+//
+// Unix-domain socket paths are capped at ~104 bytes on macOS. `t.TempDir()`
+// nests under `os.TempDir()` *and* the test name, easily blowing past
+// the cap; we mkdir under /tmp directly so the path stays short.
+func startSandboxTmux(t *testing.T) (socket string) {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "orchard-tmux-test-")
+	if err != nil {
+		t.Fatalf("mkdir tmp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	socket = filepath.Join(dir, "s.sock")
+
+	// Spawn the server with a single dummy session so list-sessions
+	// returns at least one row immediately. `tmux new-session -d`
+	// daemonises the server; the -t target is unused.
+	args := []string{
+		"-S", socket,
+		"new-session", "-d", "-s", "alpha",
+		"-x", "80", "-y", "24",
+		"bash", "-c", "while true; do sleep 1; done",
+	}
+	cmd := exec.Command("tmux", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("start sandbox tmux: %v: %s", err, out)
+	}
+
+	t.Cleanup(func() {
+		_ = exec.Command("tmux", "-S", socket, "kill-server").Run()
+	})
+	return socket
+}
+
+// killSession kills a session by name on the sandbox socket. Helper
+// keeps the assertion site readable.
+func killSession(t *testing.T, socket, session string) {
+	t.Helper()
+	out, err := exec.Command("tmux", "-S", socket, "kill-session", "-t", session).CombinedOutput()
+	if err != nil {
+		t.Fatalf("kill session %q: %v: %s", session, err, out)
+	}
+}
+
+// graphQLPost issues a single GraphQL POST and returns the decoded
+// envelope so the caller can dive into `data`/`errors` without
+// duplicating the HTTP boilerplate.
+func graphQLPost(t *testing.T, base, query string) map[string]any {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	resp, err := http.Post(base+"/graphql", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	var env map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if errs, ok := env["errors"]; ok && errs != nil {
+		// Promote graphql errors so the test fails loudly with the
+		// resolver message instead of a confusing nil-deref.
+		t.Fatalf("graphql errors: %v", errs)
+	}
+	return env
+}
+
+// TestEndToEnd_SessionAppearsAndDisappears is the headline AC test.
+// Spin a sandbox tmux, walk it through the provider, serve it through
+// httptest, then kill the session and watch the cache evict it.
+func TestEndToEnd_SessionAppearsAndDisappears(t *testing.T) {
+	tmuxAvailable(t)
+
+	socket := startSandboxTmux(t)
+	host := tmux.HostID("sandbox")
+
+	adapter := tmux.NewAdapter(host).WithSocket(socket)
+	provider := tmux.New(adapter, nil).WithPollInterval(testPollInterval)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("provider start: %v", err)
+	}
+
+	srv := server.New("", nil, server.WithTmuxProvider(provider))
+	httpSrv := httptest.NewServer(srv.GraphQLHandler())
+	t.Cleanup(httpSrv.Close)
+
+	// 1. Session "alpha" should be visible — we created it in the
+	//    sandbox tmux above.
+	env := graphQLPost(t, httpSrv.URL, `{ tmuxSessions { name } }`)
+	names := extractSessionNames(t, env)
+	if !contains(names, "alpha") {
+		t.Fatalf("expected 'alpha' in sessions; got %v", names)
+	}
+
+	// 2. Server entry point returns Alive=true with our socket path.
+	env = graphQLPost(t, httpSrv.URL, `{ tmuxServer { id alive socketPath } }`)
+	srvData := env["data"].(map[string]any)["tmuxServer"].(map[string]any)
+	if alive, _ := srvData["alive"].(bool); !alive {
+		t.Fatalf("tmuxServer.alive false: %v", srvData)
+	}
+	if got, _ := srvData["socketPath"].(string); got != socket {
+		t.Fatalf("socketPath: want %q, got %q", socket, got)
+	}
+
+	// 3. Add another session, force a refresh, observe the new entry.
+	add := exec.Command("tmux", "-S", socket, "new-session", "-d", "-s", "beta",
+		"bash", "-c", "while true; do sleep 1; done")
+	if out, err := add.CombinedOutput(); err != nil {
+		t.Fatalf("create beta: %v: %s", err, out)
+	}
+	if err := provider.Refresh(ctx); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	env = graphQLPost(t, httpSrv.URL, `{ tmuxSessions { name } }`)
+	if names = extractSessionNames(t, env); !contains(names, "beta") {
+		t.Fatalf("expected 'beta' after create; got %v", names)
+	}
+
+	// 4. Pane filtering — the bash dummy should be visible per-session.
+	env = graphQLPost(t, httpSrv.URL,
+		`{ tmuxPanes(filter: { sessionIn: ["alpha"] }) { paneId currentCommand } }`)
+	panes := mustList(t, env, "tmuxPanes")
+	if len(panes) == 0 {
+		t.Fatalf("expected at least one alpha pane")
+	}
+	for _, p := range panes {
+		if !strings.HasPrefix(p["paneId"].(string), "%") {
+			t.Fatalf("pane id should begin with %%: %v", p)
+		}
+	}
+
+	// 5. Kill alpha and watch it disappear after one poll cycle.
+	killSession(t, socket, "alpha")
+	gone := waitFor(ctx, func() bool {
+		env := graphQLPost(t, httpSrv.URL, `{ tmuxSessions { name } }`)
+		return !contains(extractSessionNames(t, env), "alpha")
+	})
+	if !gone {
+		t.Fatalf("alpha did not disappear after kill")
+	}
+}
+
+// TestProvider_NoTmux verifies the resolver gracefully reports a dead
+// server when the socket path points at no daemon.
+func TestProvider_NoTmux(t *testing.T) {
+	tmuxAvailable(t)
+
+	dir, err := os.MkdirTemp("/tmp", "orchard-tmux-dead-")
+	if err != nil {
+		t.Fatalf("mkdir tmp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dead := filepath.Join(dir, "x.sock")
+
+	adapter := tmux.NewAdapter("solo").WithSocket(dead)
+	provider := tmux.New(adapter, nil).WithPollInterval(testPollInterval)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("provider start: %v", err)
+	}
+
+	srv := server.New("", nil, server.WithTmuxProvider(provider))
+	httpSrv := httptest.NewServer(srv.GraphQLHandler())
+	t.Cleanup(httpSrv.Close)
+
+	// tmuxServer is nullable and should be null when the daemon is dead.
+	body, err := json.Marshal(map[string]string{"query": `{ tmuxServer { id alive } }`})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	resp, err := http.Post(httpSrv.URL+"/graphql", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var env map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	data, ok := env["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing data: %v", env)
+	}
+	if data["tmuxServer"] != nil {
+		t.Fatalf("expected null tmuxServer, got %v", data["tmuxServer"])
+	}
+}
+
+// ----------------------------------------------------------------------
+// Tiny test helpers — purely local to the package.
+// ----------------------------------------------------------------------
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func mustList(t *testing.T, env map[string]any, key string) []map[string]any {
+	t.Helper()
+	data, ok := env["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope missing data: %v", env)
+	}
+	raw, ok := data[key].([]any)
+	if !ok {
+		t.Fatalf("data[%q] not list: %v", key, data[key])
+	}
+	out := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("data[%q] item not object: %v", key, item)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func extractSessionNames(t *testing.T, env map[string]any) []string {
+	t.Helper()
+	list := mustList(t, env, "tmuxSessions")
+	names := make([]string, 0, len(list))
+	for _, s := range list {
+		name, ok := s["name"].(string)
+		if !ok {
+			t.Fatalf("session missing name: %v", s)
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+// errorsAreNil keeps the bash linter happy — referenced from a path
+// that may not always run, depending on how tmux behaves under load.
+var _ = errors.Is

--- a/internal/server/providers/tmux/types.go
+++ b/internal/server/providers/tmux/types.go
@@ -1,0 +1,129 @@
+// Package tmux exposes the tmux-server / tmux-session / tmux-window /
+// tmux-pane / tmux-client hierarchy as an orchard provider per
+// ADR-011 §5.1.
+//
+// Layering (worker-standards §5):
+//
+//	resolvers/  ─►  tmux.Provider  ─►  tmux.Adapter  ─►  `tmux ...`
+//
+// The provider owns the cache + watcher; the adapter is stateless I/O.
+// All interaction with the tmux daemon goes through the adapter — the
+// provider never shells out directly.
+package tmux
+
+import "time"
+
+// HostID identifies the host the tmux daemon runs on. v1 only ever holds
+// the local machine's id; the prefix is preserved in every node id so
+// federation in Workstream F can disambiguate without a schema bump.
+type HostID string
+
+// SessionKey is the cache key for a TmuxSession. Sessions are uniquely
+// identified by name within a server.
+type SessionKey struct {
+	Host HostID
+	Name string
+}
+
+// WindowKey identifies a window within a session.
+type WindowKey struct {
+	Host    HostID
+	Session string
+	Index   int
+}
+
+// PaneKey identifies a pane globally within a host. tmux assigns each
+// pane a stable `%N` id that survives window/session moves.
+type PaneKey struct {
+	Host   HostID
+	PaneID string // includes leading '%'
+}
+
+// ClientKey identifies an attached client by tty.
+type ClientKey struct {
+	Host       HostID
+	ClientName string
+}
+
+// ServerInfo is what the adapter reports about the tmux daemon itself.
+// Pid is best-effort — older tmux releases don't expose it through the
+// CLI; resolvers surface zero as "unknown".
+type ServerInfo struct {
+	SocketPath string
+	Pid        int
+	Alive      bool
+}
+
+// Session mirrors the parts of `tmux list-sessions -F` we care about.
+// Field meanings track tmux's documented format-variables so a reader
+// can map straight back to `man 1 tmux`.
+type Session struct {
+	Key            SessionKey
+	CreatedAt      time.Time
+	Attached       bool
+	AttachedCount  int
+	LastActivityAt time.Time // zero when tmux returned no value
+	WindowCount    int
+	CurrentWindow  int // index of the focused window
+}
+
+// Window mirrors `tmux list-windows -F`.
+type Window struct {
+	Key         WindowKey
+	Name        string
+	Active      bool
+	PaneCount   int
+	CurrentPane string // pane id of the active pane in this window
+}
+
+// Pane mirrors `tmux list-panes -F`. The tracking fields here are
+// intentionally narrow — content captures travel through a separate
+// adapter call so the poll cycle stays cheap.
+type Pane struct {
+	Key            PaneKey
+	WindowKey      WindowKey
+	Title          string
+	CurrentCommand string
+	CurrentPid     int
+	Width          int
+	Height         int
+	Dead           bool
+	WatchingTTYs   []string // tty paths from `client_active_pane`
+}
+
+// Client mirrors `tmux list-clients -F`.
+type Client struct {
+	Key            ClientKey
+	Session        string
+	TTY            string
+	Hostname       string
+	TermName       string
+	AttachedAt     time.Time
+	LastActivityAt time.Time // zero when tmux returned no value
+	Readonly       bool
+	CurrentWindow  int    // index, -1 when unknown
+	CurrentPane    string // pane id, "" when unknown
+}
+
+// Snapshot is the adapter's full per-tick view of a tmux server. The
+// provider does a single bulk fetch each poll tick because the four
+// `list-*` commands share the same socket connection cost.
+type Snapshot struct {
+	Server   ServerInfo
+	Sessions map[SessionKey]Session
+	Windows  map[WindowKey]Window
+	Panes    map[PaneKey]Pane
+	Clients  map[ClientKey]Client
+}
+
+// EmptySnapshot is the value the adapter returns when no tmux daemon is
+// reachable. Callers can pass it through the provider's Store unchanged
+// — every map is non-nil so resolvers don't crash on a cold-boot lookup.
+func EmptySnapshot() Snapshot {
+	return Snapshot{
+		Sessions: map[SessionKey]Session{},
+		Windows:  map[WindowKey]Window{},
+		Panes:    map[PaneKey]Pane{},
+		Clients:  map[ClientKey]Client{},
+	}
+}

--- a/internal/server/providers/tmux/watcher.go
+++ b/internal/server/providers/tmux/watcher.go
@@ -1,0 +1,130 @@
+// Watcher is a heartbeat-fsnotify hybrid per ADR-011 §12 line 413.
+// tmux exposes no native event stream, so the canonical signal is a 1s
+// poll over `list-*`. To shorten "I just attached / detached / opened a
+// window" latency below the poll interval, the watcher also subscribes
+// to fsnotify events on the tmux socket directory and pokes the poll
+// loop early when the daemon writes to its socket.
+//
+// Failures of either side degrade gracefully — fsnotify failures fall
+// back to poll-only; poll failures get logged and re-tried next tick.
+
+package tmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// SocketDir returns the directory holding the tmux socket the adapter
+// is bound to. For the default socket on macOS / Linux this is
+// `$TMPDIR/tmux-<uid>/`; for a custom -S path it's the directory
+// containing that file.
+//
+// Returns "" with no error when the socket dir cannot be determined —
+// the watcher falls back to poll-only.
+func (a *Adapter) SocketDir() (string, error) {
+	if a.socket != "" {
+		dir := filepath.Dir(a.socket)
+		if dir == "" {
+			return "", nil
+		}
+		if _, err := os.Stat(dir); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return "", nil
+			}
+			return "", fmt.Errorf("stat socket dir: %w", err)
+		}
+		return dir, nil
+	}
+	// Default socket dir is `$TMPDIR/tmux-<uid>/`. We don't need it for
+	// the polling fallback, so absence is a no-op rather than an error.
+	tmp := os.Getenv("TMPDIR")
+	if tmp == "" {
+		tmp = "/tmp"
+	}
+	candidates, err := filepath.Glob(filepath.Join(tmp, "tmux-*"))
+	if err != nil || len(candidates) == 0 {
+		return "", nil
+	}
+	return candidates[0], nil
+}
+
+// StartWatcher installs the fsnotify watcher on the tmux socket dir and
+// pokes the provider's poll loop on each event. It is non-fatal: when
+// fsnotify is unavailable the function logs and returns nil so the
+// provider continues poll-only.
+func StartWatcher(ctx context.Context, p *Provider, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	dir, err := p.adapter.SocketDir()
+	if err != nil {
+		logger.Warn("tmux watcher: socket dir lookup failed; falling back to poll-only", "err", err)
+		return nil
+	}
+	if dir == "" {
+		// No socket dir to watch yet (no tmux server has run). Poll
+		// loop will pick the dir up when it appears.
+		return nil
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		logger.Warn("tmux watcher: fsnotify unavailable; falling back to poll-only", "err", err)
+		return nil
+	}
+	if err := watcher.Add(dir); err != nil {
+		_ = watcher.Close()
+		logger.Warn("tmux watcher: cannot watch socket dir; falling back to poll-only", "dir", dir, "err", err)
+		return nil
+	}
+
+	go func() {
+		defer func() { _ = watcher.Close() }()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				// Only socket-relevant events should poke the poll loop.
+				// Filter out the noise from temporary files in the same dir.
+				if !relevantSocketEvent(ev) {
+					continue
+				}
+				p.PokeRefresh()
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				logger.Warn("tmux watcher: fsnotify error", "err", err)
+			}
+		}
+	}()
+	return nil
+}
+
+// relevantSocketEvent decides whether an fsnotify event should trigger
+// a refresh. Tmux writes its socket as a unix-domain file inside the
+// socket dir; create/remove/write events on a name starting with
+// "default" (or the adapter's chosen socket basename) are the ones that
+// matter. Everything else (temp files, lock files) we ignore.
+func relevantSocketEvent(ev fsnotify.Event) bool {
+	if ev.Op == 0 {
+		return false
+	}
+	base := filepath.Base(ev.Name)
+	if base == "" || strings.HasPrefix(base, ".") {
+		return false
+	}
+	return true
+}

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -12,6 +12,7 @@ import (
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 )
 
 // ProjectsLister is the narrow read-side contract the project resolver
@@ -36,12 +37,10 @@ type Resolver struct {
 	ProjectsProvider ProjectsLister
 	Git              *gitprovider.Provider
 	PS               *ps.Provider
+	Tmux             *tmux.Provider
 }
 
-// New constructs a Resolver with the daemon's start time captured. The
-// caller (the daemon entry point) calls this once at boot. Optional
-// dependencies (the providers) are wired with the With* setters below
-// so callers can swap implementations in tests.
+// New constructs a Resolver with the daemon's start time captured.
 func New(startedAt time.Time) *Resolver {
 	return &Resolver{StartedAt: startedAt}
 }
@@ -58,16 +57,20 @@ func (r *Resolver) WithProjects(p ProjectsLister) *Resolver {
 	return r
 }
 
-// WithGit wires the git provider that backs Project.worktrees and
-// Worktree.* resolvers.
+// WithGit wires the git provider that backs Project.worktrees and Worktree.*.
 func (r *Resolver) WithGit(g *gitprovider.Provider) *Resolver {
 	r.Git = g
 	return r
 }
 
-// WithPS wires the ps provider that backs Host.processes and Process
-// node resolution.
+// WithPS wires the ps provider that backs Host.processes and Process resolution.
 func (r *Resolver) WithPS(p *ps.Provider) *Resolver {
 	r.PS = p
+	return r
+}
+
+// WithTmux wires the tmux provider that backs TmuxServer/Session/Window/Pane/Client.
+func (r *Resolver) WithTmux(p *tmux.Provider) *Resolver {
+	r.Tmux = p
 	return r
 }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -81,12 +81,12 @@ func (r *processResolver) Cwd(ctx context.Context, obj *graphql1.Process) (*stri
 	return &cwd, nil
 }
 
-// Worktree is the resolver for the process.worktree field. Placeholder until ws-b-git wires the cwd lookup.
+// Worktree is the resolver for the process.worktree field.
 func (r *processResolver) Worktree(_ context.Context, _ *graphql1.Process) (*graphql1.Worktree, error) {
 	return nil, nil
 }
 
-// ClaudeInstance is the resolver for the process.claudeInstance field. Placeholder until ws-b-claudeinstance lands.
+// ClaudeInstance is the resolver for the process.claudeInstance field.
 func (r *processResolver) ClaudeInstance(_ context.Context, _ *graphql1.Process) (*graphql1.ClaudeInstance, error) {
 	return nil, nil
 }
@@ -100,10 +100,7 @@ func (r *queryResolver) Health(ctx context.Context) (*graphql1.Health, error) {
 	}, nil
 }
 
-// Host is the resolver for the host field. When HostProvider is wired,
-// returns the real local Host node. Otherwise (e.g. test harnesses that
-// only wire the ps provider) returns a stub Host carrying the ps
-// provider's host id so Host.processes still resolves.
+// Host is the resolver for the host field.
 func (r *queryResolver) Host(ctx context.Context) (*graphql1.Host, error) {
 	if r.HostProvider != nil {
 		h, _, err := r.HostProvider.Get(ctx, r.HostProvider.LocalID())
@@ -148,9 +145,154 @@ func (r *queryResolver) Projects(ctx context.Context) ([]*graphql1.Project, erro
 	return out, nil
 }
 
-// Processes is the resolver for the worktree.processes field. Placeholder until cwd-to-worktree join lands.
+// TmuxServer is the resolver for the tmuxServer field. Stub until commit 3 wires the provider.
+func (r *queryResolver) TmuxServer(_ context.Context) (*graphql1.TmuxServer, error) {
+	return nil, fmt.Errorf("tmux provider not wired")
+}
+
+// TmuxSessions is the resolver for the tmuxSessions field. Stub until commit 3.
+func (r *queryResolver) TmuxSessions(_ context.Context, _ *graphql1.TmuxSessionFilter) ([]*graphql1.TmuxSession, error) {
+	return nil, fmt.Errorf("tmux provider not wired")
+}
+
+// TmuxPanes is the resolver for the tmuxPanes field. Stub until commit 3.
+func (r *queryResolver) TmuxPanes(_ context.Context, _ *graphql1.TmuxPaneFilter) ([]*graphql1.TmuxPane, error) {
+	return nil, fmt.Errorf("tmux provider not wired")
+}
+
+// Processes is the resolver for the worktree.processes field.
 func (r *worktreeResolver) Processes(_ context.Context, _ *graphql1.Worktree) ([]*graphql1.Process, error) {
 	return []*graphql1.Process{}, nil
+}
+
+// TmuxServer field-resolver stubs — replaced in commit 3.
+func (r *tmuxServerResolver) Sessions(_ context.Context, _ *graphql1.TmuxServer) ([]*graphql1.TmuxSession, error) {
+	return nil, fmt.Errorf("tmux provider not wired")
+}
+func (r *tmuxServerResolver) Clients(_ context.Context, _ *graphql1.TmuxServer) ([]*graphql1.TmuxClient, error) {
+	return nil, fmt.Errorf("tmux provider not wired")
+}
+func (r *tmuxServerResolver) Pid(_ context.Context, _ *graphql1.TmuxServer) (*int64, error) {
+	return nil, nil
+}
+func (r *tmuxServerResolver) Alive(_ context.Context, _ *graphql1.TmuxServer) (bool, error) {
+	return false, nil
+}
+
+// TmuxSession stubs.
+func (r *tmuxSessionResolver) Server(_ context.Context, _ *graphql1.TmuxSession) (*graphql1.TmuxServer, error) {
+	return nil, fmt.Errorf("tmux provider not wired")
+}
+func (r *tmuxSessionResolver) Attached(_ context.Context, _ *graphql1.TmuxSession) (bool, error) {
+	return false, nil
+}
+func (r *tmuxSessionResolver) ActiveAttached(_ context.Context, _ *graphql1.TmuxSession) (bool, error) {
+	return false, nil
+}
+func (r *tmuxSessionResolver) AttachedClients(_ context.Context, _ *graphql1.TmuxSession) ([]*graphql1.TmuxClient, error) {
+	return nil, nil
+}
+func (r *tmuxSessionResolver) LastActivityAt(_ context.Context, _ *graphql1.TmuxSession) (*string, error) {
+	return nil, nil
+}
+func (r *tmuxSessionResolver) Windows(_ context.Context, _ *graphql1.TmuxSession) ([]*graphql1.TmuxWindow, error) {
+	return nil, nil
+}
+func (r *tmuxSessionResolver) CurrentWindow(_ context.Context, _ *graphql1.TmuxSession) (*graphql1.TmuxWindow, error) {
+	return nil, nil
+}
+func (r *tmuxSessionResolver) CreatedAt(_ context.Context, _ *graphql1.TmuxSession) (string, error) {
+	return "", nil
+}
+
+// TmuxWindow stubs.
+func (r *tmuxWindowResolver) Session(_ context.Context, _ *graphql1.TmuxWindow) (*graphql1.TmuxSession, error) {
+	return nil, nil
+}
+func (r *tmuxWindowResolver) Panes(_ context.Context, _ *graphql1.TmuxWindow) ([]*graphql1.TmuxPane, error) {
+	return nil, nil
+}
+func (r *tmuxWindowResolver) CurrentPane(_ context.Context, _ *graphql1.TmuxWindow) (*graphql1.TmuxPane, error) {
+	return nil, nil
+}
+func (r *tmuxWindowResolver) Active(_ context.Context, _ *graphql1.TmuxWindow) (bool, error) {
+	return false, nil
+}
+func (r *tmuxWindowResolver) Name(_ context.Context, _ *graphql1.TmuxWindow) (string, error) {
+	return "", nil
+}
+
+// TmuxPane stubs.
+func (r *tmuxPaneResolver) Window(_ context.Context, _ *graphql1.TmuxPane) (*graphql1.TmuxWindow, error) {
+	return nil, nil
+}
+func (r *tmuxPaneResolver) Title(_ context.Context, _ *graphql1.TmuxPane) (string, error) {
+	return "", nil
+}
+func (r *tmuxPaneResolver) CurrentCommand(_ context.Context, _ *graphql1.TmuxPane) (string, error) {
+	return "", nil
+}
+func (r *tmuxPaneResolver) CurrentPid(_ context.Context, _ *graphql1.TmuxPane) (*int64, error) {
+	return nil, nil
+}
+func (r *tmuxPaneResolver) Width(_ context.Context, _ *graphql1.TmuxPane) (int64, error) {
+	return 0, nil
+}
+func (r *tmuxPaneResolver) Height(_ context.Context, _ *graphql1.TmuxPane) (int64, error) {
+	return 0, nil
+}
+func (r *tmuxPaneResolver) Dead(_ context.Context, _ *graphql1.TmuxPane) (bool, error) {
+	return false, nil
+}
+func (r *tmuxPaneResolver) WatchingClients(_ context.Context, _ *graphql1.TmuxPane) ([]*graphql1.TmuxClient, error) {
+	return nil, nil
+}
+func (r *tmuxPaneResolver) Process(_ context.Context, _ *graphql1.TmuxPane) (*graphql1.Process, error) {
+	return nil, nil
+}
+func (r *tmuxPaneResolver) ClaudeInstance(_ context.Context, _ *graphql1.TmuxPane) (*graphql1.ClaudeInstance, error) {
+	return nil, nil
+}
+func (r *tmuxPaneResolver) Content(_ context.Context, _ *graphql1.TmuxPane, _ *int64, _ *bool) (string, error) {
+	return "", fmt.Errorf("tmux provider not wired")
+}
+func (r *tmuxPaneResolver) ContentRange(_ context.Context, _ *graphql1.TmuxPane, _ int64, _ int64, _ *bool) (string, error) {
+	return "", fmt.Errorf("tmux provider not wired")
+}
+func (r *tmuxPaneResolver) ContentFull(_ context.Context, _ *graphql1.TmuxPane, _ *bool) (string, error) {
+	return "", fmt.Errorf("tmux provider not wired")
+}
+
+// TmuxClient stubs.
+func (r *tmuxClientResolver) Server(_ context.Context, _ *graphql1.TmuxClient) (*graphql1.TmuxServer, error) {
+	return nil, nil
+}
+func (r *tmuxClientResolver) Session(_ context.Context, _ *graphql1.TmuxClient) (*graphql1.TmuxSession, error) {
+	return nil, nil
+}
+func (r *tmuxClientResolver) Tty(_ context.Context, _ *graphql1.TmuxClient) (string, error) {
+	return "", nil
+}
+func (r *tmuxClientResolver) Hostname(_ context.Context, _ *graphql1.TmuxClient) (string, error) {
+	return "", nil
+}
+func (r *tmuxClientResolver) TermName(_ context.Context, _ *graphql1.TmuxClient) (string, error) {
+	return "", nil
+}
+func (r *tmuxClientResolver) AttachedAt(_ context.Context, _ *graphql1.TmuxClient) (string, error) {
+	return "", nil
+}
+func (r *tmuxClientResolver) LastActivityAt(_ context.Context, _ *graphql1.TmuxClient) (*string, error) {
+	return nil, nil
+}
+func (r *tmuxClientResolver) Readonly(_ context.Context, _ *graphql1.TmuxClient) (bool, error) {
+	return false, nil
+}
+func (r *tmuxClientResolver) CurrentWindow(_ context.Context, _ *graphql1.TmuxClient) (*graphql1.TmuxWindow, error) {
+	return nil, nil
+}
+func (r *tmuxClientResolver) CurrentPane(_ context.Context, _ *graphql1.TmuxClient) (*graphql1.TmuxPane, error) {
+	return nil, nil
 }
 
 // Host returns graphql1.HostResolver implementation.
@@ -168,11 +310,31 @@ func (r *Resolver) Query() graphql1.QueryResolver { return &queryResolver{r} }
 // Worktree returns graphql1.WorktreeResolver implementation.
 func (r *Resolver) Worktree() graphql1.WorktreeResolver { return &worktreeResolver{r} }
 
+// TmuxServer returns graphql1.TmuxServerResolver implementation.
+func (r *Resolver) TmuxServer() graphql1.TmuxServerResolver { return &tmuxServerResolver{r} }
+
+// TmuxSession returns graphql1.TmuxSessionResolver implementation.
+func (r *Resolver) TmuxSession() graphql1.TmuxSessionResolver { return &tmuxSessionResolver{r} }
+
+// TmuxWindow returns graphql1.TmuxWindowResolver implementation.
+func (r *Resolver) TmuxWindow() graphql1.TmuxWindowResolver { return &tmuxWindowResolver{r} }
+
+// TmuxPane returns graphql1.TmuxPaneResolver implementation.
+func (r *Resolver) TmuxPane() graphql1.TmuxPaneResolver { return &tmuxPaneResolver{r} }
+
+// TmuxClient returns graphql1.TmuxClientResolver implementation.
+func (r *Resolver) TmuxClient() graphql1.TmuxClientResolver { return &tmuxClientResolver{r} }
+
 type hostResolver struct{ *Resolver }
 type processResolver struct{ *Resolver }
 type projectResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type worktreeResolver struct{ *Resolver }
+type tmuxServerResolver struct{ *Resolver }
+type tmuxSessionResolver struct{ *Resolver }
+type tmuxWindowResolver struct{ *Resolver }
+type tmuxPaneResolver struct{ *Resolver }
+type tmuxClientResolver struct{ *Resolver }
 
 // toGraphQLWorktree projects a git provider Worktree into the GraphQL model.
 func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
@@ -209,7 +371,6 @@ func projectProcess(p *ps.Process, hostID string) *graphql1.Process {
 }
 
 // applyProcessFilter applies the resolver-layer filter.
-// Cheap filters (pidIn, commandIn) run first; cwdPrefix forces a slow lsof batch.
 func applyProcessFilter(ctx context.Context, p *ps.Provider, in []ps.Process, filter *graphql1.ProcessFilter) []ps.Process {
 	if filter == nil {
 		return in

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -8,12 +8,14 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 )
 
 // Worktrees is the resolver for the project.worktrees field.
@@ -91,14 +93,22 @@ func (r *processResolver) ClaudeInstance(_ context.Context, _ *graphql1.Process)
 	return nil, nil
 }
 
-// Health is the resolver for the health field.
-func (r *queryResolver) Health(ctx context.Context) (*graphql1.Health, error) {
-	uptime := int64(time.Since(r.StartedAt).Round(time.Second).Seconds())
-	return &graphql1.Health{
-		Status:  "ok",
-		UptimeS: uptime,
-	}, nil
+// Processes is the resolver for the worktree.processes field.
+func (r *worktreeResolver) Processes(_ context.Context, _ *graphql1.Worktree) ([]*graphql1.Process, error) {
+	return []*graphql1.Process{}, nil
 }
+
+// Host returns graphql1.HostResolver implementation.
+func (r *Resolver) Host() graphql1.HostResolver { return &hostResolver{r} }
+
+// Process returns graphql1.ProcessResolver implementation.
+func (r *Resolver) Process() graphql1.ProcessResolver { return &processResolver{r} }
+
+// Project returns graphql1.ProjectResolver implementation.
+func (r *Resolver) Project() graphql1.ProjectResolver { return &projectResolver{r} }
+
+// Worktree returns graphql1.WorktreeResolver implementation.
+func (r *Resolver) Worktree() graphql1.WorktreeResolver { return &worktreeResolver{r} }
 
 // Host is the resolver for the host field.
 func (r *queryResolver) Host(ctx context.Context) (*graphql1.Host, error) {
@@ -145,170 +155,562 @@ func (r *queryResolver) Projects(ctx context.Context) ([]*graphql1.Project, erro
 	return out, nil
 }
 
-// TmuxServer is the resolver for the tmuxServer field. Stub until commit 3 wires the provider.
-func (r *queryResolver) TmuxServer(_ context.Context) (*graphql1.TmuxServer, error) {
-	return nil, fmt.Errorf("tmux provider not wired")
+// Health is the resolver for the health field.
+func (r *queryResolver) Health(ctx context.Context) (*graphql1.Health, error) {
+	uptime := int64(time.Since(r.StartedAt).Round(time.Second).Seconds())
+	return &graphql1.Health{
+		Status:  "ok",
+		UptimeS: uptime,
+	}, nil
 }
 
-// TmuxSessions is the resolver for the tmuxSessions field. Stub until commit 3.
-func (r *queryResolver) TmuxSessions(_ context.Context, _ *graphql1.TmuxSessionFilter) ([]*graphql1.TmuxSession, error) {
-	return nil, fmt.Errorf("tmux provider not wired")
+// TmuxServer is the resolver for the tmuxServer field.
+func (r *queryResolver) TmuxServer(ctx context.Context) (*graphql1.TmuxServer, error) {
+	if r.Tmux == nil {
+		return nil, nil
+	}
+	info := r.Tmux.Server()
+	if !info.Alive {
+		return nil, nil
+	}
+	return projectServer(r.Tmux.Host(), info), nil
 }
 
-// TmuxPanes is the resolver for the tmuxPanes field. Stub until commit 3.
-func (r *queryResolver) TmuxPanes(_ context.Context, _ *graphql1.TmuxPaneFilter) ([]*graphql1.TmuxPane, error) {
-	return nil, fmt.Errorf("tmux provider not wired")
+// TmuxSessions is the resolver for the tmuxSessions field.
+func (r *queryResolver) TmuxSessions(ctx context.Context, filter *graphql1.TmuxSessionFilter) ([]*graphql1.TmuxSession, error) {
+	if r.Tmux == nil {
+		return []*graphql1.TmuxSession{}, nil
+	}
+	snap := r.Tmux.Snapshot()
+	out := make([]*graphql1.TmuxSession, 0, len(snap.Sessions))
+	for _, s := range snap.Sessions {
+		if !sessionMatchesFilter(s, filter) {
+			continue
+		}
+		out = append(out, projectSession(s))
+	}
+	return out, nil
 }
 
-// Processes is the resolver for the worktree.processes field.
-func (r *worktreeResolver) Processes(_ context.Context, _ *graphql1.Worktree) ([]*graphql1.Process, error) {
-	return []*graphql1.Process{}, nil
+// TmuxPanes is the resolver for the tmuxPanes field.
+func (r *queryResolver) TmuxPanes(ctx context.Context, filter *graphql1.TmuxPaneFilter) ([]*graphql1.TmuxPane, error) {
+	if r.Tmux == nil {
+		return []*graphql1.TmuxPane{}, nil
+	}
+	snap := r.Tmux.Snapshot()
+	out := make([]*graphql1.TmuxPane, 0, len(snap.Panes))
+	for _, p := range snap.Panes {
+		if !paneMatchesFilter(p, filter) {
+			continue
+		}
+		out = append(out, projectPane(p))
+	}
+	return out, nil
 }
 
-// TmuxServer field-resolver stubs — replaced in commit 3.
-func (r *tmuxServerResolver) Sessions(_ context.Context, _ *graphql1.TmuxServer) ([]*graphql1.TmuxSession, error) {
-	return nil, fmt.Errorf("tmux provider not wired")
+// Server is the resolver for the server field.
+func (r *tmuxClientResolver) Server(ctx context.Context, obj *graphql1.TmuxClient) (*graphql1.TmuxServer, error) {
+	if r.Tmux == nil {
+		return nil, nil
+	}
+	return projectServer(r.Tmux.Host(), r.Tmux.Server()), nil
 }
-func (r *tmuxServerResolver) Clients(_ context.Context, _ *graphql1.TmuxServer) ([]*graphql1.TmuxClient, error) {
-	return nil, fmt.Errorf("tmux provider not wired")
+
+// Session is the resolver for the session field.
+func (r *tmuxClientResolver) Session(ctx context.Context, obj *graphql1.TmuxClient) (*graphql1.TmuxSession, error) {
+	if r.Tmux == nil {
+		return &graphql1.TmuxSession{ID: "TmuxSession:"}, nil
+	}
+	c, ok := r.lookupClient(obj.ID)
+	if !ok {
+		return nil, nil
+	}
+	host := r.Tmux.Host()
+	s, ok := r.Tmux.Snapshot().Sessions[tmux.SessionKey{Host: host, Name: c.Session}]
+	if !ok {
+		return nil, nil
+	}
+	return projectSession(s), nil
 }
-func (r *tmuxServerResolver) Pid(_ context.Context, _ *graphql1.TmuxServer) (*int64, error) {
+
+// Tty is the resolver for the tty field.
+func (r *tmuxClientResolver) Tty(ctx context.Context, obj *graphql1.TmuxClient) (string, error) {
+	c, ok := r.lookupClient(obj.ID)
+	if !ok {
+		return "", nil
+	}
+	return c.TTY, nil
+}
+
+// Hostname is the resolver for the hostname field.
+func (r *tmuxClientResolver) Hostname(ctx context.Context, obj *graphql1.TmuxClient) (string, error) {
+	c, ok := r.lookupClient(obj.ID)
+	if !ok {
+		return "", nil
+	}
+	return c.Hostname, nil
+}
+
+// TermName is the resolver for the termName field.
+func (r *tmuxClientResolver) TermName(ctx context.Context, obj *graphql1.TmuxClient) (string, error) {
+	c, ok := r.lookupClient(obj.ID)
+	if !ok {
+		return "", nil
+	}
+	return c.TermName, nil
+}
+
+// AttachedAt is the resolver for the attachedAt field.
+func (r *tmuxClientResolver) AttachedAt(ctx context.Context, obj *graphql1.TmuxClient) (string, error) {
+	c, ok := r.lookupClient(obj.ID)
+	if !ok || c.AttachedAt.IsZero() {
+		return "", nil
+	}
+	return c.AttachedAt.Format(time.RFC3339), nil
+}
+
+// LastActivityAt is the resolver for the lastActivityAt field.
+func (r *tmuxClientResolver) LastActivityAt(ctx context.Context, obj *graphql1.TmuxClient) (*string, error) {
+	c, ok := r.lookupClient(obj.ID)
+	if !ok || c.LastActivityAt.IsZero() {
+		return nil, nil
+	}
+	s := c.LastActivityAt.Format(time.RFC3339)
+	return &s, nil
+}
+
+// Readonly is the resolver for the readonly field.
+func (r *tmuxClientResolver) Readonly(ctx context.Context, obj *graphql1.TmuxClient) (bool, error) {
+	c, ok := r.lookupClient(obj.ID)
+	if !ok {
+		return false, nil
+	}
+	return c.Readonly, nil
+}
+
+// CurrentWindow is the resolver for the currentWindow field.
+func (r *tmuxClientResolver) CurrentWindow(ctx context.Context, obj *graphql1.TmuxClient) (*graphql1.TmuxWindow, error) {
+	if r.Tmux == nil {
+		return nil, nil
+	}
+	c, ok := r.lookupClient(obj.ID)
+	if !ok || c.CurrentWindow < 0 {
+		return nil, nil
+	}
+	host := r.Tmux.Host()
+	w, ok := r.Tmux.Snapshot().Windows[tmux.WindowKey{Host: host, Session: c.Session, Index: c.CurrentWindow}]
+	if !ok {
+		return nil, nil
+	}
+	return projectWindow(w), nil
+}
+
+// CurrentPane is the resolver for the currentPane field.
+func (r *tmuxClientResolver) CurrentPane(ctx context.Context, obj *graphql1.TmuxClient) (*graphql1.TmuxPane, error) {
+	if r.Tmux == nil {
+		return nil, nil
+	}
+	c, ok := r.lookupClient(obj.ID)
+	if !ok || c.CurrentPane == "" {
+		return nil, nil
+	}
+	host := r.Tmux.Host()
+	p, ok := r.Tmux.Snapshot().Panes[tmux.PaneKey{Host: host, PaneID: c.CurrentPane}]
+	if !ok {
+		return nil, nil
+	}
+	return projectPane(p), nil
+}
+
+// Window is the resolver for the window field.
+func (r *tmuxPaneResolver) Window(ctx context.Context, obj *graphql1.TmuxPane) (*graphql1.TmuxWindow, error) {
+	if r.Tmux == nil {
+		return nil, nil
+	}
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
+		return nil, nil
+	}
+	w, ok := r.Tmux.Snapshot().Windows[p.WindowKey]
+	if !ok {
+		return nil, nil
+	}
+	return projectWindow(w), nil
+}
+
+// Title is the resolver for the title field.
+func (r *tmuxPaneResolver) Title(ctx context.Context, obj *graphql1.TmuxPane) (string, error) {
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
+		return "", nil
+	}
+	return p.Title, nil
+}
+
+// CurrentCommand is the resolver for the currentCommand field.
+func (r *tmuxPaneResolver) CurrentCommand(ctx context.Context, obj *graphql1.TmuxPane) (string, error) {
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
+		return "", nil
+	}
+	return p.CurrentCommand, nil
+}
+
+// CurrentPid is the resolver for the currentPid field.
+func (r *tmuxPaneResolver) CurrentPid(ctx context.Context, obj *graphql1.TmuxPane) (*int64, error) {
+	p, ok := r.lookupPane(obj.ID)
+	if !ok || p.CurrentPid == 0 {
+		return nil, nil
+	}
+	pid := int64(p.CurrentPid)
+	return &pid, nil
+}
+
+// Width is the resolver for the width field.
+func (r *tmuxPaneResolver) Width(ctx context.Context, obj *graphql1.TmuxPane) (int64, error) {
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
+		return 0, nil
+	}
+	return int64(p.Width), nil
+}
+
+// Height is the resolver for the height field.
+func (r *tmuxPaneResolver) Height(ctx context.Context, obj *graphql1.TmuxPane) (int64, error) {
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
+		return 0, nil
+	}
+	return int64(p.Height), nil
+}
+
+// Dead is the resolver for the dead field.
+func (r *tmuxPaneResolver) Dead(ctx context.Context, obj *graphql1.TmuxPane) (bool, error) {
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
+		return false, nil
+	}
+	return p.Dead, nil
+}
+
+// WatchingClients is the resolver for the watchingClients field.
+func (r *tmuxPaneResolver) WatchingClients(ctx context.Context, obj *graphql1.TmuxPane) ([]*graphql1.TmuxClient, error) {
+	if r.Tmux == nil {
+		return []*graphql1.TmuxClient{}, nil
+	}
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
+		return []*graphql1.TmuxClient{}, nil
+	}
+	out := make([]*graphql1.TmuxClient, 0)
+	for _, c := range r.Tmux.Snapshot().Clients {
+		if c.CurrentPane == p.Key.PaneID {
+			out = append(out, projectClient(c))
+		}
+	}
+	return out, nil
+}
+
+// Process is the resolver for the process field. Stub — ws-b-ps wires it.
+func (r *tmuxPaneResolver) Process(ctx context.Context, obj *graphql1.TmuxPane) (*graphql1.Process, error) {
 	return nil, nil
 }
-func (r *tmuxServerResolver) Alive(_ context.Context, _ *graphql1.TmuxServer) (bool, error) {
+
+// ClaudeInstance is the resolver for the claudeInstance field. Stub — ws-b-claudeinstance wires it.
+func (r *tmuxPaneResolver) ClaudeInstance(ctx context.Context, obj *graphql1.TmuxPane) (*graphql1.ClaudeInstance, error) {
+	return nil, nil
+}
+
+// Content is the resolver for the content field.
+func (r *tmuxPaneResolver) Content(ctx context.Context, obj *graphql1.TmuxPane, lines *int64, stripAnsi *bool) (string, error) {
+	if r.Tmux == nil {
+		return "", nil
+	}
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
+		return "", nil
+	}
+	n := 50
+	if lines != nil && *lines > 0 {
+		n = int(*lines)
+	}
+	strip := true
+	if stripAnsi != nil {
+		strip = *stripAnsi
+	}
+	return r.Tmux.CapturePaneTail(ctx, p.Key, n, strip)
+}
+
+// ContentRange is the resolver for the contentRange field.
+func (r *tmuxPaneResolver) ContentRange(ctx context.Context, obj *graphql1.TmuxPane, startLine int64, endLine int64, stripAnsi *bool) (string, error) {
+	if r.Tmux == nil {
+		return "", nil
+	}
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
+		return "", nil
+	}
+	strip := true
+	if stripAnsi != nil {
+		strip = *stripAnsi
+	}
+	return r.Tmux.CapturePane(ctx, p.Key, int(startLine), int(endLine), false, strip)
+}
+
+// ContentFull is the resolver for the contentFull field.
+func (r *tmuxPaneResolver) ContentFull(ctx context.Context, obj *graphql1.TmuxPane, stripAnsi *bool) (string, error) {
+	if r.Tmux == nil {
+		return "", nil
+	}
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
+		return "", nil
+	}
+	strip := true
+	if stripAnsi != nil {
+		strip = *stripAnsi
+	}
+	return r.Tmux.CapturePane(ctx, p.Key, 0, 0, true, strip)
+}
+
+// Pid is the resolver for the pid field.
+func (r *tmuxServerResolver) Pid(ctx context.Context, obj *graphql1.TmuxServer) (*int64, error) {
+	if r.Tmux == nil {
+		return nil, nil
+	}
+	pid := r.Tmux.Server().Pid
+	if pid == 0 {
+		return nil, nil
+	}
+	v := int64(pid)
+	return &v, nil
+}
+
+// Alive is the resolver for the alive field.
+func (r *tmuxServerResolver) Alive(ctx context.Context, obj *graphql1.TmuxServer) (bool, error) {
+	if r.Tmux == nil {
+		return false, nil
+	}
+	return r.Tmux.Server().Alive, nil
+}
+
+// Sessions is the resolver for the sessions field.
+func (r *tmuxServerResolver) Sessions(ctx context.Context, obj *graphql1.TmuxServer) ([]*graphql1.TmuxSession, error) {
+	if r.Tmux == nil {
+		return []*graphql1.TmuxSession{}, nil
+	}
+	snap := r.Tmux.Snapshot()
+	out := make([]*graphql1.TmuxSession, 0, len(snap.Sessions))
+	for _, s := range snap.Sessions {
+		out = append(out, projectSession(s))
+	}
+	return out, nil
+}
+
+// Clients is the resolver for the clients field.
+func (r *tmuxServerResolver) Clients(ctx context.Context, obj *graphql1.TmuxServer) ([]*graphql1.TmuxClient, error) {
+	if r.Tmux == nil {
+		return []*graphql1.TmuxClient{}, nil
+	}
+	snap := r.Tmux.Snapshot()
+	out := make([]*graphql1.TmuxClient, 0, len(snap.Clients))
+	for _, c := range snap.Clients {
+		out = append(out, projectClient(c))
+	}
+	return out, nil
+}
+
+// Server is the resolver for the server field.
+func (r *tmuxSessionResolver) Server(ctx context.Context, obj *graphql1.TmuxSession) (*graphql1.TmuxServer, error) {
+	if r.Tmux == nil {
+		return nil, nil
+	}
+	return projectServer(r.Tmux.Host(), r.Tmux.Server()), nil
+}
+
+// CreatedAt is the resolver for the createdAt field.
+func (r *tmuxSessionResolver) CreatedAt(ctx context.Context, obj *graphql1.TmuxSession) (string, error) {
+	s, ok := r.lookupSession(obj.ID)
+	if !ok || s.CreatedAt.IsZero() {
+		return "", nil
+	}
+	return s.CreatedAt.Format(time.RFC3339), nil
+}
+
+// Attached is the resolver for the attached field.
+func (r *tmuxSessionResolver) Attached(ctx context.Context, obj *graphql1.TmuxSession) (bool, error) {
+	s, ok := r.lookupSession(obj.ID)
+	if !ok {
+		return false, nil
+	}
+	return s.Attached, nil
+}
+
+// ActiveAttached is the resolver for the activeAttached field.
+func (r *tmuxSessionResolver) ActiveAttached(ctx context.Context, obj *graphql1.TmuxSession) (bool, error) {
+	if r.Tmux == nil {
+		return false, nil
+	}
+	s, ok := r.lookupSession(obj.ID)
+	if !ok || !s.Attached {
+		return false, nil
+	}
+	host := r.Tmux.Host()
+	cutoff := time.Now().Add(-tmux.ActiveAttachedWindow)
+	for _, c := range r.Tmux.Snapshot().Clients {
+		if c.Key.Host != host {
+			continue
+		}
+		if c.Session != s.Key.Name {
+			continue
+		}
+		if !c.LastActivityAt.IsZero() && c.LastActivityAt.After(cutoff) {
+			return true, nil
+		}
+	}
 	return false, nil
 }
 
-// TmuxSession stubs.
-func (r *tmuxSessionResolver) Server(_ context.Context, _ *graphql1.TmuxSession) (*graphql1.TmuxServer, error) {
-	return nil, fmt.Errorf("tmux provider not wired")
-}
-func (r *tmuxSessionResolver) Attached(_ context.Context, _ *graphql1.TmuxSession) (bool, error) {
-	return false, nil
-}
-func (r *tmuxSessionResolver) ActiveAttached(_ context.Context, _ *graphql1.TmuxSession) (bool, error) {
-	return false, nil
-}
-func (r *tmuxSessionResolver) AttachedClients(_ context.Context, _ *graphql1.TmuxSession) ([]*graphql1.TmuxClient, error) {
-	return nil, nil
-}
-func (r *tmuxSessionResolver) LastActivityAt(_ context.Context, _ *graphql1.TmuxSession) (*string, error) {
-	return nil, nil
-}
-func (r *tmuxSessionResolver) Windows(_ context.Context, _ *graphql1.TmuxSession) ([]*graphql1.TmuxWindow, error) {
-	return nil, nil
-}
-func (r *tmuxSessionResolver) CurrentWindow(_ context.Context, _ *graphql1.TmuxSession) (*graphql1.TmuxWindow, error) {
-	return nil, nil
-}
-func (r *tmuxSessionResolver) CreatedAt(_ context.Context, _ *graphql1.TmuxSession) (string, error) {
-	return "", nil
+// AttachedClients is the resolver for the attachedClients field.
+func (r *tmuxSessionResolver) AttachedClients(ctx context.Context, obj *graphql1.TmuxSession) ([]*graphql1.TmuxClient, error) {
+	if r.Tmux == nil {
+		return []*graphql1.TmuxClient{}, nil
+	}
+	s, ok := r.lookupSession(obj.ID)
+	if !ok {
+		return []*graphql1.TmuxClient{}, nil
+	}
+	out := make([]*graphql1.TmuxClient, 0)
+	for _, c := range r.Tmux.Snapshot().Clients {
+		if c.Session == s.Key.Name {
+			out = append(out, projectClient(c))
+		}
+	}
+	return out, nil
 }
 
-// TmuxWindow stubs.
-func (r *tmuxWindowResolver) Session(_ context.Context, _ *graphql1.TmuxWindow) (*graphql1.TmuxSession, error) {
-	return nil, nil
-}
-func (r *tmuxWindowResolver) Panes(_ context.Context, _ *graphql1.TmuxWindow) ([]*graphql1.TmuxPane, error) {
-	return nil, nil
-}
-func (r *tmuxWindowResolver) CurrentPane(_ context.Context, _ *graphql1.TmuxWindow) (*graphql1.TmuxPane, error) {
-	return nil, nil
-}
-func (r *tmuxWindowResolver) Active(_ context.Context, _ *graphql1.TmuxWindow) (bool, error) {
-	return false, nil
-}
-func (r *tmuxWindowResolver) Name(_ context.Context, _ *graphql1.TmuxWindow) (string, error) {
-	return "", nil
+// LastActivityAt is the resolver for the lastActivityAt field.
+func (r *tmuxSessionResolver) LastActivityAt(ctx context.Context, obj *graphql1.TmuxSession) (*string, error) {
+	s, ok := r.lookupSession(obj.ID)
+	if !ok || s.LastActivityAt.IsZero() {
+		return nil, nil
+	}
+	v := s.LastActivityAt.Format(time.RFC3339)
+	return &v, nil
 }
 
-// TmuxPane stubs.
-func (r *tmuxPaneResolver) Window(_ context.Context, _ *graphql1.TmuxPane) (*graphql1.TmuxWindow, error) {
-	return nil, nil
-}
-func (r *tmuxPaneResolver) Title(_ context.Context, _ *graphql1.TmuxPane) (string, error) {
-	return "", nil
-}
-func (r *tmuxPaneResolver) CurrentCommand(_ context.Context, _ *graphql1.TmuxPane) (string, error) {
-	return "", nil
-}
-func (r *tmuxPaneResolver) CurrentPid(_ context.Context, _ *graphql1.TmuxPane) (*int64, error) {
-	return nil, nil
-}
-func (r *tmuxPaneResolver) Width(_ context.Context, _ *graphql1.TmuxPane) (int64, error) {
-	return 0, nil
-}
-func (r *tmuxPaneResolver) Height(_ context.Context, _ *graphql1.TmuxPane) (int64, error) {
-	return 0, nil
-}
-func (r *tmuxPaneResolver) Dead(_ context.Context, _ *graphql1.TmuxPane) (bool, error) {
-	return false, nil
-}
-func (r *tmuxPaneResolver) WatchingClients(_ context.Context, _ *graphql1.TmuxPane) ([]*graphql1.TmuxClient, error) {
-	return nil, nil
-}
-func (r *tmuxPaneResolver) Process(_ context.Context, _ *graphql1.TmuxPane) (*graphql1.Process, error) {
-	return nil, nil
-}
-func (r *tmuxPaneResolver) ClaudeInstance(_ context.Context, _ *graphql1.TmuxPane) (*graphql1.ClaudeInstance, error) {
-	return nil, nil
-}
-func (r *tmuxPaneResolver) Content(_ context.Context, _ *graphql1.TmuxPane, _ *int64, _ *bool) (string, error) {
-	return "", fmt.Errorf("tmux provider not wired")
-}
-func (r *tmuxPaneResolver) ContentRange(_ context.Context, _ *graphql1.TmuxPane, _ int64, _ int64, _ *bool) (string, error) {
-	return "", fmt.Errorf("tmux provider not wired")
-}
-func (r *tmuxPaneResolver) ContentFull(_ context.Context, _ *graphql1.TmuxPane, _ *bool) (string, error) {
-	return "", fmt.Errorf("tmux provider not wired")
+// Windows is the resolver for the windows field.
+func (r *tmuxSessionResolver) Windows(ctx context.Context, obj *graphql1.TmuxSession) ([]*graphql1.TmuxWindow, error) {
+	if r.Tmux == nil {
+		return []*graphql1.TmuxWindow{}, nil
+	}
+	s, ok := r.lookupSession(obj.ID)
+	if !ok {
+		return []*graphql1.TmuxWindow{}, nil
+	}
+	out := make([]*graphql1.TmuxWindow, 0)
+	for _, w := range r.Tmux.Snapshot().Windows {
+		if w.Key.Session == s.Key.Name {
+			out = append(out, projectWindow(w))
+		}
+	}
+	return out, nil
 }
 
-// TmuxClient stubs.
-func (r *tmuxClientResolver) Server(_ context.Context, _ *graphql1.TmuxClient) (*graphql1.TmuxServer, error) {
-	return nil, nil
-}
-func (r *tmuxClientResolver) Session(_ context.Context, _ *graphql1.TmuxClient) (*graphql1.TmuxSession, error) {
-	return nil, nil
-}
-func (r *tmuxClientResolver) Tty(_ context.Context, _ *graphql1.TmuxClient) (string, error) {
-	return "", nil
-}
-func (r *tmuxClientResolver) Hostname(_ context.Context, _ *graphql1.TmuxClient) (string, error) {
-	return "", nil
-}
-func (r *tmuxClientResolver) TermName(_ context.Context, _ *graphql1.TmuxClient) (string, error) {
-	return "", nil
-}
-func (r *tmuxClientResolver) AttachedAt(_ context.Context, _ *graphql1.TmuxClient) (string, error) {
-	return "", nil
-}
-func (r *tmuxClientResolver) LastActivityAt(_ context.Context, _ *graphql1.TmuxClient) (*string, error) {
-	return nil, nil
-}
-func (r *tmuxClientResolver) Readonly(_ context.Context, _ *graphql1.TmuxClient) (bool, error) {
-	return false, nil
-}
-func (r *tmuxClientResolver) CurrentWindow(_ context.Context, _ *graphql1.TmuxClient) (*graphql1.TmuxWindow, error) {
-	return nil, nil
-}
-func (r *tmuxClientResolver) CurrentPane(_ context.Context, _ *graphql1.TmuxClient) (*graphql1.TmuxPane, error) {
-	return nil, nil
+// CurrentWindow is the resolver for the currentWindow field.
+func (r *tmuxSessionResolver) CurrentWindow(ctx context.Context, obj *graphql1.TmuxSession) (*graphql1.TmuxWindow, error) {
+	if r.Tmux == nil {
+		return nil, nil
+	}
+	s, ok := r.lookupSession(obj.ID)
+	if !ok {
+		return nil, nil
+	}
+	host := r.Tmux.Host()
+	w, ok := r.Tmux.Snapshot().Windows[tmux.WindowKey{Host: host, Session: s.Key.Name, Index: s.CurrentWindow}]
+	if !ok {
+		return nil, nil
+	}
+	return projectWindow(w), nil
 }
 
-// Host returns graphql1.HostResolver implementation.
-func (r *Resolver) Host() graphql1.HostResolver { return &hostResolver{r} }
+// Session is the resolver for the session field.
+func (r *tmuxWindowResolver) Session(ctx context.Context, obj *graphql1.TmuxWindow) (*graphql1.TmuxSession, error) {
+	if r.Tmux == nil {
+		return nil, nil
+	}
+	w, ok := r.lookupWindow(obj.ID)
+	if !ok {
+		return nil, nil
+	}
+	s, ok := r.Tmux.Snapshot().Sessions[tmux.SessionKey{Host: w.Key.Host, Name: w.Key.Session}]
+	if !ok {
+		return nil, nil
+	}
+	return projectSession(s), nil
+}
 
-// Process returns graphql1.ProcessResolver implementation.
-func (r *Resolver) Process() graphql1.ProcessResolver { return &processResolver{r} }
+// Name is the resolver for the name field.
+func (r *tmuxWindowResolver) Name(ctx context.Context, obj *graphql1.TmuxWindow) (string, error) {
+	w, ok := r.lookupWindow(obj.ID)
+	if !ok {
+		return "", nil
+	}
+	return w.Name, nil
+}
 
-// Project returns graphql1.ProjectResolver implementation.
-func (r *Resolver) Project() graphql1.ProjectResolver { return &projectResolver{r} }
+// Active is the resolver for the active field.
+func (r *tmuxWindowResolver) Active(ctx context.Context, obj *graphql1.TmuxWindow) (bool, error) {
+	w, ok := r.lookupWindow(obj.ID)
+	if !ok {
+		return false, nil
+	}
+	return w.Active, nil
+}
+
+// Panes is the resolver for the panes field.
+func (r *tmuxWindowResolver) Panes(ctx context.Context, obj *graphql1.TmuxWindow) ([]*graphql1.TmuxPane, error) {
+	if r.Tmux == nil {
+		return []*graphql1.TmuxPane{}, nil
+	}
+	w, ok := r.lookupWindow(obj.ID)
+	if !ok {
+		return []*graphql1.TmuxPane{}, nil
+	}
+	out := make([]*graphql1.TmuxPane, 0)
+	for _, p := range r.Tmux.Snapshot().Panes {
+		if p.WindowKey == w.Key {
+			out = append(out, projectPane(p))
+		}
+	}
+	return out, nil
+}
+
+// CurrentPane is the resolver for the currentPane field.
+func (r *tmuxWindowResolver) CurrentPane(ctx context.Context, obj *graphql1.TmuxWindow) (*graphql1.TmuxPane, error) {
+	if r.Tmux == nil {
+		return nil, nil
+	}
+	w, ok := r.lookupWindow(obj.ID)
+	if !ok || w.CurrentPane == "" {
+		return nil, nil
+	}
+	host := r.Tmux.Host()
+	p, ok := r.Tmux.Snapshot().Panes[tmux.PaneKey{Host: host, PaneID: w.CurrentPane}]
+	if !ok {
+		return nil, nil
+	}
+	return projectPane(p), nil
+}
 
 // Query returns graphql1.QueryResolver implementation.
 func (r *Resolver) Query() graphql1.QueryResolver { return &queryResolver{r} }
 
-// Worktree returns graphql1.WorktreeResolver implementation.
-func (r *Resolver) Worktree() graphql1.WorktreeResolver { return &worktreeResolver{r} }
+// TmuxClient returns graphql1.TmuxClientResolver implementation.
+func (r *Resolver) TmuxClient() graphql1.TmuxClientResolver { return &tmuxClientResolver{r} }
+
+// TmuxPane returns graphql1.TmuxPaneResolver implementation.
+func (r *Resolver) TmuxPane() graphql1.TmuxPaneResolver { return &tmuxPaneResolver{r} }
 
 // TmuxServer returns graphql1.TmuxServerResolver implementation.
 func (r *Resolver) TmuxServer() graphql1.TmuxServerResolver { return &tmuxServerResolver{r} }
@@ -319,22 +721,16 @@ func (r *Resolver) TmuxSession() graphql1.TmuxSessionResolver { return &tmuxSess
 // TmuxWindow returns graphql1.TmuxWindowResolver implementation.
 func (r *Resolver) TmuxWindow() graphql1.TmuxWindowResolver { return &tmuxWindowResolver{r} }
 
-// TmuxPane returns graphql1.TmuxPaneResolver implementation.
-func (r *Resolver) TmuxPane() graphql1.TmuxPaneResolver { return &tmuxPaneResolver{r} }
-
-// TmuxClient returns graphql1.TmuxClientResolver implementation.
-func (r *Resolver) TmuxClient() graphql1.TmuxClientResolver { return &tmuxClientResolver{r} }
-
 type hostResolver struct{ *Resolver }
 type processResolver struct{ *Resolver }
 type projectResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type worktreeResolver struct{ *Resolver }
+type tmuxClientResolver struct{ *Resolver }
+type tmuxPaneResolver struct{ *Resolver }
 type tmuxServerResolver struct{ *Resolver }
 type tmuxSessionResolver struct{ *Resolver }
 type tmuxWindowResolver struct{ *Resolver }
-type tmuxPaneResolver struct{ *Resolver }
-type tmuxClientResolver struct{ *Resolver }
 
 // toGraphQLWorktree projects a git provider Worktree into the GraphQL model.
 func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
@@ -370,7 +766,7 @@ func projectProcess(p *ps.Process, hostID string) *graphql1.Process {
 	return out
 }
 
-// applyProcessFilter applies the resolver-layer filter.
+// applyProcessFilter applies the resolver-layer ProcessFilter.
 func applyProcessFilter(ctx context.Context, p *ps.Provider, in []ps.Process, filter *graphql1.ProcessFilter) []ps.Process {
 	if filter == nil {
 		return in
@@ -428,11 +824,142 @@ func applyProcessFilter(ctx context.Context, p *ps.Provider, in []ps.Process, fi
 	return out
 }
 
-// splitProcessNodeID extracts (host, pid) from a Process node id of the form host:pid.
+// splitProcessNodeID extracts (host, pid) from a Process node id.
 func splitProcessNodeID(s string) (string, string) {
 	idx := strings.LastIndexByte(s, ':')
 	if idx <= 0 {
 		return "local", s
 	}
 	return s[:idx], s[idx+1:]
+}
+
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//     it when you're done.
+//   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func projectServer(host tmux.HostID, info tmux.ServerInfo) *graphql1.TmuxServer {
+	return &graphql1.TmuxServer{
+		ID:         "TmuxServer:" + string(host) + ":" + info.SocketPath,
+		SocketPath: info.SocketPath,
+	}
+}
+func projectSession(s tmux.Session) *graphql1.TmuxSession {
+	return &graphql1.TmuxSession{
+		ID:   "TmuxSession:" + string(s.Key.Host) + ":" + s.Key.Name,
+		Name: s.Key.Name,
+	}
+}
+func projectWindow(w tmux.Window) *graphql1.TmuxWindow {
+	return &graphql1.TmuxWindow{
+		ID:    "TmuxWindow:" + string(w.Key.Host) + ":" + w.Key.Session + ":" + strconv.Itoa(w.Key.Index),
+		Index: int64(w.Key.Index),
+	}
+}
+func projectPane(p tmux.Pane) *graphql1.TmuxPane {
+	return &graphql1.TmuxPane{
+		ID:     "TmuxPane:" + string(p.Key.Host) + ":" + p.Key.PaneID,
+		PaneID: p.Key.PaneID,
+	}
+}
+func projectClient(c tmux.Client) *graphql1.TmuxClient {
+	return &graphql1.TmuxClient{
+		ID: "TmuxClient:" + string(c.Key.Host) + ":" + c.Key.ClientName,
+	}
+}
+func stripPrefix(s, prefix string) string {
+	if strings.HasPrefix(s, prefix) {
+		return s[len(prefix):]
+	}
+	return s
+}
+func sessionMatchesFilter(s tmux.Session, f *graphql1.TmuxSessionFilter) bool {
+	if f == nil {
+		return true
+	}
+	if names := f.NameIn; len(names) > 0 && !contains(names, s.Key.Name) {
+		return false
+	}
+	if f.AttachedOnly != nil && *f.AttachedOnly && !s.Attached {
+		return false
+	}
+	if f.ActiveAttachedOnly != nil && *f.ActiveAttachedOnly && !s.Attached {
+		return false
+	}
+	return true
+}
+func paneMatchesFilter(p tmux.Pane, f *graphql1.TmuxPaneFilter) bool {
+	if f == nil {
+		return true
+	}
+	if ids := f.PaneIDIn; len(ids) > 0 && !contains(ids, p.Key.PaneID) {
+		return false
+	}
+	if cmds := f.CurrentCommandIn; len(cmds) > 0 && !contains(cmds, p.CurrentCommand) {
+		return false
+	}
+	if sessions := f.SessionIn; len(sessions) > 0 && !contains(sessions, p.WindowKey.Session) {
+		return false
+	}
+	if f.TitleContains != nil && *f.TitleContains != "" && !strings.Contains(p.Title, *f.TitleContains) {
+		return false
+	}
+	if f.Dead != nil && *f.Dead != p.Dead {
+		return false
+	}
+	return true
+}
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+func (r *tmuxClientResolver) lookupClient(id string) (tmux.Client, bool) {
+	if r.Tmux == nil {
+		return tmux.Client{}, false
+	}
+	host := r.Tmux.Host()
+	name := stripPrefix(id, "TmuxClient:"+string(host)+":")
+	c, ok := r.Tmux.Snapshot().Clients[tmux.ClientKey{Host: host, ClientName: name}]
+	return c, ok
+}
+func (r *tmuxPaneResolver) lookupPane(id string) (tmux.Pane, bool) {
+	if r.Tmux == nil {
+		return tmux.Pane{}, false
+	}
+	host := r.Tmux.Host()
+	paneID := stripPrefix(id, "TmuxPane:"+string(host)+":")
+	p, ok := r.Tmux.Snapshot().Panes[tmux.PaneKey{Host: host, PaneID: paneID}]
+	return p, ok
+}
+func (r *tmuxSessionResolver) lookupSession(id string) (tmux.Session, bool) {
+	if r.Tmux == nil {
+		return tmux.Session{}, false
+	}
+	host := r.Tmux.Host()
+	name := stripPrefix(id, "TmuxSession:"+string(host)+":")
+	s, ok := r.Tmux.Snapshot().Sessions[tmux.SessionKey{Host: host, Name: name}]
+	return s, ok
+}
+func (r *tmuxWindowResolver) lookupWindow(id string) (tmux.Window, bool) {
+	if r.Tmux == nil {
+		return tmux.Window{}, false
+	}
+	host := r.Tmux.Host()
+	rest := stripPrefix(id, "TmuxWindow:"+string(host)+":")
+	idx := strings.LastIndex(rest, ":")
+	if idx == -1 {
+		return tmux.Window{}, false
+	}
+	session := rest[:idx]
+	indexN, err := strconv.Atoi(rest[idx+1:])
+	if err != nil {
+		return tmux.Window{}, false
+	}
+	w, ok := r.Tmux.Snapshot().Windows[tmux.WindowKey{Host: host, Session: session, Index: indexN}]
+	return w, ok
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,28 +2,13 @@
 // endpoint and the /health probe. It is the deployment shell that runs
 // the gqlgen-generated executable schema.
 //
-// Workstream A scope: GraphQL with the stub Health resolver, a /health
-// JSON endpoint for cheap liveness checks, graceful shutdown on context
-// cancellation. Subscriptions are not wired yet — Workstream C lights
-// them up alongside the rest of the schema.
-//
-// Workstream B-host: the host Provider is constructed here and started
-// in Run, so the resolver root has it ready before any GraphQL request
-// arrives. Subsequent provider workstreams hang their constructors off
-// New the same way.
-//
-// Workstream B-config: providers introduced by later workstreams are
-// wired through the Option pattern (WithFoo(p)), so New keeps a tight
-// signature as the provider set grows.
-//
-// Workstream B-git: WithGit wires the git provider that backs
-// Project.worktrees and Worktree.* resolvers.
-//
-// Workstream B-ps: WithPS attaches a ps provider so resolvers can serve
-// `host.processes` and the Process node fields. The server takes
-// responsibility for the provider's lifecycle: Run() calls Start()
-// before opening the listener and (implicitly) tears it down by
-// cancelling its context on shutdown.
+// Workstream A: GraphQL with the stub Health resolver, /health, graceful shutdown.
+// Workstream B-host: host Provider constructed and started in Run.
+// Workstream B-config: Option pattern (WithFoo) wires optional providers.
+// Workstream B-git: WithGit wires the git provider.
+// Workstream B-ps: WithPS attaches a ps provider; Run() starts it.
+// Workstream B-tmux: WithTmux attaches a tmux provider; Run() starts it
+// + the fsnotify-backed watcher.
 package server
 
 import (
@@ -42,15 +27,14 @@ import (
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
 )
 
-// DefaultAddr is where the daemon listens. Hard-coded for v1; promote to
-// config if multi-binding becomes a real need.
+// DefaultAddr is where the daemon listens.
 const DefaultAddr = "localhost:7777"
 
 // Server wraps the http.Server plus the resolver root and provider set.
-// One instance per daemon process.
 type Server struct {
 	addr      string
 	startedAt time.Time
@@ -59,10 +43,10 @@ type Server struct {
 	host      *host.Provider
 	resolver  *resolvers.Resolver
 	psProv    *ps.Provider
+	tmuxProv  *tmux.Provider
 }
 
-// Option mutates a Server during construction. Used for wiring optional
-// providers without bloating the New signature.
+// Option mutates a Server during construction.
 type Option func(*Server, *resolvers.Resolver)
 
 // WithProjects wires a projects provider into the resolver.
@@ -75,9 +59,7 @@ func WithGit(g *gitprovider.Provider) Option {
 	return func(_ *Server, r *resolvers.Resolver) { r.WithGit(g) }
 }
 
-// WithPS attaches a ps provider to the server's resolver root. The
-// server takes responsibility for the provider's lifecycle: Run()
-// calls Start() before opening the listener.
+// WithPS attaches a ps provider; Run() calls Start() before the listener opens.
 func WithPS(p *ps.Provider) Option {
 	return func(s *Server, r *resolvers.Resolver) {
 		s.psProv = p
@@ -85,10 +67,15 @@ func WithPS(p *ps.Provider) Option {
 	}
 }
 
-// New constructs a Server bound to addr. The host provider is constructed
-// here but not started — Run owns lifecycle so the poll loops are tied
-// to the same ctx as the HTTP listener. Optional providers are wired
-// via the With* options.
+// WithTmux attaches a tmux provider; Run() calls Start()+StartWatcher.
+func WithTmux(p *tmux.Provider) Option {
+	return func(s *Server, r *resolvers.Resolver) {
+		s.tmuxProv = p
+		r.WithTmux(p)
+	}
+}
+
+// New constructs a Server bound to addr.
 func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 	if addr == "" {
 		addr = DefaultAddr
@@ -125,38 +112,37 @@ func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 	return srv
 }
 
-// Addr returns the configured listen address. Useful for tests using
-// httptest or for callers that need to print the URL.
+// Addr returns the configured listen address.
 func (s *Server) Addr() string { return s.addr }
 
-// HTTPHandler returns the underlying HTTP mux for tests that wrap the
-// daemon in httptest.Server without binding a real port.
+// HTTPHandler returns the underlying HTTP mux for tests.
 func (s *Server) HTTPHandler() http.Handler { return s.httpSrv.Handler }
 
-// Resolver returns the resolver root the server was built with. Tests
-// that need to inject providers post-construction can use this.
+// Resolver returns the resolver root the server was built with.
 func (s *Server) Resolver() *resolvers.Resolver { return s.resolver }
 
-// GraphQLHandler returns a fresh handler bound to the server's
-// resolver. Useful for in-process tests that drive the schema through
-// httptest.Server without standing up the full HTTP listener.
+// GraphQLHandler returns a fresh handler bound to the server's resolver.
 func (s *Server) GraphQLHandler() http.Handler {
 	return graphqlHandlerFor(s.resolver)
 }
 
 // Run starts providers, the HTTP server, and blocks until ctx is
 // cancelled, then drains in-flight requests with a 5-second deadline.
-// Returns the underlying ListenAndServe error unless it is the expected
-// http.ErrServerClosed.
 func (s *Server) Run(ctx context.Context) error {
 	if err := s.host.Start(ctx); err != nil {
-		// Identity is load-bearing — fail fast so the operator sees it
-		// rather than getting half-populated GraphQL responses.
 		return fmt.Errorf("start host provider: %w", err)
 	}
 	if s.psProv != nil {
 		if err := s.psProv.Start(ctx); err != nil {
 			return fmt.Errorf("ps provider start: %w", err)
+		}
+	}
+	if s.tmuxProv != nil {
+		if err := s.tmuxProv.Start(ctx); err != nil {
+			return fmt.Errorf("tmux provider start: %w", err)
+		}
+		if err := tmux.StartWatcher(ctx, s.tmuxProv, s.logger); err != nil {
+			s.logger.Warn("tmux watcher start failed; continuing poll-only", "err", err)
 		}
 	}
 
@@ -183,9 +169,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 }
 
-// healthHandler reflects the server's uptime as JSON. Mirrors the
-// GraphQL `health` field so callers can pick the cheaper transport for
-// liveness probes.
+// healthHandler reflects the server's uptime as JSON.
 func healthHandler(startedAt time.Time) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		uptime := int64(time.Since(startedAt).Round(time.Second).Seconds())
@@ -197,11 +181,7 @@ func healthHandler(startedAt time.Time) http.HandlerFunc {
 	}
 }
 
-// graphqlHandlerFor wires the gqlgen executable schema with an
-// already-constructed Resolver root, so callers can inject providers
-// before serving any requests. POST + GET (for query strings) are both
-// accepted; multipart and websocket transports stay deferred to
-// Workstream C.
+// graphqlHandlerFor wires the gqlgen executable schema with an already-constructed Resolver root.
 func graphqlHandlerFor(res *resolvers.Resolver) http.Handler {
 	cfg := gql.Config{Resolvers: res}
 	srv := handler.New(gql.NewExecutableSchema(cfg))

--- a/schema.graphql
+++ b/schema.graphql
@@ -4,24 +4,12 @@
 # under internal/server/graphql/. The Rust TUI codegens its client from
 # the same file. Schema-first is intentional; see ADR-011.
 #
-# Workstream A scope: only the `health` field. Real node types come in
-# later workstreams.
-#
-# Workstream B-host: Host node + ResourceLoad. Identity surfaces machine
-# id, hostname, OS, kernel; resourceLoad surfaces live CPU/mem/disk/load
-# averages. peers ships empty until Workstream F federates orchard
-# instances together. Other providers add their own back-edges.
-#
-# Workstream B-config: Project node — projects declared in the orchard
-# config. Read-only; mutations go through `orchard config add-repo`.
-#
-# Workstream B-git: Worktree node + Project.worktrees back-edge. Process
-# is forward-declared so Worktree.processes can reference it; ws-b-ps
-# fills in the rest.
-#
-# Workstream B-ps: full Process node + Host.processes(filter). Edges
-# to Worktree (via cwd) and ClaudeInstance (via foreground claude pid)
-# stay placeholder until their owning workstreams land.
+# Workstream A: only the `health` field.
+# Workstream B-host: Host node + ResourceLoad.
+# Workstream B-config: Project node — projects declared in orchard config.
+# Workstream B-git: Worktree node + Project.worktrees back-edge.
+# Workstream B-ps: full Process node + Host.processes(filter).
+# Workstream B-tmux: TmuxServer/Session/Window/Pane/Client + filtered queries.
 
 """
 A node in the orchard graph. Every node has a globally-unique id so
@@ -34,9 +22,6 @@ interface Node {
 }
 
 # Process is an OS-level process surfaced via the `ps` adapter.
-# Identity: (host_id, pid). Lifetime: alive AND visible to ps.
-# Not enumerable from root — reach via `host.processes` etc.
-# See ADR-011 §5.1.
 type Process implements Node {
   "Stable id formatted as `<host>:<pid>`."
   id: ID!
@@ -70,11 +55,6 @@ type Process implements Node {
 
   "Controlling terminal, or null if none."
   tty: String
-
-  # Cross-provider edges — placeholders until their owning workstreams land.
-  # ws-b-git wires `worktree` via cwd → git worktree lookup;
-  # ws-b-claudeinstance (Wave 3) wires `claudeInstance` as the back-edge
-  # from a Claude pid.
 
   "Worktree this process is running inside, derived from cwd. Null until ws-b-git wires the lookup."
   worktree: Worktree
@@ -115,6 +95,15 @@ type Query {
 
   "All projects declared in ~/.config/orchard/config.json. Read-only — projects are added with `orchard config add-repo`."
   projects: [Project!]!
+
+  "The tmux server running on the local host. Null when no tmux daemon is reachable."
+  tmuxServer: TmuxServer
+
+  "Tmux sessions on the local host, optionally filtered. Empty when no tmux daemon is reachable."
+  tmuxSessions(filter: TmuxSessionFilter): [TmuxSession!]!
+
+  "Tmux panes on the local host, optionally filtered. Cheaper than walking the tree per-pane."
+  tmuxPanes(filter: TmuxPaneFilter): [TmuxPane!]!
 }
 
 type Health {
@@ -223,4 +212,230 @@ type Worktree implements Node {
 
   "Processes whose cwd lies under `path`. Resolved by the ps provider (ws-b-ps); returns `[]` until that provider lands."
   processes: [Process!]!
+}
+
+# ---------------------------------------------------------------------
+# Tmux node hierarchy — see ADR-011 §5.1.
+#
+# Identity scheme:
+#   TmuxServer:   `TmuxServer:<host>:<socketPath>`
+#   TmuxSession:  `TmuxSession:<host>:<sessionName>`
+#   TmuxWindow:   `TmuxWindow:<host>:<sessionName>:<windowIndex>`
+#   TmuxPane:     `TmuxPane:<host>:<paneId>`            (e.g. `%26`)
+#   TmuxClient:   `TmuxClient:<host>:<clientName>`
+# ---------------------------------------------------------------------
+
+"""
+The tmux daemon process on a host. v1 surfaces the local tmux only;
+multi-server setups (custom -L socket names) are reachable via socketPath.
+"""
+type TmuxServer implements Node {
+  "Stable id `TmuxServer:<host>:<socketPath>`."
+  id: ID!
+
+  "Filesystem path of the tmux socket the daemon is listening on."
+  socketPath: String!
+
+  "Pid of the tmux daemon process. Null if not currently determinable."
+  pid: Int
+
+  "True while the tmux daemon answers a heartbeat command."
+  alive: Boolean!
+
+  "Sessions hosted on this server."
+  sessions: [TmuxSession!]!
+
+  "Clients currently connected to this server."
+  clients: [TmuxClient!]!
+}
+
+"""
+A named tmux session. Stable across detach/reattach. Identity is the
+session name within its server.
+"""
+type TmuxSession implements Node {
+  "Stable id `TmuxSession:<host>:<sessionName>`."
+  id: ID!
+
+  "Server hosting this session."
+  server: TmuxServer!
+
+  "Session name."
+  name: String!
+
+  "RFC3339 timestamp of when the session was created."
+  createdAt: String!
+
+  "True when at least one client is attached to this session."
+  attached: Boolean!
+
+  "True when at least one attached client has had activity within the freshness window (default 5m)."
+  activeAttached: Boolean!
+
+  "Clients currently attached to this session."
+  attachedClients: [TmuxClient!]!
+
+  "Most recent activity timestamp across all panes/windows. RFC3339; null if never observed."
+  lastActivityAt: String
+
+  "Windows in this session."
+  windows: [TmuxWindow!]!
+
+  "The currently-focused window in this session."
+  currentWindow: TmuxWindow
+}
+
+"""
+A window inside a tmux session. Identity is the window index within its
+session.
+"""
+type TmuxWindow implements Node {
+  "Stable id `TmuxWindow:<host>:<sessionName>:<windowIndex>`."
+  id: ID!
+
+  "Session this window belongs to."
+  session: TmuxSession!
+
+  "Window index, zero-based as tmux numbers them when -base-index is 0."
+  index: Int!
+
+  "Window name (tmux's `window_name`)."
+  name: String!
+
+  "True when this window is the currently-focused window in its session."
+  active: Boolean!
+
+  "Panes in this window."
+  panes: [TmuxPane!]!
+
+  "The currently-focused pane in this window."
+  currentPane: TmuxPane
+}
+
+"""
+A pane inside a window — the leaf where commands actually run. Identity
+is the global tmux pane id (e.g. `%26`) within a host.
+
+Content fields (`content`, `contentRange`, `contentFull`) shell out to
+`tmux capture-pane`. They are not poll-cached; queries that ask for them
+pay the per-call cost.
+"""
+type TmuxPane implements Node {
+  "Stable id `TmuxPane:<host>:<paneId>`."
+  id: ID!
+
+  "Window this pane belongs to."
+  window: TmuxWindow!
+
+  "tmux pane id, including the leading `%` (e.g. `%26`)."
+  paneId: String!
+
+  "Pane title (tmux `pane_title`)."
+  title: String!
+
+  "Foreground command basename (tmux `pane_current_command`, e.g. 'claude', 'zsh')."
+  currentCommand: String!
+
+  "Pid of the foreground process. Null when tmux reports no current pid."
+  currentPid: Int
+
+  "Pane width in cells."
+  width: Int!
+
+  "Pane height in cells."
+  height: Int!
+
+  "True when tmux marks the pane as dead (process exited, awaiting reuse/close)."
+  dead: Boolean!
+
+  "Clients with their cursor on this pane."
+  watchingClients: [TmuxClient!]!
+
+  "OS-level Process for the foreground pid. Null until ws-b-ps wires it."
+  process: Process
+
+  "Claude instance running in this pane, if the foreground command is claude. Null until ws-b-claudeinstance wires it."
+  claudeInstance: ClaudeInstance
+
+  "Last N lines of pane output, default 50. Strips ANSI escapes by default."
+  content(lines: Int = 50, stripAnsi: Boolean = true): String!
+
+  "Output between two history line numbers (tmux's -S/-E semantics)."
+  contentRange(startLine: Int!, endLine: Int!, stripAnsi: Boolean = true): String!
+
+  "Full visible-history pane buffer."
+  contentFull(stripAnsi: Boolean = true): String!
+}
+
+"""
+A client (terminal) attached to a tmux server. Multiple clients may share
+the same session/window/pane.
+"""
+type TmuxClient implements Node {
+  "Stable id `TmuxClient:<host>:<clientName>`."
+  id: ID!
+
+  "Server this client connects to."
+  server: TmuxServer!
+
+  "Session this client is attached to."
+  session: TmuxSession!
+
+  "Client tty path (e.g. `/dev/ttys003`)."
+  tty: String!
+
+  "Hostname the client originated from. Empty for local clients."
+  hostname: String!
+
+  "TERM value the client advertises (e.g. `xterm-256color`)."
+  termName: String!
+
+  "RFC3339 attach time."
+  attachedAt: String!
+
+  "RFC3339 last activity time. Null if tmux returned no value."
+  lastActivityAt: String
+
+  "True when the client is in read-only mode."
+  readonly: Boolean!
+
+  "Window the client is currently looking at."
+  currentWindow: TmuxWindow
+
+  "Pane the client is currently looking at."
+  currentPane: TmuxPane
+}
+
+# ---------------------------------------------------------------------
+# Filter inputs — applied at the resolver layer per ADR-011 §6.
+# ---------------------------------------------------------------------
+
+"Filter for `Query.tmuxSessions`. AND-combined when multiple are set."
+input TmuxSessionFilter {
+  "Session names to include."
+  nameIn: [String!]
+
+  "Only include sessions with at least one attached client."
+  attachedOnly: Boolean
+
+  "Only include sessions with active-attached clients within the freshness window."
+  activeAttachedOnly: Boolean
+}
+
+"Filter for `Query.tmuxPanes`. AND-combined when multiple are set."
+input TmuxPaneFilter {
+  "Pane ids (e.g. `%26`) to include."
+  paneIdIn: [String!]
+
+  "Only include panes whose `currentCommand` is in this list."
+  currentCommandIn: [String!]
+
+  "Only include panes in these session names."
+  sessionIn: [String!]
+
+  "Only include panes whose `pane_title` matches the substring (case-sensitive)."
+  titleContains: String
+
+  "Only include dead (or non-dead) panes."
+  dead: Boolean
 }


### PR DESCRIPTION
## Summary

Workstream B-tmux delivers the tmux provider layer for the orchard daemon per ADR-011 §5.1 — five GraphQL nodes (`TmuxServer`, `TmuxSession`, `TmuxWindow`, `TmuxPane`, `TmuxClient`) backed by a `tmux list-*` adapter, an in-memory provider with a 1s heartbeat-fsnotify watcher, and a `orchard query panes --where …` CLI verb.

Targets `ws-a-scaffold` (the WS-A scaffolding PR #380). Independent of sibling WS-B branches; conflicts with WS-C / WS-B-host on the shared `Provider`/`Adapter`/`Store` scaffolding will be resolved at WS-C merge time (this PR mirrors the package shape ws-b-ps put down, since ws-b-host took a slightly different organisation that WS-C will reconcile).

## Acceptance criteria

- [x] **AC1** — `schema.graphql` adds `TmuxServer`, `TmuxSession`, `TmuxWindow`, `TmuxPane`, `TmuxClient`. Each implements `Node`. Edges per ADR-011 §5.1. `b2ca1e7`
- [x] **AC2** — On-demand pane content fields: `content(lines)`, `contentRange(startLine, endLine)`, `contentFull` — fire `tmux capture-pane`, not poll-cached. `c0bd08c`
- [x] **AC3** — `make generate` re-runs gqlgen cleanly; generated models in `internal/server/graphql/`. Verified locally — output is idempotent across re-runs. `b2ca1e7`
- [x] **AC4** — Provider at `internal/server/providers/tmux/`:
  - `adapter.go` — wraps `tmux list-sessions`, `list-windows`, `list-panes`, `list-clients`, `capture-pane`. U+0001 field separators in `-F` format strings. Stateless. `c0bd08c`
  - `provider.go` — implements `Provider[K, V]` for each node type via four typed facets. 1s default poll. `c0bd08c`
  - `watcher.go` — heartbeat-fsnotify hybrid; fsnotify failures gracefully fall back to poll-only. `c0bd08c`
  - `types.go` — Go domain types mirroring the GraphQL models. `c0bd08c`
- [x] **AC5** — Resolvers in `internal/server/resolvers/schema.resolvers.go` for `Query.tmuxServer`, all `TmuxServer` / `TmuxSession` / `TmuxWindow` / `TmuxPane` / `TmuxClient` field traversals, plus on-demand `content*`. `90bb5d9`
- [x] **AC6** — Stubs (return nil) for `TmuxPane.process` and `TmuxPane.claudeInstance` — those resolve in WS-B-ps and WS-B-claudeinstance. `90bb5d9`
- [x] **AC7** — Server wiring: `Server.New` accepts a `WithTmuxProvider` option; `Run` constructs and starts the provider before opening the listener. `90bb5d9`
- [x] **AC8** — CLI: `orchard query panes --where 'currentCommand=claude'` (cobra subcommand under `internal/cli/query/`), filter happens at resolver layer. `a87fb17`
- [x] **AC9** — `golangci-lint run ./internal/server/providers/tmux/... ./internal/cli/query/...` clean. Verified locally. `a87fb17`
- [x] **AC10** — E2E test in `internal/server/providers/tmux/tmux_e2e_test.go`: spawn real tmux server in temp socket, GraphQL POST against `httptest.Server`, assert entities appear; kill session, assert disappearance after one poll cycle. Plus `TestProvider_NoTmux` for the dead-server null case, plus three parser-pinning unit tests. `c0bd08c`
- [x] **AC11** — `go test ./internal/server/providers/tmux/...` green on macOS — six tests, ~0.5s. Verified locally.

## Notes for the WS-C merger

- This branch adds `internal/server/provider/`, `internal/server/store/`, and `internal/server/providers/tmux/` independently. ws-b-host took a slightly different layering (provider-private adapter package). Pick one shape at WS-C; the resolver code on this branch only depends on the generic `Provider[K, V]` interface so it's portable across either choice.
- `daemon.go` constructs the tmux provider with a fixed `local` `HostID`. ws-b-host promotes this to the OS-issued machine id; the merge swaps `tmux.HostID("local")` for `host.LocalID()`.
- gqlgen.yml's tmux-field resolver overrides duplicate the kind of declarations ws-b-ps has for ProcessFilter etc. — they don't collide.

## Test plan

- [x] `go test ./internal/server/providers/tmux/...` — 6 tests green
- [x] `golangci-lint run ./internal/server/providers/tmux/... ./internal/cli/query/...` — 0 issues
- [x] `go build ./...` — clean
- [x] `make generate` — idempotent (no diff on re-run)
- [x] Daemon smoke test: `orchard daemon start --addr 127.0.0.1:7799`, `curl /graphql` returns real local tmux sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tmux integration with GraphQL API support for querying tmux servers, sessions, windows, panes, and clients.
  * Added `orchard query panes` command for querying panes with configurable filters.
  * Added automatic synchronization of tmux state changes through filesystem monitoring.
  * Added filtering support for tmux sessions and panes by name, command, and other attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->