### PR TITLE
Workstream B-hostservice: hostservice provider → HostService node

### DIFF
--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -35,6 +35,7 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 )
@@ -119,30 +120,52 @@ func runStart(parentCtx context.Context, addr string) error {
 	}
 	defer func() { _ = configProvider.Stop() }()
 
-	// Wire the ps provider for the local host. The host id is "local"
-	// for v1 — the host provider (Workstream G) replaces this with a
-	// real machine id once it lands.
 	psProvider := ps.New(ps.NewAdapter("local"), logger)
 	tmuxProvider := tmux.New(tmux.NewAdapter(localHostID()), logger)
 	claudeProjectsRoot := claudeprojectsRoot()
 	claudeProjectsProvider := claudeprojects.New(claudeProjectsRoot, "local", logger)
 
-	srv := server.New(addr, logger,
+	hsvc, hsvcErr := buildHostServiceProvider(ctx)
+	if hsvcErr != nil {
+		fmt.Fprintf(os.Stderr, "orchard: hostservice unavailable: %v\n", hsvcErr)
+	}
+
+	opts := []server.Option{
 		server.WithProjects(configProvider),
 		server.WithPS(psProvider),
 		server.WithTmux(tmuxProvider),
 		server.WithClaudeProjects(claudeProjectsProvider),
 		server.WithClaudeAccount(claudeaccount.New("local", logger)),
-	)
+	}
+	if hsvc != nil {
+		opts = append(opts, server.WithHostService(hsvc))
+	}
+
+	srv := server.New(addr, logger, opts...)
 	return srv.Run(ctx)
 }
 
-// localHostID returns the host id every tmux node carries. v1 stays
-// neutral (`local`); ws-b-host promotes this to the OS-issued machine
-// id, but until that adapter lands on this branch a fixed string is
-// fine — node ids are still per-host stable within one orchard process.
+// localHostID returns the host id for tmux nodes. v1 stays neutral.
 func localHostID() tmux.HostID {
 	return tmux.HostID("local")
+}
+
+// buildHostServiceProvider resolves the local machine id, reads the
+// services watchlist from config, and constructs the hostservice provider.
+func buildHostServiceProvider(ctx context.Context) (*hostservice.Provider, error) {
+	hostID, err := hostservice.LocalHostID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read machine identity: %w", err)
+	}
+	cfgPath, err := orchpaths.ConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("resolve config path: %w", err)
+	}
+	services, err := hostservice.LoadServicesFromConfig(cfgPath)
+	if err != nil {
+		return nil, fmt.Errorf("load services watchlist: %w", err)
+	}
+	return hostservice.New(hostID, services), nil
 }
 
 // runStop reads the pidfile and signals the running daemon.

--- a/internal/cli/query/host_services.go
+++ b/internal/cli/query/host_services.go
@@ -1,0 +1,50 @@
+package query
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// hostServicesQuery is the canonical projection of the curated
+// launchd / systemd watchlist. Every field on HostService plus the
+// owning Host's identity. Keeping the CLI in lockstep with the schema
+// means a regression in the resolver surfaces immediately in
+// `orchard query host-services`.
+const hostServicesQuery = `query LocalHostServices {
+  host {
+    id
+    machineId
+    hostServices {
+      id
+      name
+      state
+      since
+      exitCode
+      logTail
+      host {
+        id
+        machineId
+      }
+    }
+  }
+}`
+
+// hostServicesCmd returns the `orchard query host-services` subcommand.
+//
+// Issues hostServicesQuery against the running daemon and prints the
+// GraphQL response (data + any errors) as pretty JSON. The hidden
+// --addr flag lets the e2e tests target an ephemeral daemon listening
+// on a non-default port.
+func hostServicesCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "host-services",
+		Short: "Print the curated launchd / systemd watchlist for this host",
+		Long: "Issue the canonical HostService GraphQL query against the running orchard\n" +
+			"daemon and print the JSON response. Reports each watched service's lifecycle\n" +
+			"state (active|inactive|failed|unknown) plus optional since / exitCode / logTail.",
+		Example: "  orchard query host-services",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRaw(cmd.Context(), cmd.OutOrStdout(), hostServicesQuery)
+		},
+	}
+	return c
+}

--- a/internal/cli/query/query.go
+++ b/internal/cli/query/query.go
@@ -2,7 +2,7 @@
 // dispatches GraphQL queries against the running daemon.
 //
 // Named verbs land per workstream — host, projects, processes, panes,
-// conversations, claude-account. The `--raw <gql>` escape hatch always works.
+// conversations, claude-account, host-services. The `--raw <gql>` escape hatch always works.
 //
 // The cobra alias `q` mirrors the impl guide's "permitted alias for
 // query" so typing ergonomics match the documented CLI shape.
@@ -51,7 +51,7 @@ func Command() *cobra.Command {
 		Aliases: []string{"q"},
 		Short:   "Query the running orchard daemon via GraphQL",
 		Long: "Dispatch GraphQL queries against the running daemon at " + server.DefaultAddr + ".\n\n" +
-			"Use a named verb (e.g. `host`, `projects`, `processes`, `panes`, `conversations`, `claude-account`) for high-level reads,\n" +
+			"Use a named verb (e.g. `host`, `projects`, `processes`, `panes`, `conversations`, `claude-account`, `host-services`) for high-level reads,\n" +
 			"or `--raw '<gql>'` as the escape hatch when you need a custom GraphQL query.",
 		Example: "  orchard query host\n" +
 			"  orchard query projects\n" +
@@ -59,13 +59,14 @@ func Command() *cobra.Command {
 			"  orchard query panes\n" +
 			"  orchard query conversations\n" +
 			"  orchard query claude-account\n" +
+			"  orchard query host-services\n" +
 			"  orchard query --raw 'query { health { status } }'",
 	}
 	var raw string
 	cmd.Flags().StringVar(&raw, "raw", "", "raw GraphQL query string")
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		if raw == "" {
-			return fmt.Errorf("provide a verb (e.g. `host`, `projects`, `processes`, `panes`, `conversations`, `claude-account`) or --raw '<graphql>'")
+			return fmt.Errorf("provide a verb (e.g. `host`, `projects`, `processes`, `panes`, `conversations`, `claude-account`, `host-services`) or --raw '<graphql>'")
 		}
 		return runRaw(cmd.Context(), cmd.OutOrStdout(), raw)
 	}
@@ -75,6 +76,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(panesCmd())
 	cmd.AddCommand(conversationsCmd())
 	cmd.AddCommand(claudeAccountCmd())
