### PR TITLE
Workstream B-claudeprojects: claudeprojects provider → Conversation node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules/
 .claude/scheduled_tasks.json
 .claude-context/
 .merge-helper-context/
+.claude/ralph-loop.local.md

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -164,3 +164,9 @@ models:
         resolver: true
       currentPane:
         resolver: true
+
+  # Time scalar maps to Go's time.Time so resolvers return native values
+  # and the wire format is RFC 3339Nano (gqlgen's default Time marshaller).
+  Time:
+    model:
+      - github.com/99designs/gqlgen/graphql.Time

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/drewdrewthis/git-orchard-rs/internal/orchpaths"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
@@ -122,11 +123,14 @@ func runStart(parentCtx context.Context, addr string) error {
 	// real machine id once it lands.
 	psProvider := ps.New(ps.NewAdapter("local"), logger)
 	tmuxProvider := tmux.New(tmux.NewAdapter(localHostID()), logger)
+	claudeProjectsRoot := claudeprojectsRoot()
+	claudeProjectsProvider := claudeprojects.New(claudeProjectsRoot, "local", logger)
 
 	srv := server.New(addr, logger,
 		server.WithProjects(configProvider),
 		server.WithPS(psProvider),
 		server.WithTmux(tmuxProvider),
+		server.WithClaudeProjects(claudeProjectsProvider),
 	)
 	return srv.Run(ctx)
 }
@@ -216,6 +220,20 @@ func probeHealth() (int64, error) {
 		return 0, fmt.Errorf("decode: %w", err)
 	}
 	return payload.UptimeS, nil
+}
+
+// claudeprojectsRoot returns the directory the daemon should watch for
+// Claude Code transcripts. CLAUDE_PROJECTS_ROOT overrides; default is
+// ~/.claude/projects.
+func claudeprojectsRoot() string {
+	if v := os.Getenv("CLAUDE_PROJECTS_ROOT"); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ".claude/projects"
+	}
+	return home + "/.claude/projects"
 }
 
 func ensureParentDir(path string) error {

--- a/internal/cli/query/conversations.go
+++ b/internal/cli/query/conversations.go
@@ -1,0 +1,59 @@
+package query
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// conversationsCmd returns the `orchard query conversations` subcommand.
+//
+// Issues a Conversation GraphQL query against the running daemon and
+// prints the JSON response. Flags:
+//
+//   - `--open`  includes the `open` heartbeat boolean.
+//   - `--recap` includes the (always-null in v1) `recap` field.
+//
+// Both default to false so the unflagged invocation produces a small,
+// stable shape: id, sessionUuid, cwd, firstSeenAt, lastSeenAt,
+// messageCount.
+func conversationsCmd() *cobra.Command {
+	var (
+		showOpen  bool
+		showRecap bool
+	)
+	c := &cobra.Command{
+		Use:   "conversations",
+		Short: "List Claude Code conversations discovered under CLAUDE_PROJECTS_ROOT",
+		Long: "Issue a Conversation GraphQL query against the running orchard daemon and\n" +
+			"print the JSON response. Reports per-conversation metadata (sessionUuid, cwd,\n" +
+			"firstSeenAt, lastSeenAt, messageCount). Use --open to include the heartbeat\n" +
+			"boolean and --recap to include the (currently null) plugin-populated summary.",
+		Example: "  orchard query conversations\n" +
+			"  orchard query conversations --open\n" +
+			"  orchard query conversations --open --recap",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRaw(cmd.Context(), cmd.OutOrStdout(), conversationsQuery(showOpen, showRecap))
+		},
+	}
+	c.Flags().BoolVar(&showOpen, "open", false, "include the `open` heartbeat boolean")
+	c.Flags().BoolVar(&showRecap, "recap", false, "include the `recap` field (always null in v1)")
+	return c
+}
+
+// conversationsQuery composes the GraphQL document for the conversations verb.
+func conversationsQuery(showOpen, showRecap bool) string {
+	q := "query Conversations {\n  conversations {\n" +
+		"    id\n" +
+		"    sessionUuid\n" +
+		"    cwd\n" +
+		"    firstSeenAt\n" +
+		"    lastSeenAt\n" +
+		"    messageCount\n"
+	if showOpen {
+		q += "    open\n"
+	}
+	if showRecap {
+		q += "    recap\n"
+	}
+	q += "  }\n}"
+	return q
+}

--- a/internal/cli/query/query.go
+++ b/internal/cli/query/query.go
@@ -1,11 +1,8 @@
 // Package query hosts the `orchard query` cobra subcommand group, which
 // dispatches GraphQL queries against the running daemon.
 //
-// Workstream A wired only `--raw <gql>`. Workstream B-host adds the
-// first named verb — `host` — which proves the verb dispatch pattern
-// against a real provider. Workstream B-config adds `projects`. Future
-// workstreams add `worktrees`, `panes`, `processes`, `conversations`,
-// `contracts`.
+// Named verbs land per workstream — host, projects, processes, panes,
+// conversations. The `--raw <gql>` escape hatch always works.
 //
 // The cobra alias `q` mirrors the impl guide's "permitted alias for
 // query" so typing ergonomics match the documented CLI shape.
@@ -54,19 +51,20 @@ func Command() *cobra.Command {
 		Aliases: []string{"q"},
 		Short:   "Query the running orchard daemon via GraphQL",
 		Long: "Dispatch GraphQL queries against the running daemon at " + server.DefaultAddr + ".\n\n" +
-			"Use a named verb (e.g. `host`, `projects`, `processes`, `panes`) for high-level reads,\n" +
+			"Use a named verb (e.g. `host`, `projects`, `processes`, `panes`, `conversations`) for high-level reads,\n" +
 			"or `--raw '<gql>'` as the escape hatch when you need a custom GraphQL query.",
 		Example: "  orchard query host\n" +
 			"  orchard query projects\n" +
 			"  orchard query processes\n" +
 			"  orchard query panes\n" +
+			"  orchard query conversations\n" +
 			"  orchard query --raw 'query { health { status } }'",
 	}
 	var raw string
 	cmd.Flags().StringVar(&raw, "raw", "", "raw GraphQL query string")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		if raw == "" {
-			return fmt.Errorf("provide a verb (e.g. `host`, `projects`, `processes`, `panes`) or --raw '<graphql>'")
+			return fmt.Errorf("provide a verb (e.g. `host`, `projects`, `processes`, `panes`, `conversations`) or --raw '<graphql>'")
 		}
 		return runRaw(cmd.Context(), cmd.OutOrStdout(), raw)
 	}
@@ -74,12 +72,11 @@ func Command() *cobra.Command {
 	cmd.AddCommand(projectsCmd())
 	cmd.AddCommand(processesCmd())
 	cmd.AddCommand(panesCmd())
+	cmd.AddCommand(conversationsCmd())
 	return cmd
 }
 
 // projectsQuery is the GraphQL document fetched by `query projects`.
-// Field selection mirrors the AC list — id, directory, name. Order is
-// fixed so the daemon's sort and the client's print agree.
 const projectsQuery = `{ projects { id directory name } }`
 
 func projectsCmd() *cobra.Command {

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
@@ -57,6 +58,17 @@ type ComplexityRoot struct {
 		ID func(childComplexity int) int
 	}
 
+	Conversation struct {
+		Cwd          func(childComplexity int) int
+		FirstSeenAt  func(childComplexity int) int
+		ID           func(childComplexity int) int
+		LastSeenAt   func(childComplexity int) int
+		MessageCount func(childComplexity int) int
+		Open         func(childComplexity int) int
+		Recap        func(childComplexity int) int
+		SessionUUID  func(childComplexity int) int
+	}
+
 	Health struct {
 		Status  func(childComplexity int) int
 		UptimeS func(childComplexity int) int
@@ -100,13 +112,15 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Health       func(childComplexity int) int
-		Host         func(childComplexity int) int
-		Hosts        func(childComplexity int) int
-		Projects     func(childComplexity int) int
-		TmuxPanes    func(childComplexity int, filter *TmuxPaneFilter) int
-		TmuxServer   func(childComplexity int) int
-		TmuxSessions func(childComplexity int, filter *TmuxSessionFilter) int
+		Conversation  func(childComplexity int, id string) int
+		Conversations func(childComplexity int) int
+		Health        func(childComplexity int) int
+		Host          func(childComplexity int) int
+		Hosts         func(childComplexity int) int
+		Projects      func(childComplexity int) int
+		TmuxPanes     func(childComplexity int, filter *TmuxPaneFilter) int
+		TmuxServer    func(childComplexity int) int
+		TmuxSessions  func(childComplexity int, filter *TmuxSessionFilter) int
 	}
 
 	ResourceLoad struct {
@@ -215,6 +229,8 @@ type QueryResolver interface {
 	TmuxServer(ctx context.Context) (*TmuxServer, error)
 	TmuxSessions(ctx context.Context, filter *TmuxSessionFilter) ([]*TmuxSession, error)
 	TmuxPanes(ctx context.Context, filter *TmuxPaneFilter) ([]*TmuxPane, error)
+	Conversations(ctx context.Context) ([]*Conversation, error)
+	Conversation(ctx context.Context, id string) (*Conversation, error)
 }
 type TmuxClientResolver interface {
 	Server(ctx context.Context, obj *TmuxClient) (*TmuxServer, error)
@@ -298,6 +314,62 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ClaudeInstance.ID(childComplexity), true
+
+	case "Conversation.cwd":
+		if e.complexity.Conversation.Cwd == nil {
+			break
+		}
+
+		return e.complexity.Conversation.Cwd(childComplexity), true
+
+	case "Conversation.firstSeenAt":
+		if e.complexity.Conversation.FirstSeenAt == nil {
+			break
+		}
+
+		return e.complexity.Conversation.FirstSeenAt(childComplexity), true
+
+	case "Conversation.id":
+		if e.complexity.Conversation.ID == nil {
+			break
+		}
+
+		return e.complexity.Conversation.ID(childComplexity), true
+
+	case "Conversation.lastSeenAt":
+		if e.complexity.Conversation.LastSeenAt == nil {
+			break
+		}
+
+		return e.complexity.Conversation.LastSeenAt(childComplexity), true
+
+	case "Conversation.messageCount":
+		if e.complexity.Conversation.MessageCount == nil {
+			break
+		}
+
+		return e.complexity.Conversation.MessageCount(childComplexity), true
+
+	case "Conversation.open":
+		if e.complexity.Conversation.Open == nil {
+			break
+		}
+
+		return e.complexity.Conversation.Open(childComplexity), true
+
+	case "Conversation.recap":
+		if e.complexity.Conversation.Recap == nil {
+			break
+		}
+
+		return e.complexity.Conversation.Recap(childComplexity), true
+
+	case "Conversation.sessionUuid":
+		if e.complexity.Conversation.SessionUUID == nil {
+			break
+		}
+
+		return e.complexity.Conversation.SessionUUID(childComplexity), true
 
 	case "Health.status":
 		if e.complexity.Health.Status == nil {
@@ -513,6 +585,25 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Project.Worktrees(childComplexity), true
+
+	case "Query.conversation":
+		if e.complexity.Query.Conversation == nil {
+			break
+		}
+
+		args, err := ec.field_Query_conversation_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Conversation(childComplexity, args["id"].(string)), true
+
+	case "Query.conversations":
+		if e.complexity.Query.Conversations == nil {
+			break
+		}
+
+		return e.complexity.Query.Conversations(childComplexity), true
 
 	case "Query.health":
 		if e.complexity.Query.Health == nil {
@@ -1120,6 +1211,8 @@ var sources = []*ast.Source{
 # Workstream B-git: Worktree node + Project.worktrees back-edge.
 # Workstream B-ps: full Process node + Host.processes(filter).
 # Workstream B-tmux: TmuxServer/Session/Window/Pane/Client + filtered queries.
+# Workstream B-claudeprojects: Conversation node + Time scalar; backed by
+# the JSONL files Claude Code writes under ~/.claude/projects/.
 
 """
 A node in the orchard graph. Every node has a globally-unique id so
@@ -1130,6 +1223,9 @@ interface Node {
   "Globally-unique id (e.g. \"Host:<machineId>\")."
   id: ID!
 }
+
+"RFC 3339 timestamp string. Mapped to Go's time.Time."
+scalar Time
 
 # Process is an OS-level process surfaced via the ` + "`" + `ps` + "`" + ` adapter.
 type Process implements Node {
@@ -1214,6 +1310,12 @@ type Query {
 
   "Tmux panes on the local host, optionally filtered. Cheaper than walking the tree per-pane."
   tmuxPanes(filter: TmuxPaneFilter): [TmuxPane!]!
+
+  "Every Claude Code conversation discovered under the projects root. Latest-first by lastSeenAt."
+  conversations: [Conversation!]!
+
+  "Look up a single conversation by its globally-unique id (e.g. \"Conversation:<sessionUuid>\"). Null when unknown."
+  conversation(id: ID!): Conversation
 }
 
 type Health {
@@ -1549,6 +1651,47 @@ input TmuxPaneFilter {
   "Only include dead (or non-dead) panes."
   dead: Boolean
 }
+
+"""
+A Claude Code conversation, backed by the JSONL transcript that the
+Claude Code CLI writes under ` + "`" + `~/.claude/projects/<project-slug>/<session-uuid>.jsonl` + "`" + `.
+
+The provider derives every field from the JSONL on disk — there is no
+sidecar metadata. Heavy fields (full transcripts, message bodies)
+deliberately do not surface here; the v1 contract is metadata + a
+single live signal (` + "`" + `open` + "`" + `) and an optional plugin-populated ` + "`" + `recap` + "`" + `.
+
+` + "`" + `open` + "`" + ` is a heartbeat: true when the JSONL was written within the last
+N seconds (default 60s, see provider.HeartbeatThreshold).
+
+` + "`" + `recap` + "`" + ` is reserved for a future conversations plugin to populate; v1
+returns null unconditionally.
+"""
+type Conversation implements Node {
+  "Stable orchard id — \"Conversation:<sessionUuid>\"."
+  id: ID!
+
+  "The session UUID embedded in the JSONL filename — globally unique across Claude Code."
+  sessionUuid: String!
+
+  "Working directory recorded in the JSONL when the session was created. Null when not yet observed."
+  cwd: String
+
+  "RFC 3339 timestamp of the first record in the JSONL."
+  firstSeenAt: Time
+
+  "RFC 3339 timestamp of the last record in the JSONL."
+  lastSeenAt: Time
+
+  "Number of newline-terminated JSON records in the JSONL."
+  messageCount: Int!
+
+  "Heartbeat: true when the JSONL was last written within the heartbeat threshold."
+  open: Boolean!
+
+  "Plugin-populated short summary. Always null in v1."
+  recap: String
+}
 `, BuiltIn: false},
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)
@@ -1584,6 +1727,21 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 		}
 	}
 	args["name"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_conversation_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
 	return args, nil
 }
 
@@ -1766,6 +1924,346 @@ func (ec *executionContext) fieldContext_ClaudeInstance_id(ctx context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Conversation_id(ctx context.Context, field graphql.CollectedField, obj *Conversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Conversation_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Conversation_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Conversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Conversation_sessionUuid(ctx context.Context, field graphql.CollectedField, obj *Conversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Conversation_sessionUuid(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SessionUUID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Conversation_sessionUuid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Conversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Conversation_cwd(ctx context.Context, field graphql.CollectedField, obj *Conversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Conversation_cwd(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cwd, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Conversation_cwd(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Conversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Conversation_firstSeenAt(ctx context.Context, field graphql.CollectedField, obj *Conversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Conversation_firstSeenAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.FirstSeenAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Conversation_firstSeenAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Conversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Conversation_lastSeenAt(ctx context.Context, field graphql.CollectedField, obj *Conversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Conversation_lastSeenAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastSeenAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Conversation_lastSeenAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Conversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Conversation_messageCount(ctx context.Context, field graphql.CollectedField, obj *Conversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Conversation_messageCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MessageCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Conversation_messageCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Conversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Conversation_open(ctx context.Context, field graphql.CollectedField, obj *Conversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Conversation_open(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Open, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Conversation_open(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Conversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Conversation_recap(ctx context.Context, field graphql.CollectedField, obj *Conversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Conversation_recap(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Recap, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Conversation_recap(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Conversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3653,6 +4151,138 @@ func (ec *executionContext) fieldContext_Query_tmuxPanes(ctx context.Context, fi
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_tmuxPanes_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_conversations(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_conversations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Conversations(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*Conversation)
+	fc.Result = res
+	return ec.marshalNConversation2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐConversationᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_conversations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Conversation_id(ctx, field)
+			case "sessionUuid":
+				return ec.fieldContext_Conversation_sessionUuid(ctx, field)
+			case "cwd":
+				return ec.fieldContext_Conversation_cwd(ctx, field)
+			case "firstSeenAt":
+				return ec.fieldContext_Conversation_firstSeenAt(ctx, field)
+			case "lastSeenAt":
+				return ec.fieldContext_Conversation_lastSeenAt(ctx, field)
+			case "messageCount":
+				return ec.fieldContext_Conversation_messageCount(ctx, field)
+			case "open":
+				return ec.fieldContext_Conversation_open(ctx, field)
+			case "recap":
+				return ec.fieldContext_Conversation_recap(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Conversation", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_conversation(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_conversation(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Conversation(rctx, fc.Args["id"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*Conversation)
+	fc.Result = res
+	return ec.marshalOConversation2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐConversation(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_conversation(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Conversation_id(ctx, field)
+			case "sessionUuid":
+				return ec.fieldContext_Conversation_sessionUuid(ctx, field)
+			case "cwd":
+				return ec.fieldContext_Conversation_cwd(ctx, field)
+			case "firstSeenAt":
+				return ec.fieldContext_Conversation_firstSeenAt(ctx, field)
+			case "lastSeenAt":
+				return ec.fieldContext_Conversation_lastSeenAt(ctx, field)
+			case "messageCount":
+				return ec.fieldContext_Conversation_messageCount(ctx, field)
+			case "open":
+				return ec.fieldContext_Conversation_open(ctx, field)
+			case "recap":
+				return ec.fieldContext_Conversation_recap(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Conversation", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_conversation_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -8842,6 +9472,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._TmuxClient(ctx, sel, obj)
+	case Conversation:
+		return ec._Conversation(ctx, sel, &obj)
+	case *Conversation:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Conversation(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -8867,6 +9504,68 @@ func (ec *executionContext) _ClaudeInstance(ctx context.Context, sel ast.Selecti
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var conversationImplementors = []string{"Conversation", "Node"}
+
+func (ec *executionContext) _Conversation(ctx context.Context, sel ast.SelectionSet, obj *Conversation) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, conversationImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Conversation")
+		case "id":
+			out.Values[i] = ec._Conversation_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "sessionUuid":
+			out.Values[i] = ec._Conversation_sessionUuid(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "cwd":
+			out.Values[i] = ec._Conversation_cwd(ctx, field, obj)
+		case "firstSeenAt":
+			out.Values[i] = ec._Conversation_firstSeenAt(ctx, field, obj)
+		case "lastSeenAt":
+			out.Values[i] = ec._Conversation_lastSeenAt(ctx, field, obj)
+		case "messageCount":
+			out.Values[i] = ec._Conversation_messageCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "open":
+			out.Values[i] = ec._Conversation_open(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "recap":
+			out.Values[i] = ec._Conversation_recap(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -9530,6 +10229,47 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "conversations":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_conversations(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "conversation":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_conversation(ctx, field)
 				return res
 			}
 
@@ -11695,6 +12435,60 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) marshalNConversation2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐConversationᚄ(ctx context.Context, sel ast.SelectionSet, v []*Conversation) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNConversation2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐConversation(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNConversation2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐConversation(ctx context.Context, sel ast.SelectionSet, v *Conversation) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Conversation(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNFloat2float64(ctx context.Context, v interface{}) (float64, error) {
 	res, err := graphql.UnmarshalFloatContext(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -12513,6 +13307,13 @@ func (ec *executionContext) marshalOClaudeInstance2ᚖgithubᚗcomᚋdrewdrewthi
 	return ec._ClaudeInstance(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOConversation2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐConversation(ctx context.Context, sel ast.SelectionSet, v *Conversation) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Conversation(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalOInt2ᚕint64ᚄ(ctx context.Context, v interface{}) ([]int64, error) {
 	if v == nil {
 		return nil, nil
@@ -12640,6 +13441,22 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 		return graphql.Null
 	}
 	res := graphql.MarshalString(*v)
+	return res
+}
+
+func (ec *executionContext) unmarshalOTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalTime(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalTime(*v)
 	return res
 }
 

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -2,6 +2,10 @@
 
 package graphql
 
+import (
+	"time"
+)
+
 // A node in the orchard graph. Every node has a globally-unique id so
 // clients can fetch it via Query.node(id) regardless of which concrete
 // type it is.
@@ -15,6 +19,43 @@ type ClaudeInstance struct {
 	// Stable id; ws-b-claudeinstance formalises (host_id, claudePid).
 	ID string `json:"id"`
 }
+
+// A Claude Code conversation, backed by the JSONL transcript that the
+// Claude Code CLI writes under `~/.claude/projects/<project-slug>/<session-uuid>.jsonl`.
+//
+// The provider derives every field from the JSONL on disk — there is no
+// sidecar metadata. Heavy fields (full transcripts, message bodies)
+// deliberately do not surface here; the v1 contract is metadata + a
+// single live signal (`open`) and an optional plugin-populated `recap`.
+//
+// `open` is a heartbeat: true when the JSONL was written within the last
+// N seconds (default 60s, see provider.HeartbeatThreshold).
+//
+// `recap` is reserved for a future conversations plugin to populate; v1
+// returns null unconditionally.
+type Conversation struct {
+	// Stable orchard id — "Conversation:<sessionUuid>".
+	ID string `json:"id"`
+	// The session UUID embedded in the JSONL filename — globally unique across Claude Code.
+	SessionUUID string `json:"sessionUuid"`
+	// Working directory recorded in the JSONL when the session was created. Null when not yet observed.
+	Cwd *string `json:"cwd,omitempty"`
+	// RFC 3339 timestamp of the first record in the JSONL.
+	FirstSeenAt *time.Time `json:"firstSeenAt,omitempty"`
+	// RFC 3339 timestamp of the last record in the JSONL.
+	LastSeenAt *time.Time `json:"lastSeenAt,omitempty"`
+	// Number of newline-terminated JSON records in the JSONL.
+	MessageCount int64 `json:"messageCount"`
+	// Heartbeat: true when the JSONL was last written within the heartbeat threshold.
+	Open bool `json:"open"`
+	// Plugin-populated short summary. Always null in v1.
+	Recap *string `json:"recap,omitempty"`
+}
+
+func (Conversation) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this Conversation) GetID() string { return this.ID }
 
 type Health struct {
 	// Daemon health status — 'ok' when serving.

--- a/internal/server/providers/claudeprojects/adapter.go
+++ b/internal/server/providers/claudeprojects/adapter.go
@@ -1,0 +1,188 @@
+package claudeprojects
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// FSAdapter implements adapter.Adapter[ConversationID, Conversation]
+// by walking the projects root and reading metadata from every JSONL
+// it finds.
+//
+// Layout assumed:
+//
+//	<root>/
+//	  <project-slug-1>/
+//	    <session-uuid>.jsonl
+//	    <session-uuid>.jsonl
+//	  <project-slug-2>/
+//	    <session-uuid>.jsonl
+//
+// Subdirectories two-deep are not enumerated (Claude Code does not
+// nest transcripts). The watcher (watcher.go) handles new project
+// subdirs appearing at runtime.
+//
+// hostID is constant for the lifetime of one daemon process; tests
+// inject a fixture id so the GraphQL responses are deterministic.
+type FSAdapter struct {
+	root   string
+	hostID string
+	logger *slog.Logger
+
+	// Watcher state — owned by Watch / Close in watcher.go. Held on
+	// the struct so Close (which the Provider calls during teardown)
+	// can shut the goroutine down.
+	watcherMu   sync.Mutex
+	watcher     *fsnotify.Watcher
+	watcherDone chan struct{}
+}
+
+// NewFSAdapter constructs an adapter rooted at root. The root is not
+// required to exist at construction time — Fetch / FetchAll degrade to
+// empty results when the directory is missing, so a daemon that boots
+// before the user has installed Claude Code does not fail.
+func NewFSAdapter(root, hostID string, logger *slog.Logger) *FSAdapter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &FSAdapter{
+		root:   root,
+		hostID: hostID,
+		logger: logger,
+	}
+}
+
+// Root returns the configured projects root. Useful for diagnostics
+// and tests; the watcher and provider both read it.
+func (a *FSAdapter) Root() string { return a.root }
+
+// HostID returns the host id stamped onto every ConversationID this
+// adapter produces.
+func (a *FSAdapter) HostID() string { return a.hostID }
+
+// Fetch returns one Conversation by id. The session UUID lookup is
+// O(N) over all .jsonl filenames since we don't keep a path index —
+// FetchAll is the dominant code path and Fetch is only the cache-miss
+// fallback. If the conversation cannot be located, returns an error
+// with %w so callers can detect not-found via errors.Is(..., fs.ErrNotExist).
+func (a *FSAdapter) Fetch(ctx context.Context, id ConversationID) (Conversation, error) {
+	if err := ctx.Err(); err != nil {
+		return Conversation{}, err
+	}
+	if id.HostID != a.hostID {
+		return Conversation{}, fmt.Errorf("unknown host id %q (this adapter serves %q)", id.HostID, a.hostID)
+	}
+	all, err := a.FetchAll(ctx)
+	if err != nil {
+		return Conversation{}, err
+	}
+	c, ok := all[id]
+	if !ok {
+		return Conversation{}, fmt.Errorf("conversation %q: %w", id.SessionUUID, fs.ErrNotExist)
+	}
+	return c, nil
+}
+
+// FetchAll enumerates every JSONL under the projects root and returns
+// the cheap-to-compute Conversation summary for each. A missing root
+// returns an empty map (not an error) so the daemon can boot before
+// Claude Code has been used on this host.
+//
+// Errors reading individual files are logged but do not fail the
+// whole walk — one corrupt transcript should not blank the GraphQL
+// response. The caller (the provider) is responsible for any
+// error-aware reporting.
+func (a *FSAdapter) FetchAll(ctx context.Context) (map[ConversationID]Conversation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out := make(map[ConversationID]Conversation)
+
+	root, err := os.Stat(a.root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return out, nil
+		}
+		return nil, fmt.Errorf("stat projects root %s: %w", a.root, err)
+	}
+	if !root.IsDir() {
+		return nil, fmt.Errorf("projects root is not a directory: %s", a.root)
+	}
+
+	projectDirs, err := os.ReadDir(a.root)
+	if err != nil {
+		return nil, fmt.Errorf("read projects root %s: %w", a.root, err)
+	}
+
+	for _, dir := range projectDirs {
+		if !dir.IsDir() {
+			continue
+		}
+		projectPath := filepath.Join(a.root, dir.Name())
+		entries, err := os.ReadDir(projectPath)
+		if err != nil {
+			a.logger.Warn("claudeprojects: skipping unreadable project dir",
+				"dir", projectPath, "err", err)
+			continue
+		}
+		for _, ent := range entries {
+			if ent.IsDir() {
+				continue
+			}
+			if !strings.HasSuffix(ent.Name(), ".jsonl") {
+				continue
+			}
+			full := filepath.Join(projectPath, ent.Name())
+			c, err := a.fromFile(full)
+			if err != nil {
+				a.logger.Warn("claudeprojects: skipping unparseable transcript",
+					"file", full, "err", err)
+				continue
+			}
+			out[c.ID] = c
+		}
+	}
+	return out, nil
+}
+
+// FetchOne reads a single transcript file and returns its summary.
+// Surfaced for the watcher hot-path: a fsnotify Write event for
+// /root/proj/abc.jsonl re-reads only that file rather than walking
+// the whole tree again.
+func (a *FSAdapter) FetchOne(ctx context.Context, path string) (Conversation, error) {
+	if err := ctx.Err(); err != nil {
+		return Conversation{}, err
+	}
+	return a.fromFile(path)
+}
+
+// fromFile builds a Conversation from one transcript path. Cheap by
+// design — the heavy lifting lives in readJSONLMeta, which never
+// loads the whole file into memory.
+func (a *FSAdapter) fromFile(path string) (Conversation, error) {
+	meta, err := readJSONLMeta(path)
+	if err != nil {
+		return Conversation{}, err
+	}
+	id := ConversationID{
+		HostID:      a.hostID,
+		SessionUUID: sessionUUIDFromPath(path),
+	}
+	return Conversation{
+		ID:           id,
+		Path:         path,
+		Cwd:          meta.Cwd,
+		FirstSeenAt:  meta.FirstSeenAt,
+		LastSeenAt:   meta.LastSeenAt,
+		MessageCount: meta.MessageCount,
+	}, nil
+}

--- a/internal/server/providers/claudeprojects/claudeprojects_e2e_test.go
+++ b/internal/server/providers/claudeprojects/claudeprojects_e2e_test.go
@@ -1,0 +1,393 @@
+package claudeprojects_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+
+	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+)
+
+// TestConversation_E2E_OpenThenClosed boots the GraphQL stack against a
+// temp dir containing one synthetic JSONL transcript and asserts the
+// brief's three transitions:
+//
+//  1. Three records, fresh mtime → open=true, messageCount=3.
+//  2. Append a fourth record → lastSeenAt advances, messageCount=4.
+//  3. Stamp mtime backwards past the heartbeat → open=false.
+//
+// The transcript content is deliberately generic — no project names,
+// no usernames, no real session text. That keeps the fixture safe to
+// commit.
+func TestConversation_E2E_OpenThenClosed(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "tmp-fixture-project")
+	if err := os.Mkdir(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+
+	const sessionUUID = "00000000-1111-2222-3333-444444444444"
+	jsonlPath := filepath.Join(projectDir, sessionUUID+".jsonl")
+
+	now := time.Now().UTC().Round(time.Millisecond)
+	t0 := now.Add(-3 * time.Second)
+	writeRecords(t, jsonlPath, []recordFixture{
+		{ts: t0, role: "user", body: "hello", cwd: projectDir},
+		{ts: t0.Add(time.Second), role: "assistant", body: "ack"},
+		{ts: t0.Add(2 * time.Second), role: "user", body: "next"},
+	})
+
+	provider, srv := bootDaemon(t, root)
+	defer srv.Close()
+
+	// Phase 1 — three records, fresh; expect open=true, messageCount=3.
+	c := queryConversations(t, srv.URL)
+	if len(c) != 1 {
+		t.Fatalf("phase1: got %d conversations, want 1", len(c))
+	}
+	got := c[0]
+	if got.SessionUUID != sessionUUID {
+		t.Errorf("phase1: sessionUuid = %q, want %q", got.SessionUUID, sessionUUID)
+	}
+	if got.MessageCount != 3 {
+		t.Errorf("phase1: messageCount = %d, want 3", got.MessageCount)
+	}
+	if !got.Open {
+		t.Errorf("phase1: open = false, want true (mtime is fresh)")
+	}
+	if got.Cwd == nil || *got.Cwd != projectDir {
+		t.Errorf("phase1: cwd = %v, want %q", got.Cwd, projectDir)
+	}
+	if got.FirstSeenAt == nil {
+		t.Fatalf("phase1: firstSeenAt is null")
+	}
+	if got.LastSeenAt == nil {
+		t.Fatalf("phase1: lastSeenAt is null")
+	}
+	firstAt := *got.LastSeenAt
+
+	// Phase 2 — append one record; expect lastSeenAt to advance.
+	t1 := t0.Add(3 * time.Second)
+	appendRecord(t, jsonlPath, recordFixture{ts: t1, role: "assistant", body: "more"})
+	// Force a refresh through the cache: stop the watcher race by
+	// asking the provider to reload manually. The watcher is also
+	// running, but tests must not depend on fsnotify timing.
+	if err := provider.Refresh(context.Background()); err != nil {
+		t.Fatalf("phase2: refresh: %v", err)
+	}
+
+	c = queryConversations(t, srv.URL)
+	if len(c) != 1 {
+		t.Fatalf("phase2: got %d conversations, want 1", len(c))
+	}
+	got = c[0]
+	if got.MessageCount != 4 {
+		t.Errorf("phase2: messageCount = %d, want 4", got.MessageCount)
+	}
+	if got.LastSeenAt == nil {
+		t.Fatalf("phase2: lastSeenAt is null")
+	}
+	if !got.LastSeenAt.After(firstAt) {
+		t.Errorf("phase2: lastSeenAt = %v, want > %v", got.LastSeenAt, firstAt)
+	}
+
+	// Phase 3 — stamp mtime backwards beyond the heartbeat.
+	old := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(jsonlPath, old, old); err != nil {
+		t.Fatalf("phase3: chtimes: %v", err)
+	}
+	// Also rewrite the file to push the last record's timestamp
+	// backwards — `open` is computed from the last record's
+	// timestamp, not the file's mtime, so a lone Chtimes is not
+	// sufficient. We replace the contents with three records all
+	// timestamped well before the heartbeat.
+	writeRecords(t, jsonlPath, []recordFixture{
+		{ts: old, role: "user", body: "old hello", cwd: projectDir},
+		{ts: old.Add(time.Second), role: "assistant", body: "old ack"},
+		{ts: old.Add(2 * time.Second), role: "user", body: "old next"},
+	})
+	if err := provider.Refresh(context.Background()); err != nil {
+		t.Fatalf("phase3: refresh: %v", err)
+	}
+
+	c = queryConversations(t, srv.URL)
+	if len(c) != 1 {
+		t.Fatalf("phase3: got %d conversations, want 1", len(c))
+	}
+	got = c[0]
+	if got.Open {
+		t.Errorf("phase3: open = true, want false (last record is %v ago)",
+			time.Since(*got.LastSeenAt))
+	}
+}
+
+// TestConversation_Lookup_ByID asserts Query.conversation(id) round-
+// trips a stable id and returns nil for unknown ids.
+func TestConversation_Lookup_ByID(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "tmp-fixture-project")
+	if err := os.Mkdir(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+	const sessionUUID = "abcd1234-0000-0000-0000-000000000000"
+	jsonlPath := filepath.Join(projectDir, sessionUUID+".jsonl")
+	writeRecords(t, jsonlPath, []recordFixture{
+		{ts: time.Now().UTC(), role: "user", body: "hi", cwd: projectDir},
+	})
+
+	_, srv := bootDaemon(t, root)
+	defer srv.Close()
+
+	id := "Conversation:" + sessionUUID
+	got := queryConversation(t, srv.URL, id)
+	if got == nil {
+		t.Fatalf("conversation(id=%q) returned nil", id)
+	}
+	if got.SessionUUID != sessionUUID {
+		t.Errorf("conversation(id).sessionUuid = %q, want %q", got.SessionUUID, sessionUUID)
+	}
+	if got.MessageCount != 1 {
+		t.Errorf("conversation(id).messageCount = %d, want 1", got.MessageCount)
+	}
+
+	if got := queryConversation(t, srv.URL, "Conversation:does-not-exist"); got != nil {
+		t.Errorf("conversation(unknown) = %+v, want nil", got)
+	}
+	if got := queryConversation(t, srv.URL, "Garbage:no-prefix"); got != nil {
+		t.Errorf("conversation(garbage) = %+v, want nil", got)
+	}
+}
+
+// TestConversation_E2E_EmptyRoot asserts a daemon booted with an empty
+// projects root returns conversations: [].
+func TestConversation_E2E_EmptyRoot(t *testing.T) {
+	root := t.TempDir()
+	_, srv := bootDaemon(t, root)
+	defer srv.Close()
+
+	c := queryConversations(t, srv.URL)
+	if len(c) != 0 {
+		t.Errorf("got %d conversations from empty root, want 0", len(c))
+	}
+}
+
+// TestConversation_RecapAlwaysNull is the v1 contract assertion — the
+// resolver must not surface recap content; the conversations plugin
+// will.
+func TestConversation_RecapAlwaysNull(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "tmp-fixture-project")
+	if err := os.Mkdir(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir project dir: %v", err)
+	}
+	const sessionUUID = "11111111-2222-3333-4444-555555555555"
+	jsonlPath := filepath.Join(projectDir, sessionUUID+".jsonl")
+	writeRecords(t, jsonlPath, []recordFixture{
+		{ts: time.Now().UTC(), role: "user", body: "hello", cwd: projectDir},
+	})
+
+	_, srv := bootDaemon(t, root)
+	defer srv.Close()
+
+	resp := postQuery(t, srv.URL, `query { conversations { id recap } }`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	if len(resp.Data.Conversations) != 1 {
+		t.Fatalf("got %d conversations, want 1", len(resp.Data.Conversations))
+	}
+	if resp.Data.Conversations[0].Recap != nil {
+		t.Errorf("recap = %v, want nil per v1 contract", resp.Data.Conversations[0].Recap)
+	}
+}
+
+// recordFixture is a tiny synthetic JSONL record. We intentionally do
+// not match the full Claude Code schema — the provider only reads
+// `timestamp` and `cwd`, so anything else is ignored. The body is
+// generic (`hello`, `ack`, …) so the file is safe to commit and to
+// surface in CI logs.
+type recordFixture struct {
+	ts   time.Time
+	role string
+	body string
+	cwd  string
+}
+
+func (r recordFixture) marshal(t *testing.T) []byte {
+	rec := map[string]any{
+		"type":      r.role,
+		"timestamp": r.ts.UTC().Format(time.RFC3339Nano),
+		"sessionId": "fixture",
+		"message": map[string]any{
+			"role":    r.role,
+			"content": r.body,
+		},
+	}
+	if r.cwd != "" {
+		rec["cwd"] = r.cwd
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("marshal record: %v", err)
+	}
+	return append(b, '\n')
+}
+
+// writeRecords replaces path with the given records, one per line.
+func writeRecords(t *testing.T, path string, records []recordFixture) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	for _, r := range records {
+		if _, err := f.Write(r.marshal(t)); err != nil {
+			t.Fatalf("write record: %v", err)
+		}
+	}
+}
+
+// appendRecord adds one line to path without truncating.
+func appendRecord(t *testing.T, path string, r recordFixture) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open %s for append: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(r.marshal(t)); err != nil {
+		t.Fatalf("append record: %v", err)
+	}
+}
+
+// bootDaemon constructs a Provider rooted at root, starts it, wires it
+// to a gqlgen handler, and exposes that on an httptest.Server. The
+// returned Provider is non-nil so tests can call helper methods like
+// InvalidateAll between phases without depending on fsnotify timing.
+//
+// NOTE: This intentionally does NOT use server.New / server.Run — those
+// bind to a fixed port and read $CLAUDE_PROJECTS_ROOT. Tests speak the
+// same GraphQL the daemon does, but on an ephemeral httptest socket.
+func bootDaemon(t *testing.T, root string) (*claudeprojects.Provider, *httptest.Server) {
+	t.Helper()
+
+	provider := claudeprojects.New(root, "test-host", nil)
+	if err := provider.Start(context.Background()); err != nil {
+		t.Fatalf("start provider: %v", err)
+	}
+	t.Cleanup(func() { _ = provider.Stop() })
+
+	cfg := gql.Config{Resolvers: resolvers.New(time.Now()).WithClaudeProjects(provider)}
+	hh := handler.New(gql.NewExecutableSchema(cfg))
+	hh.AddTransport(transport.POST{})
+	hh.AddTransport(transport.GET{})
+
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", hh)
+	srv := httptest.NewServer(mux)
+	return provider, srv
+}
+
+// graphqlResponse is the projected shape we deserialize from the
+// daemon's JSON reply. We model only the fields the tests assert
+// against; gqlgen's responses include surrounding noise (extensions,
+// path) we ignore.
+type graphqlResponse struct {
+	Data   graphqlData `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+type graphqlData struct {
+	Conversations []*conversationDTO `json:"conversations"`
+	Conversation  *conversationDTO   `json:"conversation"`
+}
+
+type conversationDTO struct {
+	ID           string     `json:"id"`
+	SessionUUID  string     `json:"sessionUuid"`
+	Cwd          *string    `json:"cwd"`
+	FirstSeenAt  *time.Time `json:"firstSeenAt"`
+	LastSeenAt   *time.Time `json:"lastSeenAt"`
+	MessageCount int64      `json:"messageCount"`
+	Open         bool       `json:"open"`
+	Recap        *string    `json:"recap"`
+}
+
+// queryConversations issues the canonical Conversations query and
+// fails the test on any GraphQL error. Returns the projected list.
+func queryConversations(t *testing.T, baseURL string) []*conversationDTO {
+	t.Helper()
+	resp := postQuery(t, baseURL, `query {
+		conversations {
+			id
+			sessionUuid
+			cwd
+			firstSeenAt
+			lastSeenAt
+			messageCount
+			open
+			recap
+		}
+	}`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	return resp.Data.Conversations
+}
+
+// queryConversation issues a Query.conversation(id) lookup and returns
+// the single result (or nil for not-found).
+func queryConversation(t *testing.T, baseURL, id string) *conversationDTO {
+	t.Helper()
+	q := fmt.Sprintf(`query { conversation(id: %q) { id sessionUuid messageCount } }`, id)
+	resp := postQuery(t, baseURL, q)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	return resp.Data.Conversation
+}
+
+// postQuery is the GraphQL transport for tests. Identical shape to the
+// CLI's runRaw but without pretty-printing.
+func postQuery(t *testing.T, baseURL, query string) graphqlResponse {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/graphql", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d: %s", resp.StatusCode, raw)
+	}
+	var out graphqlResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}

--- a/internal/server/providers/claudeprojects/jsonl.go
+++ b/internal/server/providers/claudeprojects/jsonl.go
@@ -1,0 +1,339 @@
+package claudeprojects
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// jsonlMeta is the cheap-to-compute summary of a JSONL transcript —
+// enough to populate every Conversation field except recap.
+//
+// All three "interesting" timestamps (and Cwd, when available) are
+// derived from the first and last record only. We never keep the
+// middle of the file in memory; that is the entire point of this
+// adapter.
+type jsonlMeta struct {
+	FirstSeenAt  *time.Time
+	LastSeenAt   *time.Time
+	Cwd          *string
+	MessageCount int64
+	ModTime      time.Time
+}
+
+// jsonlRecord is the parsed shape of a single JSONL line. Fields are
+// pointers so absence on any specific line falls through cleanly — we
+// only need a handful, and Claude Code's JSONL has many shapes (user
+// turn, assistant turn, summary record, sidechain marker, …).
+//
+// Timestamp uses RFC 3339Nano via *time.Time so the standard library
+// parses it for us. CWD is the only string we need from the body, and
+// only on the latest record we have it on (newer records carry it).
+type jsonlRecord struct {
+	Timestamp *time.Time `json:"timestamp,omitempty"`
+	Cwd       *string    `json:"cwd,omitempty"`
+}
+
+// readJSONLMeta returns the metadata summary of the JSONL at path
+// without reading the entire file into memory. Approach:
+//
+//   - stat() once to get size + modtime.
+//   - count newlines by streaming the file through a fixed-size
+//     buffer; we never allocate per-line.
+//   - parse the first record by reading from offset 0 until the first
+//     newline.
+//   - parse the last record by seeking near EOF and walking backwards
+//     for the last newline that precedes another (or BOF), then
+//     parsing the slice between them.
+//
+// The function is robust to files in mid-write: a partial trailing
+// line (no terminating newline) is ignored — better to under-count
+// than to surface a parse error to the GraphQL caller.
+//
+// All three reads are independent; we do not hold a lock on the file.
+// fsnotify will fire again if a write lands between passes, and the
+// provider's cache will refresh.
+func readJSONLMeta(path string) (jsonlMeta, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return jsonlMeta{}, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return jsonlMeta{}, fmt.Errorf("not a file: %s", path)
+	}
+
+	meta := jsonlMeta{ModTime: info.ModTime()}
+
+	if info.Size() == 0 {
+		return meta, nil
+	}
+
+	count, err := countNewlines(path)
+	if err != nil {
+		return jsonlMeta{}, fmt.Errorf("count records in %s: %w", path, err)
+	}
+	meta.MessageCount = count
+
+	first, err := readFirstRecord(path)
+	if err != nil {
+		return jsonlMeta{}, fmt.Errorf("read first record of %s: %w", path, err)
+	}
+	if first != nil {
+		meta.FirstSeenAt = first.Timestamp
+		if first.Cwd != nil && *first.Cwd != "" {
+			meta.Cwd = first.Cwd
+		}
+	}
+
+	last, err := readLastRecord(path, info.Size())
+	if err != nil {
+		return jsonlMeta{}, fmt.Errorf("read last record of %s: %w", path, err)
+	}
+	if last != nil {
+		meta.LastSeenAt = last.Timestamp
+		// Prefer cwd from the latest record — older transcripts may
+		// only carry it on later turns.
+		if last.Cwd != nil && *last.Cwd != "" {
+			meta.Cwd = last.Cwd
+		}
+	}
+
+	return meta, nil
+}
+
+// countNewlines streams the file and returns the number of '\n' bytes.
+//
+// We deliberately count bytes rather than lines — bufio.Scanner.Scan()
+// can panic on a single line longer than its max-token size, and
+// Claude Code's JSONL records sometimes embed large base64 attachments
+// that would overflow the default 64KB limit. Counting raw bytes is
+// O(file size) but with a fixed-size 64KB buffer regardless of how
+// long any single line happens to be.
+//
+// A trailing partial line (no '\n' at the very end of the file) is
+// not counted — same as `wc -l`.
+func countNewlines(path string) (int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	const bufSize = 64 * 1024
+	buf := make([]byte, bufSize)
+	var count int64
+	for {
+		n, err := f.Read(buf)
+		if n > 0 {
+			count += int64(bytes.Count(buf[:n], []byte{'\n'}))
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return 0, err
+		}
+	}
+	return count, nil
+}
+
+// readFirstRecord parses the first newline-terminated JSON record in
+// path. Returns (nil, nil) when the file is empty or contains no
+// terminated record.
+//
+// Implementation: a buffered reader with bufio.ReadBytes('\n'). We
+// cap the line length at 1 MB to defend against runaway records — a
+// single 1 MB log line is already absurd; refusing to parse beyond
+// that is a feature, not a regression.
+func readFirstRecord(path string) (*jsonlRecord, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	r := bufio.NewReaderSize(f, 64*1024)
+	line, err := readBoundedLine(r, maxLineBytes)
+	if err != nil {
+		if errors.Is(err, io.EOF) && len(line) == 0 {
+			return nil, nil
+		}
+		if errors.Is(err, errLineTooLong) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return decodeRecord(line)
+}
+
+// readLastRecord parses the last newline-terminated JSON record in
+// path. Returns (nil, nil) when the file is empty or contains no
+// terminated record.
+//
+// Implementation: seek to a small tail window (default 64 KB), search
+// backwards for the last '\n' (which terminates the last record) and
+// the second-to-last '\n' (which terminates the record before it). The
+// slice between them is the last full record. If the window contains
+// no newline-pair, double the window and retry, up to a hard cap so
+// we never read more than a few MB to find the tail.
+//
+// Edge case: a single-record file. There is exactly one '\n' at the
+// end (or no terminator at all). We treat the prefix (offset 0 → last
+// '\n') as the record body in that case.
+func readLastRecord(path string, size int64) (*jsonlRecord, error) {
+	if size == 0 {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Walk the tail in expanding chunks until we find a complete
+	// trailing record or hit the hard cap.
+	chunk := int64(initialTailWindow)
+	for {
+		if chunk > size {
+			chunk = size
+		}
+		off := size - chunk
+		if _, err := f.Seek(off, io.SeekStart); err != nil {
+			return nil, err
+		}
+		buf := make([]byte, chunk)
+		if _, err := io.ReadFull(f, buf); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+			return nil, err
+		}
+
+		// We want the last *complete* (newline-terminated) record. If
+		// the file ends with a trailing newline we drop it so the
+		// search for the prior newline points at the terminator of
+		// the *last* record body. If it does not — i.e. the file ends
+		// mid-write — we drop the partial trailing fragment by walking
+		// back to the most recent newline and treating that as the
+		// effective EOF.
+		end := len(buf)
+		if end > 0 && buf[end-1] == '\n' {
+			end--
+		} else {
+			// Partial trailing line: prune it. After this, end points
+			// at the position immediately after the last terminating
+			// '\n', i.e. exclusive of the partial fragment.
+			lastNL := bytes.LastIndexByte(buf[:end], '\n')
+			if lastNL == -1 {
+				// No newline at all in this window. If we have read
+				// the whole file there is no complete record; if not,
+				// expand the window.
+				if off == 0 {
+					return nil, nil
+				}
+				if chunk >= maxTailWindow {
+					return nil, nil
+				}
+				chunk *= 2
+				continue
+			}
+			end = lastNL
+		}
+
+		// The body of the last record runs from (lastInternalNewline+1)
+		// up to `end`. lastInternalNewline is the most-recent '\n' we
+		// can find before `end`; it terminates the record *before* the
+		// last one.
+		lastInternal := bytes.LastIndexByte(buf[:end], '\n')
+		if lastInternal == -1 {
+			// No internal newline yet — either we have only one record
+			// in the entire file, or the chunk is too small. If we
+			// have already read the whole file, the body runs from 0
+			// to `end`.
+			if off == 0 {
+				return decodeRecord(buf[:end])
+			}
+			if chunk >= maxTailWindow {
+				return nil, nil
+			}
+			chunk *= 2
+			continue
+		}
+		body := buf[lastInternal+1 : end]
+		return decodeRecord(body)
+	}
+}
+
+const (
+	// initialTailWindow is the first chunk size we read from EOF when
+	// searching for the last record. 64 KB is large enough for most
+	// records (Claude Code lines are typically <8 KB) and small
+	// enough to be cheap.
+	initialTailWindow int64 = 64 * 1024
+
+	// maxTailWindow is the hard cap on how much of the file we will
+	// re-read while hunting for the second-to-last newline. A 4 MB
+	// last record is implausible enough that returning "no last
+	// record" is the right answer.
+	maxTailWindow int64 = 4 * 1024 * 1024
+
+	// maxLineBytes guards readBoundedLine. Records longer than this
+	// are skipped — we surface (nil, nil) to the caller, which
+	// degrades to "unknown firstSeenAt/lastSeenAt" on the node.
+	maxLineBytes = 1024 * 1024
+)
+
+// errLineTooLong is the sentinel error returned by readBoundedLine
+// when a single line exceeds maxLineBytes. Callers convert it to a
+// soft "no record" outcome.
+var errLineTooLong = errors.New("jsonl line exceeds bound")
+
+// readBoundedLine reads up to limit bytes or until '\n', whichever
+// comes first. Returns the line *without* the trailing newline.
+func readBoundedLine(r *bufio.Reader, limit int) ([]byte, error) {
+	out := make([]byte, 0, 4096)
+	for {
+		if len(out) >= limit {
+			// Drain to next newline so the reader is left in a sane
+			// state, but report the bound-busting error to the caller.
+			for {
+				b, err := r.ReadByte()
+				if err != nil {
+					return out, errLineTooLong
+				}
+				if b == '\n' {
+					return out, errLineTooLong
+				}
+			}
+		}
+		b, err := r.ReadByte()
+		if err != nil {
+			return out, err
+		}
+		if b == '\n' {
+			return out, nil
+		}
+		out = append(out, b)
+	}
+}
+
+// decodeRecord parses one JSONL line into a jsonlRecord. We tolerate
+// records that don't have a `timestamp` (returns the record with a
+// nil pointer) but a parse error on the JSON itself surfaces — those
+// records are corrupt and the caller should know.
+//
+// An empty body (zero bytes after newline trimming) returns
+// (nil, nil) — there is no record to decode.
+func decodeRecord(line []byte) (*jsonlRecord, error) {
+	line = bytes.TrimRight(line, "\r\n")
+	if len(line) == 0 {
+		return nil, nil
+	}
+	var rec jsonlRecord
+	if err := json.Unmarshal(line, &rec); err != nil {
+		return nil, fmt.Errorf("decode jsonl record: %w", err)
+	}
+	return &rec, nil
+}

--- a/internal/server/providers/claudeprojects/jsonl_test.go
+++ b/internal/server/providers/claudeprojects/jsonl_test.go
@@ -1,0 +1,178 @@
+package claudeprojects
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestReadJSONLMeta_Empty asserts an empty file degrades cleanly to
+// zero records and nil timestamps — important so a freshly-created
+// transcript does not panic the provider.
+func TestReadJSONLMeta_Empty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("write empty: %v", err)
+	}
+	meta, err := readJSONLMeta(path)
+	if err != nil {
+		t.Fatalf("readJSONLMeta: %v", err)
+	}
+	if meta.MessageCount != 0 {
+		t.Errorf("messageCount = %d, want 0", meta.MessageCount)
+	}
+	if meta.FirstSeenAt != nil || meta.LastSeenAt != nil {
+		t.Errorf("expected nil timestamps for empty file, got first=%v last=%v",
+			meta.FirstSeenAt, meta.LastSeenAt)
+	}
+}
+
+// TestReadJSONLMeta_Single ensures a one-record file reports both
+// firstSeenAt and lastSeenAt as the same value.
+func TestReadJSONLMeta_Single(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "single.jsonl")
+	ts := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	cwd := "/tmp/fixture"
+	body := `{"timestamp":"` + ts.Format(time.RFC3339Nano) + `","cwd":"` + cwd + `","type":"user"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	meta, err := readJSONLMeta(path)
+	if err != nil {
+		t.Fatalf("readJSONLMeta: %v", err)
+	}
+	if meta.MessageCount != 1 {
+		t.Errorf("messageCount = %d, want 1", meta.MessageCount)
+	}
+	if meta.FirstSeenAt == nil || !meta.FirstSeenAt.Equal(ts) {
+		t.Errorf("firstSeenAt = %v, want %v", meta.FirstSeenAt, ts)
+	}
+	if meta.LastSeenAt == nil || !meta.LastSeenAt.Equal(ts) {
+		t.Errorf("lastSeenAt = %v, want %v", meta.LastSeenAt, ts)
+	}
+	if meta.Cwd == nil || *meta.Cwd != cwd {
+		t.Errorf("cwd = %v, want %q", meta.Cwd, cwd)
+	}
+}
+
+// TestReadJSONLMeta_Many reads a 5-line transcript and confirms we
+// pick the last record's timestamp, not the file's mtime.
+func TestReadJSONLMeta_Many(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "many.jsonl")
+	t0 := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	var b strings.Builder
+	for i := 0; i < 5; i++ {
+		ts := t0.Add(time.Duration(i) * time.Second)
+		b.WriteString(`{"timestamp":"` + ts.Format(time.RFC3339Nano) + `","type":"user"}` + "\n")
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	meta, err := readJSONLMeta(path)
+	if err != nil {
+		t.Fatalf("readJSONLMeta: %v", err)
+	}
+	if meta.MessageCount != 5 {
+		t.Errorf("messageCount = %d, want 5", meta.MessageCount)
+	}
+	if !meta.FirstSeenAt.Equal(t0) {
+		t.Errorf("firstSeenAt = %v, want %v", meta.FirstSeenAt, t0)
+	}
+	wantLast := t0.Add(4 * time.Second)
+	if !meta.LastSeenAt.Equal(wantLast) {
+		t.Errorf("lastSeenAt = %v, want %v", meta.LastSeenAt, wantLast)
+	}
+}
+
+// TestReadJSONLMeta_PartialTrailingLine asserts a file that ends mid-
+// write (no terminating newline on the final line) does not crash and
+// counts only fully-terminated records — same as wc -l.
+func TestReadJSONLMeta_PartialTrailingLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "partial.jsonl")
+	t0 := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	body := `{"timestamp":"` + t0.Format(time.RFC3339Nano) + `","type":"user"}` + "\n" +
+		`{"timestamp":"` + t0.Add(time.Second).Format(time.RFC3339Nano) + `","type":"assistant"}` + "\n" +
+		`{"timestamp":"`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	meta, err := readJSONLMeta(path)
+	if err != nil {
+		t.Fatalf("readJSONLMeta: %v", err)
+	}
+	if meta.MessageCount != 2 {
+		t.Errorf("messageCount = %d, want 2 (partial trailing line ignored)", meta.MessageCount)
+	}
+}
+
+// TestReadJSONLMeta_NoTimestamp tolerates records that omit timestamps —
+// firstSeenAt/lastSeenAt are nil but messageCount still reflects the
+// line count.
+func TestReadJSONLMeta_NoTimestamp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nots.jsonl")
+	body := `{"type":"summary"}` + "\n" + `{"type":"summary"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	meta, err := readJSONLMeta(path)
+	if err != nil {
+		t.Fatalf("readJSONLMeta: %v", err)
+	}
+	if meta.MessageCount != 2 {
+		t.Errorf("messageCount = %d, want 2", meta.MessageCount)
+	}
+	if meta.FirstSeenAt != nil || meta.LastSeenAt != nil {
+		t.Errorf("expected nil timestamps, got first=%v last=%v",
+			meta.FirstSeenAt, meta.LastSeenAt)
+	}
+}
+
+// TestReadJSONLMeta_LongLineSkipped asserts a single line longer than
+// maxLineBytes does not crash the parser; we surface (nil, nil) for
+// firstSeenAt/lastSeenAt rather than failing the whole walk.
+func TestReadJSONLMeta_LongLineSkipped(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "long.jsonl")
+	huge := strings.Repeat("x", maxLineBytes+10)
+	body := `{"timestamp":"2026-05-04T12:00:00Z","blob":"` + huge + `"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	meta, err := readJSONLMeta(path)
+	if err != nil {
+		t.Fatalf("readJSONLMeta: %v", err)
+	}
+	// One newline → one record counted, but the firstRecord parser
+	// hits the bound and returns nil.
+	if meta.MessageCount != 1 {
+		t.Errorf("messageCount = %d, want 1", meta.MessageCount)
+	}
+	if meta.FirstSeenAt != nil {
+		t.Errorf("firstSeenAt should be nil after a too-long record, got %v", meta.FirstSeenAt)
+	}
+}
+
+// TestSessionUUIDFromPath asserts the filename → uuid extraction
+// peels only the .jsonl suffix and respects directory components.
+func TestSessionUUIDFromPath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/a/b/c/abcd.jsonl", "abcd"},
+		{"abcd.jsonl", "abcd"},
+		{"/x/abcd.jsonl.bak", "abcd.jsonl.bak"}, // not a .jsonl, returns base unchanged
+	}
+	for _, c := range cases {
+		if got := sessionUUIDFromPath(c.in); got != c.want {
+			t.Errorf("sessionUUIDFromPath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestConversationID_GraphQLID confirms the orchard id format
+// matches the schema docs: "Conversation:<sessionUuid>".
+func TestConversationID_GraphQLID(t *testing.T) {
+	id := ConversationID{HostID: "test-host", SessionUUID: "abcd"}
+	if got, want := id.GraphQLID(), "Conversation:abcd"; got != want {
+		t.Errorf("GraphQLID = %q, want %q", got, want)
+	}
+}

--- a/internal/server/providers/claudeprojects/provider.go
+++ b/internal/server/providers/claudeprojects/provider.go
@@ -1,0 +1,471 @@
+package claudeprojects
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// HeartbeatThreshold is the cutoff for `open: Boolean!`. A
+// Conversation is reported open when its last record was written
+// within this window, computed against the provider's clock.
+//
+// Default 60 seconds — large enough that human typing pauses do not
+// flicker the field, small enough that an abandoned session settles
+// to closed within a minute. Tuneable via NewWith.
+const HeartbeatThreshold = 60 * time.Second
+
+// Provider exposes Conversation nodes to the GraphQL resolver layer.
+//
+// Owns:
+//   - one FSAdapter (filesystem walk + jsonl parse).
+//   - one fsnotify watcher (started by adapter.Watch).
+//   - an in-memory cache keyed by ConversationID.
+//   - a fan-out for Subscribers.
+//
+// Per ADR-011 §2 the surface is read-only — writes happen out-of-band
+// (Claude Code itself appends to the JSONL); the watcher turns those
+// writes into invalidation events, and the next read picks up the
+// fresh metadata.
+type Provider struct {
+	adapter   *FSAdapter
+	logger    *slog.Logger
+	clock     func() time.Time
+	heartbeat time.Duration
+
+	mu     sync.RWMutex
+	cache  map[ConversationID]Conversation
+	fresh  map[ConversationID]adapter.Freshness
+	loaded bool
+
+	subMu sync.Mutex
+	subs  map[chan adapter.InvalidationEvent[ConversationID]]struct{}
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+}
+
+// New constructs a Provider with sensible production defaults: real
+// filesystem adapter, real wall-clock, default heartbeat threshold.
+func New(root, hostID string, logger *slog.Logger) *Provider {
+	return NewWith(NewFSAdapter(root, hostID, logger), logger, time.Now, HeartbeatThreshold)
+}
+
+// NewWith is the test-friendly constructor. Callers inject the adapter,
+// clock, and heartbeat so unit tests can drive openness deterministically
+// without touching the real filesystem clock.
+func NewWith(a *FSAdapter, logger *slog.Logger, clock func() time.Time, heartbeat time.Duration) *Provider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	if heartbeat <= 0 {
+		heartbeat = HeartbeatThreshold
+	}
+	return &Provider{
+		adapter:   a,
+		logger:    logger,
+		clock:     clock,
+		heartbeat: heartbeat,
+		cache:     map[ConversationID]Conversation{},
+		fresh:     map[ConversationID]adapter.Freshness{},
+		subs:      map[chan adapter.InvalidationEvent[ConversationID]]struct{}{},
+		stopCh:    make(chan struct{}),
+		doneCh:    make(chan struct{}),
+	}
+}
+
+// Start hydrates the cache from the adapter and launches the watcher
+// goroutine. Subsequent calls are no-ops; one provider, one lifecycle.
+func (p *Provider) Start(ctx context.Context) error {
+	var startErr error
+	p.startOnce.Do(func() {
+		if err := p.reload(ctx, "boot", adapter.SourcePoll); err != nil {
+			startErr = fmt.Errorf("hydrate claudeprojects cache: %w", err)
+			return
+		}
+		ch, err := p.adapter.Watch(ctx)
+		if err != nil {
+			startErr = fmt.Errorf("start watcher: %w", err)
+			return
+		}
+		go p.run(ctx, ch)
+	})
+	return startErr
+}
+
+// Stop tears down the watcher and any subscribers. Idempotent.
+func (p *Provider) Stop() error {
+	var err error
+	p.stopOnce.Do(func() {
+		close(p.stopCh)
+		<-p.doneCh
+		err = p.adapter.Close()
+		p.subMu.Lock()
+		for ch := range p.subs {
+			close(ch)
+			delete(p.subs, ch)
+		}
+		p.subMu.Unlock()
+	})
+	return err
+}
+
+// Get returns one conversation by ID plus its freshness. Cache hit is
+// the common path; on miss the adapter reads only the affected file.
+func (p *Provider) Get(ctx context.Context, key ConversationID) (Conversation, adapter.Freshness, error) {
+	if v, f, ok := p.cacheGet(key); ok {
+		return v, f, nil
+	}
+	v, err := p.adapter.Fetch(ctx, key)
+	if err != nil {
+		return Conversation{}, adapter.Freshness{}, err
+	}
+	f := adapter.Freshness{LastFetchedAt: p.clock(), Source: adapter.SourcePoll}
+	p.cachePut(key, v, f)
+	return v, f, nil
+}
+
+// GetMany is the DataLoader-friendly batch read. Unique keys hit the
+// cache first; misses share a single FetchAll call.
+func (p *Provider) GetMany(ctx context.Context, keys []ConversationID) (map[ConversationID]Conversation, map[ConversationID]adapter.Freshness, error) {
+	out := make(map[ConversationID]Conversation, len(keys))
+	freshness := make(map[ConversationID]adapter.Freshness, len(keys))
+
+	missing := make([]ConversationID, 0)
+	seen := make(map[ConversationID]struct{}, len(keys))
+	for _, k := range keys {
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		if v, f, ok := p.cacheGet(k); ok {
+			out[k] = v
+			freshness[k] = f
+			continue
+		}
+		missing = append(missing, k)
+	}
+	if len(missing) == 0 {
+		return out, freshness, nil
+	}
+
+	// One FetchAll covers all misses — the per-file cost dominates
+	// regardless of whether we ask for one or many ids.
+	all, err := p.adapter.FetchAll(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	now := p.clock()
+	for _, k := range missing {
+		v, ok := all[k]
+		if !ok {
+			continue
+		}
+		f := adapter.Freshness{LastFetchedAt: now, Source: adapter.SourcePoll}
+		p.cachePut(k, v, f)
+		out[k] = v
+		freshness[k] = f
+	}
+	return out, freshness, nil
+}
+
+// Keys returns every cached ConversationID. Cold boot returns an
+// empty slice; the watcher hydrates the cache before any resolver
+// calls in well-formed setups.
+func (p *Provider) Keys(_ context.Context) ([]ConversationID, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]ConversationID, 0, len(p.cache))
+	for k := range p.cache {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// List returns every cached Conversation, sorted descending by
+// LastSeenAt (so the most-recently active conversation is first).
+// Conversations with a nil LastSeenAt sort to the end. This is what
+// the Query.conversations resolver calls.
+func (p *Provider) List(_ context.Context) ([]Conversation, error) {
+	p.mu.RLock()
+	out := make([]Conversation, 0, len(p.cache))
+	for _, v := range p.cache {
+		out = append(out, v)
+	}
+	p.mu.RUnlock()
+
+	sort.SliceStable(out, func(i, j int) bool {
+		ti, tj := out[i].LastSeenAt, out[j].LastSeenAt
+		switch {
+		case ti == nil && tj == nil:
+			return out[i].ID.SessionUUID < out[j].ID.SessionUUID
+		case ti == nil:
+			return false
+		case tj == nil:
+			return true
+		default:
+			return ti.After(*tj)
+		}
+	})
+	return out, nil
+}
+
+// Subscribe returns a buffered channel that receives invalidation
+// events for as long as ctx is alive. Closing ctx (or calling Stop)
+// cleans the subscription up.
+func (p *Provider) Subscribe(ctx context.Context) <-chan adapter.InvalidationEvent[ConversationID] {
+	ch := make(chan adapter.InvalidationEvent[ConversationID], 8)
+	p.subMu.Lock()
+	p.subs[ch] = struct{}{}
+	p.subMu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		p.subMu.Lock()
+		if _, ok := p.subs[ch]; ok {
+			delete(p.subs, ch)
+			close(ch)
+		}
+		p.subMu.Unlock()
+	}()
+	return ch
+}
+
+// IsOpen returns whether a conversation is "open" (heartbeat) at the
+// provider's current clock. Exported so the resolver can compute the
+// flag at read time — the cache stores raw timestamps, the heartbeat
+// horizon is a presentation concern.
+//
+// **doc-as-code**: a Conversation is reported open when its
+// LastSeenAt timestamp is within HeartbeatThreshold (default 60s) of
+// the provider's clock. Conversations with a nil LastSeenAt (an
+// empty JSONL file) are reported closed. The provider does not
+// inspect the Claude process — a long-quiet session whose process
+// happens to still be running will still report closed once the
+// JSONL falls silent.
+func (p *Provider) IsOpen(c Conversation) bool {
+	if c.LastSeenAt == nil {
+		return false
+	}
+	return p.clock().Sub(*c.LastSeenAt) < p.heartbeat
+}
+
+// ToGraphQL maps an in-memory Conversation onto the wire-level
+// graphql.Conversation type the resolver returns. `recap` is always
+// nil in v1 — a TODO placeholder is returned so the JSON shape is
+// stable for clients now and the conversations plugin can populate it
+// later without an API change.
+//
+// TODO(plugin): populated by conversations plugin when it ships.
+func (p *Provider) ToGraphQL(c Conversation) *graphql.Conversation {
+	return &graphql.Conversation{
+		ID:           c.ID.GraphQLID(),
+		SessionUUID:  c.ID.SessionUUID,
+		Cwd:          c.Cwd,
+		FirstSeenAt:  c.FirstSeenAt,
+		LastSeenAt:   c.LastSeenAt,
+		MessageCount: c.MessageCount,
+		Open:         p.IsOpen(c),
+		Recap:        nil,
+	}
+}
+
+// Refresh forces a full re-walk of the projects root and updates the
+// cache from disk. Useful in tests that want a deterministic read
+// without relying on fsnotify timing — production callers should let
+// the watcher do this work.
+func (p *Provider) Refresh(ctx context.Context) error {
+	return p.reload(ctx, "manual-refresh", adapter.SourcePoll)
+}
+
+// run drains the adapter's Watch channel, refreshes affected entries,
+// and broadcasts invalidations to subscribers. Exits on ctx
+// cancellation, on stopCh, or when the adapter closes the channel.
+func (p *Provider) run(ctx context.Context, ch <-chan ConversationID) {
+	defer close(p.doneCh)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.stopCh:
+			return
+		case key, ok := <-ch:
+			if !ok {
+				return
+			}
+			if err := p.refreshOne(ctx, key); err != nil {
+				p.logger.Warn("claudeprojects: refresh failed",
+					"session_uuid", key.SessionUUID, "err", err)
+			}
+		}
+	}
+}
+
+// refreshOne re-reads metadata for one conversation after a watcher
+// event. The conversation's path is derived from the cache; if the
+// cache has no entry yet (a brand-new session was created), we fall
+// back to a FetchAll to discover and slot it.
+//
+// On fs.ErrNotExist (the file was removed), the entry is dropped
+// from the cache and an invalidation event is broadcast.
+func (p *Provider) refreshOne(ctx context.Context, key ConversationID) error {
+	p.mu.RLock()
+	cached, hit := p.cache[key]
+	p.mu.RUnlock()
+
+	now := p.clock()
+
+	if !hit {
+		// New conversation — reload everything. We could try to find
+		// the path from the watcher event, but FetchAll handles the
+		// case where multiple new files appeared in a burst.
+		return p.reload(ctx, "watcher-create", adapter.SourceWatcherPush)
+	}
+
+	v, err := p.adapter.FetchOne(ctx, cached.Path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			p.mu.Lock()
+			delete(p.cache, key)
+			delete(p.fresh, key)
+			p.mu.Unlock()
+			p.broadcast([]ConversationID{key}, "watcher-remove", now)
+			return nil
+		}
+		return err
+	}
+	f := adapter.Freshness{LastFetchedAt: now, Source: adapter.SourceWatcherPush}
+	p.cachePut(key, v, f)
+	p.broadcast([]ConversationID{key}, "watcher-write", now)
+	return nil
+}
+
+// reload fetches every conversation, replaces the cache, and
+// broadcasts invalidations for added/changed/removed keys.
+func (p *Provider) reload(ctx context.Context, reason string, source adapter.FreshnessSource) error {
+	all, err := p.adapter.FetchAll(ctx)
+	if err != nil {
+		return err
+	}
+	now := p.clock()
+
+	p.mu.Lock()
+	old := p.cache
+	p.cache = all
+	p.fresh = make(map[ConversationID]adapter.Freshness, len(all))
+	for k := range all {
+		p.fresh[k] = adapter.Freshness{LastFetchedAt: now, Source: source}
+	}
+	p.loaded = true
+	p.mu.Unlock()
+
+	changed := make([]ConversationID, 0)
+	for k, v := range all {
+		ov, had := old[k]
+		if !had || !conversationsEqual(ov, v) {
+			changed = append(changed, k)
+		}
+	}
+	for k := range old {
+		if _, still := all[k]; !still {
+			changed = append(changed, k)
+		}
+	}
+	if len(changed) == 0 && reason == "boot" {
+		return nil
+	}
+	p.broadcast(changed, reason, now)
+	return nil
+}
+
+// conversationsEqual returns true when two Conversations have
+// identical metadata — pointer-derefs included. We use it to suppress
+// invalidation broadcasts for no-op refreshes (a fsnotify Create that
+// did not actually change anything we care about).
+func conversationsEqual(a, b Conversation) bool {
+	if a.ID != b.ID || a.Path != b.Path || a.MessageCount != b.MessageCount {
+		return false
+	}
+	if !timesEqual(a.FirstSeenAt, b.FirstSeenAt) {
+		return false
+	}
+	if !timesEqual(a.LastSeenAt, b.LastSeenAt) {
+		return false
+	}
+	if !stringsEqual(a.Cwd, b.Cwd) {
+		return false
+	}
+	return true
+}
+
+func timesEqual(a, b *time.Time) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	default:
+		return a.Equal(*b)
+	}
+}
+
+func stringsEqual(a, b *string) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	default:
+		return *a == *b
+	}
+}
+
+// broadcast fans an InvalidationEvent out to every subscriber. The
+// per-channel buffer is small; we drop on a full buffer rather than
+// block the watcher goroutine — subscribers that fall behind miss
+// events but stay alive.
+func (p *Provider) broadcast(keys []ConversationID, reason string, at time.Time) {
+	p.subMu.Lock()
+	defer p.subMu.Unlock()
+	for _, k := range keys {
+		ev := adapter.InvalidationEvent[ConversationID]{Key: k, Reason: reason, At: at}
+		for ch := range p.subs {
+			select {
+			case ch <- ev:
+			default:
+				p.logger.Warn("claudeprojects: subscriber lagging, dropping event",
+					"session_uuid", k.SessionUUID)
+			}
+		}
+	}
+}
+
+func (p *Provider) cacheGet(k ConversationID) (Conversation, adapter.Freshness, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	v, ok := p.cache[k]
+	if !ok {
+		return Conversation{}, adapter.Freshness{}, false
+	}
+	return v, p.fresh[k], true
+}
+
+func (p *Provider) cachePut(k ConversationID, v Conversation, f adapter.Freshness) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.cache[k] = v
+	p.fresh[k] = f
+}

--- a/internal/server/providers/claudeprojects/types.go
+++ b/internal/server/providers/claudeprojects/types.go
@@ -1,0 +1,80 @@
+// Package claudeprojects implements the Conversation provider — read
+// access to the JSONL transcripts that the Claude Code CLI writes
+// under `~/.claude/projects/<project-slug>/<session-uuid>.jsonl`.
+//
+// Each conversation has exactly one JSONL on disk. The provider derives
+// every Conversation field (firstSeenAt, lastSeenAt, messageCount,
+// open) from the file itself — no sidecar metadata, no embedded
+// process state. `recap` is reserved for the conversations plugin and
+// is always null in v1.
+//
+// Per ADR-011 §5.1 the v1 contract is metadata + `open` + `recap`;
+// `status`, `focus`, `awaitingDrew`, `artifacts` are all out of scope.
+//
+// Why this provider is non-trivial:
+//
+//   - **JSONL size.** A long-running Claude session can write tens of
+//     megabytes. The adapter MUST avoid loading whole files into RAM.
+//     We tail the last record, head the first, and stream a counted
+//     scan for messageCount. Each pass touches only a small window.
+//   - **fsnotify recursion.** The projects root contains one
+//     subdirectory per project, and each subdirectory contains the
+//     JSONLs we care about. fsnotify on macOS does not recurse, so we
+//     watch the root for new project subdirs and add subdir watchers
+//     on the fly. See watcher.go.
+package claudeprojects
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ConversationID uniquely identifies a Conversation across hosts. v1
+// only enumerates the local host, but the host-qualified shape lets
+// federated daemons (WS-F) merge tables without rekeying.
+//
+// HostID is a free-form string in v1 — typically the local machine's
+// id (e.g. /etc/machine-id on Linux, IOPlatformUUID on macOS). Tests
+// use a stable fixture (e.g. "test-host").
+type ConversationID struct {
+	HostID      string
+	SessionUUID string
+}
+
+// Conversation is the in-memory representation of a Claude Code
+// transcript. It is what the provider's cache holds and what the
+// resolver maps onto graphql.Conversation.
+//
+// FirstSeenAt and LastSeenAt are pointers because an empty JSONL (the
+// file was just created with no records yet) has neither timestamp.
+// Cwd is a pointer because older Claude Code transcripts omit `cwd` on
+// every record, in which case we have nothing to surface.
+//
+// MessageCount is the number of newline-terminated JSON records — i.e.
+// every `type: user`, `type: assistant`, `type: summary`, etc. We do
+// not filter to a specific role; the count is a coarse "how many
+// turns" signal.
+type Conversation struct {
+	ID           ConversationID
+	Path         string
+	Cwd          *string
+	FirstSeenAt  *time.Time
+	LastSeenAt   *time.Time
+	MessageCount int64
+}
+
+// GraphQLID returns the stable orchard id for a Conversation node. The
+// shape mirrors other Node implementers (e.g. "Host:<machineId>"),
+// keeping the Query.node(id) lookup uniform across types.
+func (id ConversationID) GraphQLID() string {
+	return "Conversation:" + id.SessionUUID
+}
+
+// sessionUUIDFromPath returns the JSONL filename minus its `.jsonl`
+// suffix. Claude Code names files by their sessionId, so the trimmed
+// filename is the canonical session UUID.
+func sessionUUIDFromPath(path string) string {
+	base := filepath.Base(path)
+	return strings.TrimSuffix(base, ".jsonl")
+}

--- a/internal/server/providers/claudeprojects/watcher.go
+++ b/internal/server/providers/claudeprojects/watcher.go
@@ -1,0 +1,218 @@
+package claudeprojects
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watch starts a recursive fsnotify watcher rooted at the adapter's
+// projects directory. fsnotify itself is non-recursive on macOS and
+// recursive only on Windows, so we do the bookkeeping by hand:
+//
+//   - Add a watcher on the root.
+//   - Walk the root once and add a watcher on every existing project
+//     subdirectory. Adapter.FetchAll already enumerates the same set,
+//     but we re-walk here so this method has no implicit dependency
+//     on the call order.
+//   - When a CREATE event fires for a directory under the root, add
+//     a watcher on it.
+//   - When a CREATE / WRITE / RENAME event fires for a `.jsonl` file
+//     under any watched directory, emit the corresponding
+//     ConversationID on the output channel.
+//
+// Returns the read-only channel and an error from initial setup. The
+// channel is closed when ctx is cancelled or Close is called.
+//
+// Sends are non-blocking — a slow consumer drops events. The provider
+// is the only consumer in v1 and reloads from the cache, so a dropped
+// event surfaces as "next refresh sees the change", which is fine.
+func (a *FSAdapter) Watch(ctx context.Context) (<-chan ConversationID, error) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	// The root may not exist yet (fresh install); ensure it so the
+	// watcher attaches and we see the first project subdir CREATE.
+	if err := os.MkdirAll(a.root, 0o755); err != nil {
+		_ = w.Close()
+		return nil, err
+	}
+	if err := w.Add(a.root); err != nil {
+		_ = w.Close()
+		return nil, err
+	}
+
+	// Hydrate watchers for every existing project subdir.
+	if err := a.addExistingSubdirs(w); err != nil {
+		_ = w.Close()
+		return nil, err
+	}
+
+	out := make(chan ConversationID, 16)
+	a.watcherMu.Lock()
+	a.watcher = w
+	a.watcherDone = make(chan struct{})
+	a.watcherMu.Unlock()
+
+	go a.runWatch(ctx, w, out)
+	return out, nil
+}
+
+// Close releases watcher resources. Safe to call when no watcher is
+// active. Idempotent.
+//
+// Closing the underlying fsnotify watcher closes its Events and
+// Errors channels, which causes runWatch to exit and the deferred
+// cleanup (driven from the goroutine itself) to close watcherDone.
+// We wait for that close to complete so the caller can rely on no
+// further channel sends after Close returns.
+func (a *FSAdapter) Close() error {
+	a.watcherMu.Lock()
+	w := a.watcher
+	done := a.watcherDone
+	a.watcher = nil
+	a.watcherMu.Unlock()
+
+	if w == nil {
+		return nil
+	}
+	err := w.Close()
+	if done != nil {
+		<-done
+	}
+	return err
+}
+
+// addExistingSubdirs walks the projects root once and attaches a
+// watcher on each direct subdirectory. We do not recurse deeper —
+// Claude Code keeps transcripts one level under the root.
+func (a *FSAdapter) addExistingSubdirs(w *fsnotify.Watcher) error {
+	entries, err := os.ReadDir(a.root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		dir := filepath.Join(a.root, ent.Name())
+		if err := w.Add(dir); err != nil {
+			a.logger.Warn("claudeprojects: failed to watch project dir",
+				"dir", dir, "err", err)
+			continue
+		}
+	}
+	return nil
+}
+
+// runWatch is the long-running goroutine that translates fsnotify
+// events into ConversationID emissions. Exits on ctx cancellation or
+// when the underlying fsnotify channels close.
+//
+// On exit, runWatch closes a.watcherDone so Close can wait on a clean
+// shutdown. We keep the channel reference on the struct (rather than
+// nilling it from Close) so the close happens here, in the goroutine
+// that owns the lifecycle.
+func (a *FSAdapter) runWatch(ctx context.Context, w *fsnotify.Watcher, out chan<- ConversationID) {
+	defer close(out)
+	defer func() {
+		a.watcherMu.Lock()
+		done := a.watcherDone
+		a.watcherDone = nil
+		a.watcherMu.Unlock()
+		if done != nil {
+			close(done)
+		}
+	}()
+
+	const interesting = fsnotify.Create | fsnotify.Write | fsnotify.Rename | fsnotify.Remove
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-w.Events:
+			if !ok {
+				return
+			}
+			if ev.Op&interesting == 0 {
+				continue
+			}
+			a.handleEvent(ev, w, ctx, out)
+		case err, ok := <-w.Errors:
+			if !ok {
+				return
+			}
+			a.logger.Warn("claudeprojects: fsnotify error", "err", err)
+		}
+	}
+}
+
+// handleEvent classifies one fsnotify event:
+//
+//   - A new directory under the root → add a watcher; do not emit a
+//     ConversationID (no transcripts yet).
+//   - A `.jsonl` file under any watched directory → emit the
+//     corresponding ConversationID.
+//   - Anything else → ignore.
+func (a *FSAdapter) handleEvent(ev fsnotify.Event, w *fsnotify.Watcher, ctx context.Context, out chan<- ConversationID) {
+	if isDirCreate(ev) {
+		// Best-effort: directory creation under the root means a new
+		// project. Add a watcher; if the path is already watched
+		// fsnotify ignores the duplicate.
+		if filepath.Dir(ev.Name) == a.root {
+			if err := w.Add(ev.Name); err != nil {
+				a.logger.Warn("claudeprojects: failed to watch new project dir",
+					"dir", ev.Name, "err", err)
+			}
+		}
+		return
+	}
+
+	if !strings.HasSuffix(ev.Name, ".jsonl") {
+		return
+	}
+	id := ConversationID{
+		HostID:      a.hostID,
+		SessionUUID: sessionUUIDFromPath(ev.Name),
+	}
+	select {
+	case out <- id:
+	case <-ctx.Done():
+		return
+	default:
+		// Drop on a full buffer rather than block the watcher loop.
+		// Subscribers that fall behind miss this notification but
+		// stay alive; the next event for the same key catches us up.
+		a.logger.Warn("claudeprojects: subscriber lagging, dropping event",
+			"session_uuid", id.SessionUUID)
+	}
+}
+
+// isDirCreate is true when ev is a CREATE for a directory. fsnotify
+// reports the path; we have to stat to decide.
+//
+// stat() failures are not fatal: a CREATE followed by an immediate
+// REMOVE leaves no entry to stat, and the right behaviour is "not a
+// dir, ignore" — which falls out of returning false on error.
+func isDirCreate(ev fsnotify.Event) bool {
+	if ev.Op&fsnotify.Create == 0 {
+		return false
+	}
+	info, err := os.Stat(ev.Name)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}
+

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
@@ -16,21 +17,12 @@ import (
 )
 
 // ProjectsLister is the narrow read-side contract the project resolver
-// depends on. Defined here (consumer-side) so the resolver doesn't reach
-// into the provider package's full surface — accept interfaces, return
-// concretes.
+// depends on.
 type ProjectsLister interface {
 	List(ctx context.Context) ([]configprovider.Project, error)
 }
 
 // Resolver is the dependency-injection root for GraphQL resolvers.
-//
-// gqlgen does NOT regenerate this file, so anything we wire here survives
-// schema iteration. Provider fields are suffixed with `Provider` to
-// avoid colliding with the generated field-resolver method names that
-// embed this struct (e.g. queryResolver.Projects(ctx)). Optional
-// dependencies are wired via With* setters so callers can swap
-// implementations in tests.
 type Resolver struct {
 	StartedAt        time.Time
 	HostProvider     *host.Provider
@@ -38,6 +30,7 @@ type Resolver struct {
 	Git              *gitprovider.Provider
 	PS               *ps.Provider
 	Tmux             *tmux.Provider
+	ClaudeProjects   *claudeprojects.Provider
 }
 
 // New constructs a Resolver with the daemon's start time captured.
@@ -57,20 +50,26 @@ func (r *Resolver) WithProjects(p ProjectsLister) *Resolver {
 	return r
 }
 
-// WithGit wires the git provider that backs Project.worktrees and Worktree.*.
+// WithGit wires the git provider.
 func (r *Resolver) WithGit(g *gitprovider.Provider) *Resolver {
 	r.Git = g
 	return r
 }
 
-// WithPS wires the ps provider that backs Host.processes and Process resolution.
+// WithPS wires the ps provider.
 func (r *Resolver) WithPS(p *ps.Provider) *Resolver {
 	r.PS = p
 	return r
 }
 
-// WithTmux wires the tmux provider that backs TmuxServer/Session/Window/Pane/Client.
+// WithTmux wires the tmux provider.
 func (r *Resolver) WithTmux(p *tmux.Provider) *Resolver {
 	r.Tmux = p
+	return r
+}
+
+// WithClaudeProjects wires the claudeprojects provider.
+func (r *Resolver) WithClaudeProjects(p *claudeprojects.Provider) *Resolver {
+	r.ClaudeProjects = p
 	return r
 }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -703,16 +703,51 @@ func (r *tmuxWindowResolver) CurrentPane(ctx context.Context, obj *graphql1.Tmux
 	return projectPane(p), nil
 }
 
-// Conversations is the resolver for the conversations field.
-// Stub until commit 2 wires the claudeprojects provider.
+//
+// Returns every Conversation the provider currently has cached,
+// sorted descending by lastSeenAt (most-recently active first).
 func (r *queryResolver) Conversations(ctx context.Context) ([]*graphql1.Conversation, error) {
-	return nil, fmt.Errorf("claudeprojects provider not wired")
+	if r.ClaudeProjects == nil {
+		return nil, fmt.Errorf("claudeprojects provider not initialised")
+	}
+	rows, err := r.ClaudeProjects.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list conversations: %w", err)
+	}
+	out := make([]*graphql1.Conversation, 0, len(rows))
+	for _, c := range rows {
+		out = append(out, r.ClaudeProjects.ToGraphQL(c))
+	}
+	return out, nil
 }
 
 // Conversation is the resolver for the conversation field.
-// Stub until commit 2 wires the claudeprojects provider.
+//
+// id is the orchard-canonical "Conversation:<sessionUuid>" string.
+// Unknown ids return (nil, nil).
 func (r *queryResolver) Conversation(ctx context.Context, id string) (*graphql1.Conversation, error) {
-	return nil, fmt.Errorf("claudeprojects provider not wired")
+	if r.ClaudeProjects == nil {
+		return nil, fmt.Errorf("claudeprojects provider not initialised")
+	}
+	uuid, ok := strings.CutPrefix(id, "Conversation:")
+	if !ok || uuid == "" {
+		return nil, nil
+	}
+	keys, err := r.ClaudeProjects.Keys(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list conversations: %w", err)
+	}
+	for _, k := range keys {
+		if k.SessionUUID != uuid {
+			continue
+		}
+		c, _, err := r.ClaudeProjects.Get(ctx, k)
+		if err != nil {
+			return nil, fmt.Errorf("get conversation %q: %w", uuid, err)
+		}
+		return r.ClaudeProjects.ToGraphQL(c), nil
+	}
+	return nil, nil
 }
 
 // Query returns graphql1.QueryResolver implementation.

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -703,6 +703,18 @@ func (r *tmuxWindowResolver) CurrentPane(ctx context.Context, obj *graphql1.Tmux
 	return projectPane(p), nil
 }
 
+// Conversations is the resolver for the conversations field.
+// Stub until commit 2 wires the claudeprojects provider.
+func (r *queryResolver) Conversations(ctx context.Context) ([]*graphql1.Conversation, error) {
+	return nil, fmt.Errorf("claudeprojects provider not wired")
+}
+
+// Conversation is the resolver for the conversation field.
+// Stub until commit 2 wires the claudeprojects provider.
+func (r *queryResolver) Conversation(ctx context.Context, id string) (*graphql1.Conversation, error) {
+	return nil, fmt.Errorf("claudeprojects provider not wired")
+}
+
 // Query returns graphql1.QueryResolver implementation.
 func (r *Resolver) Query() graphql1.QueryResolver { return &queryResolver{r} }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,5 @@
 // Package server hosts the orchard daemon's HTTP surface: the GraphQL
-// endpoint and the /health probe. It is the deployment shell that runs
-// the gqlgen-generated executable schema.
+// endpoint and the /health probe.
 //
 // Workstream A: GraphQL with the stub Health resolver, /health, graceful shutdown.
 // Workstream B-host: host Provider constructed and started in Run.
@@ -9,6 +8,8 @@
 // Workstream B-ps: WithPS attaches a ps provider; Run() starts it.
 // Workstream B-tmux: WithTmux attaches a tmux provider; Run() starts it
 // + the fsnotify-backed watcher.
+// Workstream B-claudeprojects: WithClaudeProjects attaches the conversation
+// provider; Run() starts it (fsnotify + initial scan).
 package server
 
 import (
@@ -18,12 +19,15 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 
 	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
@@ -34,16 +38,20 @@ import (
 // DefaultAddr is where the daemon listens.
 const DefaultAddr = "localhost:7777"
 
+// claudeProjectsRootEnv overrides the Claude transcripts root path.
+const claudeProjectsRootEnv = "CLAUDE_PROJECTS_ROOT"
+
 // Server wraps the http.Server plus the resolver root and provider set.
 type Server struct {
-	addr      string
-	startedAt time.Time
-	logger    *slog.Logger
-	httpSrv   *http.Server
-	host      *host.Provider
-	resolver  *resolvers.Resolver
-	psProv    *ps.Provider
-	tmuxProv  *tmux.Provider
+	addr           string
+	startedAt      time.Time
+	logger         *slog.Logger
+	httpSrv        *http.Server
+	host           *host.Provider
+	resolver       *resolvers.Resolver
+	psProv         *ps.Provider
+	tmuxProv       *tmux.Provider
+	claudeProjects *claudeprojects.Provider
 }
 
 // Option mutates a Server during construction.
@@ -72,6 +80,14 @@ func WithTmux(p *tmux.Provider) Option {
 	return func(s *Server, r *resolvers.Resolver) {
 		s.tmuxProv = p
 		r.WithTmux(p)
+	}
+}
+
+// WithClaudeProjects attaches a claudeprojects provider; Run() calls Start().
+func WithClaudeProjects(p *claudeprojects.Provider) Option {
+	return func(s *Server, r *resolvers.Resolver) {
+		s.claudeProjects = p
+		r.WithClaudeProjects(p)
 	}
 }
 
@@ -118,7 +134,7 @@ func (s *Server) Addr() string { return s.addr }
 // HTTPHandler returns the underlying HTTP mux for tests.
 func (s *Server) HTTPHandler() http.Handler { return s.httpSrv.Handler }
 
-// Resolver returns the resolver root the server was built with.
+// Resolver returns the resolver root.
 func (s *Server) Resolver() *resolvers.Resolver { return s.resolver }
 
 // GraphQLHandler returns a fresh handler bound to the server's resolver.
@@ -126,8 +142,7 @@ func (s *Server) GraphQLHandler() http.Handler {
 	return graphqlHandlerFor(s.resolver)
 }
 
-// Run starts providers, the HTTP server, and blocks until ctx is
-// cancelled, then drains in-flight requests with a 5-second deadline.
+// Run starts providers, the HTTP server, and blocks until ctx is cancelled.
 func (s *Server) Run(ctx context.Context) error {
 	if err := s.host.Start(ctx); err != nil {
 		return fmt.Errorf("start host provider: %w", err)
@@ -145,6 +160,11 @@ func (s *Server) Run(ctx context.Context) error {
 			s.logger.Warn("tmux watcher start failed; continuing poll-only", "err", err)
 		}
 	}
+	if s.claudeProjects != nil {
+		if err := s.claudeProjects.Start(ctx); err != nil {
+			return fmt.Errorf("start claudeprojects provider: %w", err)
+		}
+	}
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -159,6 +179,9 @@ func (s *Server) Run(ctx context.Context) error {
 		if err := s.httpSrv.Shutdown(shutdownCtx); err != nil {
 			return fmt.Errorf("shutdown: %w", err)
 		}
+		if s.claudeProjects != nil {
+			_ = s.claudeProjects.Stop()
+		}
 		s.logger.Info("orchard daemon stopped")
 		return nil
 	case err := <-errCh:
@@ -167,6 +190,19 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 		return err
 	}
+}
+
+// claudeProjectsRoot returns the directory the daemon should watch for
+// Claude Code transcripts. Precedence: env var, ~/.claude/projects, fallback.
+func claudeProjectsRoot() string {
+	if v := os.Getenv(claudeProjectsRootEnv); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return filepath.Join(".claude", "projects")
+	}
+	return filepath.Join(home, ".claude", "projects")
 }
 
 // healthHandler reflects the server's uptime as JSON.
@@ -181,7 +217,7 @@ func healthHandler(startedAt time.Time) http.HandlerFunc {
 	}
 }
 
-// graphqlHandlerFor wires the gqlgen executable schema with an already-constructed Resolver root.
+// graphqlHandlerFor wires the gqlgen executable schema.
 func graphqlHandlerFor(res *resolvers.Resolver) http.Handler {
 	cfg := gql.Config{Resolvers: res}
 	srv := handler.New(gql.NewExecutableSchema(cfg))

--- a/schema.graphql
+++ b/schema.graphql
@@ -10,6 +10,8 @@
 # Workstream B-git: Worktree node + Project.worktrees back-edge.
 # Workstream B-ps: full Process node + Host.processes(filter).
 # Workstream B-tmux: TmuxServer/Session/Window/Pane/Client + filtered queries.
+# Workstream B-claudeprojects: Conversation node + Time scalar; backed by
+# the JSONL files Claude Code writes under ~/.claude/projects/.
 
 """
 A node in the orchard graph. Every node has a globally-unique id so
@@ -20,6 +22,9 @@ interface Node {
   "Globally-unique id (e.g. \"Host:<machineId>\")."
   id: ID!
 }
+
+"RFC 3339 timestamp string. Mapped to Go's time.Time."
+scalar Time
 
 # Process is an OS-level process surfaced via the `ps` adapter.
 type Process implements Node {
@@ -104,6 +109,12 @@ type Query {
 
   "Tmux panes on the local host, optionally filtered. Cheaper than walking the tree per-pane."
   tmuxPanes(filter: TmuxPaneFilter): [TmuxPane!]!
+
+  "Every Claude Code conversation discovered under the projects root. Latest-first by lastSeenAt."
+  conversations: [Conversation!]!
+
+  "Look up a single conversation by its globally-unique id (e.g. \"Conversation:<sessionUuid>\"). Null when unknown."
+  conversation(id: ID!): Conversation
 }
 
 type Health {
@@ -438,4 +449,45 @@ input TmuxPaneFilter {
 
   "Only include dead (or non-dead) panes."
   dead: Boolean
+}
+
+"""
+A Claude Code conversation, backed by the JSONL transcript that the
+Claude Code CLI writes under `~/.claude/projects/<project-slug>/<session-uuid>.jsonl`.
+
+The provider derives every field from the JSONL on disk — there is no
+sidecar metadata. Heavy fields (full transcripts, message bodies)
+deliberately do not surface here; the v1 contract is metadata + a
+single live signal (`open`) and an optional plugin-populated `recap`.
+
+`open` is a heartbeat: true when the JSONL was written within the last
+N seconds (default 60s, see provider.HeartbeatThreshold).
+
+`recap` is reserved for a future conversations plugin to populate; v1
+returns null unconditionally.
+"""
+type Conversation implements Node {
+  "Stable orchard id — \"Conversation:<sessionUuid>\"."
+  id: ID!
+
+  "The session UUID embedded in the JSONL filename — globally unique across Claude Code."
+  sessionUuid: String!
+
+  "Working directory recorded in the JSONL when the session was created. Null when not yet observed."
+  cwd: String
+
+  "RFC 3339 timestamp of the first record in the JSONL."
+  firstSeenAt: Time
+
+  "RFC 3339 timestamp of the last record in the JSONL."
+  lastSeenAt: Time
+
+  "Number of newline-terminated JSON records in the JSONL."
+  messageCount: Int!
+
+  "Heartbeat: true when the JSONL was last written within the heartbeat threshold."
+  open: Boolean!
+
+  "Plugin-populated short summary. Always null in v1."
+  recap: String
 }


### PR DESCRIPTION
## Summary

Workstream B-claudeprojects per ADR-011 §5.1: implement the
`Conversation` node — read-only access to the JSONL transcripts that
Claude Code writes under `~/.claude/projects/<slug>/<uuid>.jsonl`.

The v1 surface is metadata + `open: Boolean!` + `recap: String`. No
`status`, no `focus`, no `awaitingDrew`, no `artifacts` — if a fact
isn't in the backend, it isn't on the node.

### What lands

- **Schema** (commit 1): `Conversation`, `Query.conversations`,
  `Query.conversation(id)`, `Time` scalar. `make generate` is clean.
- **Provider** (commit 2): `internal/server/providers/claudeprojects/`
  with `adapter.go` (filesystem walk + per-file metadata read), 
  `jsonl.go` (tail-then-head reader that never loads a whole file
  into RAM — crucial because long sessions can be tens of MB), 
  `watcher.go` (recursive fsnotify by hand because macOS does not
  recurse natively), `provider.go` (cache + Subscribe fan-out).
- **Wiring** (commit 3): resolver root holds `ClaudeProjects`;
  `server.New` constructs and `server.Run` lifecycles it. CLI gains
  `orchard query conversations` (with optional `--open`, `--recap`,
  `--addr`) — first named verb under `query`, mirroring the host
  sibling.
- **Tests** (commit 4): E2E suite walks open → append → closed across
  a synthetic JSONL written into `t.TempDir()`. Plus jsonl unit tests
  for empty / single / many / partial-trailing / no-timestamp /
  too-long-line. **All synthetic, no PII.**

### Key design notes

**`open` is a heartbeat, not process state.** A Conversation reports
open when its last record's `timestamp` is within
`HeartbeatThreshold` (default 60s, tunable on the Provider). The
provider does not inspect Claude processes. See the doc-as-code block
on `Provider.IsOpen`.

**`recap` is always nil in v1.** A `TODO(plugin)` marks the line
where the conversations plugin will populate it.

**JSONL size is the difficulty hint.** `jsonl.go` reads only the
first record (head) and the last record (tail-seek backwards to the
penultimate newline) and streams a 64KB byte scan to count newlines.
Bounds: `maxLineBytes = 1MB`, `maxTailWindow = 4MB`. Partial
trailing lines (file mid-write) are dropped, matching `wc -l`.

**Watcher recursion.** fsnotify is non-recursive on macOS, so the
adapter watches the root + every existing project subdir, and adds a
new watch when CREATE fires for a directory under the root.

### Worker-standard checklist

- [x] Schema-first GraphQL ✓
- [x] Provider/Adapter layering matches ADR-011 §2/§3 ✓
- [x] `recap` always null in v1 with `TODO(plugin):` marker ✓
- [x] `open` doc-as-code on the resolver ✓
- [x] `make generate` clean ✓
- [x] `go test ./internal/server/providers/claudeprojects/...` green
- [x] `golangci-lint run ./internal/server/providers/claudeprojects/...
      ./internal/cli/query/...` clean (0 issues)
- [x] `go test ./...` green
- [x] `go build ./...` green
- [x] `orchard query conversations --help` shows the verb
- [x] No PII in fixtures: `t.TempDir()` everywhere, generic record
      bodies (`hello`, `ack`, `next`)
- [x] Targets `ws-a-scaffold`, draft

### Sibling note

`internal/server/adapter/adapter.go` is identical to the version
sibling PR `ws-b-host` introduces — both PRs land it concurrently;
the merge is a no-op.

The brief named `internal/cli/query/processes.go` as the mirror for
the CLI verb; that file does not yet exist on `ws-a-scaffold`, so I
mirrored the merged sibling `ws-b-host`'s `host.go` shape instead.

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./...`
- [x] `golangci-lint run ./internal/server/providers/claudeprojects/...
      ./internal/cli/query/...`
- [ ] CI green on the draft PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `orchard query conversations` CLI command with `--open` and `--recap` flags.
  * Extended GraphQL API with `conversations` and `conversation(id)` queries to discover and lookup conversations.
  * New `Conversation` GraphQL type exposing session UUID, working directory, timestamps, message count, and activity status.
  * Added `Time` scalar for RFC3339 timestamps in GraphQL.

* **Tests**
  * Added comprehensive test coverage for conversation queries and metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->