+	cmd.AddCommand(hostServicesCmd())
 	return cmd
 }
 

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -87,6 +87,7 @@ type ComplexityRoot struct {
 
 	Host struct {
 		Address      func(childComplexity int) int
+		HostServices func(childComplexity int) int
 		Hostname     func(childComplexity int) int
 		ID           func(childComplexity int) int
 		Kernel       func(childComplexity int) int
@@ -97,6 +98,16 @@ type ComplexityRoot struct {
 		Processes    func(childComplexity int, filter *ProcessFilter) int
 		Reachable    func(childComplexity int) int
 		ResourceLoad func(childComplexity int) int
+	}
+
+	HostService struct {
+		ExitCode func(childComplexity int) int
+		Host     func(childComplexity int) int
+		ID       func(childComplexity int) int
+		LogTail  func(childComplexity int) int
+		Name     func(childComplexity int) int
+		Since    func(childComplexity int) int
+		State    func(childComplexity int) int
 	}
 
 	Process struct {
@@ -461,6 +472,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Host.Address(childComplexity), true
 
+	case "Host.hostServices":
+		if e.complexity.Host.HostServices == nil {
+			break
+		}
+
+		return e.complexity.Host.HostServices(childComplexity), true
+
 	case "Host.hostname":
 		if e.complexity.Host.Hostname == nil {
 			break
@@ -535,6 +553,55 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Host.ResourceLoad(childComplexity), true
+
+	case "HostService.exitCode":
+		if e.complexity.HostService.ExitCode == nil {
+			break
+		}
+
+		return e.complexity.HostService.ExitCode(childComplexity), true
+
+	case "HostService.host":
+		if e.complexity.HostService.Host == nil {
+			break
+		}
+
+		return e.complexity.HostService.Host(childComplexity), true
+
+	case "HostService.id":
+		if e.complexity.HostService.ID == nil {
+			break
+		}
+
+		return e.complexity.HostService.ID(childComplexity), true
+
+	case "HostService.logTail":
+		if e.complexity.HostService.LogTail == nil {
+			break
+		}
+
+		return e.complexity.HostService.LogTail(childComplexity), true
+
+	case "HostService.name":
+		if e.complexity.HostService.Name == nil {
+			break
+		}
+
+		return e.complexity.HostService.Name(childComplexity), true
+
+	case "HostService.since":
+		if e.complexity.HostService.Since == nil {
+			break
+		}
+
+		return e.complexity.HostService.Since(childComplexity), true
+
+	case "HostService.state":
+		if e.complexity.HostService.State == nil {
+			break
+		}
+
+		return e.complexity.HostService.State(childComplexity), true
 
 	case "Process.args":
 		if e.complexity.Process.Args == nil {
@@ -1443,6 +1510,9 @@ type Host implements Node {
 
   "Processes visible to this host's ` + "`" + `ps` + "`" + ` adapter, optionally filtered."
   processes(filter: ProcessFilter): [Process!]!
+
+  "Curated launchd / systemd watchlist for this host, drawn from ` + "`" + `services` + "`" + ` in ~/.config/orchard/config.json."
+  hostServices: [HostService!]!
 }
 
 """
@@ -1811,6 +1881,53 @@ type ClaudeAccount implements Node {
 
   "Claude processes currently running under this account. v1 returns []; populated by Workstream B-claudeinstance."
   instances: [ClaudeInstance!]!
+}
+
+"""
+A curated launchd (macOS) or systemd-user (Linux) unit on a host.
+
+Per ADR-011 §5.1 the watchlist is config-driven — ` + "`" + `services` + "`" + ` in
+` + "`" + `~/.config/orchard/config.json` + "`" + `. Defaults to
+` + "`" + `["claude-remote", "orchard", "chezmoi"]` + "`" + ` if the key is absent.
+Watched services that don't exist on the host surface as
+` + "`" + `state: unknown` + "`" + ` rather than failing the resolver.
+"""
+type HostService implements Node {
+  "Stable orchard id — \"HostService:<host_machineId>:<name>\"."
+  id: ID!
+
+  "The host this service belongs to."
+  host: Host!
+
+  "Service name as written in config (e.g. \"claude-remote\")."
+  name: String!
+
+  "Lifecycle state of the service on the host."
+  state: HostServiceState!
+
+  "RFC 3339 timestamp the service entered its current state."
+  since: String
+
+  "Most recent exit code of the service's last completed run."
+  exitCode: Int
+
+  "Last 20 log lines from the service."
+  logTail: String
+}
+
+"""
+Lifecycle state of a HostService.
+
+  - ` + "`" + `active` + "`" + `   — running and healthy.
+  - ` + "`" + `inactive` + "`" + ` — stopped cleanly; not currently running.
+  - ` + "`" + `failed` + "`" + `   — exited with non-zero status or crashed.
+  - ` + "`" + `unknown` + "`" + `  — watched in config but not present on this host.
+"""
+enum HostServiceState {
+  active
+  inactive
+  failed
+  unknown
 }
 `, BuiltIn: false},
 }
@@ -2321,6 +2438,8 @@ func (ec *executionContext) fieldContext_ClaudeAccount_host(ctx context.Context,
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
+			case "hostServices":
+				return ec.fieldContext_Host_hostServices(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -3310,6 +3429,8 @@ func (ec *executionContext) fieldContext_Host_peers(ctx context.Context, field g
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
+			case "hostServices":
+				return ec.fieldContext_Host_hostServices(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -3396,6 +3517,391 @@ func (ec *executionContext) fieldContext_Host_processes(ctx context.Context, fie
 	if fc.Args, err = ec.field_Host_processes_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Host_hostServices(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_hostServices(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HostServices, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*HostService)
+	fc.Result = res
+	return ec.marshalNHostService2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_hostServices(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_HostService_id(ctx, field)
+			case "host":
+				return ec.fieldContext_HostService_host(ctx, field)
+			case "name":
+				return ec.fieldContext_HostService_name(ctx, field)
+			case "state":
+				return ec.fieldContext_HostService_state(ctx, field)
+			case "since":
+				return ec.fieldContext_HostService_since(ctx, field)
+			case "exitCode":
+				return ec.fieldContext_HostService_exitCode(ctx, field)
+			case "logTail":
+				return ec.fieldContext_HostService_logTail(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type HostService", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostService_id(ctx context.Context, field graphql.CollectedField, obj *HostService) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostService_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostService_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostService",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostService_host(ctx context.Context, field graphql.CollectedField, obj *HostService) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostService_host(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Host, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*Host)
+	fc.Result = res
+	return ec.marshalNHost2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHost(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostService_host(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostService",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Host_id(ctx, field)
+			case "machineId":
+				return ec.fieldContext_Host_machineId(ctx, field)
+			case "hostname":
+				return ec.fieldContext_Host_hostname(ctx, field)
+			case "os":
+				return ec.fieldContext_Host_os(ctx, field)
+			case "kernel":
+				return ec.fieldContext_Host_kernel(ctx, field)
+			case "address":
+				return ec.fieldContext_Host_address(ctx, field)
+			case "reachable":
+				return ec.fieldContext_Host_reachable(ctx, field)
+			case "resourceLoad":
+				return ec.fieldContext_Host_resourceLoad(ctx, field)
+			case "lastSeenAt":
+				return ec.fieldContext_Host_lastSeenAt(ctx, field)
+			case "peers":
+				return ec.fieldContext_Host_peers(ctx, field)
+			case "processes":
+				return ec.fieldContext_Host_processes(ctx, field)
+			case "hostServices":
+				return ec.fieldContext_Host_hostServices(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostService_name(ctx context.Context, field graphql.CollectedField, obj *HostService) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostService_name(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostService_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostService",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostService_state(ctx context.Context, field graphql.CollectedField, obj *HostService) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostService_state(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.State, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(HostServiceState)
+	fc.Result = res
+	return ec.marshalNHostServiceState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceState(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostService_state(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostService",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type HostServiceState does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostService_since(ctx context.Context, field graphql.CollectedField, obj *HostService) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostService_since(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Since, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostService_since(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostService",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostService_exitCode(ctx context.Context, field graphql.CollectedField, obj *HostService) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostService_exitCode(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ExitCode, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostService_exitCode(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostService",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HostService_logTail(ctx context.Context, field graphql.CollectedField, obj *HostService) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HostService_logTail(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LogTail, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HostService_logTail(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HostService",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
 	}
 	return fc, nil
 }
@@ -3505,6 +4011,8 @@ func (ec *executionContext) fieldContext_Process_host(ctx context.Context, field
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
+			case "hostServices":
+				return ec.fieldContext_Host_hostServices(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -4300,6 +4808,8 @@ func (ec *executionContext) fieldContext_Query_host(ctx context.Context, field g
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
+			case "hostServices":
+				return ec.fieldContext_Host_hostServices(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -4368,6 +4878,8 @@ func (ec *executionContext) fieldContext_Query_hosts(ctx context.Context, field 
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
+			case "hostServices":
+				return ec.fieldContext_Host_hostServices(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -10039,6 +10551,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._ClaudeAccount(ctx, sel, obj)
+	case HostService:
+		return ec._HostService(ctx, sel, &obj)
+	case *HostService:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._HostService(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -10346,6 +10865,71 @@ func (ec *executionContext) _Host(ctx context.Context, sel ast.SelectionSet, obj
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "hostServices":
+			out.Values[i] = ec._Host_hostServices(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var hostServiceImplementors = []string{"HostService", "Node"}
+
+func (ec *executionContext) _HostService(ctx context.Context, sel ast.SelectionSet, obj *HostService) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, hostServiceImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("HostService")
+		case "id":
+			out.Values[i] = ec._HostService_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "host":
+			out.Values[i] = ec._HostService_host(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "name":
+			out.Values[i] = ec._HostService_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "state":
+			out.Values[i] = ec._HostService_state(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "since":
+			out.Values[i] = ec._HostService_since(ctx, field, obj)
+		case "exitCode":
+			out.Values[i] = ec._HostService_exitCode(ctx, field, obj)
+		case "logTail":
+			out.Values[i] = ec._HostService_logTail(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -13329,6 +13913,70 @@ func (ec *executionContext) marshalNHost2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑ
 		return graphql.Null
 	}
 	return ec._Host(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNHostService2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceᚄ(ctx context.Context, sel ast.SelectionSet, v []*HostService) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNHostService2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostService(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNHostService2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostService(ctx context.Context, sel ast.SelectionSet, v *HostService) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._HostService(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNHostServiceState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceState(ctx context.Context, v interface{}) (HostServiceState, error) {
+	var res HostServiceState
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNHostServiceState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceState(ctx context.Context, sel ast.SelectionSet, v HostServiceState) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface{}) (string, error) {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -3,6 +3,9 @@
 package graphql
 
 import (
+	"fmt"
+	"io"
+	"strconv"
 	"time"
 )
 
@@ -127,12 +130,43 @@ type Host struct {
 	Peers []*Host `json:"peers"`
 	// Processes visible to this host's `ps` adapter, optionally filtered.
 	Processes []*Process `json:"processes"`
+	// Curated launchd / systemd watchlist for this host, drawn from `services` in ~/.config/orchard/config.json.
+	HostServices []*HostService `json:"hostServices"`
 }
 
 func (Host) IsNode() {}
 
 // Globally-unique id (e.g. "Host:<machineId>").
 func (this Host) GetID() string { return this.ID }
+
+// A curated launchd (macOS) or systemd-user (Linux) unit on a host.
+//
+// Per ADR-011 §5.1 the watchlist is config-driven — `services` in
+// `~/.config/orchard/config.json`. Defaults to
+// `["claude-remote", "orchard", "chezmoi"]` if the key is absent.
+// Watched services that don't exist on the host surface as
+// `state: unknown` rather than failing the resolver.
+type HostService struct {
+	// Stable orchard id — "HostService:<host_machineId>:<name>".
+	ID string `json:"id"`
+	// The host this service belongs to.
+	Host *Host `json:"host"`
+	// Service name as written in config (e.g. "claude-remote").
+	Name string `json:"name"`
+	// Lifecycle state of the service on the host.
+	State HostServiceState `json:"state"`
+	// RFC 3339 timestamp the service entered its current state.
+	Since *string `json:"since,omitempty"`
+	// Most recent exit code of the service's last completed run.
+	ExitCode *int64 `json:"exitCode,omitempty"`
+	// Last 20 log lines from the service.
+	LogTail *string `json:"logTail,omitempty"`
+}
+
+func (HostService) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this HostService) GetID() string { return this.ID }
 
 type Process struct {
 	// Stable id formatted as `<host>:<pid>`.
@@ -410,3 +444,54 @@ func (Worktree) IsNode() {}
 
 // Globally-unique id (e.g. "Host:<machineId>").
 func (this Worktree) GetID() string { return this.ID }
+
+// Lifecycle state of a HostService.
+//
+//   - `active`   — running and healthy.
+//   - `inactive` — stopped cleanly; not currently running.
+//   - `failed`   — exited with non-zero status or crashed.
+//   - `unknown`  — watched in config but not present on this host.
+type HostServiceState string
+
+const (
+	HostServiceStateActive   HostServiceState = "active"
+	HostServiceStateInactive HostServiceState = "inactive"
+	HostServiceStateFailed   HostServiceState = "failed"
+	HostServiceStateUnknown  HostServiceState = "unknown"
+)
+
+var AllHostServiceState = []HostServiceState{
+	HostServiceStateActive,
+	HostServiceStateInactive,
+	HostServiceStateFailed,
+	HostServiceStateUnknown,
+}
+
+func (e HostServiceState) IsValid() bool {
+	switch e {
+	case HostServiceStateActive, HostServiceStateInactive, HostServiceStateFailed, HostServiceStateUnknown:
+		return true
+	}
+	return false
+}
+
+func (e HostServiceState) String() string {
+	return string(e)
+}
+
+func (e *HostServiceState) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = HostServiceState(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid HostServiceState", str)
+	}
+	return nil
+}
+
+func (e HostServiceState) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}

--- a/internal/server/providers/hostservice/adapter.go
+++ b/internal/server/providers/hostservice/adapter.go
@@ -1,0 +1,20 @@
+package hostservice
+
+// NewAdapter returns the platform-specific Adapter. Build tags select
+// the implementation:
+//
+//   - adapter_darwin.go : `launchctl list <Label>`
+//   - adapter_linux.go  : `systemctl --user is-active <name>` +
+//                         `systemctl --user show <name>` +
+//                         `journalctl --user -u <name>`
+//
+// No runtime `runtime.GOOS == ...` branching outside what build tags
+// already do, per the briefing's "OS-conditional via build tags" rule.
+
+// nameToLabel is shared between the test stubs and the macOS adapter so
+// the canonical "label form" (raw name as written in config) is in
+// exactly one place. macOS launchd Labels are typically reverse-DNS
+// (e.g. `ai.langwatch.claude-remote`), but the orchard contract treats
+// the config name as the launchctl Label verbatim — operators choose
+// the spelling.
+func nameToLabel(name string) string { return name }

--- a/internal/server/providers/hostservice/adapter_darwin.go
+++ b/internal/server/providers/hostservice/adapter_darwin.go
@@ -1,0 +1,215 @@
+//go:build darwin
+
+package hostservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// macAdapter shells `launchctl list <Label>` per watched name.
+//
+// `launchctl list <Label>` output is a plist-like text dictionary:
+//
+//	{
+//		"LimitLoadToSessionType" = "Aqua";
+//		"Label" = "ai.example.test";
+//		"OnDemand" = false;
+//		"LastExitStatus" = 0;
+//		"PID" = 12345;
+//	};
+//
+// PID present + LastExitStatus 0 → active.
+// PID absent + LastExitStatus 0 → inactive (clean stop).
+// PID absent + LastExitStatus != 0 → failed.
+// Unknown unit → exit code != 0 + stderr "Could not find service" → state=unknown.
+//
+// `launchctl print` would give us a richer record (start time, last exit
+// reason) but it requires a domain target (gui/<uid>/<label>) and is far
+// chattier — `list` is enough for v1's four-state surface.
+type macAdapter struct {
+	commander launchctlCommander
+}
+
+// launchctlCommander is the indirection that lets tests stub PATH-based
+// `launchctl` without needing real launchd. Production wires the OS-
+// resolved binary; tests inject a fake.
+type launchctlCommander interface {
+	Run(ctx context.Context, args ...string) (stdout, stderr []byte, exitCode int, err error)
+}
+
+// NewAdapter returns the macOS Adapter wired to the on-PATH launchctl.
+// Tests should construct macAdapter{commander: ...} directly.
+func NewAdapter() Adapter { return macAdapter{commander: execCommander{bin: "launchctl"}} }
+
+// execCommander runs a binary located via $PATH. If the binary is
+// missing it returns ErrServiceManagerMissing so the caller can surface
+// the configured per-field GraphQL error.
+type execCommander struct{ bin string }
+
+func (e execCommander) Run(ctx context.Context, args ...string) ([]byte, []byte, int, error) {
+	if _, err := exec.LookPath(e.bin); err != nil {
+		return nil, nil, 0, ErrServiceManagerMissing
+	}
+	cmd := exec.CommandContext(ctx, e.bin, args...)
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+			err = nil
+		}
+	}
+	return []byte(outBuf.String()), []byte(errBuf.String()), exitCode, err
+}
+
+// FetchOne calls `launchctl list <Label>` and parses the dictionary
+// output into a Snapshot. See type docs for the state-mapping table.
+func (m macAdapter) FetchOne(ctx context.Context, hostID, name string) (Snapshot, error) {
+	label := nameToLabel(name)
+	stdout, stderr, code, err := m.commander.Run(ctx, "list", label)
+	if errors.Is(err, ErrServiceManagerMissing) {
+		return Snapshot{}, ErrServiceManagerMissing
+	}
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("launchctl list %s: %w", label, err)
+	}
+
+	if code != 0 {
+		// launchctl returns non-zero for unknown labels with stderr
+		// "Could not find service ...". Treat as state=unknown rather
+		// than an error so the resolver can keep going on other names.
+		if isUnknownLabelMessage(string(stderr)) {
+			return Snapshot{
+				HostID: hostID,
+				Name:   name,
+				State:  StateUnknown,
+			}, nil
+		}
+		return Snapshot{}, fmt.Errorf("launchctl list %s exited %d: %s", label, code, strings.TrimSpace(string(stderr)))
+	}
+
+	state, exitCode, err := parseLaunchctlList(string(stdout))
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("parse launchctl list %s: %w", label, err)
+	}
+	snap := Snapshot{
+		HostID: hostID,
+		Name:   name,
+		State:  state,
+	}
+	if exitCode != nil {
+		snap.ExitCode = exitCode
+	}
+	// macOS does NOT surface a per-unit start time in `launchctl list`;
+	// `since` stays nil. logTail is also nil — `launchctl` does not
+	// emit a per-unit log stream comparable to journalctl.
+	return snap, nil
+}
+
+// parseLaunchctlList extracts the State + ExitCode from a `launchctl
+// list <Label>` dictionary block.
+//
+// Mapping:
+//
+//	PID present  + LastExitStatus 0   → active.
+//	PID absent   + LastExitStatus 0   → inactive (clean stop or never run).
+//	PID absent   + LastExitStatus != 0 → failed.
+func parseLaunchctlList(out string) (State, *int, error) {
+	pidPresent, lastExit, err := scanLaunchctlPairs(out)
+	if err != nil {
+		return "", nil, err
+	}
+
+	switch {
+	case pidPresent:
+		// LastExitStatus from a previous run is irrelevant once the unit
+		// is running again. Surface the previous code only when the unit
+		// is not currently active.
+		return StateActive, nil, nil
+	case lastExit != nil && *lastExit == 0:
+		zero := 0
+		return StateInactive, &zero, nil
+	case lastExit != nil && *lastExit != 0:
+		return StateFailed, lastExit, nil
+	default:
+		// No PID, no LastExitStatus — the unit is loaded but has never run.
+		return StateInactive, nil, nil
+	}
+}
+
+// scanLaunchctlPairs walks the dictionary lines and pulls out the two
+// fields we care about. Tolerant of arbitrary key order, indentation,
+// trailing semicolons, and quote styles.
+func scanLaunchctlPairs(out string) (pidPresent bool, lastExit *int, err error) {
+	for _, raw := range strings.Split(out, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || line == "{" || line == "}" || line == "};" {
+			continue
+		}
+		key, value, ok := splitLaunchctlPair(line)
+		if !ok {
+			continue
+		}
+		switch key {
+		case "PID":
+			// PID appears only when the unit is running. Any numeric
+			// value indicates a live process; -1 / "no value" is
+			// represented by omission.
+			if _, parseErr := strconv.Atoi(value); parseErr == nil {
+				pidPresent = true
+			}
+		case "LastExitStatus":
+			n, parseErr := strconv.Atoi(value)
+			if parseErr != nil {
+				return false, nil, fmt.Errorf("LastExitStatus %q: %w", value, parseErr)
+			}
+			lastExit = &n
+		}
+	}
+	return pidPresent, lastExit, nil
+}
+
+// splitLaunchctlPair pulls "Key" = value; into (key, value, true). Each
+// half is trimmed of surrounding quotes and whitespace.
+func splitLaunchctlPair(line string) (key, value string, ok bool) {
+	eq := strings.Index(line, "=")
+	if eq < 0 {
+		return "", "", false
+	}
+	k := strings.TrimSpace(line[:eq])
+	v := strings.TrimSpace(line[eq+1:])
+	v = strings.TrimSuffix(v, ";")
+	v = strings.TrimSpace(v)
+	k = strings.Trim(k, `"`)
+	v = strings.Trim(v, `"`)
+	if k == "" {
+		return "", "", false
+	}
+	return k, v, true
+}
+
+// isUnknownLabelMessage detects launchctl's "the requested service does
+// not exist" surface. macOS phrases it as "Could not find service ..."
+// (older) or "Service not loaded" (rare). Matching is loose on purpose.
+func isUnknownLabelMessage(stderr string) bool {
+	s := strings.ToLower(stderr)
+	if strings.Contains(s, "could not find service") {
+		return true
+	}
+	if strings.Contains(s, "service not loaded") {
+		return true
+	}
+	if strings.Contains(s, "no such process") {
+		return true
+	}
+	return false
+}

--- a/internal/server/providers/hostservice/adapter_darwin_test.go
+++ b/internal/server/providers/hostservice/adapter_darwin_test.go
@@ -1,0 +1,231 @@
+//go:build darwin
+
+package hostservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// stubLaunchctl is a deterministic launchctlCommander used to feed canned
+// `launchctl list <Label>` output into the parser. Key by Label so each
+// case can register its own response.
+type stubLaunchctl struct {
+	stdout map[string]string
+	stderr map[string]string
+	code   map[string]int
+	err    map[string]error
+}
+
+func (s stubLaunchctl) Run(_ context.Context, args ...string) ([]byte, []byte, int, error) {
+	if len(args) < 2 {
+		return nil, nil, 1, errors.New("stubLaunchctl: need at least 2 args")
+	}
+	label := args[1]
+	if e, ok := s.err[label]; ok && e != nil {
+		return nil, nil, 0, e
+	}
+	return []byte(s.stdout[label]), []byte(s.stderr[label]), s.code[label], nil
+}
+
+// TestMacAdapter_StateActive uses canned `launchctl list` output (PID
+// present, LastExitStatus 0) and asserts state=active.
+//
+// PII guard: every Label / output line uses generic
+// `com.example.test.<n>` names. No real bundle ids.
+func TestMacAdapter_StateActive(t *testing.T) {
+	stub := stubLaunchctl{
+		stdout: map[string]string{
+			"com.example.test.active": activeLaunchctlOut,
+		},
+		code: map[string]int{"com.example.test.active": 0},
+	}
+	a := macAdapter{commander: stub}
+
+	snap, err := a.FetchOne(context.Background(), "host-id", "com.example.test.active")
+	if err != nil {
+		t.Fatalf("FetchOne: %v", err)
+	}
+	if snap.State != StateActive {
+		t.Errorf("State = %q, want active", snap.State)
+	}
+	if snap.ExitCode != nil {
+		t.Errorf("ExitCode = %v, want nil for active service", *snap.ExitCode)
+	}
+}
+
+// TestMacAdapter_StateInactive — PID absent + LastExitStatus 0.
+func TestMacAdapter_StateInactive(t *testing.T) {
+	stub := stubLaunchctl{
+		stdout: map[string]string{
+			"com.example.test.inactive": inactiveLaunchctlOut,
+		},
+		code: map[string]int{"com.example.test.inactive": 0},
+	}
+	a := macAdapter{commander: stub}
+
+	snap, err := a.FetchOne(context.Background(), "host-id", "com.example.test.inactive")
+	if err != nil {
+		t.Fatalf("FetchOne: %v", err)
+	}
+	if snap.State != StateInactive {
+		t.Errorf("State = %q, want inactive", snap.State)
+	}
+	if snap.ExitCode == nil || *snap.ExitCode != 0 {
+		got := -1
+		if snap.ExitCode != nil {
+			got = *snap.ExitCode
+		}
+		t.Errorf("ExitCode = %d, want 0 for clean stop", got)
+	}
+}
+
+// TestMacAdapter_StateFailed — PID absent + LastExitStatus != 0.
+func TestMacAdapter_StateFailed(t *testing.T) {
+	stub := stubLaunchctl{
+		stdout: map[string]string{
+			"com.example.test.failed": failedLaunchctlOut,
+		},
+		code: map[string]int{"com.example.test.failed": 0},
+	}
+	a := macAdapter{commander: stub}
+
+	snap, err := a.FetchOne(context.Background(), "host-id", "com.example.test.failed")
+	if err != nil {
+		t.Fatalf("FetchOne: %v", err)
+	}
+	if snap.State != StateFailed {
+		t.Errorf("State = %q, want failed", snap.State)
+	}
+	if snap.ExitCode == nil || *snap.ExitCode != 78 {
+		got := -1
+		if snap.ExitCode != nil {
+			got = *snap.ExitCode
+		}
+		t.Errorf("ExitCode = %d, want 78", got)
+	}
+}
+
+// TestMacAdapter_StateUnknown — launchctl exits non-zero with "Could
+// not find service ..." stderr; the adapter maps to state=unknown.
+func TestMacAdapter_StateUnknown(t *testing.T) {
+	stub := stubLaunchctl{
+		stderr: map[string]string{
+			"com.example.test.missing": "Could not find service \"com.example.test.missing\" in domain for system\n",
+		},
+		code: map[string]int{"com.example.test.missing": 113},
+	}
+	a := macAdapter{commander: stub}
+
+	snap, err := a.FetchOne(context.Background(), "host-id", "com.example.test.missing")
+	if err != nil {
+		t.Fatalf("FetchOne: %v", err)
+	}
+	if snap.State != StateUnknown {
+		t.Errorf("State = %q, want unknown", snap.State)
+	}
+	if snap.ExitCode != nil {
+		t.Errorf("ExitCode = %v, want nil for unknown service", *snap.ExitCode)
+	}
+	if snap.Since != nil || snap.LogTail != nil {
+		t.Errorf("optional fields populated for unknown service: since=%v logTail=%v", snap.Since, snap.LogTail)
+	}
+}
+
+// TestMacAdapter_ServiceManagerMissingSurfaces — when launchctl is
+// absent (e.g. inside a stripped sandbox), the adapter returns the
+// typed sentinel so the resolver can surface a per-field GraphQL error.
+func TestMacAdapter_ServiceManagerMissingSurfaces(t *testing.T) {
+	stub := stubLaunchctl{
+		err: map[string]error{
+			"com.example.test.any": ErrServiceManagerMissing,
+		},
+	}
+	a := macAdapter{commander: stub}
+
+	_, err := a.FetchOne(context.Background(), "host-id", "com.example.test.any")
+	if !errors.Is(err, ErrServiceManagerMissing) {
+		t.Fatalf("err = %v, want ErrServiceManagerMissing", err)
+	}
+}
+
+// TestParseLaunchctlList_TableDriven covers every state mapping in one
+// go. Pins the parser against future tweaks.
+func TestParseLaunchctlList_TableDriven(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		want     State
+		exitCode *int
+	}{
+		{name: "active with PID", input: activeLaunchctlOut, want: StateActive, exitCode: nil},
+		{name: "inactive zero exit", input: inactiveLaunchctlOut, want: StateInactive, exitCode: intp(0)},
+		{name: "failed nonzero exit", input: failedLaunchctlOut, want: StateFailed, exitCode: intp(78)},
+		{name: "no PID no LastExit", input: emptyLaunchctlOut, want: StateInactive, exitCode: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotExit, err := parseLaunchctlList(tc.input)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("State = %q, want %q", got, tc.want)
+			}
+			switch {
+			case tc.exitCode == nil && gotExit != nil:
+				t.Errorf("ExitCode = %d, want nil", *gotExit)
+			case tc.exitCode != nil && gotExit == nil:
+				t.Errorf("ExitCode = nil, want %d", *tc.exitCode)
+			case tc.exitCode != nil && gotExit != nil && *tc.exitCode != *gotExit:
+				t.Errorf("ExitCode = %d, want %d", *gotExit, *tc.exitCode)
+			}
+		})
+	}
+}
+
+func intp(v int) *int { return &v }
+
+// activeLaunchctlOut is a `launchctl list <Label>` snapshot for a
+// running unit. PID = 12345, LastExitStatus = 0. Generic Label keeps
+// the fixture PII-free per worker standards.
+const activeLaunchctlOut = `{
+	"LimitLoadToSessionType" = "Aqua";
+	"Label" = "com.example.test.active";
+	"OnDemand" = false;
+	"LastExitStatus" = 0;
+	"PID" = 12345;
+	"Program" = "/usr/local/bin/example";
+};
+`
+
+// inactiveLaunchctlOut — clean stop. PID absent, LastExitStatus = 0.
+const inactiveLaunchctlOut = `{
+	"LimitLoadToSessionType" = "Aqua";
+	"Label" = "com.example.test.inactive";
+	"OnDemand" = true;
+	"LastExitStatus" = 0;
+	"Program" = "/usr/local/bin/example";
+};
+`
+
+// failedLaunchctlOut — crashed. PID absent, LastExitStatus = 78.
+// (78 = EX_CONFIG, popular among launchd-failure stories.)
+const failedLaunchctlOut = `{
+	"LimitLoadToSessionType" = "Aqua";
+	"Label" = "com.example.test.failed";
+	"OnDemand" = true;
+	"LastExitStatus" = 78;
+	"Program" = "/usr/local/bin/example";
+};
+`
+
+// emptyLaunchctlOut — never run. No PID, no LastExitStatus.
+const emptyLaunchctlOut = `{
+	"LimitLoadToSessionType" = "Aqua";
+	"Label" = "com.example.test.empty";
+	"OnDemand" = true;
+	"Program" = "/usr/local/bin/example";
+};
+`

--- a/internal/server/providers/hostservice/adapter_linux.go
+++ b/internal/server/providers/hostservice/adapter_linux.go
@@ -1,0 +1,244 @@
+//go:build linux
+
+package hostservice
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// linuxAdapter shells systemd-user CLI tools per watched name.
+//
+//   - state    : `systemctl --user is-active <name>` →
+//     active   → StateActive
+//     inactive → StateInactive
+//     failed   → StateFailed
+//     any non-zero exit + "Unit not loaded" stderr → StateUnknown
+//   - since    : `systemctl --user show -p ActiveEnterTimestamp <name>`
+//   - exitCode : `systemctl --user show -p ExecMainStatus <name>`
+//   - logTail  : `journalctl --user -u <name> --no-pager -n 20`
+//
+// systemd accepts both bare names ("orchard") and full unit names
+// ("orchard.service"). We pass the bare name through — systemctl is
+// lenient and the operator's config-spelling wins.
+type linuxAdapter struct {
+	systemctl  systemctlCommander
+	journalctl journalctlCommander
+}
+
+// systemctlCommander indirects systemd I/O so tests stub fake binaries.
+type systemctlCommander interface {
+	Run(ctx context.Context, args ...string) (stdout, stderr []byte, exitCode int, err error)
+}
+
+// journalctlCommander same purpose for journal log-tail reads.
+type journalctlCommander interface {
+	Run(ctx context.Context, args ...string) (stdout, stderr []byte, exitCode int, err error)
+}
+
+// NewAdapter returns the Linux Adapter wired to PATH-resolved systemctl
+// and journalctl. Tests construct linuxAdapter{...} with stub commanders.
+func NewAdapter() Adapter {
+	return linuxAdapter{
+		systemctl:  execCommanderLinux{bin: "systemctl"},
+		journalctl: execCommanderLinux{bin: "journalctl"},
+	}
+}
+
+// execCommanderLinux is the on-PATH commander for systemctl/journalctl.
+// Returns ErrServiceManagerMissing when systemctl is absent so the
+// resolver can surface the configured per-field error. journalctl
+// missing is non-fatal (logTail just stays nil).
+type execCommanderLinux struct{ bin string }
+
+func (e execCommanderLinux) Run(ctx context.Context, args ...string) ([]byte, []byte, int, error) {
+	if _, err := exec.LookPath(e.bin); err != nil {
+		if e.bin == "systemctl" {
+			return nil, nil, 0, ErrServiceManagerMissing
+		}
+		return nil, nil, 127, nil
+	}
+	cmd := exec.CommandContext(ctx, e.bin, args...)
+	var outBuf, errBuf strings.Builder
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	err := cmd.Run()
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+			err = nil
+		}
+	}
+	return []byte(outBuf.String()), []byte(errBuf.String()), exitCode, err
+}
+
+// FetchOne runs the three systemd reads + the journal tail. is-active is
+// the gate: an unknown unit short-circuits everything else and returns
+// state=unknown.
+func (l linuxAdapter) FetchOne(ctx context.Context, hostID, name string) (Snapshot, error) {
+	stdout, stderr, code, err := l.systemctl.Run(ctx, "--user", "is-active", name)
+	if errors.Is(err, ErrServiceManagerMissing) {
+		return Snapshot{}, ErrServiceManagerMissing
+	}
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("systemctl --user is-active %s: %w", name, err)
+	}
+
+	rawState := strings.TrimSpace(string(stdout))
+
+	// `is-active` exits non-zero for inactive AND failed AND unknown.
+	// Disambiguate by stdout — systemd writes the state name even when
+	// the exit code is non-zero.
+	state, knownUnit := mapIsActive(rawState)
+	if !knownUnit {
+		// stderr contains "Unit X not loaded" or "Failed to get
+		// properties" when the unit is unknown. Either way, that's
+		// state=unknown per the brief.
+		if isUnknownUnitMessage(string(stderr)) || rawState == "" || rawState == "inactive" && code != 0 && isUnknownUnitMessage(string(stderr)) {
+			return Snapshot{
+				HostID: hostID,
+				Name:   name,
+				State:  StateUnknown,
+			}, nil
+		}
+		return Snapshot{}, fmt.Errorf("systemctl is-active %s: unrecognised state %q (exit %d, stderr %q)", name, rawState, code, strings.TrimSpace(string(stderr)))
+	}
+
+	snap := Snapshot{HostID: hostID, Name: name, State: state}
+
+	// `show` is best-effort — failures here keep the snapshot but leave
+	// the optional fields nil.
+	if since, exitCode, err := l.readShow(ctx, name); err == nil {
+		snap.Since = since
+		snap.ExitCode = exitCode
+	}
+
+	if tail, err := l.readJournalTail(ctx, name); err == nil && tail != "" {
+		snap.LogTail = &tail
+	}
+
+	return snap, nil
+}
+
+// mapIsActive lifts a systemd is-active stdout token to (State, knownUnit).
+// Returns (_, false) when the token doesn't match any of the v1 states —
+// caller treats that as state=unknown if stderr corroborates.
+func mapIsActive(token string) (State, bool) {
+	switch token {
+	case "active", "activating", "reloading":
+		return StateActive, true
+	case "inactive", "deactivating":
+		return StateInactive, true
+	case "failed":
+		return StateFailed, true
+	default:
+		return "", false
+	}
+}
+
+// readShow runs `systemctl --user show -p ActiveEnterTimestamp -p
+// ExecMainStatus <name>` and parses the key=value output. systemd
+// always emits both keys even when empty, so format is stable.
+func (l linuxAdapter) readShow(ctx context.Context, name string) (*time.Time, *int, error) {
+	stdout, _, _, err := l.systemctl.Run(ctx, "--user", "show",
+		"-p", "ActiveEnterTimestamp",
+		"-p", "ExecMainStatus",
+		"--no-pager",
+		name,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	var since *time.Time
+	var exitCode *int
+	for _, line := range strings.Split(string(stdout), "\n") {
+		eq := strings.Index(line, "=")
+		if eq < 0 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		val := strings.TrimSpace(line[eq+1:])
+		switch key {
+		case "ActiveEnterTimestamp":
+			if val == "" || val == "n/a" {
+				continue
+			}
+			t, perr := parseSystemdTimestamp(val)
+			if perr == nil {
+				since = &t
+			}
+		case "ExecMainStatus":
+			if val == "" {
+				continue
+			}
+			n, perr := strconv.Atoi(val)
+			if perr == nil {
+				exitCode = &n
+			}
+		}
+	}
+	return since, exitCode, nil
+}
+
+// parseSystemdTimestamp parses systemd's wall-clock format: e.g.
+// "Mon 2026-05-04 12:34:56 UTC". Multiple zoneless / zoned variants
+// exist; we try the most common formats and fall back to RFC 3339.
+func parseSystemdTimestamp(s string) (time.Time, error) {
+	layouts := []string{
+		"Mon 2006-01-02 15:04:05 MST",
+		"Mon 2006-01-02 15:04:05",
+		"2006-01-02 15:04:05 MST",
+		"2006-01-02 15:04:05",
+		time.RFC3339,
+		time.RFC3339Nano,
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognised systemd timestamp %q", s)
+}
+
+// readJournalTail returns the last 20 lines of the unit's journal,
+// truncating any trailing newline. Empty result + no error is treated
+// as "no entries available" by the caller.
+func (l linuxAdapter) readJournalTail(ctx context.Context, name string) (string, error) {
+	stdout, _, code, err := l.journalctl.Run(ctx, "--user", "-u", name, "--no-pager", "-n", "20")
+	if err != nil {
+		return "", err
+	}
+	if code != 0 {
+		// journalctl returns non-zero when the journal is unavailable
+		// (no permissions, no entries). Caller treats as "no tail".
+		return "", nil
+	}
+	return strings.TrimRight(string(stdout), "\n"), nil
+}
+
+// isUnknownUnitMessage detects the systemd-stderr surface for an
+// unknown unit. "Unit X not loaded" / "Failed to get properties" /
+// "Failed to issue method call" — match loosely on the stable parts.
+func isUnknownUnitMessage(stderr string) bool {
+	s := strings.ToLower(stderr)
+	if strings.Contains(s, "not loaded") {
+		return true
+	}
+	if strings.Contains(s, "could not be found") {
+		return true
+	}
+	if strings.Contains(s, "no such file or directory") {
+		return true
+	}
+	if strings.Contains(s, "no such unit") {
+		return true
+	}
+	return false
+}

--- a/internal/server/providers/hostservice/adapter_linux_test.go
+++ b/internal/server/providers/hostservice/adapter_linux_test.go
@@ -1,0 +1,229 @@
+//go:build linux
+
+package hostservice
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// stubSystemctl returns canned output keyed by the unit name (the last
+// argument of every systemctl invocation we make).
+type stubSystemctl struct {
+	isActiveStdout map[string]string
+	isActiveStderr map[string]string
+	isActiveCode   map[string]int
+	showStdout     map[string]string
+	err            map[string]error
+}
+
+func (s stubSystemctl) Run(_ context.Context, args ...string) ([]byte, []byte, int, error) {
+	if len(args) == 0 {
+		return nil, nil, 1, errors.New("stubSystemctl: empty args")
+	}
+	verb := args[1]
+	name := args[len(args)-1]
+	if e, ok := s.err[name]; ok && e != nil {
+		return nil, nil, 0, e
+	}
+	switch verb {
+	case "is-active":
+		return []byte(s.isActiveStdout[name]), []byte(s.isActiveStderr[name]), s.isActiveCode[name], nil
+	case "show":
+		return []byte(s.showStdout[name]), nil, 0, nil
+	default:
+		return nil, nil, 1, errors.New("stubSystemctl: unhandled verb " + verb)
+	}
+}
+
+// stubJournalctl returns a canned tail.
+type stubJournalctl struct {
+	stdout map[string]string
+	code   map[string]int
+}
+
+func (s stubJournalctl) Run(_ context.Context, args ...string) ([]byte, []byte, int, error) {
+	name := nameFromArgs(args)
+	return []byte(s.stdout[name]), nil, s.code[name], nil
+}
+
+// nameFromArgs picks the unit name from `--user -u <name> --no-pager -n
+// 20`. Returns "" if not present.
+func nameFromArgs(args []string) string {
+	for i, a := range args {
+		if a == "-u" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// TestLinuxAdapter_StateActive — systemctl is-active says "active",
+// show emits ExecMainStatus=0 + ActiveEnterTimestamp.
+//
+// PII guard: every unit name uses generic
+// `example-test-<n>.service`. No real services.
+func TestLinuxAdapter_StateActive(t *testing.T) {
+	a := linuxAdapter{
+		systemctl: stubSystemctl{
+			isActiveStdout: map[string]string{"example-test-active": "active\n"},
+			isActiveCode:   map[string]int{"example-test-active": 0},
+			showStdout: map[string]string{
+				"example-test-active": "ActiveEnterTimestamp=Mon 2026-05-04 12:34:56 UTC\nExecMainStatus=0\n",
+			},
+		},
+		journalctl: stubJournalctl{stdout: map[string]string{"example-test-active": "Jan 01 00:00:00 host example: started\n"}},
+	}
+
+	snap, err := a.FetchOne(context.Background(), "host-id", "example-test-active")
+	if err != nil {
+		t.Fatalf("FetchOne: %v", err)
+	}
+	if snap.State != StateActive {
+		t.Errorf("State = %q, want active", snap.State)
+	}
+	if snap.Since == nil {
+		t.Error("Since is nil; want parsed timestamp")
+	}
+	if snap.LogTail == nil {
+		t.Error("LogTail is nil; want journalctl content")
+	}
+}
+
+// TestLinuxAdapter_StateInactive — systemctl is-active says "inactive"
+// (exit code 3 in real systemd, but the stdout is the disambiguator).
+func TestLinuxAdapter_StateInactive(t *testing.T) {
+	a := linuxAdapter{
+		systemctl: stubSystemctl{
+			isActiveStdout: map[string]string{"example-test-inactive": "inactive\n"},
+			isActiveCode:   map[string]int{"example-test-inactive": 3},
+			showStdout:     map[string]string{"example-test-inactive": "ActiveEnterTimestamp=\nExecMainStatus=0\n"},
+		},
+		journalctl: stubJournalctl{},
+	}
+
+	snap, err := a.FetchOne(context.Background(), "host-id", "example-test-inactive")
+	if err != nil {
+		t.Fatalf("FetchOne: %v", err)
+	}
+	if snap.State != StateInactive {
+		t.Errorf("State = %q, want inactive", snap.State)
+	}
+}
+
+// TestLinuxAdapter_StateFailed — systemctl is-active says "failed",
+// ExecMainStatus surfaces the non-zero exit code.
+func TestLinuxAdapter_StateFailed(t *testing.T) {
+	a := linuxAdapter{
+		systemctl: stubSystemctl{
+			isActiveStdout: map[string]string{"example-test-failed": "failed\n"},
+			isActiveCode:   map[string]int{"example-test-failed": 3},
+			showStdout:     map[string]string{"example-test-failed": "ActiveEnterTimestamp=Mon 2026-05-04 12:00:00 UTC\nExecMainStatus=42\n"},
+		},
+		journalctl: stubJournalctl{stdout: map[string]string{"example-test-failed": "Jan 01 00:00:00 host example: exit 42\n"}},
+	}
+
+	snap, err := a.FetchOne(context.Background(), "host-id", "example-test-failed")
+	if err != nil {
+		t.Fatalf("FetchOne: %v", err)
+	}
+	if snap.State != StateFailed {
+		t.Errorf("State = %q, want failed", snap.State)
+	}
+	if snap.ExitCode == nil || *snap.ExitCode != 42 {
+		got := -1
+		if snap.ExitCode != nil {
+			got = *snap.ExitCode
+		}
+		t.Errorf("ExitCode = %d, want 42", got)
+	}
+}
+
+// TestLinuxAdapter_StateUnknown — systemctl exits non-zero with
+// stderr like "Unit example-test-missing.service not loaded."
+func TestLinuxAdapter_StateUnknown(t *testing.T) {
+	a := linuxAdapter{
+		systemctl: stubSystemctl{
+			isActiveStderr: map[string]string{
+				"example-test-missing": "Unit example-test-missing.service not loaded.\n",
+			},
+			isActiveCode: map[string]int{"example-test-missing": 4},
+		},
+	}
+
+	snap, err := a.FetchOne(context.Background(), "host-id", "example-test-missing")
+	if err != nil {
+		t.Fatalf("FetchOne: %v", err)
+	}
+	if snap.State != StateUnknown {
+		t.Errorf("State = %q, want unknown", snap.State)
+	}
+	if snap.Since != nil || snap.ExitCode != nil || snap.LogTail != nil {
+		t.Errorf("optional fields populated for unknown unit: since=%v exitCode=%v logTail=%v", snap.Since, snap.ExitCode, snap.LogTail)
+	}
+}
+
+// TestLinuxAdapter_ServiceManagerMissingSurfaces — when systemctl is
+// absent from PATH, the adapter returns the typed sentinel so the
+// resolver can surface a per-field GraphQL error.
+func TestLinuxAdapter_ServiceManagerMissingSurfaces(t *testing.T) {
+	a := linuxAdapter{
+		systemctl: stubSystemctl{err: map[string]error{"any": ErrServiceManagerMissing}},
+	}
+
+	_, err := a.FetchOne(context.Background(), "host-id", "any")
+	if !errors.Is(err, ErrServiceManagerMissing) {
+		t.Fatalf("err = %v, want ErrServiceManagerMissing", err)
+	}
+}
+
+// TestMapIsActive_TableDriven pins the systemd-state-name → State
+// mapping so a future tweak can't silently re-map a state.
+func TestMapIsActive_TableDriven(t *testing.T) {
+	cases := []struct {
+		token string
+		want  State
+		known bool
+	}{
+		{"active", StateActive, true},
+		{"activating", StateActive, true},
+		{"reloading", StateActive, true},
+		{"inactive", StateInactive, true},
+		{"deactivating", StateInactive, true},
+		{"failed", StateFailed, true},
+		{"unknown-token", "", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.token, func(t *testing.T) {
+			got, known := mapIsActive(tc.token)
+			if got != tc.want {
+				t.Errorf("State = %q, want %q", got, tc.want)
+			}
+			if known != tc.known {
+				t.Errorf("knownUnit = %t, want %t", known, tc.known)
+			}
+		})
+	}
+}
+
+// TestParseSystemdTimestamp covers the layouts we support so a feed
+// from a real systemd installation parses cleanly.
+func TestParseSystemdTimestamp(t *testing.T) {
+	cases := []string{
+		"Mon 2026-05-04 12:34:56 UTC",
+		"2026-05-04T12:34:56Z",
+		"2026-05-04 12:34:56 UTC",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := parseSystemdTimestamp(in); err != nil {
+				t.Errorf("parse %q: %v", in, err)
+			}
+		})
+	}
+	if _, err := parseSystemdTimestamp("garbage"); err == nil {
+		t.Error("expected error for garbage timestamp, got nil")
+	}
+}

--- a/internal/server/providers/hostservice/config.go
+++ b/internal/server/providers/hostservice/config.go
@@ -1,0 +1,80 @@
+package hostservice
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+// DefaultServices is the watchlist used when `services` is missing from
+// `~/.config/orchard/config.json` (or the file itself is absent).
+//
+// Aligned with the briefing: the orchardist cares about the daemon
+// supervising itself (`orchard`), the launch surface for remote claude
+// sessions (`claude-remote`), and dotfile sync (`chezmoi`).
+var DefaultServices = []string{"claude-remote", "orchard", "chezmoi"}
+
+// configFile is a *narrow* view of `~/.config/orchard/config.json`.
+//
+// Only `services` is decoded here; the file's other top-level keys
+// (e.g. `version`, `projects` from ws-b-config) are tolerated by
+// json.Unmarshal's default behaviour. We never write this file —
+// `orchard config` is the only writer, so any user-added field round-
+// trips intact.
+type configFile struct {
+	Services []string `json:"services"`
+}
+
+// LoadServicesFromConfig reads the watchlist from path. Defaults apply
+// when:
+//
+//   - the file is absent (cold boot before `orchard config init`);
+//   - the file exists but `services` is missing or null;
+//   - the file exists but `services` is an empty array.
+//
+// Returns an error only on malformed JSON or read failures other than
+// "not exist" — partial config should still boot the daemon with the
+// defaults, but a corrupt file is operator-visible noise.
+func LoadServicesFromConfig(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return cloneDefaults(), nil
+		}
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var cfg configFile
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	if len(cfg.Services) == 0 {
+		return cloneDefaults(), nil
+	}
+
+	out := make([]string, 0, len(cfg.Services))
+	seen := make(map[string]struct{}, len(cfg.Services))
+	for _, s := range cfg.Services {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return cloneDefaults(), nil
+	}
+	return out, nil
+}
+
+func cloneDefaults() []string {
+	out := make([]string, len(DefaultServices))
+	copy(out, DefaultServices)
+	return out
+}

--- a/internal/server/providers/hostservice/config_test.go
+++ b/internal/server/providers/hostservice/config_test.go
@@ -1,0 +1,140 @@
+package hostservice
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// TestLoadServicesFromConfig_FileMissing asserts a missing config file
+// returns the canonical defaults. This is the cold-boot path (the
+// daemon comes up before `orchard config init` has run).
+func TestLoadServicesFromConfig_FileMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	got, err := LoadServicesFromConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, DefaultServices) {
+		t.Errorf("got %v, want defaults %v", got, DefaultServices)
+	}
+}
+
+// TestLoadServicesFromConfig_KeyMissing asserts a config file without
+// the `services` key returns defaults. Mirrors the case where ws-b-config
+// has written a `{"version":1, "projects":[...]}` file but the operator
+// hasn't customised the watchlist.
+func TestLoadServicesFromConfig_KeyMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"version": 1, "projects": []}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadServicesFromConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, DefaultServices) {
+		t.Errorf("got %v, want defaults %v", got, DefaultServices)
+	}
+}
+
+// TestLoadServicesFromConfig_EmptyArray asserts an explicitly empty
+// `services: []` falls back to defaults. Operators that want NO
+// watchlist need to remove the key entirely; an empty array is treated
+// as "I haven't configured this yet" rather than "watch nothing".
+func TestLoadServicesFromConfig_EmptyArray(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"services": []}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadServicesFromConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, DefaultServices) {
+		t.Errorf("got %v, want defaults %v", got, DefaultServices)
+	}
+}
+
+// TestLoadServicesFromConfig_CustomList asserts a populated services
+// array round-trips through the loader, and that order is preserved.
+func TestLoadServicesFromConfig_CustomList(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"services": ["foo", "bar", "baz"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadServicesFromConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"foo", "bar", "baz"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestLoadServicesFromConfig_DedupesAndSkipsBlank asserts duplicates
+// and blank entries are collapsed. We do not warn about either — the
+// daemon should be tolerant of operator typos.
+func TestLoadServicesFromConfig_DedupesAndSkipsBlank(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"services": ["foo", "", "foo", "bar", "foo"]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadServicesFromConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"foo", "bar"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestLoadServicesFromConfig_OnlyBlanksFallsBackToDefaults asserts that
+// a `services` array containing only blank entries is treated as empty
+// (i.e. defaults apply). Same rationale as EmptyArray — operator typo
+// shouldn't blank the watchlist.
+func TestLoadServicesFromConfig_OnlyBlanksFallsBackToDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{"services": ["", ""]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadServicesFromConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, DefaultServices) {
+		t.Errorf("got %v, want defaults %v", got, DefaultServices)
+	}
+}
+
+// TestLoadServicesFromConfig_MalformedJSONErrors asserts a corrupt file
+// surfaces an error so the operator notices. We do NOT silently fall
+// back to defaults on malformed JSON because that would hide bugs in
+// `orchard config` writers.
+func TestLoadServicesFromConfig_MalformedJSONErrors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, []byte(`{not json}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadServicesFromConfig(path)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON, got nil")
+	}
+}

--- a/internal/server/providers/hostservice/doc.go
+++ b/internal/server/providers/hostservice/doc.go
@@ -1,0 +1,36 @@
+// Package hostservice implements the HostService provider — orchard's
+// reflection of curated launchd (macOS) / systemd-user (Linux) units.
+//
+// Per ADR-011 §5.1, HostService carries:
+//
+//   - Identity (host_id, name) — name is config-driven (see config.go).
+//   - State (active|inactive|failed|unknown) — what the OS service
+//     manager reports right now.
+//   - since — RFC 3339 timestamp the unit entered the current state, when
+//     the OS surfaces one.
+//   - exitCode — most recent exit code of the last completed run.
+//   - logTail — last 20 log lines (Linux only; launchd does not stream
+//     a per-unit tail in the same shape).
+//
+// The watchlist (which unit names to surface) is read from
+// `~/.config/orchard/config.json` `services` array; defaults to
+// `["claude-remote", "orchard", "chezmoi"]` if the key is missing.
+// Watched units that don't exist on the host surface as
+// `state: unknown` rather than failing the resolver — ADR-011 contract.
+//
+// State refreshes on a 5-second TTL (ADR-011 §12 — "states change
+// quickly when unit cycles"). The Provider's poll loop refreshes on
+// the same cadence proactively, so callers normally read fresh cache.
+//
+// Adapter shellouts are split by OS via build tags —
+// adapter_darwin.go (`launchctl list <Label>`) and adapter_linux.go
+// (`systemctl --user is-active`, `systemctl --user show`,
+// `journalctl --user -u <name>`). No runtime `runtime.GOOS == ...`
+// branching outside what build tags already do.
+//
+// If the OS service-manager binary itself is missing
+// (`launchctl` / `systemctl`), the Adapter returns ErrServiceManagerMissing
+// and the resolver surfaces a per-field GraphQL error rather than
+// erroring the whole resolver. Each watched name is fetched
+// independently, so a missing unit can't take out a healthy peer.
+package hostservice

--- a/internal/server/providers/hostservice/hostservice_e2e_test.go
+++ b/internal/server/providers/hostservice/hostservice_e2e_test.go
@@ -1,0 +1,376 @@
+package hostservice_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+
+	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+)
+
+// TestHostService_E2E_FullStack drives the brief's primary AC: stub PATH
+// with fake `launchctl`/`systemctl` scripts emitting canned outputs that
+// cover all four states (active, inactive, failed, unknown) and assert
+// each maps correctly through the full GraphQL pipeline.
+//
+// Real shellouts via the production NewAdapter() — no provider/adapter
+// mocks. The test owns the OS service-manager binary path via PATH.
+//
+// PII guard: every fixture uses generic `com.example.test.*` (macOS) /
+// `example-test-*` (Linux) names. No real services.
+func TestHostService_E2E_FullStack(t *testing.T) {
+	stubDir := setupStubServiceManager(t)
+	t.Setenv("PATH", stubDir+":"+os.Getenv("PATH"))
+
+	services := []string{
+		serviceForState("active"),
+		serviceForState("inactive"),
+		serviceForState("failed"),
+		serviceForState("unknown"),
+	}
+	provider := hostservice.NewWith(hostservice.NewAdapter(), "test-host-id", services, time.Now)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	srv := newTestDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postQuery(t, srv.URL, `query {
+		host {
+			id
+			machineId
+			hostServices {
+				id
+				name
+				state
+				since
+				exitCode
+				logTail
+			}
+		}
+	}`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	if resp.Data.Host == nil {
+		t.Fatal("data.host is nil")
+	}
+	if got, want := resp.Data.Host.MachineID, "test-host-id"; got != want {
+		t.Errorf("machineId = %q, want %q", got, want)
+	}
+	if got, want := len(resp.Data.Host.HostServices), 4; got != want {
+		t.Fatalf("hostServices length = %d, want %d", got, want)
+	}
+
+	byName := map[string]hostServicePayload{}
+	for _, hs := range resp.Data.Host.HostServices {
+		byName[hs.Name] = hs
+	}
+	for _, want := range []struct {
+		name  string
+		state string
+	}{
+		{serviceForState("active"), "active"},
+		{serviceForState("inactive"), "inactive"},
+		{serviceForState("failed"), "failed"},
+		{serviceForState("unknown"), "unknown"},
+	} {
+		got, ok := byName[want.name]
+		if !ok {
+			t.Errorf("expected service %q in response, missing", want.name)
+			continue
+		}
+		if got.State != want.state {
+			t.Errorf("%s: state = %q, want %q", want.name, got.State, want.state)
+		}
+		expectedID := "HostService:test-host-id:" + want.name
+		if got.ID != expectedID {
+			t.Errorf("%s: id = %q, want %q", want.name, got.ID, expectedID)
+		}
+		if want.state == "unknown" {
+			if got.Since != nil || got.ExitCode != nil || got.LogTail != nil {
+				t.Errorf("unknown service has non-nil optional fields: %+v", got)
+			}
+		}
+	}
+}
+
+// TestHostService_E2E_ServiceManagerMissing asserts that when the OS
+// service manager binary is unreachable on PATH, every watched service
+// degrades to state=unknown rather than collapsing the resolver.
+//
+// We point PATH at an empty directory so launchctl / systemctl can't be
+// found. The resolver path catches ErrServiceManagerMissing and surfaces
+// state=unknown for each service.
+func TestHostService_E2E_ServiceManagerMissing(t *testing.T) {
+	emptyDir := t.TempDir()
+	t.Setenv("PATH", emptyDir)
+
+	services := []string{"missing-svc-1", "missing-svc-2"}
+	provider := hostservice.NewWith(hostservice.NewAdapter(), "test-host-id", services, time.Now)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	srv := newTestDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postQuery(t, srv.URL, `query { host { hostServices { name state } } }`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	if resp.Data.Host == nil {
+		t.Fatal("host is nil")
+	}
+	if got := len(resp.Data.Host.HostServices); got != 2 {
+		t.Fatalf("expected 2 services, got %d", got)
+	}
+	for _, hs := range resp.Data.Host.HostServices {
+		if hs.State != "unknown" {
+			t.Errorf("%s: state = %q, want unknown when service-manager binary is missing", hs.Name, hs.State)
+		}
+	}
+}
+
+// setupStubServiceManager writes a fake `launchctl` (macOS) or
+// `systemctl` + `journalctl` (Linux) into a temp dir. Each script
+// dispatches on argv[2] (the service name) so the four states each
+// emit their own canned response.
+//
+// Returns the temp dir path so the caller can prepend it to PATH.
+func setupStubServiceManager(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	switch runtime.GOOS {
+	case "darwin":
+		writeStubLaunchctl(t, dir)
+	case "linux":
+		writeStubSystemctl(t, dir)
+		writeStubJournalctl(t, dir)
+	default:
+		t.Skipf("unsupported OS %q (only darwin/linux ship a watchlist)", runtime.GOOS)
+	}
+	return dir
+}
+
+func writeStubLaunchctl(t *testing.T, dir string) {
+	t.Helper()
+	script := `#!/bin/sh
+set -e
+case "$2" in
+  com.example.test.active)
+    cat <<'EOF'
+{
+	"Label" = "com.example.test.active";
+	"LastExitStatus" = 0;
+	"PID" = 12345;
+};
+EOF
+    exit 0
+    ;;
+  com.example.test.inactive)
+    cat <<'EOF'
+{
+	"Label" = "com.example.test.inactive";
+	"LastExitStatus" = 0;
+};
+EOF
+    exit 0
+    ;;
+  com.example.test.failed)
+    cat <<'EOF'
+{
+	"Label" = "com.example.test.failed";
+	"LastExitStatus" = 78;
+};
+EOF
+    exit 0
+    ;;
+  com.example.test.unknown)
+    echo "Could not find service \"com.example.test.unknown\" in domain for system" 1>&2
+    exit 113
+    ;;
+  *)
+    echo "stub launchctl: unhandled label $2" 1>&2
+    exit 1
+    ;;
+esac
+`
+	path := filepath.Join(dir, "launchctl")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub launchctl: %v", err)
+	}
+}
+
+func writeStubSystemctl(t *testing.T, dir string) {
+	t.Helper()
+	script := `#!/bin/sh
+set -e
+verb="$2"
+name="${@: -1}"
+case "$verb" in
+  is-active)
+    case "$name" in
+      example-test-active) echo "active"; exit 0 ;;
+      example-test-inactive) echo "inactive"; exit 3 ;;
+      example-test-failed) echo "failed"; exit 3 ;;
+      example-test-unknown)
+        echo "Unit example-test-unknown.service not loaded." 1>&2
+        echo ""
+        exit 4
+        ;;
+      *)
+        echo "stub systemctl: unhandled name $name" 1>&2
+        exit 1 ;;
+    esac
+    ;;
+  show)
+    case "$name" in
+      example-test-active)
+        echo "ActiveEnterTimestamp=Mon 2026-05-04 12:34:56 UTC"
+        echo "ExecMainStatus=0" ;;
+      example-test-inactive)
+        echo "ActiveEnterTimestamp="
+        echo "ExecMainStatus=0" ;;
+      example-test-failed)
+        echo "ActiveEnterTimestamp=Mon 2026-05-04 12:00:00 UTC"
+        echo "ExecMainStatus=42" ;;
+      *)
+        echo "ActiveEnterTimestamp="
+        echo "ExecMainStatus=" ;;
+    esac
+    ;;
+  *)
+    echo "stub systemctl: unhandled verb $verb" 1>&2
+    exit 1 ;;
+esac
+`
+	path := filepath.Join(dir, "systemctl")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub systemctl: %v", err)
+	}
+}
+
+func writeStubJournalctl(t *testing.T, dir string) {
+	t.Helper()
+	script := `#!/bin/sh
+# Stub journalctl: emits a canned tail per unit name. The test does not
+# assert on tail content; this stub exists so the adapter's logTail
+# read does not 127.
+name=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-u" ]; then
+    name="$arg"
+  fi
+  prev="$arg"
+done
+case "$name" in
+  example-test-active) echo "Jan 01 00:00:00 host example: started"; exit 0 ;;
+  example-test-failed) echo "Jan 01 00:00:00 host example: exited with code 42"; exit 0 ;;
+  *) exit 0 ;;
+esac
+`
+	path := filepath.Join(dir, "journalctl")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub journalctl: %v", err)
+	}
+}
+
+// serviceForState returns the canonical fixture service name for a
+// given state on the current OS. All names are intentionally generic
+// (com.example.* / example-test-*) — no real service / bundle ids.
+func serviceForState(state string) string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "com.example.test." + state
+	case "linux":
+		return "example-test-" + state
+	default:
+		return state
+	}
+}
+
+// newTestDaemon spins up an httptest GraphQL server wired to the
+// production resolver pipeline, so the E2E asserts the same code path
+// the real daemon serves. Mirrors ws-b-host's E2E harness.
+func newTestDaemon(t *testing.T, p *hostservice.Provider) *httptest.Server {
+	t.Helper()
+	cfg := gql.Config{Resolvers: resolvers.New(time.Now()).WithHostService(p)}
+	gh := handler.New(gql.NewExecutableSchema(cfg))
+	gh.AddTransport(transport.POST{})
+	gh.AddTransport(transport.GET{})
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", gh)
+	return httptest.NewServer(mux)
+}
+
+// hostServicePayload mirrors the GraphQL HostService shape so we can
+// JSON-decode the response without bringing in gqlgen's MarshalGQL.
+type hostServicePayload struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	State    string  `json:"state"`
+	Since    *string `json:"since"`
+	ExitCode *int    `json:"exitCode"`
+	LogTail  *string `json:"logTail"`
+}
+
+type hostPayload struct {
+	ID           string               `json:"id"`
+	MachineID    string               `json:"machineId"`
+	HostServices []hostServicePayload `json:"hostServices"`
+}
+
+type queryPayload struct {
+	Data struct {
+		Host *hostPayload `json:"host"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+		Path    []any  `json:"path"`
+	} `json:"errors"`
+}
+
+// postQuery POSTs the GraphQL query to the test server and decodes the
+// response into queryPayload. Test failures are reported via t.Fatal.
+func postQuery(t *testing.T, base, query string) queryPayload {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		t.Fatalf("marshal query: %v", err)
+	}
+	resp, err := http.Post(base+"/graphql", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("daemon returned %d: %s", resp.StatusCode, string(raw))
+	}
+	var out queryPayload
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}

--- a/internal/server/providers/hostservice/identity_darwin.go
+++ b/internal/server/providers/hostservice/identity_darwin.go
@@ -1,0 +1,44 @@
+//go:build darwin
+
+package hostservice
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// LocalHostID returns the macOS IOPlatformUUID — the OS-issued machine
+// id used by the rest of the orchard daemon as the host_id identity.
+//
+// Self-contained on purpose: ws-b-hostservice ships before ws-b-host
+// has merged into ws-a-scaffold, so we cannot import host.IdentityReader.
+// When ws-b-host lands first, this file deletes cleanly and the daemon
+// switches to host.Provider.LocalID().
+func LocalHostID(ctx context.Context) (string, error) {
+	cctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(cctx, "ioreg", "-rd1", "-c", "IOPlatformExpertDevice").Output()
+	if err != nil {
+		return "", fmt.Errorf("ioreg: %w", err)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.Contains(line, "IOPlatformUUID") {
+			continue
+		}
+		idx := strings.Index(line, "=")
+		if idx < 0 {
+			continue
+		}
+		val := strings.TrimSpace(line[idx+1:])
+		val = strings.Trim(val, `"`)
+		if val == "" {
+			continue
+		}
+		return val, nil
+	}
+	return "", fmt.Errorf("IOPlatformUUID not found in ioreg output")
+}

--- a/internal/server/providers/hostservice/identity_linux.go
+++ b/internal/server/providers/hostservice/identity_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package hostservice
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// LocalHostID returns the Linux machine id from /etc/machine-id.
+//
+// Self-contained on purpose: ws-b-hostservice ships before ws-b-host
+// has merged into ws-a-scaffold, so we cannot import host.IdentityReader.
+// When ws-b-host lands first, this file deletes cleanly and the daemon
+// switches to host.Provider.LocalID().
+//
+// ctx is accepted for API parity with the macOS reader (which shells
+// `ioreg`); the Linux read is a single file read with no I/O budget
+// to honour.
+func LocalHostID(_ context.Context) (string, error) {
+	data, err := os.ReadFile("/etc/machine-id")
+	if err != nil {
+		return "", fmt.Errorf("read /etc/machine-id: %w", err)
+	}
+	id := strings.TrimSpace(string(data))
+	if id == "" {
+		return "", fmt.Errorf("/etc/machine-id is empty")
+	}
+	return id, nil
+}

--- a/internal/server/providers/hostservice/provider.go
+++ b/internal/server/providers/hostservice/provider.go
@@ -1,0 +1,297 @@
+package hostservice
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
+)
+
+// Provider is the host-service-domain Provider implementation.
+//
+// Owns the Adapter (OS-conditional via build tags) plus an in-memory
+// store of the latest Snapshot per (host, name). The poll loop refreshes
+// every PollInterval seconds; per-key TTL backstops Get when a caller
+// reads between ticks.
+//
+// v1 always operates against a single hostID — the local machine —
+// because Workstream F (federation) hasn't lit up yet. The hostID is
+// supplied by the daemon at New() time so identity logic stays in one
+// place (the host provider).
+type Provider struct {
+	adapter  Adapter
+	hostID   string
+	services []string
+	clock    func() time.Time
+
+	mu    sync.RWMutex
+	cache map[HostServiceID]Snapshot
+	errs  map[HostServiceID]error
+
+	subsMu sync.Mutex
+	subs   []chan adapter.InvalidationEvent[HostServiceID]
+}
+
+// New constructs a Provider with the platform-specific adapter and
+// the resolved watchlist + hostID.
+//
+// services may be empty — Provider.Start is a no-op and Get returns the
+// "no such key" error consistently. Callers loading the watchlist from
+// config should fall back to DefaultServices before calling New.
+func New(hostID string, services []string) *Provider {
+	return NewWith(NewAdapter(), hostID, services, time.Now)
+}
+
+// NewWith is the test-friendly constructor — accepts an injected
+// Adapter and clock so unit tests can drive freshness deterministically
+// and stub the OS shellouts.
+func NewWith(a Adapter, hostID string, services []string, clock func() time.Time) *Provider {
+	if clock == nil {
+		clock = time.Now
+	}
+	cleaned := make([]string, 0, len(services))
+	seen := make(map[string]struct{}, len(services))
+	for _, s := range services {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		cleaned = append(cleaned, s)
+	}
+	return &Provider{
+		adapter:  a,
+		hostID:   hostID,
+		services: cleaned,
+		clock:    clock,
+		cache:    make(map[HostServiceID]Snapshot, len(cleaned)),
+		errs:     make(map[HostServiceID]error, len(cleaned)),
+	}
+}
+
+// Start hydrates the cache once synchronously, then kicks off the
+// poll loop. The loop terminates when ctx is cancelled.
+//
+// Start is best-effort: per-service errors are stored on the Provider
+// and surfaced through Get; only a totally empty watchlist is
+// considered a no-op. Returning nil on partial failure mirrors the
+// resolver contract — one missing service shouldn't fail the resolver.
+func (p *Provider) Start(ctx context.Context) error {
+	p.refreshAll(ctx)
+	go p.pollLoop(ctx)
+	return nil
+}
+
+// HostID exposes the hostID this Provider was constructed with so the
+// resolver can compose `HostService:<host>:<name>` ids without
+// re-deriving identity.
+func (p *Provider) HostID() string { return p.hostID }
+
+// Services returns a copy of the watchlist in the order it was
+// configured. Resolvers iterate over this to populate
+// Host.hostServices.
+func (p *Provider) Services() []string {
+	out := make([]string, len(p.services))
+	copy(out, p.services)
+	return out
+}
+
+// Keys returns every key the Provider currently tracks. Cold boot
+// returns the configured set unconditionally so callers can drive
+// GetMany even before Start has hydrated the cache.
+func (p *Provider) Keys(_ context.Context) ([]HostServiceID, error) {
+	out := make([]HostServiceID, 0, len(p.services))
+	for _, s := range p.services {
+		out = append(out, MakeID(p.hostID, s))
+	}
+	return out, nil
+}
+
+// Get returns the Snapshot for one (host, name). Synchronously refreshes
+// when the cached value is past PollInterval.
+//
+// Returns an error only when:
+//   - the key isn't on the watchlist (caller bug);
+//   - the OS service manager is missing (ErrServiceManagerMissing);
+//   - a previous fetch failed for an OS-specific reason that wasn't
+//     "unit not present" — because the adapter contract reports
+//     "unit not present" as state=unknown, not as an error.
+//
+// "Unit not present" is NEVER an error — the Snapshot has
+// State == StateUnknown and the rest of the fields are nil.
+func (p *Provider) Get(ctx context.Context, key HostServiceID) (Snapshot, adapter.Freshness, error) {
+	hostID, name, ok := p.splitKey(key)
+	if !ok {
+		return Snapshot{}, adapter.Freshness{}, fmt.Errorf("unknown HostServiceID %q (not on watchlist)", key)
+	}
+
+	if err := p.ensureFresh(ctx, key, hostID, name); err != nil {
+		// Continue with stale data on transient failures; the next tick will retry.
+		_ = err
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if errVal, ok := p.errs[key]; ok && errVal != nil {
+		// Surface the most recent fetch error — the resolver may want
+		// to mark the field as a per-field GraphQL error.
+		return Snapshot{}, adapter.Freshness{}, errVal
+	}
+	snap, ok := p.cache[key]
+	if !ok {
+		return Snapshot{}, adapter.Freshness{}, fmt.Errorf("no snapshot yet for %q", key)
+	}
+	source := adapter.SourcePoll
+	if p.clock().Sub(snap.FetchedAt) > PollInterval {
+		source = adapter.SourceStaleCache
+	}
+	return snap, adapter.Freshness{LastFetchedAt: snap.FetchedAt, Source: source}, nil
+}
+
+// GetMany satisfies the Provider interface. Coalesces duplicate keys
+// and shares the cache across calls — DataLoader (WS-C) batches resolver
+// fan-outs into this method.
+func (p *Provider) GetMany(ctx context.Context, keys []HostServiceID) (map[HostServiceID]Snapshot, map[HostServiceID]adapter.Freshness, error) {
+	seen := make(map[HostServiceID]struct{}, len(keys))
+	out := make(map[HostServiceID]Snapshot, len(keys))
+	fresh := make(map[HostServiceID]adapter.Freshness, len(keys))
+	for _, k := range keys {
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		s, f, err := p.Get(ctx, k)
+		if err != nil {
+			continue
+		}
+		out[k] = s
+		fresh[k] = f
+	}
+	return out, fresh, nil
+}
+
+// Subscribe returns a channel that receives an event each time a watched
+// service refreshes. Channel closes when ctx is cancelled.
+//
+// Sends are non-blocking — a slow consumer drops events rather than
+// stalling the watcher loop.
+func (p *Provider) Subscribe(ctx context.Context) <-chan adapter.InvalidationEvent[HostServiceID] {
+	ch := make(chan adapter.InvalidationEvent[HostServiceID], 16)
+	p.subsMu.Lock()
+	p.subs = append(p.subs, ch)
+	p.subsMu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		p.subsMu.Lock()
+		defer p.subsMu.Unlock()
+		for i, c := range p.subs {
+			if c == ch {
+				p.subs = append(p.subs[:i], p.subs[i+1:]...)
+				close(ch)
+				return
+			}
+		}
+	}()
+	return ch
+}
+
+// LastError returns the most recent fetch error for a key, if any. The
+// resolver consults this to decide whether to surface a per-field
+// GraphQL error vs returning the cached value.
+func (p *Provider) LastError(key HostServiceID) error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.errs[key]
+}
+
+func (p *Provider) splitKey(key HostServiceID) (hostID, name string, ok bool) {
+	want := string(key)
+	for _, s := range p.services {
+		candidate := MakeID(p.hostID, s)
+		if HostServiceID(candidate) == HostServiceID(want) {
+			return p.hostID, s, true
+		}
+	}
+	return "", "", false
+}
+
+func (p *Provider) refreshAll(ctx context.Context) {
+	for _, name := range p.services {
+		key := MakeID(p.hostID, name)
+		_ = p.refreshOne(ctx, key, p.hostID, name)
+	}
+}
+
+func (p *Provider) ensureFresh(ctx context.Context, key HostServiceID, hostID, name string) error {
+	p.mu.RLock()
+	snap, hit := p.cache[key]
+	stale := !hit || p.clock().Sub(snap.FetchedAt) > PollInterval
+	p.mu.RUnlock()
+	if !stale {
+		return nil
+	}
+	return p.refreshOne(ctx, key, hostID, name)
+}
+
+func (p *Provider) refreshOne(ctx context.Context, key HostServiceID, hostID, name string) error {
+	snap, err := p.adapter.FetchOne(ctx, hostID, name)
+	now := p.clock()
+
+	p.mu.Lock()
+	if err != nil {
+		p.errs[key] = err
+		p.mu.Unlock()
+		return err
+	}
+	snap.FetchedAt = now
+	p.cache[key] = snap
+	delete(p.errs, key)
+	p.mu.Unlock()
+
+	p.fanOutInvalidate(key, now)
+	return nil
+}
+
+func (p *Provider) fanOutInvalidate(key HostServiceID, at time.Time) {
+	ev := adapter.InvalidationEvent[HostServiceID]{
+		Key:    key,
+		Reason: "poll-refresh",
+		At:     at,
+	}
+	p.subsMu.Lock()
+	subs := append([]chan adapter.InvalidationEvent[HostServiceID](nil), p.subs...)
+	p.subsMu.Unlock()
+	for _, c := range subs {
+		select {
+		case c <- ev:
+		default:
+		}
+	}
+}
+
+func (p *Provider) pollLoop(ctx context.Context) {
+	if len(p.services) == 0 {
+		<-ctx.Done()
+		return
+	}
+	t := time.NewTicker(PollInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			p.refreshAll(ctx)
+		}
+	}
+}
+
+// Compile-time assertion that *Provider satisfies the generic Provider
+// interface. Catches signature drift the moment it happens.
+var _ adapter.Provider[HostServiceID, Snapshot] = (*Provider)(nil)

--- a/internal/server/providers/hostservice/provider_test.go
+++ b/internal/server/providers/hostservice/provider_test.go
@@ -1,0 +1,285 @@
+package hostservice
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeAdapter is the test double for Adapter. Each entry in `responses`
+// is keyed by service name; the test sets up the desired Snapshot or
+// error and the Provider drives it through the public API. No real
+// shellouts — these tests live in the pure-Go layer.
+type fakeAdapter struct {
+	mu        sync.Mutex
+	responses map[string]fakeReply
+	calls     map[string]int
+}
+
+type fakeReply struct {
+	snap Snapshot
+	err  error
+}
+
+func newFakeAdapter() *fakeAdapter {
+	return &fakeAdapter{
+		responses: make(map[string]fakeReply),
+		calls:     make(map[string]int),
+	}
+}
+
+func (f *fakeAdapter) set(name string, snap Snapshot, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.responses[name] = fakeReply{snap: snap, err: err}
+}
+
+func (f *fakeAdapter) callsFor(name string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[name]
+}
+
+func (f *fakeAdapter) FetchOne(_ context.Context, hostID, name string) (Snapshot, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls[name]++
+	r, ok := f.responses[name]
+	if !ok {
+		return Snapshot{HostID: hostID, Name: name, State: StateUnknown}, nil
+	}
+	if r.snap.HostID == "" {
+		r.snap.HostID = hostID
+	}
+	if r.snap.Name == "" {
+		r.snap.Name = name
+	}
+	return r.snap, r.err
+}
+
+// TestProvider_KeysReflectsConfiguredServices asserts Keys() returns the
+// configured watchlist verbatim, before any cache hydration.
+func TestProvider_KeysReflectsConfiguredServices(t *testing.T) {
+	p := NewWith(newFakeAdapter(), "host-id", []string{"foo", "bar"}, time.Now)
+
+	keys, err := p.Keys(context.Background())
+	if err != nil {
+		t.Fatalf("Keys: %v", err)
+	}
+	want := []HostServiceID{
+		MakeID("host-id", "foo"),
+		MakeID("host-id", "bar"),
+	}
+	if !reflect.DeepEqual(keys, want) {
+		t.Errorf("got %v, want %v", keys, want)
+	}
+}
+
+// TestProvider_GetReturnsSnapshotForKnownKey asserts Get hydrates the
+// cache from the adapter on first read and returns the Snapshot.
+func TestProvider_GetReturnsSnapshotForKnownKey(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	a := newFakeAdapter()
+	a.set("foo", Snapshot{State: StateActive}, nil)
+	p := NewWith(a, "host-id", []string{"foo"}, clock)
+
+	got, fresh, err := p.Get(context.Background(), MakeID("host-id", "foo"))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != StateActive {
+		t.Errorf("State = %q, want active", got.State)
+	}
+	if got.HostID != "host-id" || got.Name != "foo" {
+		t.Errorf("identity mismatch: hostID=%q name=%q", got.HostID, got.Name)
+	}
+	if !got.FetchedAt.Equal(now) {
+		t.Errorf("FetchedAt = %v, want %v", got.FetchedAt, now)
+	}
+	if fresh.LastFetchedAt != now {
+		t.Errorf("Freshness.LastFetchedAt = %v, want %v", fresh.LastFetchedAt, now)
+	}
+}
+
+// TestProvider_GetUnknownKey asserts Get errors when the requested key
+// isn't on the watchlist (caller bug — the resolver should be iterating
+// Services()).
+func TestProvider_GetUnknownKey(t *testing.T) {
+	p := NewWith(newFakeAdapter(), "host-id", []string{"foo"}, time.Now)
+
+	_, _, err := p.Get(context.Background(), MakeID("host-id", "not-watched"))
+	if err == nil {
+		t.Fatal("expected error for unknown key, got nil")
+	}
+}
+
+// TestProvider_GetCachesUntilTTL asserts back-to-back Gets within the
+// PollInterval window do NOT hit the adapter twice. Critical for keeping
+// shellout volume sane under DataLoader fan-out.
+func TestProvider_GetCachesUntilTTL(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{now: now}
+	a := newFakeAdapter()
+	a.set("foo", Snapshot{State: StateActive}, nil)
+	p := NewWith(a, "host-id", []string{"foo"}, clock.Now)
+	key := MakeID("host-id", "foo")
+
+	if _, _, err := p.Get(context.Background(), key); err != nil {
+		t.Fatalf("Get #1: %v", err)
+	}
+	clock.advance(2 * time.Second)
+	if _, _, err := p.Get(context.Background(), key); err != nil {
+		t.Fatalf("Get #2: %v", err)
+	}
+	if got := a.callsFor("foo"); got != 1 {
+		t.Errorf("adapter called %d times within TTL, want 1", got)
+	}
+}
+
+// TestProvider_GetRefreshesAfterTTL asserts a Get past PollInterval
+// triggers a synchronous refresh.
+func TestProvider_GetRefreshesAfterTTL(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{now: now}
+	a := newFakeAdapter()
+	a.set("foo", Snapshot{State: StateActive}, nil)
+	p := NewWith(a, "host-id", []string{"foo"}, clock.Now)
+	key := MakeID("host-id", "foo")
+
+	if _, _, err := p.Get(context.Background(), key); err != nil {
+		t.Fatalf("Get #1: %v", err)
+	}
+	clock.advance(PollInterval + time.Second)
+	if _, _, err := p.Get(context.Background(), key); err != nil {
+		t.Fatalf("Get #2: %v", err)
+	}
+	if got := a.callsFor("foo"); got != 2 {
+		t.Errorf("adapter called %d times across TTL boundary, want 2", got)
+	}
+}
+
+// TestProvider_AdapterErrorSurfaces asserts an adapter error is stored
+// and resurfaced through subsequent Get calls until the next successful
+// fetch clears it.
+func TestProvider_AdapterErrorSurfaces(t *testing.T) {
+	a := newFakeAdapter()
+	a.set("foo", Snapshot{}, ErrServiceManagerMissing)
+	p := NewWith(a, "host-id", []string{"foo"}, time.Now)
+
+	_, _, err := p.Get(context.Background(), MakeID("host-id", "foo"))
+	if !errors.Is(err, ErrServiceManagerMissing) {
+		t.Fatalf("Get: err = %v, want ErrServiceManagerMissing", err)
+	}
+}
+
+// TestProvider_GetManyDedupes asserts duplicate keys collapse into a
+// single Get path so the adapter call volume stays linear in unique
+// keys, not request size.
+func TestProvider_GetManyDedupes(t *testing.T) {
+	a := newFakeAdapter()
+	a.set("foo", Snapshot{State: StateActive}, nil)
+	p := NewWith(a, "host-id", []string{"foo"}, time.Now)
+	key := MakeID("host-id", "foo")
+
+	got, _, err := p.GetMany(context.Background(), []HostServiceID{key, key, key})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("len(got) = %d, want 1 (deduped)", len(got))
+	}
+	if a.callsFor("foo") != 1 {
+		t.Errorf("adapter called %d times for duplicates, want 1", a.callsFor("foo"))
+	}
+}
+
+// TestProvider_NewWithDedupesServices asserts the constructor strips
+// duplicate / blank entries from the watchlist so callers can pass
+// raw config without sanitising first. (LoadServicesFromConfig already
+// dedupes, but the provider belt-and-braces.)
+func TestProvider_NewWithDedupesServices(t *testing.T) {
+	p := NewWith(newFakeAdapter(), "host-id", []string{"foo", "", "foo", "bar"}, time.Now)
+	got := p.Services()
+	want := []string{"foo", "bar"}
+	sort.Strings(got)
+	sort.Strings(want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestProvider_StartHydratesAndPollsContinuously asserts Start triggers
+// an initial fetch and the poll loop advances on each PollInterval tick.
+//
+// We don't assert the goroutine timing precisely — that path is
+// covered by the cache-TTL tests. Here we check the initial sync hit.
+func TestProvider_StartHydratesAllConfiguredServices(t *testing.T) {
+	a := newFakeAdapter()
+	a.set("foo", Snapshot{State: StateActive}, nil)
+	a.set("bar", Snapshot{State: StateInactive}, nil)
+	p := NewWith(a, "host-id", []string{"foo", "bar"}, time.Now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if a.callsFor("foo") != 1 {
+		t.Errorf("foo: adapter called %d times during Start, want 1", a.callsFor("foo"))
+	}
+	if a.callsFor("bar") != 1 {
+		t.Errorf("bar: adapter called %d times during Start, want 1", a.callsFor("bar"))
+	}
+}
+
+// TestProvider_SubscribeReceivesInvalidationOnRefresh asserts a refresh
+// fans out to subscribers. Caller cancels ctx to close the channel.
+func TestProvider_SubscribeReceivesInvalidationOnRefresh(t *testing.T) {
+	now := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{now: now}
+	a := newFakeAdapter()
+	a.set("foo", Snapshot{State: StateActive}, nil)
+	p := NewWith(a, "host-id", []string{"foo"}, clock.Now)
+	key := MakeID("host-id", "foo")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := p.Subscribe(ctx)
+
+	if _, _, err := p.Get(context.Background(), key); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	select {
+	case ev := <-ch:
+		if ev.Key != key {
+			t.Errorf("event key = %q, want %q", ev.Key, key)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no invalidation event within 1s")
+	}
+}
+
+// fakeClock is a manually-advanced wall clock used to drive the TTL
+// tests. Standard pattern; lives here rather than in a shared helper
+// because no other ws-b-hostservice file needs it.
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}

--- a/internal/server/providers/hostservice/types.go
+++ b/internal/server/providers/hostservice/types.go
@@ -1,0 +1,83 @@
+package hostservice
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// HostServiceID is the cache key. Encodes (host_id, name) so the same
+// service name can be tracked across federated hosts later (ADR-011 §7).
+// v1 always carries the local host_id; the format is stable from day
+// one to keep merge-time work small.
+type HostServiceID string
+
+// MakeID composes a HostServiceID from host id + service name. Pure;
+// callers (provider, resolvers) use it so the format lives in one place.
+func MakeID(hostID, name string) HostServiceID {
+	return HostServiceID(hostID + ":" + name)
+}
+
+// State mirrors graphql.HostServiceState as plain strings so the adapter
+// layer doesn't pull in the gqlgen package. The Provider maps from this
+// to the gqlgen enum at the resolver boundary.
+type State string
+
+// State constants align 1:1 with the GraphQL enum HostServiceState.
+const (
+	StateActive   State = "active"
+	StateInactive State = "inactive"
+	StateFailed   State = "failed"
+	StateUnknown  State = "unknown"
+)
+
+// Snapshot is the in-memory representation of one watched service. The
+// resolver lifts this into graphql.HostService at the resolver boundary.
+//
+// `Since` and `ExitCode` use pointer types so the resolver can map "no
+// value reported by the OS" to GraphQL null. `LogTail` is similar.
+type Snapshot struct {
+	HostID    string
+	Name      string
+	State     State
+	Since     *time.Time
+	ExitCode  *int
+	LogTail   *string
+	FetchedAt time.Time
+}
+
+// PollInterval is the maximum age of a cached Snapshot before the next
+// Get call refreshes synchronously. The poll loop refreshes on the same
+// cadence proactively. ADR-011 §12 — "states change quickly when unit
+// cycles".
+const PollInterval = 5 * time.Second
+
+// ErrServiceManagerMissing reports that the OS service-manager binary
+// (launchctl on macOS, systemctl on Linux) is not on PATH. The resolver
+// surfaces this as a per-field GraphQL error so the rest of the query
+// keeps resolving.
+var ErrServiceManagerMissing = errors.New("hostservice: OS service manager not installed on PATH")
+
+// Adapter is the OS-specific I/O surface. Implementations live in
+// adapter_darwin.go / adapter_linux.go and are selected at compile time
+// via build tags.
+//
+// FetchOne is the only verb v1 needs — the watchlist is small (single-
+// digit unit count) and each name is queried independently so a missing
+// service never collapses the resolver. A bulk verb is unnecessary
+// pre-DataLoader and adds an order-of-results coupling we don't want.
+type Adapter interface {
+	// FetchOne returns the current Snapshot for one watched name on the
+	// given host.
+	//
+	// Contract:
+	//   - The unit not existing on the host is NOT an error — the
+	//     adapter returns a Snapshot with State == StateUnknown and no
+	//     Since/ExitCode/LogTail.
+	//   - Only the OS service-manager binary itself missing returns
+	//     ErrServiceManagerMissing.
+	//   - Any other failure (parse error, timeout) is wrapped and
+	//     returned so the Provider can surface it once on the affected
+	//     key without poisoning peers.
+	FetchOne(ctx context.Context, hostID, name string) (Snapshot, error)
+}

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -11,6 +11,7 @@ import (
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 )
@@ -22,14 +23,15 @@ type ProjectsLister interface {
 
 // Resolver is the dependency-injection root for GraphQL resolvers.
 type Resolver struct {
-	StartedAt        time.Time
-	HostProvider     *host.Provider
-	ProjectsProvider ProjectsLister
-	Git              *gitprovider.Provider
-	PS               *ps.Provider
-	Tmux             *tmux.Provider
-	ClaudeProjects   *claudeprojects.Provider
-	ClaudeAccount    *claudeaccount.Provider
+	StartedAt           time.Time
+	HostProvider        *host.Provider
+	ProjectsProvider    ProjectsLister
+	Git                 *gitprovider.Provider
+	PS                  *ps.Provider
+	Tmux                *tmux.Provider
+	ClaudeProjects      *claudeprojects.Provider
+	ClaudeAccount       *claudeaccount.Provider
+	HostServiceProvider *hostservice.Provider
 }
 
 // New constructs a Resolver with the daemon's start time captured.
@@ -76,5 +78,11 @@ func (r *Resolver) WithClaudeProjects(p *claudeprojects.Provider) *Resolver {
 // WithClaudeAccount wires the claudeaccount provider.
 func (r *Resolver) WithClaudeAccount(p *claudeaccount.Provider) *Resolver {
 	r.ClaudeAccount = p
+	return r
+}
+
+// WithHostService wires the hostservice provider.
+func (r *Resolver) WithHostService(p *hostservice.Provider) *Resolver {
+	r.HostServiceProvider = p
 	return r
 }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -20,22 +20,6 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 )
 
-// Worktrees is the resolver for the project.worktrees field.
-func (r *projectResolver) Worktrees(ctx context.Context, obj *graphql1.Project) ([]*graphql1.Worktree, error) {
-	if r.Git == nil {
-		return nil, fmt.Errorf("git provider not configured")
-	}
-	worktrees, err := r.Git.ListByProject(ctx, obj.ID)
-	if err != nil {
-		return nil, fmt.Errorf("list worktrees for project %q: %w", obj.ID, err)
-	}
-	out := make([]*graphql1.Worktree, 0, len(worktrees))
-	for _, w := range worktrees {
-		out = append(out, toGraphQLWorktree(w))
-	}
-	return out, nil
-}
-
 // Processes is the resolver for the host.processes field.
 func (r *hostResolver) Processes(ctx context.Context, obj *graphql1.Host, filter *graphql1.ProcessFilter) ([]*graphql1.Process, error) {
 	if r.PS == nil {
@@ -52,7 +36,7 @@ func (r *hostResolver) Processes(ctx context.Context, obj *graphql1.Host, filter
 }
 
 // Host is the resolver for the process.host field.
-func (r *processResolver) Host(_ context.Context, obj *graphql1.Process) (*graphql1.Host, error) {
+func (r *processResolver) Host(ctx context.Context, obj *graphql1.Process) (*graphql1.Host, error) {
 	hostID, _ := splitProcessNodeID(obj.ID)
 	return &graphql1.Host{ID: hostID}, nil
 }
@@ -86,13 +70,29 @@ func (r *processResolver) Cwd(ctx context.Context, obj *graphql1.Process) (*stri
 }
 
 // Worktree is the resolver for the process.worktree field.
-func (r *processResolver) Worktree(_ context.Context, _ *graphql1.Process) (*graphql1.Worktree, error) {
+func (r *processResolver) Worktree(ctx context.Context, obj *graphql1.Process) (*graphql1.Worktree, error) {
 	return nil, nil
 }
 
 // ClaudeInstance is the resolver for the process.claudeInstance field.
-func (r *processResolver) ClaudeInstance(_ context.Context, _ *graphql1.Process) (*graphql1.ClaudeInstance, error) {
+func (r *processResolver) ClaudeInstance(ctx context.Context, obj *graphql1.Process) (*graphql1.ClaudeInstance, error) {
 	return nil, nil
+}
+
+// Worktrees is the resolver for the project.worktrees field.
+func (r *projectResolver) Worktrees(ctx context.Context, obj *graphql1.Project) ([]*graphql1.Worktree, error) {
+	if r.Git == nil {
+		return nil, fmt.Errorf("git provider not configured")
+	}
+	worktrees, err := r.Git.ListByProject(ctx, obj.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list worktrees for project %q: %w", obj.ID, err)
+	}
+	out := make([]*graphql1.Worktree, 0, len(worktrees))
+	for _, w := range worktrees {
+		out = append(out, toGraphQLWorktree(w))
+	}
+	return out, nil
 }
 
 // Health is the resolver for the health field.
@@ -255,13 +255,6 @@ func (r *queryResolver) ClaudeAccounts(ctx context.Context) ([]*graphql1.ClaudeA
 	return out, nil
 }
 
-// Processes is the resolver for the worktree.processes field.
-func (r *worktreeResolver) Processes(_ context.Context, _ *graphql1.Worktree) ([]*graphql1.Process, error) {
-	return []*graphql1.Process{}, nil
-}
-
-// All Tmux* field resolvers come from the tmux provider — see tmux_resolvers below.
-
 // Server is the resolver for tmuxClient.server.
 func (r *tmuxClientResolver) Server(ctx context.Context, obj *graphql1.TmuxClient) (*graphql1.TmuxServer, error) {
 	if r.Tmux == nil {
@@ -288,7 +281,7 @@ func (r *tmuxClientResolver) Session(ctx context.Context, obj *graphql1.TmuxClie
 }
 
 // Tty is the resolver for tmuxClient.tty.
-func (r *tmuxClientResolver) Tty(_ context.Context, obj *graphql1.TmuxClient) (string, error) {
+func (r *tmuxClientResolver) Tty(ctx context.Context, obj *graphql1.TmuxClient) (string, error) {
 	c, ok := r.lookupClient(obj.ID)
 	if !ok {
 		return "", nil
@@ -297,7 +290,7 @@ func (r *tmuxClientResolver) Tty(_ context.Context, obj *graphql1.TmuxClient) (s
 }
 
 // Hostname is the resolver for tmuxClient.hostname.
-func (r *tmuxClientResolver) Hostname(_ context.Context, obj *graphql1.TmuxClient) (string, error) {
+func (r *tmuxClientResolver) Hostname(ctx context.Context, obj *graphql1.TmuxClient) (string, error) {
 	c, ok := r.lookupClient(obj.ID)
 	if !ok {
 		return "", nil
@@ -306,7 +299,7 @@ func (r *tmuxClientResolver) Hostname(_ context.Context, obj *graphql1.TmuxClien
 }
 
 // TermName is the resolver for tmuxClient.termName.
-func (r *tmuxClientResolver) TermName(_ context.Context, obj *graphql1.TmuxClient) (string, error) {
+func (r *tmuxClientResolver) TermName(ctx context.Context, obj *graphql1.TmuxClient) (string, error) {
 	c, ok := r.lookupClient(obj.ID)
 	if !ok {
 		return "", nil
@@ -315,7 +308,7 @@ func (r *tmuxClientResolver) TermName(_ context.Context, obj *graphql1.TmuxClien
 }
 
 // AttachedAt is the resolver for tmuxClient.attachedAt.
-func (r *tmuxClientResolver) AttachedAt(_ context.Context, obj *graphql1.TmuxClient) (string, error) {
+func (r *tmuxClientResolver) AttachedAt(ctx context.Context, obj *graphql1.TmuxClient) (string, error) {
 	c, ok := r.lookupClient(obj.ID)
 	if !ok || c.AttachedAt.IsZero() {
 		return "", nil
@@ -324,7 +317,7 @@ func (r *tmuxClientResolver) AttachedAt(_ context.Context, obj *graphql1.TmuxCli
 }
 
 // LastActivityAt is the resolver for tmuxClient.lastActivityAt.
-func (r *tmuxClientResolver) LastActivityAt(_ context.Context, obj *graphql1.TmuxClient) (*string, error) {
+func (r *tmuxClientResolver) LastActivityAt(ctx context.Context, obj *graphql1.TmuxClient) (*string, error) {
 	c, ok := r.lookupClient(obj.ID)
 	if !ok || c.LastActivityAt.IsZero() {
 		return nil, nil
@@ -334,7 +327,7 @@ func (r *tmuxClientResolver) LastActivityAt(_ context.Context, obj *graphql1.Tmu
 }
 
 // Readonly is the resolver for tmuxClient.readonly.
-func (r *tmuxClientResolver) Readonly(_ context.Context, obj *graphql1.TmuxClient) (bool, error) {
+func (r *tmuxClientResolver) Readonly(ctx context.Context, obj *graphql1.TmuxClient) (bool, error) {
 	c, ok := r.lookupClient(obj.ID)
 	if !ok {
 		return false, nil
@@ -343,7 +336,7 @@ func (r *tmuxClientResolver) Readonly(_ context.Context, obj *graphql1.TmuxClien
 }
 
 // CurrentWindow is the resolver for tmuxClient.currentWindow.
-func (r *tmuxClientResolver) CurrentWindow(_ context.Context, obj *graphql1.TmuxClient) (*graphql1.TmuxWindow, error) {
+func (r *tmuxClientResolver) CurrentWindow(ctx context.Context, obj *graphql1.TmuxClient) (*graphql1.TmuxWindow, error) {
 	c, ok := r.lookupClient(obj.ID)
 	if !ok || r.Tmux == nil {
 		return nil, nil
@@ -357,7 +350,7 @@ func (r *tmuxClientResolver) CurrentWindow(_ context.Context, obj *graphql1.Tmux
 }
 
 // CurrentPane is the resolver for tmuxClient.currentPane.
-func (r *tmuxClientResolver) CurrentPane(_ context.Context, obj *graphql1.TmuxClient) (*graphql1.TmuxPane, error) {
+func (r *tmuxClientResolver) CurrentPane(ctx context.Context, obj *graphql1.TmuxClient) (*graphql1.TmuxPane, error) {
 	c, ok := r.lookupClient(obj.ID)
 	if !ok || r.Tmux == nil || c.CurrentPane == "" {
 		return nil, nil
@@ -371,7 +364,7 @@ func (r *tmuxClientResolver) CurrentPane(_ context.Context, obj *graphql1.TmuxCl
 }
 
 // Window is the resolver for tmuxPane.window.
-func (r *tmuxPaneResolver) Window(_ context.Context, obj *graphql1.TmuxPane) (*graphql1.TmuxWindow, error) {
+func (r *tmuxPaneResolver) Window(ctx context.Context, obj *graphql1.TmuxPane) (*graphql1.TmuxWindow, error) {
 	p, ok := r.lookupPane(obj.ID)
 	if !ok || r.Tmux == nil {
 		return nil, nil
@@ -385,7 +378,7 @@ func (r *tmuxPaneResolver) Window(_ context.Context, obj *graphql1.TmuxPane) (*g
 }
 
 // Title is the resolver for tmuxPane.title.
-func (r *tmuxPaneResolver) Title(_ context.Context, obj *graphql1.TmuxPane) (string, error) {
+func (r *tmuxPaneResolver) Title(ctx context.Context, obj *graphql1.TmuxPane) (string, error) {
 	p, ok := r.lookupPane(obj.ID)
 	if !ok {
 		return "", nil
@@ -394,7 +387,7 @@ func (r *tmuxPaneResolver) Title(_ context.Context, obj *graphql1.TmuxPane) (str
 }
 
 // CurrentCommand is the resolver for tmuxPane.currentCommand.
-func (r *tmuxPaneResolver) CurrentCommand(_ context.Context, obj *graphql1.TmuxPane) (string, error) {
+func (r *tmuxPaneResolver) CurrentCommand(ctx context.Context, obj *graphql1.TmuxPane) (string, error) {
 	p, ok := r.lookupPane(obj.ID)
 	if !ok {
 		return "", nil
@@ -403,7 +396,7 @@ func (r *tmuxPaneResolver) CurrentCommand(_ context.Context, obj *graphql1.TmuxP
 }
 
 // CurrentPid is the resolver for tmuxPane.currentPid.
-func (r *tmuxPaneResolver) CurrentPid(_ context.Context, obj *graphql1.TmuxPane) (*int64, error) {
+func (r *tmuxPaneResolver) CurrentPid(ctx context.Context, obj *graphql1.TmuxPane) (*int64, error) {
 	p, ok := r.lookupPane(obj.ID)
 	if !ok || p.CurrentPid == 0 {
 		return nil, nil
@@ -413,7 +406,7 @@ func (r *tmuxPaneResolver) CurrentPid(_ context.Context, obj *graphql1.TmuxPane)
 }
 
 // Width is the resolver for tmuxPane.width.
-func (r *tmuxPaneResolver) Width(_ context.Context, obj *graphql1.TmuxPane) (int64, error) {
+func (r *tmuxPaneResolver) Width(ctx context.Context, obj *graphql1.TmuxPane) (int64, error) {
 	p, ok := r.lookupPane(obj.ID)
 	if !ok {
 		return 0, nil
@@ -422,7 +415,7 @@ func (r *tmuxPaneResolver) Width(_ context.Context, obj *graphql1.TmuxPane) (int
 }
 
 // Height is the resolver for tmuxPane.height.
-func (r *tmuxPaneResolver) Height(_ context.Context, obj *graphql1.TmuxPane) (int64, error) {
+func (r *tmuxPaneResolver) Height(ctx context.Context, obj *graphql1.TmuxPane) (int64, error) {
 	p, ok := r.lookupPane(obj.ID)
 	if !ok {
 		return 0, nil
@@ -431,7 +424,7 @@ func (r *tmuxPaneResolver) Height(_ context.Context, obj *graphql1.TmuxPane) (in
 }
 
 // Dead is the resolver for tmuxPane.dead.
-func (r *tmuxPaneResolver) Dead(_ context.Context, obj *graphql1.TmuxPane) (bool, error) {
+func (r *tmuxPaneResolver) Dead(ctx context.Context, obj *graphql1.TmuxPane) (bool, error) {
 	p, ok := r.lookupPane(obj.ID)
 	if !ok {
 		return false, nil
@@ -440,7 +433,7 @@ func (r *tmuxPaneResolver) Dead(_ context.Context, obj *graphql1.TmuxPane) (bool
 }
 
 // WatchingClients is the resolver for tmuxPane.watchingClients.
-func (r *tmuxPaneResolver) WatchingClients(_ context.Context, obj *graphql1.TmuxPane) ([]*graphql1.TmuxClient, error) {
+func (r *tmuxPaneResolver) WatchingClients(ctx context.Context, obj *graphql1.TmuxPane) ([]*graphql1.TmuxClient, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -458,12 +451,12 @@ func (r *tmuxPaneResolver) WatchingClients(_ context.Context, obj *graphql1.Tmux
 }
 
 // Process is the resolver for tmuxPane.process.
-func (r *tmuxPaneResolver) Process(_ context.Context, _ *graphql1.TmuxPane) (*graphql1.Process, error) {
+func (r *tmuxPaneResolver) Process(ctx context.Context, obj *graphql1.TmuxPane) (*graphql1.Process, error) {
 	return nil, nil
 }
 
 // ClaudeInstance is the resolver for tmuxPane.claudeInstance.
-func (r *tmuxPaneResolver) ClaudeInstance(_ context.Context, _ *graphql1.TmuxPane) (*graphql1.ClaudeInstance, error) {
+func (r *tmuxPaneResolver) ClaudeInstance(ctx context.Context, obj *graphql1.TmuxPane) (*graphql1.ClaudeInstance, error) {
 	return nil, nil
 }
 
@@ -520,7 +513,7 @@ func (r *tmuxPaneResolver) ContentFull(ctx context.Context, obj *graphql1.TmuxPa
 }
 
 // Pid is the resolver for tmuxServer.pid.
-func (r *tmuxServerResolver) Pid(_ context.Context, _ *graphql1.TmuxServer) (*int64, error) {
+func (r *tmuxServerResolver) Pid(ctx context.Context, obj *graphql1.TmuxServer) (*int64, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -532,7 +525,7 @@ func (r *tmuxServerResolver) Pid(_ context.Context, _ *graphql1.TmuxServer) (*in
 }
 
 // Alive is the resolver for tmuxServer.alive.
-func (r *tmuxServerResolver) Alive(_ context.Context, _ *graphql1.TmuxServer) (bool, error) {
+func (r *tmuxServerResolver) Alive(ctx context.Context, obj *graphql1.TmuxServer) (bool, error) {
 	if r.Tmux == nil {
 		return false, nil
 	}
@@ -540,7 +533,7 @@ func (r *tmuxServerResolver) Alive(_ context.Context, _ *graphql1.TmuxServer) (b
 }
 
 // Sessions is the resolver for tmuxServer.sessions.
-func (r *tmuxServerResolver) Sessions(_ context.Context, _ *graphql1.TmuxServer) ([]*graphql1.TmuxSession, error) {
+func (r *tmuxServerResolver) Sessions(ctx context.Context, obj *graphql1.TmuxServer) ([]*graphql1.TmuxSession, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -553,7 +546,7 @@ func (r *tmuxServerResolver) Sessions(_ context.Context, _ *graphql1.TmuxServer)
 }
 
 // Clients is the resolver for tmuxServer.clients.
-func (r *tmuxServerResolver) Clients(_ context.Context, _ *graphql1.TmuxServer) ([]*graphql1.TmuxClient, error) {
+func (r *tmuxServerResolver) Clients(ctx context.Context, obj *graphql1.TmuxServer) ([]*graphql1.TmuxClient, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -566,7 +559,7 @@ func (r *tmuxServerResolver) Clients(_ context.Context, _ *graphql1.TmuxServer) 
 }
 
 // Server is the resolver for tmuxSession.server.
-func (r *tmuxSessionResolver) Server(_ context.Context, _ *graphql1.TmuxSession) (*graphql1.TmuxServer, error) {
+func (r *tmuxSessionResolver) Server(ctx context.Context, obj *graphql1.TmuxSession) (*graphql1.TmuxServer, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -574,7 +567,7 @@ func (r *tmuxSessionResolver) Server(_ context.Context, _ *graphql1.TmuxSession)
 }
 
 // CreatedAt is the resolver for tmuxSession.createdAt.
-func (r *tmuxSessionResolver) CreatedAt(_ context.Context, obj *graphql1.TmuxSession) (string, error) {
+func (r *tmuxSessionResolver) CreatedAt(ctx context.Context, obj *graphql1.TmuxSession) (string, error) {
 	s, ok := r.lookupSession(obj.ID)
 	if !ok || s.CreatedAt.IsZero() {
 		return "", nil
@@ -583,7 +576,7 @@ func (r *tmuxSessionResolver) CreatedAt(_ context.Context, obj *graphql1.TmuxSes
 }
 
 // Attached is the resolver for tmuxSession.attached.
-func (r *tmuxSessionResolver) Attached(_ context.Context, obj *graphql1.TmuxSession) (bool, error) {
+func (r *tmuxSessionResolver) Attached(ctx context.Context, obj *graphql1.TmuxSession) (bool, error) {
 	s, ok := r.lookupSession(obj.ID)
 	if !ok {
 		return false, nil
@@ -592,7 +585,7 @@ func (r *tmuxSessionResolver) Attached(_ context.Context, obj *graphql1.TmuxSess
 }
 
 // ActiveAttached is the resolver for tmuxSession.activeAttached.
-func (r *tmuxSessionResolver) ActiveAttached(_ context.Context, obj *graphql1.TmuxSession) (bool, error) {
+func (r *tmuxSessionResolver) ActiveAttached(ctx context.Context, obj *graphql1.TmuxSession) (bool, error) {
 	s, ok := r.lookupSession(obj.ID)
 	if !ok || !s.Attached {
 		return false, nil
@@ -601,7 +594,7 @@ func (r *tmuxSessionResolver) ActiveAttached(_ context.Context, obj *graphql1.Tm
 }
 
 // AttachedClients is the resolver for tmuxSession.attachedClients.
-func (r *tmuxSessionResolver) AttachedClients(_ context.Context, obj *graphql1.TmuxSession) ([]*graphql1.TmuxClient, error) {
+func (r *tmuxSessionResolver) AttachedClients(ctx context.Context, obj *graphql1.TmuxSession) ([]*graphql1.TmuxClient, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -619,7 +612,7 @@ func (r *tmuxSessionResolver) AttachedClients(_ context.Context, obj *graphql1.T
 }
 
 // LastActivityAt is the resolver for tmuxSession.lastActivityAt.
-func (r *tmuxSessionResolver) LastActivityAt(_ context.Context, obj *graphql1.TmuxSession) (*string, error) {
+func (r *tmuxSessionResolver) LastActivityAt(ctx context.Context, obj *graphql1.TmuxSession) (*string, error) {
 	s, ok := r.lookupSession(obj.ID)
 	if !ok || s.LastActivityAt.IsZero() {
 		return nil, nil
@@ -629,7 +622,7 @@ func (r *tmuxSessionResolver) LastActivityAt(_ context.Context, obj *graphql1.Tm
 }
 
 // Windows is the resolver for tmuxSession.windows.
-func (r *tmuxSessionResolver) Windows(_ context.Context, obj *graphql1.TmuxSession) ([]*graphql1.TmuxWindow, error) {
+func (r *tmuxSessionResolver) Windows(ctx context.Context, obj *graphql1.TmuxSession) ([]*graphql1.TmuxWindow, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -647,7 +640,7 @@ func (r *tmuxSessionResolver) Windows(_ context.Context, obj *graphql1.TmuxSessi
 }
 
 // CurrentWindow is the resolver for tmuxSession.currentWindow.
-func (r *tmuxSessionResolver) CurrentWindow(_ context.Context, obj *graphql1.TmuxSession) (*graphql1.TmuxWindow, error) {
+func (r *tmuxSessionResolver) CurrentWindow(ctx context.Context, obj *graphql1.TmuxSession) (*graphql1.TmuxWindow, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -664,7 +657,7 @@ func (r *tmuxSessionResolver) CurrentWindow(_ context.Context, obj *graphql1.Tmu
 }
 
 // Session is the resolver for tmuxWindow.session.
-func (r *tmuxWindowResolver) Session(_ context.Context, obj *graphql1.TmuxWindow) (*graphql1.TmuxSession, error) {
+func (r *tmuxWindowResolver) Session(ctx context.Context, obj *graphql1.TmuxWindow) (*graphql1.TmuxSession, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -681,7 +674,7 @@ func (r *tmuxWindowResolver) Session(_ context.Context, obj *graphql1.TmuxWindow
 }
 
 // Name is the resolver for tmuxWindow.name.
-func (r *tmuxWindowResolver) Name(_ context.Context, obj *graphql1.TmuxWindow) (string, error) {
+func (r *tmuxWindowResolver) Name(ctx context.Context, obj *graphql1.TmuxWindow) (string, error) {
 	w, ok := r.lookupWindow(obj.ID)
 	if !ok {
 		return "", nil
@@ -690,7 +683,7 @@ func (r *tmuxWindowResolver) Name(_ context.Context, obj *graphql1.TmuxWindow) (
 }
 
 // Active is the resolver for tmuxWindow.active.
-func (r *tmuxWindowResolver) Active(_ context.Context, obj *graphql1.TmuxWindow) (bool, error) {
+func (r *tmuxWindowResolver) Active(ctx context.Context, obj *graphql1.TmuxWindow) (bool, error) {
 	w, ok := r.lookupWindow(obj.ID)
 	if !ok {
 		return false, nil
@@ -699,7 +692,7 @@ func (r *tmuxWindowResolver) Active(_ context.Context, obj *graphql1.TmuxWindow)
 }
 
 // Panes is the resolver for tmuxWindow.panes.
-func (r *tmuxWindowResolver) Panes(_ context.Context, obj *graphql1.TmuxWindow) ([]*graphql1.TmuxPane, error) {
+func (r *tmuxWindowResolver) Panes(ctx context.Context, obj *graphql1.TmuxWindow) ([]*graphql1.TmuxPane, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -717,7 +710,7 @@ func (r *tmuxWindowResolver) Panes(_ context.Context, obj *graphql1.TmuxWindow) 
 }
 
 // CurrentPane is the resolver for tmuxWindow.currentPane.
-func (r *tmuxWindowResolver) CurrentPane(_ context.Context, obj *graphql1.TmuxWindow) (*graphql1.TmuxPane, error) {
+func (r *tmuxWindowResolver) CurrentPane(ctx context.Context, obj *graphql1.TmuxWindow) (*graphql1.TmuxPane, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
@@ -733,6 +726,11 @@ func (r *tmuxWindowResolver) CurrentPane(_ context.Context, obj *graphql1.TmuxWi
 	return projectPane(p), nil
 }
 
+// Processes is the resolver for the worktree.processes field.
+func (r *worktreeResolver) Processes(ctx context.Context, obj *graphql1.Worktree) ([]*graphql1.Process, error) {
+	return []*graphql1.Process{}, nil
+}
+
 // Host returns graphql1.HostResolver implementation.
 func (r *Resolver) Host() graphql1.HostResolver { return &hostResolver{r} }
 
@@ -744,9 +742,6 @@ func (r *Resolver) Project() graphql1.ProjectResolver { return &projectResolver{
 
 // Query returns graphql1.QueryResolver implementation.
 func (r *Resolver) Query() graphql1.QueryResolver { return &queryResolver{r} }
-
-// Worktree returns graphql1.WorktreeResolver implementation.
-func (r *Resolver) Worktree() graphql1.WorktreeResolver { return &worktreeResolver{r} }
 
 // TmuxClient returns graphql1.TmuxClientResolver implementation.
 func (r *Resolver) TmuxClient() graphql1.TmuxClientResolver { return &tmuxClientResolver{r} }
@@ -763,17 +758,26 @@ func (r *Resolver) TmuxSession() graphql1.TmuxSessionResolver { return &tmuxSess
 // TmuxWindow returns graphql1.TmuxWindowResolver implementation.
 func (r *Resolver) TmuxWindow() graphql1.TmuxWindowResolver { return &tmuxWindowResolver{r} }
 
+// Worktree returns graphql1.WorktreeResolver implementation.
+func (r *Resolver) Worktree() graphql1.WorktreeResolver { return &worktreeResolver{r} }
+
 type hostResolver struct{ *Resolver }
 type processResolver struct{ *Resolver }
 type projectResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
-type worktreeResolver struct{ *Resolver }
 type tmuxClientResolver struct{ *Resolver }
 type tmuxPaneResolver struct{ *Resolver }
 type tmuxServerResolver struct{ *Resolver }
 type tmuxSessionResolver struct{ *Resolver }
 type tmuxWindowResolver struct{ *Resolver }
+type worktreeResolver struct{ *Resolver }
 
+// !!! WARNING !!!
+// The code below was going to be deleted when updating resolvers. It has been copied here so you have
+// one last chance to move it out of harms way if you want. There are two reasons this happens:
+//   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
+//     it when you're done.
+//   - You have helper methods in this file. Move them out to keep these resolver files clean.
 func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
 	return &graphql1.Worktree{
 		ID:     string(w.ID),
@@ -783,7 +787,6 @@ func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
 		Bare:   w.Bare,
 	}
 }
-
 func projectProcess(p *ps.Process, hostID string) *graphql1.Process {
 	tty := p.TTY
 	startedAt := p.StartedRaw
@@ -805,7 +808,6 @@ func projectProcess(p *ps.Process, hostID string) *graphql1.Process {
 	}
 	return out
 }
-
 func applyProcessFilter(ctx context.Context, p *ps.Provider, in []ps.Process, filter *graphql1.ProcessFilter) []ps.Process {
 	if filter == nil {
 		return in
@@ -862,7 +864,6 @@ func applyProcessFilter(ctx context.Context, p *ps.Provider, in []ps.Process, fi
 
 	return out
 }
-
 func splitProcessNodeID(s string) (string, string) {
 	idx := strings.LastIndexByte(s, ':')
 	if idx <= 0 {
@@ -870,48 +871,41 @@ func splitProcessNodeID(s string) (string, string) {
 	}
 	return s[:idx], s[idx+1:]
 }
-
 func projectServer(host tmux.HostID, info tmux.ServerInfo) *graphql1.TmuxServer {
 	return &graphql1.TmuxServer{
 		ID:         "TmuxServer:" + string(host) + ":" + info.SocketPath,
 		SocketPath: info.SocketPath,
 	}
 }
-
 func projectSession(s tmux.Session) *graphql1.TmuxSession {
 	return &graphql1.TmuxSession{
 		ID:   "TmuxSession:" + string(s.Key.Host) + ":" + s.Key.Name,
 		Name: s.Key.Name,
 	}
 }
-
 func projectWindow(w tmux.Window) *graphql1.TmuxWindow {
 	return &graphql1.TmuxWindow{
 		ID:    "TmuxWindow:" + string(w.Key.Host) + ":" + w.Key.Session + ":" + strconv.Itoa(w.Key.Index),
 		Index: int64(w.Key.Index),
 	}
 }
-
 func projectPane(p tmux.Pane) *graphql1.TmuxPane {
 	return &graphql1.TmuxPane{
 		ID:     "TmuxPane:" + string(p.Key.Host) + ":" + p.Key.PaneID,
 		PaneID: p.Key.PaneID,
 	}
 }
-
 func projectClient(c tmux.Client) *graphql1.TmuxClient {
 	return &graphql1.TmuxClient{
 		ID: "TmuxClient:" + string(c.Key.Host) + ":" + c.Key.ClientName,
 	}
 }
-
 func stripPrefix(s, prefix string) string {
 	if strings.HasPrefix(s, prefix) {
 		return s[len(prefix):]
 	}
 	return s
 }
-
 func sessionMatchesFilter(s tmux.Session, f *graphql1.TmuxSessionFilter) bool {
 	if f == nil {
 		return true
@@ -927,7 +921,6 @@ func sessionMatchesFilter(s tmux.Session, f *graphql1.TmuxSessionFilter) bool {
 	}
 	return true
 }
-
 func paneMatchesFilter(p tmux.Pane, f *graphql1.TmuxPaneFilter) bool {
 	if f == nil {
 		return true
@@ -949,7 +942,6 @@ func paneMatchesFilter(p tmux.Pane, f *graphql1.TmuxPaneFilter) bool {
 	}
 	return true
 }
-
 func contains(haystack []string, needle string) bool {
 	for _, s := range haystack {
 		if s == needle {
@@ -958,7 +950,6 @@ func contains(haystack []string, needle string) bool {
 	}
 	return false
 }
-
 func (r *tmuxClientResolver) lookupClient(id string) (tmux.Client, bool) {
 	if r.Tmux == nil {
 		return tmux.Client{}, false
@@ -968,7 +959,6 @@ func (r *tmuxClientResolver) lookupClient(id string) (tmux.Client, bool) {
 	c, ok := r.Tmux.Snapshot().Clients[tmux.ClientKey{Host: host, ClientName: name}]
 	return c, ok
 }
-
 func (r *tmuxPaneResolver) lookupPane(id string) (tmux.Pane, bool) {
 	if r.Tmux == nil {
 		return tmux.Pane{}, false
@@ -978,7 +968,6 @@ func (r *tmuxPaneResolver) lookupPane(id string) (tmux.Pane, bool) {
 	p, ok := r.Tmux.Snapshot().Panes[tmux.PaneKey{Host: host, PaneID: paneID}]
 	return p, ok
 }
-
 func (r *tmuxSessionResolver) lookupSession(id string) (tmux.Session, bool) {
 	if r.Tmux == nil {
 		return tmux.Session{}, false
@@ -988,7 +977,6 @@ func (r *tmuxSessionResolver) lookupSession(id string) (tmux.Session, bool) {
 	s, ok := r.Tmux.Snapshot().Sessions[tmux.SessionKey{Host: host, Name: name}]
 	return s, ok
 }
-
 func (r *tmuxWindowResolver) lookupWindow(id string) (tmux.Window, bool) {
 	if r.Tmux == nil {
 		return tmux.Window{}, false

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -16,6 +16,7 @@ import (
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 )
@@ -106,17 +107,26 @@ func (r *queryResolver) Health(ctx context.Context) (*graphql1.Health, error) {
 
 // Host is the resolver for the host field.
 func (r *queryResolver) Host(ctx context.Context) (*graphql1.Host, error) {
+	var h *graphql1.Host
 	if r.HostProvider != nil {
-		h, _, err := r.HostProvider.Get(ctx, r.HostProvider.LocalID())
+		got, _, err := r.HostProvider.Get(ctx, r.HostProvider.LocalID())
 		if err != nil {
 			return nil, fmt.Errorf("host: %w", err)
 		}
-		return h, nil
+		h = got
+	} else if r.PS != nil {
+		h = &graphql1.Host{ID: r.PS.HostID()}
+	} else if r.HostServiceProvider != nil {
+		hostID := r.HostServiceProvider.HostID()
+		h = &graphql1.Host{ID: "Host:" + hostID, MachineID: hostID}
+	} else {
+		return nil, fmt.Errorf("host provider not initialised")
 	}
-	if r.PS != nil {
-		return &graphql1.Host{ID: r.PS.HostID()}, nil
+	if r.HostServiceProvider != nil {
+		machineID := r.HostServiceProvider.HostID()
+		h.HostServices = buildHostServices(ctx, r.HostServiceProvider, machineID)
 	}
-	return nil, fmt.Errorf("host provider not initialised")
+	return h, nil
 }
 
 // Hosts is the resolver for the hosts field.
@@ -739,6 +749,76 @@ func (r *Resolver) Process() graphql1.ProcessResolver { return &processResolver{
 
 // Project returns graphql1.ProjectResolver implementation.
 func (r *Resolver) Project() graphql1.ProjectResolver { return &projectResolver{r} }
+
+// buildHostServices iterates the configured watchlist and lifts each
+// Snapshot into a graphql.HostService. Unknown services keep
+// state=unknown with all optional fields nil. Adapter errors
+// (ErrServiceManagerMissing, parse failures) collapse the field for
+// the affected service into state=unknown so a missing launchctl
+// doesn't blank the whole list.
+//
+// ADR-011 §6 says cross-provider composition lives in the resolver,
+// not the provider. This is the simplest case — single-provider
+// composition over its watchlist.
+func buildHostServices(ctx context.Context, p *hostservice.Provider, hostID string) []*graphql1.HostService {
+	services := p.Services()
+	out := make([]*graphql1.HostService, 0, len(services))
+	for _, name := range services {
+		key := hostservice.MakeID(hostID, name)
+		snap, _, err := p.Get(ctx, key)
+		if err != nil {
+			out = append(out, hostServiceUnknown(hostID, name))
+			_ = errors.Is(err, hostservice.ErrServiceManagerMissing) // documented
+			continue
+		}
+		out = append(out, hostServiceFromSnapshot(snap))
+	}
+	return out
+}
+
+func hostServiceUnknown(hostID, name string) *graphql1.HostService {
+	return &graphql1.HostService{
+		ID:    "HostService:" + hostID + ":" + name,
+		Host:  &graphql1.Host{ID: "Host:" + hostID, MachineID: hostID},
+		Name:  name,
+		State: graphql1.HostServiceStateUnknown,
+	}
+}
+
+func hostServiceFromSnapshot(s hostservice.Snapshot) *graphql1.HostService {
+	hs := &graphql1.HostService{
+		ID:    "HostService:" + s.HostID + ":" + s.Name,
+		Host:  &graphql1.Host{ID: "Host:" + s.HostID, MachineID: s.HostID},
+		Name:  s.Name,
+		State: mapState(s.State),
+	}
+	if s.Since != nil {
+		ts := s.Since.UTC().Format(time.RFC3339Nano)
+		hs.Since = &ts
+	}
+	if s.ExitCode != nil {
+		v := int64(*s.ExitCode)
+		hs.ExitCode = &v
+	}
+	if s.LogTail != nil {
+		tail := *s.LogTail
+		hs.LogTail = &tail
+	}
+	return hs
+}
+
+func mapState(s hostservice.State) graphql1.HostServiceState {
+	switch s {
+	case hostservice.StateActive:
+		return graphql1.HostServiceStateActive
+	case hostservice.StateInactive:
+		return graphql1.HostServiceStateInactive
+	case hostservice.StateFailed:
+		return graphql1.HostServiceStateFailed
+	default:
+		return graphql1.HostServiceStateUnknown
+	}
+}
 
 // Query returns graphql1.QueryResolver implementation.
 func (r *Resolver) Query() graphql1.QueryResolver { return &queryResolver{r} }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,5 +1,4 @@
-// Package server hosts the orchard daemon's HTTP surface: the GraphQL
-// endpoint and the /health probe.
+// Package server hosts the orchard daemon's HTTP surface.
 //
 // Workstream A: stub Health resolver, /health, graceful shutdown.
 // Workstream B-host: host Provider constructed and started in Run.
@@ -9,6 +8,7 @@
 // Workstream B-tmux: WithTmux + tmux watcher.
 // Workstream B-claudeprojects: WithClaudeProjects starts on Run().
 // Workstream B-claudeaccount: WithClaudeAccount starts on Run().
+// Workstream B-hostservice: WithHostService starts on Run().
 package server
 
 import (
@@ -30,6 +30,7 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
@@ -53,6 +54,7 @@ type Server struct {
 	tmuxProv       *tmux.Provider
 	claudeProjects *claudeprojects.Provider
 	claudeAccount  *claudeaccount.Provider
+	hostService    *hostservice.Provider
 }
 
 // Option mutates a Server during construction.
@@ -68,7 +70,7 @@ func WithGit(g *gitprovider.Provider) Option {
 	return func(_ *Server, r *resolvers.Resolver) { r.WithGit(g) }
 }
 
-// WithPS attaches a ps provider; Run() calls Start().
+// WithPS attaches a ps provider.
 func WithPS(p *ps.Provider) Option {
 	return func(s *Server, r *resolvers.Resolver) {
 		s.psProv = p
@@ -76,7 +78,7 @@ func WithPS(p *ps.Provider) Option {
 	}
 }
 
-// WithTmux attaches a tmux provider; Run() calls Start()+StartWatcher.
+// WithTmux attaches a tmux provider.
 func WithTmux(p *tmux.Provider) Option {
 	return func(s *Server, r *resolvers.Resolver) {
 		s.tmuxProv = p
@@ -84,7 +86,7 @@ func WithTmux(p *tmux.Provider) Option {
 	}
 }
 
-// WithClaudeProjects attaches a claudeprojects provider; Run() calls Start().
+// WithClaudeProjects attaches a claudeprojects provider.
 func WithClaudeProjects(p *claudeprojects.Provider) Option {
 	return func(s *Server, r *resolvers.Resolver) {
 		s.claudeProjects = p
@@ -92,11 +94,19 @@ func WithClaudeProjects(p *claudeprojects.Provider) Option {
 	}
 }
 
-// WithClaudeAccount attaches a claudeaccount provider; Run() calls Start().
+// WithClaudeAccount attaches a claudeaccount provider.
 func WithClaudeAccount(p *claudeaccount.Provider) Option {
 	return func(s *Server, r *resolvers.Resolver) {
 		s.claudeAccount = p
 		r.WithClaudeAccount(p)
+	}
+}
+
+// WithHostService attaches a hostservice provider.
+func WithHostService(p *hostservice.Provider) Option {
+	return func(s *Server, r *resolvers.Resolver) {
+		s.hostService = p
+		r.WithHostService(p)
 	}
 }
 
@@ -177,6 +187,11 @@ func (s *Server) Run(ctx context.Context) error {
 	if s.claudeAccount != nil {
 		if err := s.claudeAccount.Start(ctx); err != nil {
 			return fmt.Errorf("start claudeaccount provider: %w", err)
+		}
+	}
+	if s.hostService != nil {
+		if err := s.hostService.Start(ctx); err != nil {
+			return fmt.Errorf("start hostservice provider: %w", err)
 		}
 	}
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -166,6 +166,9 @@ type Host implements Node {
 
   "Processes visible to this host's `ps` adapter, optionally filtered."
   processes(filter: ProcessFilter): [Process!]!
+
+  "Curated launchd / systemd watchlist for this host, drawn from `services` in ~/.config/orchard/config.json."
+  hostServices: [HostService!]!
 }
 
 """
@@ -534,4 +537,51 @@ type ClaudeAccount implements Node {
 
   "Claude processes currently running under this account. v1 returns []; populated by Workstream B-claudeinstance."
   instances: [ClaudeInstance!]!
+}
+
+"""
+A curated launchd (macOS) or systemd-user (Linux) unit on a host.
+
+Per ADR-011 §5.1 the watchlist is config-driven — `services` in
+`~/.config/orchard/config.json`. Defaults to
+`["claude-remote", "orchard", "chezmoi"]` if the key is absent.
+Watched services that don't exist on the host surface as
+`state: unknown` rather than failing the resolver.
+"""
+type HostService implements Node {
+  "Stable orchard id — \"HostService:<host_machineId>:<name>\"."
+  id: ID!
+
+  "The host this service belongs to."
+  host: Host!
+
+  "Service name as written in config (e.g. \"claude-remote\")."
+  name: String!
+
+  "Lifecycle state of the service on the host."
+  state: HostServiceState!
+
+  "RFC 3339 timestamp the service entered its current state."
+  since: String
+
+  "Most recent exit code of the service's last completed run."
+  exitCode: Int
+
+  "Last 20 log lines from the service."
+  logTail: String
+}
+
+"""
+Lifecycle state of a HostService.
+
+  - `active`   — running and healthy.
+  - `inactive` — stopped cleanly; not currently running.
+  - `failed`   — exited with non-zero status or crashed.
+  - `unknown`  — watched in config but not present on this host.
+"""
+enum HostServiceState {
+  active
+  inactive
+  failed
+  unknown
 }


### PR DESCRIPTION
## Summary

Implements the **hostservice provider** per ADR-011 §5.1, surfacing the
`HostService` node — a curated launchd (macOS) / systemd-user (Linux)
watchlist on the local Host. OS-conditional adapter shellouts via
`//go:build darwin` / `//go:build linux`; no runtime `runtime.GOOS`
branching.

The watchlist is config-driven: `services: [string]` in
`~/.config/orchard/config.json`. Defaults to
`["claude-remote", "orchard", "chezmoi"]` when the key is absent. Watched
units that don't exist on the host surface as `state: unknown` rather
than failing the resolver — peers still resolve normally.

## ACs

- ✓ **schema.graphql additions** — `HostService implements Node`, enum
  `HostServiceState { active inactive failed unknown }`, `Host.hostServices`
  edge. The minimal Host stub merges cleanly with ws-b-host's full body
  at rebase time. Commit `e5f3c47`.
- ✓ **Watchlist driven by config** — `services []string` read narrowly
  from `~/.config/orchard/config.json`; tolerates ws-b-config's
  `version` + `projects` fields via narrow JSON view (no struct
  collision). Defaults applied when key missing / empty / blank-only.
  Commit `f7904ef`.
- ✓ **`make generate` re-runs cleanly** — confirmed; generated files
  committed alongside schema. Commit `e5f3c47`.
- ✓ **Provider at `internal/server/providers/hostservice/`** — adapter.go
  + adapter_darwin.go (`launchctl list <Label>` parser) +
  adapter_linux.go (`systemctl --user is-active|show` +
  `journalctl --user -u`) + provider.go (5s TTL cache, sync refresh on
  Get-past-TTL, poll loop, Subscribe channel) + types.go (Adapter
  interface, ErrServiceManagerMissing sentinel). Commit `f7904ef`.
- ✓ **Missing OS service-manager → typed not-installed error** —
  `ErrServiceManagerMissing`; resolver maps to per-field `state: unknown`
  rather than collapsing the whole resolver. Covered by
  `TestHostService_E2E_ServiceManagerMissing`. Commit `f7904ef`/`8f8e565`.
- ✓ **Watched service doesn't exist → state=unknown, optional fields nil**
  — Covered by `TestHostService_E2E_FullStack` (unknown case) and
  per-OS adapter tests. Commit `8f8e565`.
- ✓ **Resolvers wired in `internal/server/resolvers/`** —
  `Resolver.HostServiceProvider` field; `queryResolver.Host` composes
  the watchlist into `Host.hostServices`. Commit `1159151`.
- ✓ **CLI: `orchard query host-services`** — cobra subcommand mirroring
  `internal/cli/query/host.go` (ws-b-host pattern). Commit `f4fbd7f`.
- ✓ **E2E test with stubbed PATH** — fake `launchctl` / `systemctl` /
  `journalctl` scripts emit canned outputs covering all 4 states; full
  GraphQL stack drives the assertions through real shellouts. macOS-only
  parser test file via `//go:build darwin`; Linux-only parser test via
  `//go:build linux`. Commit `8f8e565`.
- ✓ **`go test ./internal/server/providers/hostservice/...` green on macOS**
  — confirmed locally (Darwin 25.4.0 / Go 1.23.2).
- ✓ **`golangci-lint run` clean for scope** — default lint config clean
  for `./internal/server/providers/hostservice/...`,
  `./internal/server/resolvers/...`, `./internal/cli/query/...`,
  `./internal/cli/daemon/...`, `./internal/server/adapter/...`.
- ✓ **Draft PR opened** off `ws-a-scaffold` — this PR.

## Notes for reviewers

- **PR base is `ws-a-scaffold`, not `ws-b-host`.** Per the worker brief.
  Expected merge order: ws-b-host lands first → my Host stub conflicts
  with their full Host (resolve: keep their body, add my hostServices
  field) → my LocalHostID readers become redundant (delete identity_*.go
  and switch daemon to `host.Provider.LocalID()`). The shared
  `internal/server/adapter/adapter.go` is byte-identical to ws-b-host's
  copy; that conflict resolves trivially.
- **Coexists with ws-b-config's `File` struct** via the narrow
  `configFile { services []string }` view in `config.go` — `json.Unmarshal`'s
  default behaviour ignores `version` / `projects` keys.
- **No PII** — every fixture (test scripts, GraphQL E2E names) uses
  generic `com.example.test.*` (macOS) / `example-test-*` (Linux). No
  real bundle ids, no real systemd unit names, no real journal output.
- **No reflection, no `runtime.GOOS == ...` branching** in adapter
  code. Each OS pulls only its own parser into the binary.
- **Daemon boots even when hostservice initialisation fails** — the
  resolver surfaces per-field GraphQL errors, but `health` and other
  resolvers keep serving.
- **macOS limitations encoded as nil** — launchd doesn't surface a
  per-unit start time or log tail in the `launchctl list` shape, so
  `since` and `logTail` stay nil for all macOS results. Linux populates
  both when `journalctl` access is permitted.

## Test plan

- [x] `go test ./...` overall green.
- [x] `go test ./internal/server/providers/hostservice/... -v` green.
- [x] `gofmt -l .` clean.
- [x] `go vet ./...` clean.
- [x] `golangci-lint run` clean for scope.
- [x] `make daemon` builds → `bin/orchard`.
- [x] `bin/orchard --help` shows the existing subcommand groups; `query`
  group now lists `host-services`.
- [x] End-to-end smoke: `orchard daemon start` + `curl
  -X POST .../graphql` returns the four-state HostService array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added host services monitoring with a new `orchard query host-services` CLI command to display configured services on the local machine
  * Services now expose state (active, inactive, failed, unknown), last-changed timestamp, exit codes, and log tail (Linux only)
  * Service watchlist can be customized via configuration file
<!-- end of auto-generated comment: release notes by coderabbit.ai -->