### PR TITLE
Workstream B-contracts: contracts provider → Contract node

### DIFF
--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -35,6 +35,7 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/contracts"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
@@ -136,6 +137,7 @@ func runStart(parentCtx context.Context, addr string) error {
 		server.WithTmux(tmuxProvider),
 		server.WithClaudeProjects(claudeProjectsProvider),
 		server.WithClaudeAccount(claudeaccount.New("local", logger)),
+		server.WithContracts(contracts.New(logger)),
 	}
 	if hsvc != nil {
 		opts = append(opts, server.WithHostService(hsvc))

--- a/internal/cli/query/contracts.go
+++ b/internal/cli/query/contracts.go
@@ -1,0 +1,149 @@
+package query
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// contractsBaseQuery is the canonical projection of every Contract
+// node — every scalar plus the questions sub-list. Mirrors host.go's
+// "one canonical query const" pattern so a regression in the resolver
+// surfaces immediately in `orchard query contracts`.
+const contractsBaseQuery = `query Contracts($filter: ContractFilter) {
+  contracts(filter: $filter) {
+    id
+    contractId
+    statement
+    ownerSessionId
+    ownerAgentName
+    reportsTo
+    parentContractId
+    status
+    createdAt
+    updatedAt
+    lastEventAt
+    criteria
+    openQuestions {
+      questionId
+      text
+      askedBy
+      askedAt
+      deadline
+      blocksClose
+    }
+  }
+}`
+
+// validStatuses lists the schema-recognised filter statuses, so we can
+// reject typos client-side without making a round-trip to the daemon.
+var validStatuses = map[string]string{
+	"open":                                "OPEN",
+	"delivered_pending_validation":        "DELIVERED_PENDING_VALIDATION",
+	"delivered_pending_parent_validation": "DELIVERED_PENDING_PARENT_VALIDATION",
+	"pending_drew_approval":               "PENDING_DREW_APPROVAL",
+	"awaiting_cancel_ack":                 "AWAITING_CANCEL_ACK",
+	"waiting_external":                    "WAITING_EXTERNAL",
+	"satisfied":                           "SATISFIED",
+	"cancelled":                           "CANCELLED",
+	"judge_rejected_terminal":             "JUDGE_REJECTED_TERMINAL",
+}
+
+// contractsCmd returns the `orchard query contracts` subcommand.
+//
+// Issues contractsBaseQuery against the running daemon and prints the
+// JSON response. The optional --status flag tightens the server-side
+// filter; multiple statuses are comma-separated. The hidden --addr
+// flag lets e2e tests target an ephemeral daemon.
+func contractsCmd() *cobra.Command {
+	var statusFlag string
+	var ownerSession string
+	var ownerAgent string
+	var parentID string
+
+	c := &cobra.Command{
+		Use:   "contracts",
+		Short: "List Contract nodes the daemon is tracking, with optional filters.",
+		Long: "Query the contracts provider for every contract folded from the\n" +
+			"claude-contracts JSONL log. Sorted descending by lastEventAt.",
+		Example: "  orchard query contracts\n" +
+			"  orchard query contracts --status open",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			filter, err := buildFilterPayload(statusFlag, ownerSession, ownerAgent, parentID)
+			if err != nil {
+				return err
+			}
+			query := buildQueryWithVars(contractsBaseQuery, filter)
+			return runRaw(cmd.Context(), cmd.OutOrStdout(), query)
+		},
+	}
+	c.Flags().StringVar(&statusFlag, "status", "", "filter by status (comma-separated)")
+	c.Flags().StringVar(&ownerSession, "owner-session", "", "filter by owner session id")
+	c.Flags().StringVar(&ownerAgent, "owner-agent", "", "filter by owner agent name")
+	c.Flags().StringVar(&parentID, "parent", "", "filter by parent contract id")
+	return c
+}
+
+// buildFilterPayload converts user-provided flag values into the
+// ContractFilter literal embedded in the GraphQL query body. Empty
+// flags collapse to nil so the server applies no filter.
+func buildFilterPayload(statusFlag, ownerSession, ownerAgent, parentID string) (string, error) {
+	parts := []string{}
+	if statusFlag != "" {
+		statuses, err := parseStatuses(statusFlag)
+		if err != nil {
+			return "", err
+		}
+		parts = append(parts, "statuses: ["+strings.Join(statuses, ", ")+"]")
+	}
+	if ownerSession != "" {
+		parts = append(parts, fmt.Sprintf("ownerSessionId: %q", ownerSession))
+	}
+	if ownerAgent != "" {
+		parts = append(parts, fmt.Sprintf("ownerAgentName: %q", ownerAgent))
+	}
+	if parentID != "" {
+		parts = append(parts, fmt.Sprintf("parentContractId: %q", parentID))
+	}
+	if len(parts) == 0 {
+		return "null", nil
+	}
+	return "{" + strings.Join(parts, ", ") + "}", nil
+}
+
+// parseStatuses turns "open,pending_drew_approval" into the SCREAMING
+// enum constants the schema expects. Unknown statuses produce a fast
+// client-side error so the user never has to hit the daemon to find
+// out about a typo.
+func parseStatuses(raw string) ([]string, error) {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		key := strings.ToLower(strings.TrimSpace(p))
+		if key == "" {
+			continue
+		}
+		val, ok := validStatuses[key]
+		if !ok {
+			return nil, fmt.Errorf("unknown status %q (try `orchard query contracts --help`)", p)
+		}
+		out = append(out, val)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--status was empty")
+	}
+	return out, nil
+}
+
+// buildQueryWithVars splices the filter literal into the parameterised
+// query body. We take this lightweight path instead of GraphQL
+// variables to keep the CLI's JSON envelope identical to runRaw — one
+// transport, one decode path.
+func buildQueryWithVars(base, filter string) string {
+	// Replace `($filter: ContractFilter)` and `filter: $filter` with
+	// the inlined literal. The replacements are exact substrings so we
+	// don't need a real parser.
+	q := strings.Replace(base, "($filter: ContractFilter)", "", 1)
+	return strings.Replace(q, "filter: $filter", "filter: "+filter, 1)
+}

--- a/internal/cli/query/query.go
+++ b/internal/cli/query/query.go
@@ -77,6 +77,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(conversationsCmd())
 	cmd.AddCommand(claudeAccountCmd())
 	cmd.AddCommand(hostServicesCmd())
+	cmd.AddCommand(contractsCmd())
 	return cmd
 }
 

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -69,6 +69,31 @@ type ComplexityRoot struct {
 		ID func(childComplexity int) int
 	}
 
+	Contract struct {
+		ContractID       func(childComplexity int) int
+		CreatedAt        func(childComplexity int) int
+		Criteria         func(childComplexity int) int
+		ID               func(childComplexity int) int
+		LastEventAt      func(childComplexity int) int
+		OpenQuestions    func(childComplexity int) int
+		OwnerAgentName   func(childComplexity int) int
+		OwnerSessionID   func(childComplexity int) int
+		ParentContractID func(childComplexity int) int
+		ReportsTo        func(childComplexity int) int
+		Statement        func(childComplexity int) int
+		Status           func(childComplexity int) int
+		UpdatedAt        func(childComplexity int) int
+	}
+
+	ContractQuestion struct {
+		AskedAt     func(childComplexity int) int
+		AskedBy     func(childComplexity int) int
+		BlocksClose func(childComplexity int) int
+		Deadline    func(childComplexity int) int
+		QuestionID  func(childComplexity int) int
+		Text        func(childComplexity int) int
+	}
+
 	Conversation struct {
 		Cwd          func(childComplexity int) int
 		FirstSeenAt  func(childComplexity int) int
@@ -135,6 +160,8 @@ type ComplexityRoot struct {
 
 	Query struct {
 		ClaudeAccounts func(childComplexity int) int
+		Contract       func(childComplexity int, id string) int
+		Contracts      func(childComplexity int, filter *ContractFilter) int
 		Conversation   func(childComplexity int, id string) int
 		Conversations  func(childComplexity int) int
 		Health         func(childComplexity int) int
@@ -255,6 +282,8 @@ type QueryResolver interface {
 	Conversations(ctx context.Context) ([]*Conversation, error)
 	Conversation(ctx context.Context, id string) (*Conversation, error)
 	ClaudeAccounts(ctx context.Context) ([]*ClaudeAccount, error)
+	Contract(ctx context.Context, id string) (*Contract, error)
+	Contracts(ctx context.Context, filter *ContractFilter) ([]*Contract, error)
 }
 type TmuxClientResolver interface {
 	Server(ctx context.Context, obj *TmuxClient) (*TmuxServer, error)
@@ -394,6 +423,139 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ClaudeInstance.ID(childComplexity), true
+
+	case "Contract.contractId":
+		if e.complexity.Contract.ContractID == nil {
+			break
+		}
+
+		return e.complexity.Contract.ContractID(childComplexity), true
+
+	case "Contract.createdAt":
+		if e.complexity.Contract.CreatedAt == nil {
+			break
+		}
+
+		return e.complexity.Contract.CreatedAt(childComplexity), true
+
+	case "Contract.criteria":
+		if e.complexity.Contract.Criteria == nil {
+			break
+		}
+
+		return e.complexity.Contract.Criteria(childComplexity), true
+
+	case "Contract.id":
+		if e.complexity.Contract.ID == nil {
+			break
+		}
+
+		return e.complexity.Contract.ID(childComplexity), true
+
+	case "Contract.lastEventAt":
+		if e.complexity.Contract.LastEventAt == nil {
+			break
+		}
+
+		return e.complexity.Contract.LastEventAt(childComplexity), true
+
+	case "Contract.openQuestions":
+		if e.complexity.Contract.OpenQuestions == nil {
+			break
+		}
+
+		return e.complexity.Contract.OpenQuestions(childComplexity), true
+
+	case "Contract.ownerAgentName":
+		if e.complexity.Contract.OwnerAgentName == nil {
+			break
+		}
+
+		return e.complexity.Contract.OwnerAgentName(childComplexity), true
+
+	case "Contract.ownerSessionId":
+		if e.complexity.Contract.OwnerSessionID == nil {
+			break
+		}
+
+		return e.complexity.Contract.OwnerSessionID(childComplexity), true
+
+	case "Contract.parentContractId":
+		if e.complexity.Contract.ParentContractID == nil {
+			break
+		}
+
+		return e.complexity.Contract.ParentContractID(childComplexity), true
+
+	case "Contract.reportsTo":
+		if e.complexity.Contract.ReportsTo == nil {
+			break
+		}
+
+		return e.complexity.Contract.ReportsTo(childComplexity), true
+
+	case "Contract.statement":
+		if e.complexity.Contract.Statement == nil {
+			break
+		}
+
+		return e.complexity.Contract.Statement(childComplexity), true
+
+	case "Contract.status":
+		if e.complexity.Contract.Status == nil {
+			break
+		}
+
+		return e.complexity.Contract.Status(childComplexity), true
+
+	case "Contract.updatedAt":
+		if e.complexity.Contract.UpdatedAt == nil {
+			break
+		}
+
+		return e.complexity.Contract.UpdatedAt(childComplexity), true
+
+	case "ContractQuestion.askedAt":
+		if e.complexity.ContractQuestion.AskedAt == nil {
+			break
+		}
+
+		return e.complexity.ContractQuestion.AskedAt(childComplexity), true
+
+	case "ContractQuestion.askedBy":
+		if e.complexity.ContractQuestion.AskedBy == nil {
+			break
+		}
+
+		return e.complexity.ContractQuestion.AskedBy(childComplexity), true
+
+	case "ContractQuestion.blocksClose":
+		if e.complexity.ContractQuestion.BlocksClose == nil {
+			break
+		}
+
+		return e.complexity.ContractQuestion.BlocksClose(childComplexity), true
+
+	case "ContractQuestion.deadline":
+		if e.complexity.ContractQuestion.Deadline == nil {
+			break
+		}
+
+		return e.complexity.ContractQuestion.Deadline(childComplexity), true
+
+	case "ContractQuestion.questionId":
+		if e.complexity.ContractQuestion.QuestionID == nil {
+			break
+		}
+
+		return e.complexity.ContractQuestion.QuestionID(childComplexity), true
+
+	case "ContractQuestion.text":
+		if e.complexity.ContractQuestion.Text == nil {
+			break
+		}
+
+		return e.complexity.ContractQuestion.Text(childComplexity), true
 
 	case "Conversation.cwd":
 		if e.complexity.Conversation.Cwd == nil {
@@ -728,6 +890,30 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.ClaudeAccounts(childComplexity), true
+
+	case "Query.contract":
+		if e.complexity.Query.Contract == nil {
+			break
+		}
+
+		args, err := ec.field_Query_contract_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Contract(childComplexity, args["id"].(string)), true
+
+	case "Query.contracts":
+		if e.complexity.Query.Contracts == nil {
+			break
+		}
+
+		args, err := ec.field_Query_contracts_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Contracts(childComplexity, args["filter"].(*ContractFilter)), true
 
 	case "Query.conversation":
 		if e.complexity.Query.Conversation == nil {
@@ -1257,6 +1443,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	rc := graphql.GetOperationContext(ctx)
 	ec := executionContext{rc, e, 0, 0, make(chan graphql.DeferredResult)}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
+		ec.unmarshalInputContractFilter,
 		ec.unmarshalInputProcessFilter,
 		ec.unmarshalInputTmuxPaneFilter,
 		ec.unmarshalInputTmuxSessionFilter,
@@ -1462,6 +1649,12 @@ type Query {
 
   "All Claude CLI accounts surfaced by the local daemon. v1 returns the single account ` + "`" + `claude auth status` + "`" + ` reports for; later workstreams may surface additional accounts."
   claudeAccounts: [ClaudeAccount!]!
+
+  "A single Contract by id. Returns null if the id is unknown."
+  contract(id: ID!): Contract
+
+  "Every Contract the daemon currently knows about, optionally filtered."
+  contracts(filter: ContractFilter): [Contract!]!
 }
 
 type Health {
@@ -1929,6 +2122,98 @@ enum HostServiceState {
   failed
   unknown
 }
+
+"""
+A commitment an agent has made to deliver something. Contracts are
+authored exclusively by the claude-contracts plugin; orchard reads
+them via the contracts provider and never writes.
+"""
+type Contract implements Node {
+  "Stable orchard id — \"Contract:<contract_id>\"."
+  id: ID!
+
+  "The contract id as written by the plugin."
+  contractId: ID!
+
+  "What the owner committed to deliver."
+  statement: String!
+
+  "Owner session id (Claude session UUID) recorded at creation time."
+  ownerSessionId: String!
+
+  "Owner agent name."
+  ownerAgentName: String!
+
+  "Routing target for status updates and question answers."
+  reportsTo: String
+
+  "Parent contract id when filed under a management contract."
+  parentContractId: ID
+
+  "Folded current status."
+  status: ContractStatus!
+
+  "RFC 3339 timestamp the contract was first created."
+  createdAt: String!
+
+  "RFC 3339 timestamp the contract was last touched."
+  updatedAt: String!
+
+  "Acceptance criteria added via ` + "`" + `criterion_added` + "`" + ` events, in original order."
+  criteria: [String!]!
+
+  "Questions awaiting an answer. Empty when nothing is pending."
+  openQuestions: [ContractQuestion!]!
+
+  "RFC 3339 timestamp of the most recent event affecting this contract."
+  lastEventAt: String!
+}
+
+"""
+Lifecycle states for Contract.
+"""
+enum ContractStatus {
+  OPEN
+  DELIVERED_PENDING_VALIDATION
+  DELIVERED_PENDING_PARENT_VALIDATION
+  PENDING_DREW_APPROVAL
+  AWAITING_CANCEL_ACK
+  WAITING_EXTERNAL
+  SATISFIED
+  CANCELLED
+  JUDGE_REJECTED_TERMINAL
+}
+
+"A blocking question recorded against a Contract."
+type ContractQuestion {
+  "Question id as written by the plugin."
+  questionId: ID!
+
+  "The question text."
+  text: String!
+
+  "Agent that asked the question."
+  askedBy: String!
+
+  "RFC 3339 timestamp the question was asked."
+  askedAt: String!
+
+  "RFC 3339 deadline after which the question times out."
+  deadline: String
+
+  "Whether this question blocks contract close while open."
+  blocksClose: Boolean!
+}
+
+"""
+Filter for ` + "`" + `Query.contracts` + "`" + `. All fields are optional.
+"""
+input ContractFilter {
+  statuses: [ContractStatus!]
+  ownerSessionId: String
+  ownerAgentName: String
+  parentContractId: ID
+}
 `, BuiltIn: false},
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)
@@ -1964,6 +2249,36 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 		}
 	}
 	args["name"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_contract_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["id"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
+		arg0, err = ec.unmarshalNID2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_contracts_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *ContractFilter
+	if tmp, ok := rawArgs["filter"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+		arg0, err = ec.unmarshalOContractFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractFilter(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["filter"] = arg0
 	return args, nil
 }
 
@@ -2534,6 +2849,847 @@ func (ec *executionContext) fieldContext_ClaudeInstance_id(ctx context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_id(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_contractId(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_contractId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ContractID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_contractId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_statement(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_statement(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Statement, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_statement(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_ownerSessionId(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_ownerSessionId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OwnerSessionID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_ownerSessionId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_ownerAgentName(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_ownerAgentName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OwnerAgentName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_ownerAgentName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_reportsTo(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_reportsTo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ReportsTo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_reportsTo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_parentContractId(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_parentContractId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ParentContractID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOID2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_parentContractId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_status(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_status(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Status, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(ContractStatus)
+	fc.Result = res
+	return ec.marshalNContractStatus2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_status(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ContractStatus does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_createdAt(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_createdAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CreatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_createdAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_updatedAt(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_updatedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.UpdatedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_updatedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_criteria(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_criteria(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Criteria, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_criteria(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_openQuestions(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_openQuestions(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OpenQuestions, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*ContractQuestion)
+	fc.Result = res
+	return ec.marshalNContractQuestion2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractQuestionᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_openQuestions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "questionId":
+				return ec.fieldContext_ContractQuestion_questionId(ctx, field)
+			case "text":
+				return ec.fieldContext_ContractQuestion_text(ctx, field)
+			case "askedBy":
+				return ec.fieldContext_ContractQuestion_askedBy(ctx, field)
+			case "askedAt":
+				return ec.fieldContext_ContractQuestion_askedAt(ctx, field)
+			case "deadline":
+				return ec.fieldContext_ContractQuestion_deadline(ctx, field)
+			case "blocksClose":
+				return ec.fieldContext_ContractQuestion_blocksClose(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ContractQuestion", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Contract_lastEventAt(ctx context.Context, field graphql.CollectedField, obj *Contract) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Contract_lastEventAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastEventAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Contract_lastEventAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Contract",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContractQuestion_questionId(ctx context.Context, field graphql.CollectedField, obj *ContractQuestion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContractQuestion_questionId(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.QuestionID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContractQuestion_questionId(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContractQuestion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContractQuestion_text(ctx context.Context, field graphql.CollectedField, obj *ContractQuestion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContractQuestion_text(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Text, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContractQuestion_text(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContractQuestion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContractQuestion_askedBy(ctx context.Context, field graphql.CollectedField, obj *ContractQuestion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContractQuestion_askedBy(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AskedBy, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContractQuestion_askedBy(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContractQuestion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContractQuestion_askedAt(ctx context.Context, field graphql.CollectedField, obj *ContractQuestion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContractQuestion_askedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AskedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContractQuestion_askedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContractQuestion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContractQuestion_deadline(ctx context.Context, field graphql.CollectedField, obj *ContractQuestion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContractQuestion_deadline(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Deadline, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContractQuestion_deadline(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContractQuestion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ContractQuestion_blocksClose(ctx context.Context, field graphql.CollectedField, obj *ContractQuestion) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ContractQuestion_blocksClose(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.BlocksClose, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ContractQuestion_blocksClose(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ContractQuestion",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -5350,6 +6506,169 @@ func (ec *executionContext) fieldContext_Query_claudeAccounts(ctx context.Contex
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ClaudeAccount", field.Name)
 		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_contract(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_contract(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Contract(rctx, fc.Args["id"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*Contract)
+	fc.Result = res
+	return ec.marshalOContract2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContract(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_contract(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Contract_id(ctx, field)
+			case "contractId":
+				return ec.fieldContext_Contract_contractId(ctx, field)
+			case "statement":
+				return ec.fieldContext_Contract_statement(ctx, field)
+			case "ownerSessionId":
+				return ec.fieldContext_Contract_ownerSessionId(ctx, field)
+			case "ownerAgentName":
+				return ec.fieldContext_Contract_ownerAgentName(ctx, field)
+			case "reportsTo":
+				return ec.fieldContext_Contract_reportsTo(ctx, field)
+			case "parentContractId":
+				return ec.fieldContext_Contract_parentContractId(ctx, field)
+			case "status":
+				return ec.fieldContext_Contract_status(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Contract_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Contract_updatedAt(ctx, field)
+			case "criteria":
+				return ec.fieldContext_Contract_criteria(ctx, field)
+			case "openQuestions":
+				return ec.fieldContext_Contract_openQuestions(ctx, field)
+			case "lastEventAt":
+				return ec.fieldContext_Contract_lastEventAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Contract", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_contract_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_contracts(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_contracts(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Contracts(rctx, fc.Args["filter"].(*ContractFilter))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*Contract)
+	fc.Result = res
+	return ec.marshalNContract2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_contracts(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Contract_id(ctx, field)
+			case "contractId":
+				return ec.fieldContext_Contract_contractId(ctx, field)
+			case "statement":
+				return ec.fieldContext_Contract_statement(ctx, field)
+			case "ownerSessionId":
+				return ec.fieldContext_Contract_ownerSessionId(ctx, field)
+			case "ownerAgentName":
+				return ec.fieldContext_Contract_ownerAgentName(ctx, field)
+			case "reportsTo":
+				return ec.fieldContext_Contract_reportsTo(ctx, field)
+			case "parentContractId":
+				return ec.fieldContext_Contract_parentContractId(ctx, field)
+			case "status":
+				return ec.fieldContext_Contract_status(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Contract_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Contract_updatedAt(ctx, field)
+			case "criteria":
+				return ec.fieldContext_Contract_criteria(ctx, field)
+			case "openQuestions":
+				return ec.fieldContext_Contract_openQuestions(ctx, field)
+			case "lastEventAt":
+				return ec.fieldContext_Contract_lastEventAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Contract", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_contracts_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -10329,6 +11648,54 @@ func (ec *executionContext) fieldContext___Type_specifiedByURL(ctx context.Conte
 
 // region    **************************** input.gotpl *****************************
 
+func (ec *executionContext) unmarshalInputContractFilter(ctx context.Context, obj interface{}) (ContractFilter, error) {
+	var it ContractFilter
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"statuses", "ownerSessionId", "ownerAgentName", "parentContractId"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "statuses":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("statuses"))
+			data, err := ec.unmarshalOContractStatus2ᚕgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractStatusᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Statuses = data
+		case "ownerSessionId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerSessionId"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OwnerSessionID = data
+		case "ownerAgentName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ownerAgentName"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.OwnerAgentName = data
+		case "parentContractId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("parentContractId"))
+			data, err := ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ParentContractID = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputProcessFilter(ctx context.Context, obj interface{}) (ProcessFilter, error) {
 	var it ProcessFilter
 	asMap := map[string]interface{}{}
@@ -10558,6 +11925,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._HostService(ctx, sel, obj)
+	case Contract:
+		return ec._Contract(ctx, sel, &obj)
+	case *Contract:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._Contract(ctx, sel, obj)
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
@@ -10645,6 +12019,160 @@ func (ec *executionContext) _ClaudeInstance(ctx context.Context, sel ast.Selecti
 			out.Values[i] = graphql.MarshalString("ClaudeInstance")
 		case "id":
 			out.Values[i] = ec._ClaudeInstance_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var contractImplementors = []string{"Contract", "Node"}
+
+func (ec *executionContext) _Contract(ctx context.Context, sel ast.SelectionSet, obj *Contract) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, contractImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Contract")
+		case "id":
+			out.Values[i] = ec._Contract_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "contractId":
+			out.Values[i] = ec._Contract_contractId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "statement":
+			out.Values[i] = ec._Contract_statement(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ownerSessionId":
+			out.Values[i] = ec._Contract_ownerSessionId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "ownerAgentName":
+			out.Values[i] = ec._Contract_ownerAgentName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "reportsTo":
+			out.Values[i] = ec._Contract_reportsTo(ctx, field, obj)
+		case "parentContractId":
+			out.Values[i] = ec._Contract_parentContractId(ctx, field, obj)
+		case "status":
+			out.Values[i] = ec._Contract_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "createdAt":
+			out.Values[i] = ec._Contract_createdAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updatedAt":
+			out.Values[i] = ec._Contract_updatedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "criteria":
+			out.Values[i] = ec._Contract_criteria(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "openQuestions":
+			out.Values[i] = ec._Contract_openQuestions(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "lastEventAt":
+			out.Values[i] = ec._Contract_lastEventAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var contractQuestionImplementors = []string{"ContractQuestion"}
+
+func (ec *executionContext) _ContractQuestion(ctx context.Context, sel ast.SelectionSet, obj *ContractQuestion) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, contractQuestionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ContractQuestion")
+		case "questionId":
+			out.Values[i] = ec._ContractQuestion_questionId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "text":
+			out.Values[i] = ec._ContractQuestion_text(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "askedBy":
+			out.Values[i] = ec._ContractQuestion_askedBy(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "askedAt":
+			out.Values[i] = ec._ContractQuestion_askedAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deadline":
+			out.Values[i] = ec._ContractQuestion_deadline(ctx, field, obj)
+		case "blocksClose":
+			out.Values[i] = ec._ContractQuestion_blocksClose(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -11498,6 +13026,47 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_claudeAccounts(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "contract":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_contract(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "contracts":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_contracts(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -13774,6 +15343,124 @@ func (ec *executionContext) marshalNClaudeInstance2ᚖgithubᚗcomᚋdrewdrewthi
 	return ec._ClaudeInstance(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNContract2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractᚄ(ctx context.Context, sel ast.SelectionSet, v []*Contract) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNContract2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContract(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNContract2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContract(ctx context.Context, sel ast.SelectionSet, v *Contract) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Contract(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNContractQuestion2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractQuestionᚄ(ctx context.Context, sel ast.SelectionSet, v []*ContractQuestion) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNContractQuestion2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractQuestion(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNContractQuestion2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractQuestion(ctx context.Context, sel ast.SelectionSet, v *ContractQuestion) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ContractQuestion(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNContractStatus2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractStatus(ctx context.Context, v interface{}) (ContractStatus, error) {
+	var res ContractStatus
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNContractStatus2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractStatus(ctx context.Context, sel ast.SelectionSet, v ContractStatus) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) marshalNConversation2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐConversationᚄ(ctx context.Context, sel ast.SelectionSet, v []*Conversation) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -14130,6 +15817,38 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
+	}
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNTmuxClient2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxClientᚄ(ctx context.Context, sel ast.SelectionSet, v []*TmuxClient) graphql.Marshaler {
@@ -14710,6 +16429,88 @@ func (ec *executionContext) marshalOClaudeInstance2ᚖgithubᚗcomᚋdrewdrewthi
 	return ec._ClaudeInstance(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalOContract2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContract(ctx context.Context, sel ast.SelectionSet, v *Contract) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Contract(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOContractFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractFilter(ctx context.Context, v interface{}) (*ContractFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputContractFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOContractStatus2ᚕgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractStatusᚄ(ctx context.Context, v interface{}) ([]ContractStatus, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []interface{}
+	if v != nil {
+		vSlice = graphql.CoerceList(v)
+	}
+	var err error
+	res := make([]ContractStatus, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNContractStatus2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractStatus(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOContractStatus2ᚕgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractStatusᚄ(ctx context.Context, sel ast.SelectionSet, v []ContractStatus) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNContractStatus2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐContractStatus(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalOConversation2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐConversation(ctx context.Context, sel ast.SelectionSet, v *Conversation) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -14731,6 +16532,22 @@ func (ec *executionContext) marshalOFloat2ᚖfloat64(ctx context.Context, sel as
 	}
 	res := graphql.MarshalFloatContext(*v)
 	return graphql.WrapContextMarshaler(ctx, res)
+}
+
+func (ec *executionContext) unmarshalOID2ᚖstring(ctx context.Context, v interface{}) (*string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalID(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOID2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalID(*v)
+	return res
 }
 
 func (ec *executionContext) unmarshalOInt2ᚕint64ᚄ(ctx context.Context, v interface{}) ([]int64, error) {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -60,6 +60,67 @@ type ClaudeInstance struct {
 	ID string `json:"id"`
 }
 
+// A commitment an agent has made to deliver something. Contracts are
+// authored exclusively by the claude-contracts plugin; orchard reads
+// them via the contracts provider and never writes.
+type Contract struct {
+	// Stable orchard id — "Contract:<contract_id>".
+	ID string `json:"id"`
+	// The contract id as written by the plugin.
+	ContractID string `json:"contractId"`
+	// What the owner committed to deliver.
+	Statement string `json:"statement"`
+	// Owner session id (Claude session UUID) recorded at creation time.
+	OwnerSessionID string `json:"ownerSessionId"`
+	// Owner agent name.
+	OwnerAgentName string `json:"ownerAgentName"`
+	// Routing target for status updates and question answers.
+	ReportsTo *string `json:"reportsTo,omitempty"`
+	// Parent contract id when filed under a management contract.
+	ParentContractID *string `json:"parentContractId,omitempty"`
+	// Folded current status.
+	Status ContractStatus `json:"status"`
+	// RFC 3339 timestamp the contract was first created.
+	CreatedAt string `json:"createdAt"`
+	// RFC 3339 timestamp the contract was last touched.
+	UpdatedAt string `json:"updatedAt"`
+	// Acceptance criteria added via `criterion_added` events, in original order.
+	Criteria []string `json:"criteria"`
+	// Questions awaiting an answer. Empty when nothing is pending.
+	OpenQuestions []*ContractQuestion `json:"openQuestions"`
+	// RFC 3339 timestamp of the most recent event affecting this contract.
+	LastEventAt string `json:"lastEventAt"`
+}
+
+func (Contract) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this Contract) GetID() string { return this.ID }
+
+// Filter for `Query.contracts`. All fields are optional.
+type ContractFilter struct {
+	Statuses         []ContractStatus `json:"statuses,omitempty"`
+	OwnerSessionID   *string          `json:"ownerSessionId,omitempty"`
+	OwnerAgentName   *string          `json:"ownerAgentName,omitempty"`
+	ParentContractID *string          `json:"parentContractId,omitempty"`
+}
+
+// A blocking question recorded against a Contract.
+type ContractQuestion struct {
+	// Question id as written by the plugin.
+	QuestionID string `json:"questionId"`
+	// The question text.
+	Text string `json:"text"`
+	// Agent that asked the question.
+	AskedBy string `json:"askedBy"`
+	// RFC 3339 timestamp the question was asked.
+	AskedAt string `json:"askedAt"`
+	// RFC 3339 deadline after which the question times out.
+	Deadline *string `json:"deadline,omitempty"`
+	// Whether this question blocks contract close while open.
+	BlocksClose bool `json:"blocksClose"`
+}
+
 // A Claude Code conversation, backed by the JSONL transcript that the
 // Claude Code CLI writes under `~/.claude/projects/<project-slug>/<session-uuid>.jsonl`.
 //
@@ -444,6 +505,62 @@ func (Worktree) IsNode() {}
 
 // Globally-unique id (e.g. "Host:<machineId>").
 func (this Worktree) GetID() string { return this.ID }
+
+// Lifecycle states for Contract.
+type ContractStatus string
+
+const (
+	ContractStatusOpen                             ContractStatus = "OPEN"
+	ContractStatusDeliveredPendingValidation       ContractStatus = "DELIVERED_PENDING_VALIDATION"
+	ContractStatusDeliveredPendingParentValidation ContractStatus = "DELIVERED_PENDING_PARENT_VALIDATION"
+	ContractStatusPendingDrewApproval              ContractStatus = "PENDING_DREW_APPROVAL"
+	ContractStatusAwaitingCancelAck                ContractStatus = "AWAITING_CANCEL_ACK"
+	ContractStatusWaitingExternal                  ContractStatus = "WAITING_EXTERNAL"
+	ContractStatusSatisfied                        ContractStatus = "SATISFIED"
+	ContractStatusCancelled                        ContractStatus = "CANCELLED"
+	ContractStatusJudgeRejectedTerminal            ContractStatus = "JUDGE_REJECTED_TERMINAL"
+)
+
+var AllContractStatus = []ContractStatus{
+	ContractStatusOpen,
+	ContractStatusDeliveredPendingValidation,
+	ContractStatusDeliveredPendingParentValidation,
+	ContractStatusPendingDrewApproval,
+	ContractStatusAwaitingCancelAck,
+	ContractStatusWaitingExternal,
+	ContractStatusSatisfied,
+	ContractStatusCancelled,
+	ContractStatusJudgeRejectedTerminal,
+}
+
+func (e ContractStatus) IsValid() bool {
+	switch e {
+	case ContractStatusOpen, ContractStatusDeliveredPendingValidation, ContractStatusDeliveredPendingParentValidation, ContractStatusPendingDrewApproval, ContractStatusAwaitingCancelAck, ContractStatusWaitingExternal, ContractStatusSatisfied, ContractStatusCancelled, ContractStatusJudgeRejectedTerminal:
+		return true
+	}
+	return false
+}
+
+func (e ContractStatus) String() string {
+	return string(e)
+}
+
+func (e *ContractStatus) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ContractStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ContractStatus", str)
+	}
+	return nil
+}
+
+func (e ContractStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
 
 // Lifecycle state of a HostService.
 //

--- a/internal/server/providers/contracts/adapter.go
+++ b/internal/server/providers/contracts/adapter.go
@@ -1,0 +1,178 @@
+package contracts
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Adapter reads events from the contracts JSONL log on disk. Stateless
+// per ADR-011 §3 — any caching, fold state, or watcher bookkeeping
+// lives in the [Provider]; this struct is a thin wrapper around file
+// I/O so unit tests can fake it cleanly.
+//
+// The log path is configurable. Callers typically obtain it via
+// [DefaultLogPath]; tests pass an explicit t.TempDir()-rooted path.
+type Adapter struct {
+	path string
+
+	// followMu protects FollowFromOffset's offset state. The fold loop
+	// is the only consumer in production; the mutex defends against a
+	// future caller that fans the channel out to multiple readers.
+	followMu sync.Mutex
+}
+
+// NewAdapter constructs an Adapter rooted at the given absolute path
+// to a JSONL file. The file does not need to exist at construction time
+// — Snapshot returns an empty slice and FollowFromOffset blocks until
+// the first byte arrives.
+func NewAdapter(path string) *Adapter {
+	return &Adapter{path: path}
+}
+
+// Path returns the absolute path the adapter reads from.
+func (a *Adapter) Path() string {
+	return a.path
+}
+
+// Snapshot reads the entire JSONL log from start to end and returns
+// every event. Used for cold-boot hydration of the Provider's cache.
+//
+// Missing file → returns ([], 0, nil). The watcher takes responsibility
+// for triggering a re-read when the file is created later.
+//
+// Returns the byte offset of the end of the file along with the events.
+// Callers feed the offset back to [FollowFromOffset] to resume from
+// where Snapshot left off.
+//
+// Malformed lines (invalid JSON or events missing a kind field) are
+// logged via the returned error. The good events seen so far are still
+// returned alongside the error so callers can decide whether to keep
+// the cache or bail out.
+func (a *Adapter) Snapshot(_ context.Context) ([]Event, int64, error) {
+	f, err := os.Open(a.path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, 0, nil
+		}
+		return nil, 0, fmt.Errorf("open contracts log %q: %w", a.path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	events, offset, err := readEvents(f, 0)
+	return events, offset, err
+}
+
+// FollowFromOffset opens the JSONL file, seeks to fromOffset, and emits
+// every newline-terminated event that appears past it. Returns the
+// channel and the byte offset reached (callers persist this when the
+// channel closes so a restart resumes correctly).
+//
+// The function is one-shot — it reads the file's current tail in one
+// pass and returns. The caller (the [Watcher]) re-invokes it on each
+// fsnotify Write event so we never hold the file open across watcher
+// ticks.
+//
+// Errors mid-read are returned alongside any events successfully
+// decoded before the error. Callers that want strict "all-or-nothing"
+// reads should discard partial output on err != nil.
+func (a *Adapter) FollowFromOffset(_ context.Context, fromOffset int64) ([]Event, int64, error) {
+	a.followMu.Lock()
+	defer a.followMu.Unlock()
+
+	f, err := os.Open(a.path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fromOffset, nil
+		}
+		return nil, fromOffset, fmt.Errorf("open contracts log %q: %w", a.path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, fromOffset, fmt.Errorf("stat contracts log %q: %w", a.path, err)
+	}
+	size := stat.Size()
+	if size < fromOffset {
+		// File rotated / truncated; restart from zero so we do not
+		// miss the rewritten prefix.
+		fromOffset = 0
+	}
+	if size == fromOffset {
+		return nil, fromOffset, nil
+	}
+	if _, err := f.Seek(fromOffset, io.SeekStart); err != nil {
+		return nil, fromOffset, fmt.Errorf("seek contracts log %q: %w", a.path, err)
+	}
+
+	events, advanced, err := readEvents(f, fromOffset)
+	return events, advanced, err
+}
+
+// Dir returns the parent directory of the configured log path. The
+// watcher uses this to attach an fsnotify subscription before the file
+// itself exists (fsnotify cannot watch a missing path).
+func (a *Adapter) Dir() string {
+	return filepath.Dir(a.path)
+}
+
+// readEvents decodes newline-delimited JSON events from r, returning
+// the decoded events plus the absolute byte offset reached (start
+// offset + bytes consumed). Stops cleanly at EOF.
+//
+// Lines that fail to decode are skipped silently — the JSONL format is
+// append-only and a half-written tail is normal during concurrent
+// writes. The loop tracks the byte offset of each newline so a partial
+// final line stays uncommitted until the next call sees its terminator.
+func readEvents(r io.Reader, start int64) ([]Event, int64, error) {
+	br := bufio.NewReaderSize(r, 64*1024)
+	offset := start
+	var events []Event
+	for {
+		line, err := br.ReadBytes('\n')
+		consumed := int64(len(line))
+		if len(line) > 0 && line[len(line)-1] == '\n' {
+			// Complete line — advance offset past the terminator.
+			offset += consumed
+			ev, ok := decodeLine(line)
+			if ok {
+				events = append(events, ev)
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			return events, offset, nil
+		}
+		if err != nil {
+			return events, offset, fmt.Errorf("read contracts log: %w", err)
+		}
+	}
+}
+
+// decodeLine parses one JSONL line into an Event. Empty lines and
+// undecodable lines return (Event{}, false) so the caller skips them
+// without aborting the whole snapshot.
+func decodeLine(line []byte) (Event, bool) {
+	// Trim the trailing newline; bufio leaves it on.
+	if n := len(line); n > 0 && line[n-1] == '\n' {
+		line = line[:n-1]
+	}
+	if len(line) == 0 {
+		return Event{}, false
+	}
+	var ev Event
+	if err := json.Unmarshal(line, &ev); err != nil {
+		return Event{}, false
+	}
+	if ev.Kind == "" {
+		return Event{}, false
+	}
+	return ev, true
+}

--- a/internal/server/providers/contracts/contracts_e2e_test.go
+++ b/internal/server/providers/contracts/contracts_e2e_test.go
@@ -1,0 +1,499 @@
+package contracts_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
+	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/contracts"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+)
+
+// TestContracts_E2E_LifecycleAndMidTestCancel walks one synthetic
+// contract from creation through the full happy-path lifecycle into
+// `satisfied`, asserts the GraphQL surface returns the right status,
+// then appends a `cancelled` event and waits for the watcher to push
+// an invalidation. The follow-up GraphQL query must observe the new
+// status.
+//
+// All fixtures are generic: agent-1 / agent-2 / session-1 — no real
+// PII per the briefing's NO PII rule.
+func TestContracts_E2E_LifecycleAndMidTestCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "contracts.jsonl")
+
+	// Seed the log with a happy-path lifecycle: created → judge_run
+	// (PASS) → status_change to delivered_pending_validation →
+	// status_change to satisfied. Mirrors the live plugin's JSONL.
+	writeEvents(t, logPath, lifecycleHappyPathEvents()...)
+
+	provider := contracts.NewWithPath(logPath, nil)
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("start contracts provider: %v", err)
+	}
+	defer func() { _ = provider.Stop() }()
+
+	srv := newTestDaemon(t, provider)
+	defer srv.Close()
+
+	// AC: GraphQL returns the satisfied contract.
+	resp := postQuery(t, srv.URL, fullContractQuery)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	if got := len(resp.Data.Contracts); got != 1 {
+		t.Fatalf("contracts count = %d, want 1", got)
+	}
+	c := resp.Data.Contracts[0]
+	if c.Status != "SATISFIED" {
+		t.Errorf("status = %q, want SATISFIED", c.Status)
+	}
+	if c.ContractID != happyContractID {
+		t.Errorf("contractId = %q, want %q", c.ContractID, happyContractID)
+	}
+	if c.Statement != happyStatement {
+		t.Errorf("statement = %q, want %q", c.Statement, happyStatement)
+	}
+	if c.OwnerSessionID != "session-1" {
+		t.Errorf("ownerSessionId = %q, want session-1", c.OwnerSessionID)
+	}
+	if c.OwnerAgentName != "agent-1" {
+		t.Errorf("ownerAgentName = %q, want agent-1", c.OwnerAgentName)
+	}
+
+	// Subscribe so we can observe the post-cancel invalidation.
+	subCtx, subCancel := context.WithCancel(ctx)
+	defer subCancel()
+	sub := provider.Subscribe(subCtx)
+
+	// Append a cancel transition mid-test.
+	appendEvent(t, logPath, statusChangeEvent(happyContractID,
+		mustParseTime(t, "2026-05-04T13:30:00Z"),
+		"satisfied", "cancelled", "drew_cancel"))
+
+	if err := waitForSubscriberEvent(sub, happyContractID, 5*time.Second); err != nil {
+		t.Fatalf("waiting for invalidation: %v", err)
+	}
+
+	// AC: GraphQL surfaces the cancelled status after the watcher tick.
+	if err := waitForStatus(t, srv.URL, happyContractID, "CANCELLED", 5*time.Second); err != nil {
+		t.Fatalf("status never moved to cancelled: %v", err)
+	}
+}
+
+// TestContracts_E2E_MissingFileEmpty asserts the daemon answers a
+// `contracts {}` query with an empty list — and no error — when the
+// JSONL file does not exist yet. The watcher remains warm so a future
+// creation event would be picked up.
+func TestContracts_E2E_MissingFileEmpty(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "contracts.jsonl") // intentionally not created.
+
+	provider := contracts.NewWithPath(logPath, nil)
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("start contracts provider: %v", err)
+	}
+	defer func() { _ = provider.Stop() }()
+
+	srv := newTestDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postQuery(t, srv.URL, fullContractQuery)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("unexpected errors: %+v", resp.Errors)
+	}
+	if got := len(resp.Data.Contracts); got != 0 {
+		t.Errorf("contracts count = %d, want 0 for missing file", got)
+	}
+}
+
+// TestContracts_E2E_StatusFilter exercises Query.contracts(filter)
+// with a status filter — the AC `orchard query contracts --status
+// started` ultimately routes through this surface.
+func TestContracts_E2E_StatusFilter(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "contracts.jsonl")
+
+	// Two contracts: one open, one satisfied.
+	openID := "C-2026-05-04-deadbeef"
+	satID := "C-2026-05-04-cafef00d"
+	t0 := mustParseTime(t, "2026-05-04T12:00:00Z")
+	t1 := t0.Add(30 * time.Minute)
+	writeEvents(t, logPath,
+		creationEvent(openID, "open thing", "agent-2", "session-2", t0),
+		creationEvent(satID, "done thing", "agent-1", "session-1", t0),
+		judgeRunEvent(satID, t0.Add(5*time.Minute), "PASS"),
+		statusChangeEvent(satID, t0.Add(10*time.Minute), "open", "delivered_pending_validation", "owner_judge_pass"),
+		statusChangeEvent(satID, t1, "delivered_pending_validation", "satisfied", "drew_approve"),
+	)
+
+	provider := contracts.NewWithPath(logPath, nil)
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("start contracts provider: %v", err)
+	}
+	defer func() { _ = provider.Stop() }()
+
+	srv := newTestDaemon(t, provider)
+	defer srv.Close()
+
+	// All — both contracts.
+	all := postQuery(t, srv.URL, fullContractQuery)
+	if got := len(all.Data.Contracts); got != 2 {
+		t.Fatalf("unfiltered count = %d, want 2", got)
+	}
+
+	// Filter for OPEN only.
+	openResp := postQuery(t, srv.URL, queryWithFilter(`{statuses: [OPEN]}`))
+	if got := len(openResp.Data.Contracts); got != 1 {
+		t.Fatalf("OPEN filter count = %d, want 1", got)
+	}
+	if openResp.Data.Contracts[0].ContractID != openID {
+		t.Errorf("OPEN filter returned %q, want %q", openResp.Data.Contracts[0].ContractID, openID)
+	}
+
+	// Filter by owner session id.
+	ownerResp := postQuery(t, srv.URL, queryWithFilter(`{ownerSessionId: "session-1"}`))
+	if got := len(ownerResp.Data.Contracts); got != 1 {
+		t.Fatalf("ownerSession filter count = %d, want 1", got)
+	}
+	if ownerResp.Data.Contracts[0].ContractID != satID {
+		t.Errorf("ownerSession filter returned %q, want %q", ownerResp.Data.Contracts[0].ContractID, satID)
+	}
+
+	// Single-contract lookup by id.
+	one := postQuery(t, srv.URL, fmt.Sprintf(`query { contract(id: %q) { contractId status } }`, satID))
+	if one.Data.Contract == nil {
+		t.Fatalf("contract(id) returned nil for known id")
+	}
+	if one.Data.Contract.ContractID != satID {
+		t.Errorf("contract(id) returned %q, want %q", one.Data.Contract.ContractID, satID)
+	}
+
+	// Single-contract lookup with unknown id returns nil with no errors.
+	none := postQuery(t, srv.URL, `query { contract(id: "C-1234-99-99-deadbeef") { contractId } }`)
+	if none.Data.Contract != nil {
+		t.Errorf("contract(id) for unknown id returned %+v, want nil", none.Data.Contract)
+	}
+}
+
+// happyContractID and happyStatement back the happy-path fixtures so a
+// single source of truth drives both the writer and the assertions.
+const (
+	happyContractID = "C-2026-05-04-aaaa1111"
+	happyStatement  = "Stand up provider X"
+)
+
+// lifecycleHappyPathEvents is the canonical happy-path series for
+// happyContractID: creation → judge_run PASS → status to
+// delivered_pending_validation → status to satisfied.
+func lifecycleHappyPathEvents() []map[string]any {
+	t0, _ := time.Parse(time.RFC3339, "2026-05-04T12:00:00Z")
+	t1 := t0.Add(30 * time.Minute)
+	t2 := t1.Add(5 * time.Minute)
+	t3 := t2.Add(10 * time.Minute)
+	return []map[string]any{
+		creationEvent(happyContractID, happyStatement, "agent-1", "session-1", t0),
+		judgeRunEvent(happyContractID, t1, "PASS"),
+		statusChangeEvent(happyContractID, t2, "open", "delivered_pending_validation", "owner_judge_pass"),
+		statusChangeEvent(happyContractID, t3, "delivered_pending_validation", "satisfied", "drew_approve"),
+	}
+}
+
+// creationEvent returns a `kind: contract` row matching the live JSONL
+// shape exactly (top-level fields embedded, owner / reports_to as
+// nested objects, drew as the reports_to so the routing field
+// surfaces).
+func creationEvent(id, statement, agentName, sessionID string, at time.Time) map[string]any {
+	return map[string]any{
+		"kind":      "contract",
+		"id":        id,
+		"statement": statement,
+		"owner": map[string]any{
+			"session_id": sessionID,
+			"agent_name": agentName,
+			"vm_address": "test-host",
+		},
+		"reports_to": map[string]any{
+			"kind":       "drew",
+			"agent_name": nil,
+			"vm_address": nil,
+		},
+		"parent_contract_id": nil,
+		"child_contract_ids": []string{},
+		"created_on":         at.UTC().Format(time.RFC3339Nano),
+		"updated_on":         at.UTC().Format(time.RFC3339Nano),
+		"closed_on":          nil,
+		"closed_on_reason":   nil,
+		"status":             "open",
+		"judge_verdict":      nil,
+		"evidence":           nil,
+	}
+}
+
+// judgeRunEvent matches the live shape: by, evidence_links, kind,
+// reason, timestamp, verdict.
+func judgeRunEvent(id string, at time.Time, verdict string) map[string]any {
+	return map[string]any{
+		"kind":           "judge_run",
+		"timestamp":      at.UTC().Format(time.RFC3339Nano),
+		"by":             "judge",
+		"verdict":        verdict,
+		"reason":         "fixture run",
+		"evidence_links": []string{},
+		"id":             id,
+	}
+}
+
+// statusChangeEvent matches the system-generated row shape: by, from,
+// to, kind, timestamp, trigger.
+func statusChangeEvent(id string, at time.Time, from, to, trigger string) map[string]any {
+	return map[string]any{
+		"kind":      "status_change",
+		"timestamp": at.UTC().Format(time.RFC3339Nano),
+		"by":        "system",
+		"from":      from,
+		"to":        to,
+		"trigger":   trigger,
+		"id":        id,
+	}
+}
+
+// writeEvents writes the given events as a freshly created JSONL file.
+func writeEvents(t *testing.T, path string, events ...map[string]any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	for _, e := range events {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("marshal event: %v", err)
+		}
+		if _, err := f.Write(append(b, '\n')); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+}
+
+// appendEvent appends a single event onto an existing JSONL file.
+// Triggers an fsnotify Write the watcher will react to.
+func appendEvent(t *testing.T, path string, ev map[string]any) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("append open: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+}
+
+// waitForSubscriberEvent blocks until an invalidation arrives whose key
+// matches the expected contract id. Times out per the deadline.
+func waitForSubscriberEvent(sub <-chan adapter.InvalidationEvent[contracts.ContractID], expected string, deadline time.Duration) error {
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	for {
+		select {
+		case ev, ok := <-sub:
+			if !ok {
+				return fmt.Errorf("subscriber channel closed")
+			}
+			if string(ev.Key) == expected {
+				return nil
+			}
+		case <-timer.C:
+			return fmt.Errorf("timeout waiting for invalidation of %q", expected)
+		}
+	}
+}
+
+// waitForStatus polls the GraphQL surface until the named contract has
+// the expected status, or returns a timeout error.
+func waitForStatus(t *testing.T, url, contractID, expected string, deadline time.Duration) error {
+	t.Helper()
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		resp := postQuery(t, url, fmt.Sprintf(`query { contract(id: %q) { contractId status } }`, contractID))
+		if resp.Data.Contract != nil && resp.Data.Contract.Status == expected {
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("status never became %s within %v", expected, deadline)
+}
+
+// fullContractQuery is the projection used in the e2e tests. Mirrors
+// the CLI subcommand's canonical query (kept in lockstep so any drift
+// fails this test before it fails a user).
+const fullContractQuery = `query {
+  contracts {
+    id
+    contractId
+    statement
+    ownerSessionId
+    ownerAgentName
+    reportsTo
+    parentContractId
+    status
+    createdAt
+    updatedAt
+    lastEventAt
+    criteria
+    openQuestions {
+      questionId
+      text
+      askedBy
+      askedAt
+      deadline
+      blocksClose
+    }
+  }
+}`
+
+// queryWithFilter splices a literal filter into the full contracts
+// query — the e2e test exercises the CLI's same approach.
+func queryWithFilter(filterLiteral string) string {
+	return strings.Replace(`query { contracts(filter: $$F$$) { contractId status ownerSessionId } }`,
+		"$$F$$", filterLiteral, 1)
+}
+
+// newTestDaemon mirrors internal/server/server.go's GraphQL wiring with
+// a pre-started Provider so the e2e test can drive it without launching
+// the full HTTP server.
+//
+// We construct a host provider too because the resolver root requires
+// one to be non-nil — the host resolver is unused in this test but
+// satisfies the dependency.
+func newTestDaemon(t *testing.T, provider *contracts.Provider) *httptest.Server {
+	t.Helper()
+	hostProvider := host.New()
+	if err := hostProvider.Start(context.Background()); err != nil {
+		t.Fatalf("start host provider: %v", err)
+	}
+	cfg := gql.Config{Resolvers: resolvers.New(time.Now()).WithHost(hostProvider).WithContracts(provider)}
+	gqlSrv := handler.New(gql.NewExecutableSchema(cfg))
+	gqlSrv.AddTransport(transport.POST{})
+	gqlSrv.AddTransport(transport.GET{})
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", gqlSrv)
+	return httptest.NewServer(mux)
+}
+
+// graphqlResponse decodes the e2e test's expected envelope. Only the
+// fields we assert are spelled out; new schema additions cannot break
+// this unmarshal.
+type graphqlResponse struct {
+	Data struct {
+		Contracts []contractNode `json:"contracts"`
+		Contract  *contractNode  `json:"contract,omitempty"`
+	} `json:"data"`
+	Errors []map[string]any `json:"errors,omitempty"`
+}
+
+type contractNode struct {
+	ID               string             `json:"id"`
+	ContractID       string             `json:"contractId"`
+	Statement        string             `json:"statement"`
+	OwnerSessionID   string             `json:"ownerSessionId"`
+	OwnerAgentName   string             `json:"ownerAgentName"`
+	ReportsTo        *string            `json:"reportsTo,omitempty"`
+	ParentContractID *string            `json:"parentContractId,omitempty"`
+	Status           string             `json:"status"`
+	CreatedAt        string             `json:"createdAt"`
+	UpdatedAt        string             `json:"updatedAt"`
+	LastEventAt      string             `json:"lastEventAt"`
+	Criteria         []string           `json:"criteria"`
+	OpenQuestions    []contractQuestion `json:"openQuestions"`
+}
+
+type contractQuestion struct {
+	QuestionID  string  `json:"questionId"`
+	Text        string  `json:"text"`
+	AskedBy     string  `json:"askedBy"`
+	AskedAt     string  `json:"askedAt"`
+	Deadline    *string `json:"deadline,omitempty"`
+	BlocksClose bool    `json:"blocksClose"`
+}
+
+func postQuery(t *testing.T, url, query string) graphqlResponse {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url+"/graphql", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d: %s", resp.StatusCode, string(raw))
+	}
+	var out graphqlResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode %q: %v", raw, err)
+	}
+	return out
+}
+
+// mustParseTime is the test-side time parser. Unlike fold_test.go's
+// version (which is in package contracts), this one lives in
+// contracts_test so we don't pull internal helpers across package
+// boundaries.
+func mustParseTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return parsed
+}

--- a/internal/server/providers/contracts/doc.go
+++ b/internal/server/providers/contracts/doc.go
@@ -1,0 +1,41 @@
+// Package contracts implements the read-only Contract provider — the
+// orchard daemon's reflection of the JSONL event log that the
+// claude-contracts plugin authors.
+//
+// Per ADR-011 §5.1 and §11, orchard never writes contracts. The
+// claude-contracts plugin (or any writer that respects the same JSONL
+// schema) appends events to a log on disk; this provider tails the
+// file, folds events into the current contract state, and surfaces
+// the result via the Contract node.
+//
+// # Why a fold
+//
+// The plugin's log is append-only by design — every status change,
+// criterion addition, question, and cancel ack is its own line. The
+// folded current state is therefore *derived*, not stored. Computing
+// it once on disk would couple two writers; computing it from events
+// keeps the plugin as the only authority and lets orchard re-derive
+// from scratch any time the cache is cold.
+//
+// # Layering
+//
+// Mirrors the host and claudeprojects sibling providers:
+//
+//   - [Adapter] does raw I/O — opens the JSONL, returns events. No
+//     state, no caching.
+//   - [Provider] holds the fold result, exposes the [adapter.Provider]
+//     surface, and runs the watcher loop.
+//   - [Watcher] uses fsnotify on the file (when it exists) and on its
+//     parent directory (so a fresh install picks up the file's first
+//     creation without polling).
+//   - [Fold] is a pure function — exhaustively unit-tested without
+//     touching the filesystem.
+//
+// # Configurable log path
+//
+// The default location is
+// $XDG_STATE_HOME/claude-contracts/contracts.jsonl, falling back to
+// $HOME/.local/state/claude-contracts/contracts.jsonl when XDG_STATE_HOME
+// is unset. The CLAUDE_CONTRACTS_LOG environment variable overrides
+// the default for ad-hoc runs and tests.
+package contracts

--- a/internal/server/providers/contracts/fold.go
+++ b/internal/server/providers/contracts/fold.go
@@ -1,0 +1,260 @@
+package contracts
+
+import "time"
+
+// Fold reduces an ordered list of events into the current state of every
+// contract they touch. Pure function — no IO, no clock, no globals; the
+// only inputs are events and the only output is the folded map.
+//
+// Event kinds Fold recognises:
+//
+//   - "contract": creation. Initialises a Contract record. Subsequent
+//     events for the same id update fields in place.
+//   - "status_change": updates Status. The plugin writes both `to`
+//     and a system-supplied `trigger`; Fold trusts the `to` field.
+//   - "criterion_added": appends to Criteria, in event order.
+//   - "question_asked": appends to OpenQuestions.
+//   - "question_answered": removes the matching QuestionID from
+//     OpenQuestions.
+//   - "question_timed_out": removes the matching QuestionID from
+//     OpenQuestions (treated identically to answered).
+//   - "cancel_requested" / "cancel_acked" / "cancel_withdrawn":
+//     LastEventAt only — the status moves via the paired
+//     status_change event the plugin always writes.
+//   - "judge_run" / "judge_run_failed": LastEventAt only — terminal
+//     verdict surfaces via the paired status_change.
+//   - "cooldown_set" / "wait_started": LastEventAt only.
+//   - "child_linked" / "child_cancelled": LastEventAt only.
+//
+// Unknown kinds are silently dropped so plugin extensions do not break
+// the daemon. Events that arrive before their contract's creation
+// record (out-of-order JSONL rows) are also dropped — a pathological
+// shape that should not occur in practice.
+//
+// Events are processed in the slice order; callers must pre-sort by
+// timestamp if their input is unsorted. The on-disk JSONL is naturally
+// in append order, so the adapter does no sorting.
+func Fold(events []Event) map[ContractID]Contract {
+	state := make(map[ContractID]Contract)
+	for _, ev := range events {
+		applyEvent(state, ev)
+	}
+	return state
+}
+
+// applyEvent dispatches one event into the fold. Extracted from Fold so
+// streaming callers (the provider's incremental update path) can apply
+// events one at a time without rebuilding the whole map.
+func applyEvent(state map[ContractID]Contract, ev Event) {
+	switch ev.Kind {
+	case "contract":
+		applyCreation(state, ev)
+	case "status_change":
+		applyStatusChange(state, ev)
+	case "criterion_added":
+		applyCriterionAdded(state, ev)
+	case "question_asked":
+		applyQuestionAsked(state, ev)
+	case "question_answered", "question_timed_out":
+		applyQuestionResolved(state, ev)
+	case "cancel_requested",
+		"cancel_acked",
+		"cancel_withdrawn",
+		"judge_run",
+		"judge_run_failed",
+		"cooldown_set",
+		"wait_started",
+		"child_linked",
+		"child_cancelled":
+		touchLastEvent(state, ContractID(ev.ID), eventTime(ev))
+	}
+}
+
+// touchLastEvent updates LastEventAt on the named contract, leaving all
+// other fields untouched. Used for events that signal activity but
+// whose effect on contract state is captured by a paired event
+// (judge_run pairs with status_change, cancel_requested with
+// status_change, etc.).
+func touchLastEvent(state map[ContractID]Contract, id ContractID, at time.Time) {
+	c, ok := state[id]
+	if !ok {
+		return
+	}
+	if !at.IsZero() {
+		c.LastEventAt = at
+	}
+	state[id] = c
+}
+
+// applyCreation initialises a contract from a `kind: contract` row. If
+// the contract already exists (re-creation), the new fields overwrite
+// in place; in practice this never happens because contract ids are
+// 8-hex random.
+func applyCreation(state map[ContractID]Contract, ev Event) {
+	if ev.ID == "" {
+		return
+	}
+	id := ContractID(ev.ID)
+
+	created := zeroOr(ev.CreatedOn)
+	updated := zeroOr(ev.UpdatedOn)
+	if updated.IsZero() {
+		updated = created
+	}
+	status := ev.InitialStatus
+	if status == "" {
+		// Older plugin versions omit status on creation; default to open.
+		status = "open"
+	}
+
+	c := Contract{
+		ID:          id,
+		Statement:   ev.Statement,
+		Status:      status,
+		CreatedAt:   created,
+		UpdatedAt:   updated,
+		LastEventAt: updated,
+	}
+	if ev.Owner != nil {
+		c.OwnerSessionID = ev.Owner.SessionID
+		if ev.Owner.AgentName != nil {
+			c.OwnerAgentName = *ev.Owner.AgentName
+		}
+	}
+	c.ReportsTo = renderParty(ev.ReportsTo)
+	if ev.Parent != nil {
+		c.ParentContractID = *ev.Parent
+	}
+
+	// Preserve criteria/questions added before the creation row in
+	// degenerate inputs — never observed in practice but cheap to
+	// guard.
+	if existing, ok := state[id]; ok {
+		c.Criteria = existing.Criteria
+		c.OpenQuestions = existing.OpenQuestions
+		if !existing.LastEventAt.IsZero() && existing.LastEventAt.After(c.LastEventAt) {
+			c.LastEventAt = existing.LastEventAt
+		}
+	}
+	state[id] = c
+}
+
+func applyStatusChange(state map[ContractID]Contract, ev Event) {
+	id := ContractID(ev.ID)
+	c, ok := state[id]
+	if !ok {
+		// status_change before creation — drop. JSONL append-order
+		// invariant should prevent this.
+		return
+	}
+	if ev.To != "" {
+		c.Status = ev.To
+	}
+	t := eventTime(ev)
+	if !t.IsZero() {
+		c.UpdatedAt = t
+		c.LastEventAt = t
+	}
+	state[id] = c
+}
+
+func applyCriterionAdded(state map[ContractID]Contract, ev Event) {
+	id := ContractID(ev.ID)
+	c, ok := state[id]
+	if !ok {
+		return
+	}
+	if ev.Criterion != "" {
+		c.Criteria = append(c.Criteria, ev.Criterion)
+	}
+	if t := eventTime(ev); !t.IsZero() {
+		c.LastEventAt = t
+	}
+	state[id] = c
+}
+
+func applyQuestionAsked(state map[ContractID]Contract, ev Event) {
+	id := ContractID(ev.ID)
+	c, ok := state[id]
+	if !ok {
+		return
+	}
+	q := OpenQuestion{
+		QuestionID:  ev.QuestionID,
+		Text:        ev.QuestionText,
+		AskedBy:     ev.By,
+		AskedAt:     zeroOr(ev.Timestamp),
+		Deadline:    ev.QuestionDeadline,
+		BlocksClose: ev.QuestionBlocks == nil || *ev.QuestionBlocks,
+	}
+	c.OpenQuestions = append(c.OpenQuestions, q)
+	if t := eventTime(ev); !t.IsZero() {
+		c.LastEventAt = t
+	}
+	state[id] = c
+}
+
+func applyQuestionResolved(state map[ContractID]Contract, ev Event) {
+	id := ContractID(ev.ID)
+	c, ok := state[id]
+	if !ok {
+		return
+	}
+	if ev.QuestionID != "" {
+		filtered := c.OpenQuestions[:0]
+		for _, q := range c.OpenQuestions {
+			if q.QuestionID == ev.QuestionID {
+				continue
+			}
+			filtered = append(filtered, q)
+		}
+		// Re-allocate so the trimmed slice does not retain backing
+		// memory pointing at removed entries.
+		c.OpenQuestions = append([]OpenQuestion(nil), filtered...)
+	}
+	if t := eventTime(ev); !t.IsZero() {
+		c.LastEventAt = t
+	}
+	state[id] = c
+}
+
+// renderParty turns a Party pointer into the schema's flat reportsTo
+// representation. Returns "" when nil so the resolver layer can decide
+// to surface a null vs an empty string.
+func renderParty(p *Party) string {
+	if p == nil {
+		return ""
+	}
+	if p.Kind == "drew" {
+		return "drew"
+	}
+	if p.Kind == "agent" && p.AgentName != nil && *p.AgentName != "" {
+		return "agent:" + *p.AgentName
+	}
+	if p.Kind != "" {
+		return p.Kind
+	}
+	return ""
+}
+
+// eventTime returns the most relevant timestamp for the event. Creation
+// rows use CreatedOn (no Timestamp field on disk); every other kind
+// uses Timestamp. A zero time.Time signals "no timestamp on this row."
+func eventTime(ev Event) time.Time {
+	if ev.Kind == "contract" {
+		t := zeroOr(ev.UpdatedOn)
+		if t.IsZero() {
+			t = zeroOr(ev.CreatedOn)
+		}
+		return t
+	}
+	return zeroOr(ev.Timestamp)
+}
+
+// zeroOr unwraps a *time.Time to a zero time.Time when nil.
+func zeroOr(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}

--- a/internal/server/providers/contracts/fold_test.go
+++ b/internal/server/providers/contracts/fold_test.go
@@ -1,0 +1,388 @@
+package contracts
+
+import (
+	"testing"
+	"time"
+)
+
+// strPtr returns a pointer to s. The fold uses *string for nullable
+// fields per the on-disk JSONL shape.
+func strPtr(s string) *string { return &s }
+
+// timePtr is the time.Time analogue of strPtr.
+func timePtr(t time.Time) *time.Time { return &t }
+
+// boolPtr lets tests pass `false` for blocks_close (the JSON unmarshal
+// has no other way to disambiguate "field omitted" from "field=false").
+func boolPtr(b bool) *bool { return &b }
+
+// mustParse is the test-side time parser. Fixtures use stable strings
+// so test failures show the original timestamp instead of a long
+// time.Now() drift.
+func mustParse(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return parsed
+}
+
+// agent constructs a Party for an agent owner. Used in fixtures so the
+// shape stays in lockstep with how the plugin writes JSONL.
+func agent(name, sessionID string) *Party {
+	return &Party{Kind: "agent", AgentName: strPtr(name), SessionID: sessionID}
+}
+
+func drew() *Party {
+	return &Party{Kind: "drew"}
+}
+
+// TestFold_Creation checks that a single `kind: contract` row produces
+// a fully populated Contract record.
+func TestFold_Creation(t *testing.T) {
+	created := mustParse(t, "2026-05-04T12:00:00Z")
+	state := Fold([]Event{
+		{
+			Kind:          "contract",
+			ID:            "C-2026-05-04-aaaa1111",
+			Statement:     "Deliver foo",
+			Owner:         agent("agent-1", "session-1"),
+			ReportsTo:     drew(),
+			CreatedOn:     timePtr(created),
+			UpdatedOn:     timePtr(created),
+			InitialStatus: "open",
+		},
+	})
+
+	c, ok := state["C-2026-05-04-aaaa1111"]
+	if !ok {
+		t.Fatalf("contract not in fold result")
+	}
+	if c.Statement != "Deliver foo" {
+		t.Errorf("Statement = %q, want %q", c.Statement, "Deliver foo")
+	}
+	if c.Status != "open" {
+		t.Errorf("Status = %q, want %q", c.Status, "open")
+	}
+	if c.OwnerSessionID != "session-1" {
+		t.Errorf("OwnerSessionID = %q, want %q", c.OwnerSessionID, "session-1")
+	}
+	if c.OwnerAgentName != "agent-1" {
+		t.Errorf("OwnerAgentName = %q, want %q", c.OwnerAgentName, "agent-1")
+	}
+	if c.ReportsTo != "drew" {
+		t.Errorf("ReportsTo = %q, want %q", c.ReportsTo, "drew")
+	}
+	if !c.CreatedAt.Equal(created) {
+		t.Errorf("CreatedAt = %v, want %v", c.CreatedAt, created)
+	}
+	if !c.LastEventAt.Equal(created) {
+		t.Errorf("LastEventAt = %v, want %v", c.LastEventAt, created)
+	}
+}
+
+// TestFold_LifecycleHappyPath traces created → delivered → judge_passed
+// → satisfied: the canonical AC scenario.
+//
+// Status moves are driven by status_change events in the live JSONL,
+// so our fold mirrors that — the final status reflects the last
+// status_change row.
+func TestFold_LifecycleHappyPath(t *testing.T) {
+	t0 := mustParse(t, "2026-05-04T12:00:00Z")
+	t1 := mustParse(t, "2026-05-04T12:30:00Z")
+	t2 := mustParse(t, "2026-05-04T12:45:00Z")
+	t3 := mustParse(t, "2026-05-04T12:50:00Z")
+
+	state := Fold([]Event{
+		{
+			Kind:          "contract",
+			ID:            "C-2026-05-04-bbbb2222",
+			Statement:     "Wire the foo provider",
+			Owner:         agent("agent-2", "session-2"),
+			ReportsTo:     drew(),
+			CreatedOn:     timePtr(t0),
+			UpdatedOn:     timePtr(t0),
+			InitialStatus: "open",
+		},
+		{
+			Kind:      "judge_run",
+			ID:        "C-2026-05-04-bbbb2222",
+			Timestamp: timePtr(t1),
+			Verdict:   "PASS",
+			Reason:    "AC verified end-to-end.",
+		},
+		{
+			Kind:      "status_change",
+			ID:        "C-2026-05-04-bbbb2222",
+			Timestamp: timePtr(t2),
+			From:      "open",
+			To:        "delivered_pending_validation",
+			Trigger:   "owner_judge_pass",
+		},
+		{
+			Kind:      "status_change",
+			ID:        "C-2026-05-04-bbbb2222",
+			Timestamp: timePtr(t3),
+			From:      "delivered_pending_validation",
+			To:        "satisfied",
+			Trigger:   "drew_approve",
+		},
+	})
+
+	c := state["C-2026-05-04-bbbb2222"]
+	if c.Status != "satisfied" {
+		t.Errorf("Status = %q, want satisfied", c.Status)
+	}
+	if !c.LastEventAt.Equal(t3) {
+		t.Errorf("LastEventAt = %v, want %v", c.LastEventAt, t3)
+	}
+	if !c.UpdatedAt.Equal(t3) {
+		t.Errorf("UpdatedAt = %v, want %v", c.UpdatedAt, t3)
+	}
+	if !c.CreatedAt.Equal(t0) {
+		t.Errorf("CreatedAt = %v, want %v (creation is immutable)", c.CreatedAt, t0)
+	}
+}
+
+// TestFold_CancelMidLife asserts that a cancel triggers the
+// status_change-driven transition to cancelled.
+func TestFold_CancelMidLife(t *testing.T) {
+	t0 := mustParse(t, "2026-05-04T12:00:00Z")
+	t1 := mustParse(t, "2026-05-04T12:10:00Z")
+	t2 := mustParse(t, "2026-05-04T12:11:00Z")
+
+	state := Fold([]Event{
+		{
+			Kind: "contract", ID: "C-2026-05-04-cccc3333",
+			Statement: "abandoned thing",
+			Owner:     agent("agent-3", "session-3"),
+			ReportsTo: drew(),
+			CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0),
+			InitialStatus: "open",
+		},
+		{
+			Kind: "cancel_requested", ID: "C-2026-05-04-cccc3333",
+			Timestamp: timePtr(t1), CancelRequestID: "CR-deadbe",
+			Reason: "scope ballooned",
+			By:     "agent-3",
+		},
+		{
+			Kind: "status_change", ID: "C-2026-05-04-cccc3333",
+			Timestamp: timePtr(t2),
+			From:      "open", To: "cancelled",
+			Trigger: "drew_cancel",
+		},
+	})
+	c := state["C-2026-05-04-cccc3333"]
+	if c.Status != "cancelled" {
+		t.Errorf("Status = %q, want cancelled", c.Status)
+	}
+	if !c.LastEventAt.Equal(t2) {
+		t.Errorf("LastEventAt = %v, want %v", c.LastEventAt, t2)
+	}
+}
+
+// TestFold_CriteriaInOrder asserts criterion_added events accumulate
+// in original order — the brief explicitly lists this as part of the
+// AC set.
+func TestFold_CriteriaInOrder(t *testing.T) {
+	t0 := mustParse(t, "2026-05-04T12:00:00Z")
+	state := Fold([]Event{
+		{Kind: "contract", ID: "C-2026-05-04-dddd4444", CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0), InitialStatus: "open"},
+		{Kind: "criterion_added", ID: "C-2026-05-04-dddd4444", Timestamp: timePtr(t0), Criterion: "first"},
+		{Kind: "criterion_added", ID: "C-2026-05-04-dddd4444", Timestamp: timePtr(t0), Criterion: "second"},
+		{Kind: "criterion_added", ID: "C-2026-05-04-dddd4444", Timestamp: timePtr(t0), Criterion: "third"},
+	})
+	got := state["C-2026-05-04-dddd4444"].Criteria
+	want := []string{"first", "second", "third"}
+	if len(got) != len(want) {
+		t.Fatalf("Criteria = %v, want %v", got, want)
+	}
+	for i, c := range got {
+		if c != want[i] {
+			t.Errorf("Criteria[%d] = %q, want %q", i, c, want[i])
+		}
+	}
+}
+
+// TestFold_OpenQuestionsLifecycle covers question_asked → answered:
+// the answered question must drop out of OpenQuestions.
+func TestFold_OpenQuestionsLifecycle(t *testing.T) {
+	t0 := mustParse(t, "2026-05-04T12:00:00Z")
+	tAsked := mustParse(t, "2026-05-04T12:30:00Z")
+	tAns := mustParse(t, "2026-05-04T12:45:00Z")
+	state := Fold([]Event{
+		{Kind: "contract", ID: "C-2026-05-04-eeee5555", Owner: agent("agent-1", "session-1"), CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0), InitialStatus: "open"},
+		{
+			Kind: "question_asked", ID: "C-2026-05-04-eeee5555",
+			Timestamp:    timePtr(tAsked),
+			QuestionID:   "Q-zzz1",
+			QuestionText: "are we go?",
+			By:           "agent-1",
+		},
+		{
+			Kind: "question_asked", ID: "C-2026-05-04-eeee5555",
+			Timestamp:    timePtr(tAsked.Add(time.Second)),
+			QuestionID:   "Q-zzz2",
+			QuestionText: "second q",
+			By:           "agent-1",
+		},
+	})
+
+	c := state["C-2026-05-04-eeee5555"]
+	if got, want := len(c.OpenQuestions), 2; got != want {
+		t.Fatalf("OpenQuestions count = %d, want %d", got, want)
+	}
+
+	// Resolve the first question; second must remain.
+	state2 := Fold([]Event{
+		{Kind: "contract", ID: "C-2026-05-04-eeee5555", Owner: agent("agent-1", "session-1"), CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0), InitialStatus: "open"},
+		{Kind: "question_asked", ID: "C-2026-05-04-eeee5555", Timestamp: timePtr(tAsked), QuestionID: "Q-zzz1", QuestionText: "are we go?", By: "agent-1"},
+		{Kind: "question_asked", ID: "C-2026-05-04-eeee5555", Timestamp: timePtr(tAsked.Add(time.Second)), QuestionID: "Q-zzz2", QuestionText: "second q", By: "agent-1"},
+		{Kind: "question_answered", ID: "C-2026-05-04-eeee5555", Timestamp: timePtr(tAns), QuestionID: "Q-zzz1", QuestionAnswer: "yes"},
+	})
+	c2 := state2["C-2026-05-04-eeee5555"]
+	if got, want := len(c2.OpenQuestions), 1; got != want {
+		t.Fatalf("OpenQuestions after answer = %d, want %d", got, want)
+	}
+	if c2.OpenQuestions[0].QuestionID != "Q-zzz2" {
+		t.Errorf("remaining question id = %q, want Q-zzz2", c2.OpenQuestions[0].QuestionID)
+	}
+}
+
+// TestFold_BlocksCloseDefault covers the wrinkle that blocks_close
+// defaults to true when the plugin omits the field on a question_asked
+// row (which it does in some older versions of the log).
+func TestFold_BlocksCloseDefault(t *testing.T) {
+	t0 := mustParse(t, "2026-05-04T12:00:00Z")
+	state := Fold([]Event{
+		{Kind: "contract", ID: "C-x", CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0), InitialStatus: "open"},
+		{
+			Kind: "question_asked", ID: "C-x",
+			Timestamp: timePtr(t0.Add(time.Second)), QuestionID: "Q-default",
+			QuestionText: "no blocks_close on the wire",
+		},
+	})
+	c := state["C-x"]
+	if !c.OpenQuestions[0].BlocksClose {
+		t.Errorf("BlocksClose = false, want true (default when field omitted)")
+	}
+
+	state2 := Fold([]Event{
+		{Kind: "contract", ID: "C-y", CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0), InitialStatus: "open"},
+		{
+			Kind: "question_asked", ID: "C-y",
+			Timestamp: timePtr(t0.Add(time.Second)), QuestionID: "Q-explicit",
+			QuestionText:   "explicit false",
+			QuestionBlocks: boolPtr(false),
+		},
+	})
+	if state2["C-y"].OpenQuestions[0].BlocksClose {
+		t.Errorf("BlocksClose = true, want false (explicit)")
+	}
+}
+
+// TestFold_UnknownKindIgnored asserts plugin extensions don't break us.
+func TestFold_UnknownKindIgnored(t *testing.T) {
+	t0 := mustParse(t, "2026-05-04T12:00:00Z")
+	state := Fold([]Event{
+		{Kind: "contract", ID: "C-1", CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0), InitialStatus: "open"},
+		{Kind: "future_extension_event", ID: "C-1", Timestamp: timePtr(t0)},
+		{Kind: "another_unknown", ID: "C-1", Timestamp: timePtr(t0)},
+	})
+	if c := state["C-1"]; c.Status != "open" {
+		t.Errorf("Status = %q, want open (unknown events should be no-ops)", c.Status)
+	}
+}
+
+// TestFold_OutOfOrderEventsBeforeCreation asserts that an event
+// arriving before its creation row is dropped silently. This shouldn't
+// happen in practice because the JSONL is append-order, but the fold
+// must be robust to corrupted input.
+func TestFold_OutOfOrderEventsBeforeCreation(t *testing.T) {
+	t0 := mustParse(t, "2026-05-04T12:00:00Z")
+	state := Fold([]Event{
+		// status_change before creation — drop.
+		{Kind: "status_change", ID: "C-orphan", Timestamp: timePtr(t0), To: "satisfied"},
+	})
+	if _, ok := state["C-orphan"]; ok {
+		t.Errorf("orphan status_change created a contract; expected drop")
+	}
+}
+
+// TestFold_HandoffPreservesCreated covers the `handoff` shape — a
+// future contract handoff (status_change with new owner). Today the
+// plugin doesn't change owner mid-life, but Fold's implementation
+// keeps CreatedAt immutable so a hypothetical handoff still surfaces a
+// stable creation timestamp.
+func TestFold_HandoffPreservesCreated(t *testing.T) {
+	t0 := mustParse(t, "2026-05-04T12:00:00Z")
+	t1 := mustParse(t, "2026-05-04T12:30:00Z")
+	state := Fold([]Event{
+		{Kind: "contract", ID: "C-h", CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0), InitialStatus: "open", Owner: agent("a", "s1")},
+		{Kind: "status_change", ID: "C-h", Timestamp: timePtr(t1), From: "open", To: "open", Trigger: "handoff"},
+	})
+	c := state["C-h"]
+	if !c.CreatedAt.Equal(t0) {
+		t.Errorf("CreatedAt = %v, want %v (creation is immutable)", c.CreatedAt, t0)
+	}
+	if !c.UpdatedAt.Equal(t1) {
+		t.Errorf("UpdatedAt = %v, want %v", c.UpdatedAt, t1)
+	}
+}
+
+// TestFold_CancelledByDrewVsAgent demonstrates that fold reflects
+// whatever the live status_change wrote; the trigger field is
+// preserved nowhere on the Contract — by design, since the resolver
+// surfaces only `status`, not `trigger`.
+func TestFold_CancelledByDrewVsAgent(t *testing.T) {
+	t0 := mustParse(t, "2026-05-04T12:00:00Z")
+	state := Fold([]Event{
+		{Kind: "contract", ID: "C-d", CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0), InitialStatus: "open"},
+		{Kind: "cancel_requested", ID: "C-d", Timestamp: timePtr(t0.Add(time.Minute)), CancelRequestID: "CR-1", Reason: "drew said so", By: "drew"},
+		{Kind: "status_change", ID: "C-d", Timestamp: timePtr(t0.Add(2 * time.Minute)), From: "open", To: "cancelled", Trigger: "drew_cancel"},
+	})
+	if state["C-d"].Status != "cancelled" {
+		t.Errorf("Status = %q, want cancelled", state["C-d"].Status)
+	}
+}
+
+// TestFold_MultipleContractsIndependent confirms IDs do not bleed
+// between distinct contracts in a single Fold.
+func TestFold_MultipleContractsIndependent(t *testing.T) {
+	t0 := mustParse(t, "2026-05-04T12:00:00Z")
+	state := Fold([]Event{
+		{Kind: "contract", ID: "C-aaa", CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0), InitialStatus: "open", Statement: "alpha"},
+		{Kind: "contract", ID: "C-bbb", CreatedOn: timePtr(t0), UpdatedOn: timePtr(t0), InitialStatus: "open", Statement: "beta"},
+		{Kind: "criterion_added", ID: "C-aaa", Timestamp: timePtr(t0), Criterion: "alpha-only"},
+	})
+	if got := state["C-aaa"].Criteria; len(got) != 1 || got[0] != "alpha-only" {
+		t.Errorf("alpha criteria = %v, want [alpha-only]", got)
+	}
+	if got := len(state["C-bbb"].Criteria); got != 0 {
+		t.Errorf("beta criteria count = %d, want 0", got)
+	}
+}
+
+// TestRenderParty exhaustively covers the Party → schema string mapping.
+func TestRenderParty(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *Party
+		want string
+	}{
+		{"nil", nil, ""},
+		{"drew", &Party{Kind: "drew"}, "drew"},
+		{"agent_with_name", &Party{Kind: "agent", AgentName: strPtr("agent-7")}, "agent:agent-7"},
+		{"agent_no_name", &Party{Kind: "agent"}, "agent"},
+		{"empty_kind", &Party{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderParty(tc.in); got != tc.want {
+				t.Errorf("renderParty(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/providers/contracts/path.go
+++ b/internal/server/providers/contracts/path.go
@@ -1,0 +1,41 @@
+package contracts
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// EnvLogPath is the environment variable that overrides the log path.
+// Set CLAUDE_CONTRACTS_LOG=/abs/path/contracts.jsonl to point the
+// daemon at a non-default file (useful for tests + per-machine
+// experiments).
+const EnvLogPath = "CLAUDE_CONTRACTS_LOG"
+
+// DefaultLogPath returns the path the contracts provider reads from
+// when no override is configured.
+//
+// Resolution order:
+//
+//  1. $CLAUDE_CONTRACTS_LOG, if non-empty.
+//  2. $XDG_STATE_HOME/claude-contracts/contracts.jsonl, if XDG_STATE_HOME
+//     is set.
+//  3. $HOME/.local/state/claude-contracts/contracts.jsonl as the
+//     XDG fallback.
+//  4. ./contracts.jsonl as a last resort when $HOME is unresolvable
+//     (should never happen on a real workstation).
+//
+// Per the brief, the daemon never creates the file or its parent
+// directory — that responsibility belongs to the writer. The provider
+// tolerates the path being missing.
+func DefaultLogPath() string {
+	if override := os.Getenv(EnvLogPath); override != "" {
+		return override
+	}
+	if xdg := os.Getenv("XDG_STATE_HOME"); xdg != "" {
+		return filepath.Join(xdg, "claude-contracts", "contracts.jsonl")
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".local", "state", "claude-contracts", "contracts.jsonl")
+	}
+	return "contracts.jsonl"
+}

--- a/internal/server/providers/contracts/provider.go
+++ b/internal/server/providers/contracts/provider.go
@@ -1,0 +1,479 @@
+package contracts
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// Provider exposes Contract nodes to the GraphQL resolver layer.
+//
+// Owns:
+//
+//   - one [Adapter] (JSONL read).
+//   - one [Watcher] (fsnotify).
+//   - the in-memory fold result, keyed by ContractID.
+//   - the per-key Subscribe fan-out for invalidation events.
+//
+// Per ADR-011 §2 the surface is read-only. Writes happen out-of-band
+// (the claude-contracts plugin appends to the JSONL); the watcher
+// turns those writes into invalidation events, the next read picks up
+// the fresh fold.
+type Provider struct {
+	adapterIO *Adapter
+	watcher   *Watcher
+	logger    *slog.Logger
+	clock     func() time.Time
+
+	mu     sync.RWMutex
+	state  map[ContractID]Contract
+	loaded bool
+	last   time.Time
+
+	// offset is the byte position the Provider has folded up to in the
+	// log. Tail reads resume from here.
+	offset int64
+
+	subMu sync.Mutex
+	subs  map[chan adapter.InvalidationEvent[ContractID]]struct{}
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+}
+
+// New constructs a Provider using the platform-default log path
+// resolved by [DefaultLogPath].
+func New(logger *slog.Logger) *Provider {
+	return NewWithPath(DefaultLogPath(), logger)
+}
+
+// NewWithPath is the test-friendly constructor — accepts an explicit
+// log path so unit tests can point at a t.TempDir() file. The clock is
+// fixed to time.Now in production; NewForTest swaps it for callers
+// that need deterministic timestamps.
+func NewWithPath(path string, logger *slog.Logger) *Provider {
+	return NewForTest(path, logger, time.Now)
+}
+
+// NewForTest is the constructor with every dependency injectable.
+// Production callers use [New] / [NewWithPath]; test callers use this
+// to drive the provider with a fake clock.
+func NewForTest(path string, logger *slog.Logger, clock func() time.Time) *Provider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	return &Provider{
+		adapterIO: NewAdapter(path),
+		watcher:   NewWatcher(path, logger),
+		logger:    logger,
+		clock:     clock,
+		state:     map[ContractID]Contract{},
+		subs:      map[chan adapter.InvalidationEvent[ContractID]]struct{}{},
+		stopCh:    make(chan struct{}),
+		doneCh:    make(chan struct{}),
+	}
+}
+
+// LogPath returns the absolute path the Provider reads from. Surfaces
+// the resolved default for diagnostics (e.g. `orchard query contracts
+// --help`).
+func (p *Provider) LogPath() string {
+	return p.adapterIO.Path()
+}
+
+// Start hydrates the cache from a Snapshot read, then launches the
+// watcher loop. Subsequent calls are no-ops.
+//
+// A missing log file is not an error — Start returns nil and the
+// watcher waits for the file to be created.
+func (p *Provider) Start(ctx context.Context) error {
+	var startErr error
+	p.startOnce.Do(func() {
+		events, offset, err := p.adapterIO.Snapshot(ctx)
+		if err != nil {
+			// Surface the error but let the daemon continue — a
+			// transient read failure should not collapse boot.
+			p.logger.Warn("contracts provider: snapshot read failed",
+				"path", p.adapterIO.Path(), "err", err)
+		}
+		p.mu.Lock()
+		p.state = Fold(events)
+		p.offset = offset
+		p.loaded = true
+		p.last = p.clock()
+		p.mu.Unlock()
+
+		go func() {
+			defer close(p.doneCh)
+			if runErr := p.watcher.Run(ctx); runErr != nil {
+				p.logger.Warn("contracts watcher exited", "err", runErr)
+			}
+		}()
+		go p.consume(ctx)
+		startErr = nil
+	})
+	return startErr
+}
+
+// Stop tears down the watcher and closes every Subscribe channel.
+// Idempotent. Safe to call before Start (no-op).
+//
+// Closing the underlying fsnotify watcher closes its event channels,
+// which causes [Watcher.Run] to exit and the provider's done channel
+// to fire. We wait for that exit so callers can rely on no further
+// invalidation events after Stop returns.
+func (p *Provider) Stop() error {
+	p.stopOnce.Do(func() {
+		close(p.stopCh)
+		p.watcher.Stop()
+		<-p.watcher.Done()
+		p.subMu.Lock()
+		for ch := range p.subs {
+			close(ch)
+			delete(p.subs, ch)
+		}
+		p.subMu.Unlock()
+	})
+	return nil
+}
+
+// Get returns one contract by id. The fold is the source of truth;
+// the adapter is consulted only when the contract is not in the cache
+// (which only happens during a watcher tick that has not landed yet).
+func (p *Provider) Get(_ context.Context, key ContractID) (*graphql.Contract, adapter.Freshness, error) {
+	p.mu.RLock()
+	c, ok := p.state[key]
+	loaded := p.loaded
+	last := p.last
+	p.mu.RUnlock()
+	if !ok {
+		if !loaded {
+			return nil, adapter.Freshness{}, fmt.Errorf("contracts provider not started")
+		}
+		return nil, adapter.Freshness{}, fmt.Errorf("unknown contract %q", key)
+	}
+	return toGraphQL(c), adapter.Freshness{LastFetchedAt: last, Source: adapter.SourceWatcherPush}, nil
+}
+
+// GetMany returns multiple contracts in a single call. Missing keys
+// are simply absent from the result maps per the Provider contract.
+func (p *Provider) GetMany(_ context.Context, keys []ContractID) (map[ContractID]*graphql.Contract, map[ContractID]adapter.Freshness, error) {
+	out := make(map[ContractID]*graphql.Contract, len(keys))
+	freshness := make(map[ContractID]adapter.Freshness, len(keys))
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if !p.loaded {
+		return out, freshness, fmt.Errorf("contracts provider not started")
+	}
+	for _, k := range keys {
+		c, ok := p.state[k]
+		if !ok {
+			continue
+		}
+		out[k] = toGraphQL(c)
+		freshness[k] = adapter.Freshness{LastFetchedAt: p.last, Source: adapter.SourceWatcherPush}
+	}
+	return out, freshness, nil
+}
+
+// Keys returns every contract id currently in the cache. Cold boot
+// returns an empty slice until [Start] hydrates.
+func (p *Provider) Keys(_ context.Context) ([]ContractID, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]ContractID, 0, len(p.state))
+	for k := range p.state {
+		out = append(out, k)
+	}
+	return out, nil
+}
+
+// List returns every cached Contract, sorted descending by
+// LastEventAt — most recently active contracts first. Optionally
+// filtered by [ContractFilter].
+//
+// Resolvers call this for `Query.contracts(filter)`. Returning the
+// graphql shape directly keeps the resolver layer trivial.
+func (p *Provider) List(_ context.Context, filter *graphql.ContractFilter) ([]*graphql.Contract, error) {
+	p.mu.RLock()
+	contracts := make([]Contract, 0, len(p.state))
+	for _, c := range p.state {
+		contracts = append(contracts, c)
+	}
+	loaded := p.loaded
+	p.mu.RUnlock()
+	if !loaded {
+		return nil, fmt.Errorf("contracts provider not started")
+	}
+
+	sort.Slice(contracts, func(i, j int) bool {
+		// Descending — most-recent first.
+		ti := contracts[i].LastEventAt
+		tj := contracts[j].LastEventAt
+		if ti.Equal(tj) {
+			return contracts[i].ID < contracts[j].ID
+		}
+		return ti.After(tj)
+	})
+
+	out := make([]*graphql.Contract, 0, len(contracts))
+	for _, c := range contracts {
+		gc := toGraphQL(c)
+		if filter != nil && !matches(gc, filter) {
+			continue
+		}
+		out = append(out, gc)
+	}
+	return out, nil
+}
+
+// Subscribe returns a channel that receives one event per contract
+// whose folded value just changed. The channel closes when ctx is
+// cancelled or [Stop] runs.
+//
+// Sends are non-blocking — a slow consumer drops events rather than
+// stalling the watcher. Callers re-fetch via [Get] or [List] in
+// response.
+func (p *Provider) Subscribe(ctx context.Context) <-chan adapter.InvalidationEvent[ContractID] {
+	ch := make(chan adapter.InvalidationEvent[ContractID], 16)
+	p.subMu.Lock()
+	p.subs[ch] = struct{}{}
+	p.subMu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		p.subMu.Lock()
+		defer p.subMu.Unlock()
+		if _, ok := p.subs[ch]; ok {
+			delete(p.subs, ch)
+			close(ch)
+		}
+	}()
+	return ch
+}
+
+// consume drives the fold loop. Each watcher tick triggers a tail read
+// from the saved offset; new events are merged into the existing state
+// (so the fold is incremental, not full-rebuild) and invalidations are
+// fanned out for whichever ids changed.
+func (p *Provider) consume(ctx context.Context) {
+	notifications := p.watcher.Notifications()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.stopCh:
+			return
+		case _, ok := <-notifications:
+			if !ok {
+				return
+			}
+			p.refresh(ctx)
+		}
+	}
+}
+
+// refresh tails the JSONL from the saved offset, applies new events to
+// the in-memory state, advances the offset, and fans out
+// InvalidationEvents for every id touched. Run on every watcher poke.
+func (p *Provider) refresh(ctx context.Context) {
+	p.mu.RLock()
+	from := p.offset
+	p.mu.RUnlock()
+
+	events, advanced, err := p.adapterIO.FollowFromOffset(ctx, from)
+	if err != nil {
+		p.logger.Warn("contracts provider: tail read failed",
+			"path", p.adapterIO.Path(), "err", err)
+	}
+
+	if len(events) == 0 && advanced == from {
+		return
+	}
+
+	touched := make(map[ContractID]struct{}, len(events))
+	now := p.clock()
+	p.mu.Lock()
+	for _, ev := range events {
+		applyEvent(p.state, ev)
+		if ev.ID != "" {
+			touched[ContractID(ev.ID)] = struct{}{}
+		}
+	}
+	p.offset = advanced
+	p.last = now
+	p.mu.Unlock()
+
+	if advanced < from {
+		// File rotated — re-fold from scratch on next tick. We dropped
+		// state; emit invalidations for every known id so subscribers
+		// re-read.
+		p.logger.Info("contracts provider: log rotated; cache may be stale",
+			"path", p.adapterIO.Path())
+	}
+
+	if len(touched) == 0 {
+		return
+	}
+	for id := range touched {
+		p.fanOut(adapter.InvalidationEvent[ContractID]{
+			Key:    id,
+			Reason: "watcher-push",
+			At:     now,
+		})
+	}
+}
+
+// fanOut broadcasts an invalidation event to every active subscriber.
+// Sends are best-effort; a slow consumer drops events.
+func (p *Provider) fanOut(ev adapter.InvalidationEvent[ContractID]) {
+	p.subMu.Lock()
+	subs := make([]chan adapter.InvalidationEvent[ContractID], 0, len(p.subs))
+	for ch := range p.subs {
+		subs = append(subs, ch)
+	}
+	p.subMu.Unlock()
+	for _, ch := range subs {
+		select {
+		case ch <- ev:
+		default:
+		}
+	}
+}
+
+// matches applies a ContractFilter to a single Contract. All filter
+// fields are AND-combined; nil/empty fields match everything.
+func matches(c *graphql.Contract, f *graphql.ContractFilter) bool {
+	if f == nil {
+		return true
+	}
+	if len(f.Statuses) > 0 {
+		ok := false
+		for _, s := range f.Statuses {
+			if s == c.Status {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	if f.OwnerSessionID != nil && *f.OwnerSessionID != "" && c.OwnerSessionID != *f.OwnerSessionID {
+		return false
+	}
+	if f.OwnerAgentName != nil && *f.OwnerAgentName != "" && c.OwnerAgentName != *f.OwnerAgentName {
+		return false
+	}
+	if f.ParentContractID != nil && *f.ParentContractID != "" {
+		if c.ParentContractID == nil || *c.ParentContractID != *f.ParentContractID {
+			return false
+		}
+	}
+	return true
+}
+
+// toGraphQL projects an internal Contract onto the GraphQL shape. Pure;
+// the resolver layer calls it after every read.
+func toGraphQL(c Contract) *graphql.Contract {
+	out := &graphql.Contract{
+		ID:             "Contract:" + string(c.ID),
+		ContractID:     string(c.ID),
+		Statement:      c.Statement,
+		OwnerSessionID: c.OwnerSessionID,
+		OwnerAgentName: c.OwnerAgentName,
+		Status:         mapStatus(c.Status),
+		CreatedAt:      formatTime(c.CreatedAt),
+		UpdatedAt:      formatTime(c.UpdatedAt),
+		LastEventAt:    formatTime(c.LastEventAt),
+		Criteria:       append([]string{}, c.Criteria...),
+		OpenQuestions:  buildOpenQuestions(c.OpenQuestions),
+	}
+	if c.ReportsTo != "" {
+		s := c.ReportsTo
+		out.ReportsTo = &s
+	}
+	if c.ParentContractID != "" {
+		s := c.ParentContractID
+		out.ParentContractID = &s
+	}
+	return out
+}
+
+// buildOpenQuestions copies the internal OpenQuestion list onto the
+// generated graphql.ContractQuestion slice. We allocate a fresh slice
+// so callers cannot mutate the cache by editing the response.
+func buildOpenQuestions(qs []OpenQuestion) []*graphql.ContractQuestion {
+	if len(qs) == 0 {
+		return []*graphql.ContractQuestion{}
+	}
+	out := make([]*graphql.ContractQuestion, 0, len(qs))
+	for _, q := range qs {
+		gq := &graphql.ContractQuestion{
+			QuestionID:  q.QuestionID,
+			Text:        q.Text,
+			AskedBy:     q.AskedBy,
+			AskedAt:     formatTime(q.AskedAt),
+			BlocksClose: q.BlocksClose,
+		}
+		if q.Deadline != nil {
+			d := formatTime(*q.Deadline)
+			gq.Deadline = &d
+		}
+		out = append(out, gq)
+	}
+	return out
+}
+
+// mapStatus maps the plugin's raw status string to the schema enum.
+// Unknown values fall through to OPEN — the safest default for a
+// future-tense enum addition.
+func mapStatus(s string) graphql.ContractStatus {
+	switch s {
+	case "open":
+		return graphql.ContractStatusOpen
+	case "delivered_pending_validation":
+		return graphql.ContractStatusDeliveredPendingValidation
+	case "delivered_pending_parent_validation":
+		return graphql.ContractStatusDeliveredPendingParentValidation
+	case "pending_drew_approval":
+		return graphql.ContractStatusPendingDrewApproval
+	case "awaiting_cancel_ack":
+		return graphql.ContractStatusAwaitingCancelAck
+	case "waiting_external":
+		return graphql.ContractStatusWaitingExternal
+	case "satisfied":
+		return graphql.ContractStatusSatisfied
+	case "cancelled":
+		return graphql.ContractStatusCancelled
+	case "judge_rejected_terminal":
+		return graphql.ContractStatusJudgeRejectedTerminal
+	default:
+		return graphql.ContractStatusOpen
+	}
+}
+
+// formatTime renders a time as RFC 3339 with nanosecond precision.
+// Mirrors the Host provider's lastSeenAt format so clients get a
+// consistent timestamp shape across the schema.
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// Compile-time assertion that Provider satisfies the generic
+// Provider interface from internal/server/adapter.
+var _ adapter.Provider[ContractID, *graphql.Contract] = (*Provider)(nil)

--- a/internal/server/providers/contracts/types.go
+++ b/internal/server/providers/contracts/types.go
@@ -1,0 +1,114 @@
+package contracts
+
+import (
+	"time"
+)
+
+// ContractID is the cache key for the Contract provider. Equal to the
+// plugin-issued contract id (e.g. "C-2026-05-04-abc12345").
+type ContractID string
+
+// Event is one line of the contract JSONL log. The plugin emits
+// several event kinds — creation, status_change, criterion_added,
+// question_asked, question_answered, cancel_requested, cancel_acked,
+// cancel_withdrawn, judge_run, cooldown_set, wait_started, etc. —
+// each with a `kind` discriminator. The shape is intentionally a
+// single struct: most fields are pointers / optional, and Fold uses
+// the discriminator to decide which fields to read.
+//
+// Field order mirrors the on-disk JSONL so that go-toolchain
+// reflection and `cmp.Diff` output read like the file does.
+type Event struct {
+	// Kind discriminates which fields are present. Required on every
+	// line. Unknown kinds are skipped by Fold so the daemon stays
+	// forward-compatible with plugin extensions.
+	Kind string `json:"kind"`
+
+	// Timestamp is required on every event except the creation
+	// record (which uses CreatedOn instead). RFC 3339 format.
+	Timestamp *time.Time `json:"timestamp,omitempty"`
+
+	// Creation events embed the full contract record inline.
+	ID            string     `json:"id,omitempty"`
+	Statement     string     `json:"statement,omitempty"`
+	Owner         *Party     `json:"owner,omitempty"`
+	ReportsTo     *Party     `json:"reports_to,omitempty"`
+	Parent        *string    `json:"parent_contract_id,omitempty"`
+	CreatedOn     *time.Time `json:"created_on,omitempty"`
+	UpdatedOn     *time.Time `json:"updated_on,omitempty"`
+	InitialStatus string     `json:"status,omitempty"` // creation status (always "open" today)
+
+	// Status-change events.
+	From    string `json:"from,omitempty"`
+	To      string `json:"to,omitempty"`
+	Trigger string `json:"trigger,omitempty"`
+
+	// Criterion-added events.
+	Criterion string `json:"criterion,omitempty"`
+	Rationale string `json:"rationale,omitempty"`
+
+	// Question events.
+	QuestionID       string     `json:"question_id,omitempty"`
+	QuestionText     string     `json:"text,omitempty"`
+	QuestionBlocks   *bool      `json:"blocks_close,omitempty"`
+	QuestionDeadline *time.Time `json:"deadline_timestamp,omitempty"`
+	QuestionAskedTo  *Party     `json:"asked_to,omitempty"`
+	QuestionAnswer   string     `json:"answer,omitempty"`
+
+	// Cancel events.
+	CancelRequestID string     `json:"cancel_request_id,omitempty"`
+	CancelDeadline  *time.Time `json:"ack_deadline_timestamp,omitempty"`
+
+	// Cooldown / wait events.
+	UntilTimestamp *time.Time `json:"until_timestamp,omitempty"`
+
+	// Judge-run events.
+	Verdict       string   `json:"verdict,omitempty"`
+	Reason        string   `json:"reason,omitempty"`
+	EvidenceLinks []string `json:"evidence_links,omitempty"`
+
+	// By is the agent that produced the event. Present on most kinds;
+	// absent on system-generated status_change rows where Trigger
+	// carries the cause.
+	By string `json:"by,omitempty"`
+}
+
+// Party identifies an agent or Drew. Matches the plugin's nested shape:
+// `{kind: "drew" | "agent", agent_name?, vm_address?, session_id?}`.
+type Party struct {
+	Kind      string  `json:"kind,omitempty"`
+	AgentName *string `json:"agent_name,omitempty"`
+	SessionID string  `json:"session_id,omitempty"`
+	VMAddress *string `json:"vm_address,omitempty"`
+}
+
+// Contract is the folded state of one contract, in the daemon's
+// internal shape. The resolver layer projects this onto graphql.Contract.
+//
+// Carries everything the schema surfaces plus a few private bookkeeping
+// fields (LastEventAt for sorting, raw event count for debugging).
+type Contract struct {
+	ID               ContractID
+	Statement        string
+	OwnerSessionID   string
+	OwnerAgentName   string
+	ReportsTo        string // empty when unset; "drew" or "agent:<name>"
+	ParentContractID string // empty when top-level
+	Status           string // raw plugin status string; resolver maps to enum
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+	LastEventAt      time.Time
+	Criteria         []string
+	OpenQuestions    []OpenQuestion
+}
+
+// OpenQuestion is a question still awaiting an answer. The fold drops
+// answered / timed-out questions from this list.
+type OpenQuestion struct {
+	QuestionID  string
+	Text        string
+	AskedBy     string
+	AskedAt     time.Time
+	Deadline    *time.Time
+	BlocksClose bool
+}

--- a/internal/server/providers/contracts/watcher.go
+++ b/internal/server/providers/contracts/watcher.go
@@ -1,0 +1,200 @@
+package contracts
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher emits a notification whenever the contracts JSONL file may
+// have new bytes appended. The Provider drives a poll-from-offset on
+// every notification so the actual fold runs in the Provider's
+// goroutine, not the watcher's.
+//
+// The watcher tracks two paths:
+//
+//   - The log file itself, when it exists. fsnotify Write / Create /
+//     Rename events all signal "re-read."
+//   - The parent directory, always. fsnotify Create on the log file
+//     name promotes the missing-file case to the file-watch path
+//     without any polling.
+//
+// A nudge channel decouples bursts of events (the writer often fires
+// several Writes within milliseconds of each other) — duplicate
+// notifications collapse to one fold pass at the consumer side.
+type Watcher struct {
+	path    string
+	logger  *slog.Logger
+	notify  chan struct{}
+	stopped chan struct{}
+
+	mu     sync.Mutex
+	fsw    *fsnotify.Watcher
+	closed bool
+}
+
+// NewWatcher constructs a Watcher rooted at the given log path.
+// Run must be called exactly once after construction.
+func NewWatcher(path string, logger *slog.Logger) *Watcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Watcher{
+		path:    path,
+		logger:  logger,
+		notify:  make(chan struct{}, 1),
+		stopped: make(chan struct{}),
+	}
+}
+
+// Notifications returns the channel callers select on. A receive
+// signals "the log file may have new data" — semantics intentionally
+// fuzzy because fsnotify's CREATE/WRITE/RENAME events can arrive in
+// any combination during a single append.
+//
+// Sends are coalesced: if a notification is pending and the consumer
+// has not yet drained it, additional events are dropped.
+func (w *Watcher) Notifications() <-chan struct{} {
+	return w.notify
+}
+
+// Run starts the fsnotify loop and blocks until ctx is cancelled or an
+// unrecoverable error occurs. It is safe to call from a goroutine; the
+// returned error reflects setup failures only — runtime errors are
+// logged and the loop continues.
+func (w *Watcher) Run(ctx context.Context) error {
+	defer close(w.stopped)
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	w.mu.Lock()
+	w.fsw = fsw
+	w.closed = false
+	w.mu.Unlock()
+	defer w.closeWatcher()
+
+	dir := filepath.Dir(w.path)
+	if err := fsw.Add(dir); err != nil {
+		// Parent directory missing → emit one notification so the
+		// Provider attempts a snapshot (which will return empty), then
+		// keep retrying every tick. In practice the parent directory
+		// is created by the contracts plugin's first write.
+		w.logger.Warn("contracts watcher: parent dir not watchable",
+			"dir", dir, "err", err)
+	}
+	if err := w.attachFile(); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		w.logger.Warn("contracts watcher: file not watchable",
+			"path", w.path, "err", err)
+	}
+
+	// Best-effort initial poke — ensures the Provider runs a snapshot
+	// at boot even when no fsnotify event has fired yet.
+	w.poke()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev, ok := <-fsw.Events:
+			if !ok {
+				return nil
+			}
+			w.handleEvent(ev)
+		case err, ok := <-fsw.Errors:
+			if !ok {
+				return nil
+			}
+			w.logger.Warn("contracts watcher: fsnotify error", "err", err)
+		}
+	}
+}
+
+// Done returns a channel that closes when Run has fully exited. Useful
+// for tests that want to wait on shutdown without polling.
+func (w *Watcher) Done() <-chan struct{} {
+	return w.stopped
+}
+
+// Stop tears down the underlying fsnotify watcher. Safe to call from
+// any goroutine; idempotent. After Stop returns, [Run] is on its way
+// to exiting (it observes the closed event channels and unwinds).
+func (w *Watcher) Stop() {
+	w.closeWatcher()
+}
+
+// Poke is a public version of poke for tests — fires a notification
+// without waiting for fsnotify.
+func (w *Watcher) Poke() {
+	w.poke()
+}
+
+// handleEvent decides whether an fsnotify event warrants a refresh.
+// Any event touching the log file (or its parent dir, when CREATE)
+// triggers a notification.
+func (w *Watcher) handleEvent(ev fsnotify.Event) {
+	cleanPath := filepath.Clean(w.path)
+	cleanEv := filepath.Clean(ev.Name)
+	if cleanEv != cleanPath {
+		// Parent-dir activity that is not our file. Two cases worth
+		// reacting to: CREATE on a path that resolves to our file
+		// (handled below) and RENAME of our file (handled by the
+		// fsnotify Op flags).
+		if ev.Op&fsnotify.Create != 0 && cleanEv == cleanPath {
+			_ = w.attachFile()
+		}
+		return
+	}
+
+	if ev.Op&fsnotify.Create != 0 {
+		// Promote the parent-dir watch to a real file watch so future
+		// Write events fire on the file path directly.
+		_ = w.attachFile()
+	}
+	if ev.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename|fsnotify.Remove) != 0 {
+		w.poke()
+	}
+}
+
+// attachFile adds the log file to the watcher. Returns fs.ErrNotExist
+// when the file does not exist yet — caller decides how to react.
+func (w *Watcher) attachFile() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.fsw == nil || w.closed {
+		return errors.New("watcher closed")
+	}
+	if _, err := os.Stat(w.path); err != nil {
+		return err
+	}
+	return w.fsw.Add(w.path)
+}
+
+// poke pushes one signal onto the notification channel, dropping it
+// silently if the channel is already full. Coalescing keeps the
+// downstream fold loop from running in lockstep with every fsnotify
+// event during a burst write.
+func (w *Watcher) poke() {
+	select {
+	case w.notify <- struct{}{}:
+	default:
+	}
+}
+
+// closeWatcher tears down the underlying fsnotify watcher. Idempotent.
+func (w *Watcher) closeWatcher() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed || w.fsw == nil {
+		return
+	}
+	_ = w.fsw.Close()
+	w.closed = true
+}

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -9,6 +9,7 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/contracts"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
@@ -32,6 +33,7 @@ type Resolver struct {
 	ClaudeProjects      *claudeprojects.Provider
 	ClaudeAccount       *claudeaccount.Provider
 	HostServiceProvider *hostservice.Provider
+	ContractsProvider   *contracts.Provider
 }
 
 // New constructs a Resolver with the daemon's start time captured.
@@ -84,5 +86,11 @@ func (r *Resolver) WithClaudeAccount(p *claudeaccount.Provider) *Resolver {
 // WithHostService wires the hostservice provider.
 func (r *Resolver) WithHostService(p *hostservice.Provider) *Resolver {
 	r.HostServiceProvider = p
+	return r
+}
+
+// WithContracts wires the contracts provider.
+func (r *Resolver) WithContracts(p *contracts.Provider) *Resolver {
+	r.ContractsProvider = p
 	return r
 }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -15,6 +15,7 @@ import (
 
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/contracts"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
@@ -243,16 +244,6 @@ func (r *queryResolver) Conversation(ctx context.Context, id string) (*graphql1.
 		return r.ClaudeProjects.ToGraphQL(c), nil
 	}
 	return nil, nil
-}
-
-// Contract is the resolver for the contract field. Stub until commit 3 wires the contracts provider.
-func (r *queryResolver) Contract(ctx context.Context, id string) (*graphql1.Contract, error) {
-	return nil, fmt.Errorf("contracts provider not wired")
-}
-
-// Contracts is the resolver for the contracts field. Stub until commit 3.
-func (r *queryResolver) Contracts(ctx context.Context, filter *graphql1.ContractFilter) ([]*graphql1.Contract, error) {
-	return nil, fmt.Errorf("contracts provider not wired")
 }
 
 // ClaudeAccounts is the resolver for the claudeAccounts field.
@@ -828,6 +819,36 @@ func mapState(s hostservice.State) graphql1.HostServiceState {
 	default:
 		return graphql1.HostServiceStateUnknown
 	}
+}
+
+// Contract is the resolver for the contract field.
+func (r *queryResolver) Contract(ctx context.Context, id string) (*graphql1.Contract, error) {
+	if r.ContractsProvider == nil {
+		return nil, fmt.Errorf("contracts provider not initialised")
+	}
+	key := contracts.ContractID(stripContractIDPrefix(id))
+	c, _, err := r.ContractsProvider.Get(ctx, key)
+	if err != nil {
+		return nil, nil
+	}
+	return c, nil
+}
+
+// Contracts is the resolver for the contracts field.
+func (r *queryResolver) Contracts(ctx context.Context, filter *graphql1.ContractFilter) ([]*graphql1.Contract, error) {
+	if r.ContractsProvider == nil {
+		return nil, fmt.Errorf("contracts provider not initialised")
+	}
+	return r.ContractsProvider.List(ctx, filter)
+}
+
+// stripContractIDPrefix tolerates both "Contract:<id>" and bare "<id>".
+func stripContractIDPrefix(id string) string {
+	const prefix = "Contract:"
+	if len(id) > len(prefix) && id[:len(prefix)] == prefix {
+		return id[len(prefix):]
+	}
+	return id
 }
 
 // Query returns graphql1.QueryResolver implementation.

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -245,6 +245,16 @@ func (r *queryResolver) Conversation(ctx context.Context, id string) (*graphql1.
 	return nil, nil
 }
 
+// Contract is the resolver for the contract field. Stub until commit 3 wires the contracts provider.
+func (r *queryResolver) Contract(ctx context.Context, id string) (*graphql1.Contract, error) {
+	return nil, fmt.Errorf("contracts provider not wired")
+}
+
+// Contracts is the resolver for the contracts field. Stub until commit 3.
+func (r *queryResolver) Contracts(ctx context.Context, filter *graphql1.ContractFilter) ([]*graphql1.Contract, error) {
+	return nil, fmt.Errorf("contracts provider not wired")
+}
+
 // ClaudeAccounts is the resolver for the claudeAccounts field.
 func (r *queryResolver) ClaudeAccounts(ctx context.Context) ([]*graphql1.ClaudeAccount, error) {
 	if r.ClaudeAccount == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@
 // Workstream B-claudeprojects: WithClaudeProjects starts on Run().
 // Workstream B-claudeaccount: WithClaudeAccount starts on Run().
 // Workstream B-hostservice: WithHostService starts on Run().
+// Workstream B-contracts: WithContracts starts on Run().
 package server
 
 import (
@@ -28,6 +29,7 @@ import (
 	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/contracts"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
@@ -55,6 +57,7 @@ type Server struct {
 	claudeProjects *claudeprojects.Provider
 	claudeAccount  *claudeaccount.Provider
 	hostService    *hostservice.Provider
+	contracts      *contracts.Provider
 }
 
 // Option mutates a Server during construction.
@@ -107,6 +110,14 @@ func WithHostService(p *hostservice.Provider) Option {
 	return func(s *Server, r *resolvers.Resolver) {
 		s.hostService = p
 		r.WithHostService(p)
+	}
+}
+
+// WithContracts attaches a contracts provider.
+func WithContracts(p *contracts.Provider) Option {
+	return func(s *Server, r *resolvers.Resolver) {
+		s.contracts = p
+		r.WithContracts(p)
 	}
 }
 
@@ -192,6 +203,11 @@ func (s *Server) Run(ctx context.Context) error {
 	if s.hostService != nil {
 		if err := s.hostService.Start(ctx); err != nil {
 			return fmt.Errorf("start hostservice provider: %w", err)
+		}
+	}
+	if s.contracts != nil {
+		if err := s.contracts.Start(ctx); err != nil {
+			return fmt.Errorf("start contracts provider: %w", err)
 		}
 	}
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -118,6 +118,12 @@ type Query {
 
   "All Claude CLI accounts surfaced by the local daemon. v1 returns the single account `claude auth status` reports for; later workstreams may surface additional accounts."
   claudeAccounts: [ClaudeAccount!]!
+
+  "A single Contract by id. Returns null if the id is unknown."
+  contract(id: ID!): Contract
+
+  "Every Contract the daemon currently knows about, optionally filtered."
+  contracts(filter: ContractFilter): [Contract!]!
 }
 
 type Health {
@@ -584,4 +590,96 @@ enum HostServiceState {
   inactive
   failed
   unknown
+}
+
+"""
+A commitment an agent has made to deliver something. Contracts are
+authored exclusively by the claude-contracts plugin; orchard reads
+them via the contracts provider and never writes.
+"""
+type Contract implements Node {
+  "Stable orchard id — \"Contract:<contract_id>\"."
+  id: ID!
+
+  "The contract id as written by the plugin."
+  contractId: ID!
+
+  "What the owner committed to deliver."
+  statement: String!
+
+  "Owner session id (Claude session UUID) recorded at creation time."
+  ownerSessionId: String!
+
+  "Owner agent name."
+  ownerAgentName: String!
+
+  "Routing target for status updates and question answers."
+  reportsTo: String
+
+  "Parent contract id when filed under a management contract."
+  parentContractId: ID
+
+  "Folded current status."
+  status: ContractStatus!
+
+  "RFC 3339 timestamp the contract was first created."
+  createdAt: String!
+
+  "RFC 3339 timestamp the contract was last touched."
+  updatedAt: String!
+
+  "Acceptance criteria added via `criterion_added` events, in original order."
+  criteria: [String!]!
+
+  "Questions awaiting an answer. Empty when nothing is pending."
+  openQuestions: [ContractQuestion!]!
+
+  "RFC 3339 timestamp of the most recent event affecting this contract."
+  lastEventAt: String!
+}
+
+"""
+Lifecycle states for Contract.
+"""
+enum ContractStatus {
+  OPEN
+  DELIVERED_PENDING_VALIDATION
+  DELIVERED_PENDING_PARENT_VALIDATION
+  PENDING_DREW_APPROVAL
+  AWAITING_CANCEL_ACK
+  WAITING_EXTERNAL
+  SATISFIED
+  CANCELLED
+  JUDGE_REJECTED_TERMINAL
+}
+
+"A blocking question recorded against a Contract."
+type ContractQuestion {
+  "Question id as written by the plugin."
+  questionId: ID!
+
+  "The question text."
+  text: String!
+
+  "Agent that asked the question."
+  askedBy: String!
+
+  "RFC 3339 timestamp the question was asked."
+  askedAt: String!
+
+  "RFC 3339 deadline after which the question times out."
+  deadline: String
+
+  "Whether this question blocks contract close while open."
+  blocksClose: Boolean!
+}
+
+"""
+Filter for `Query.contracts`. All fields are optional.
+"""
+input ContractFilter {
+  statuses: [ContractStatus!]
+  ownerSessionId: String
+  ownerAgentName: String
+  parentContractId: ID
 }


### PR DESCRIPTION
## Summary

- Implements the contracts provider per ADR-011 §5.1 + §11. Read-only adapter against the JSONL log the claude-contracts plugin writes; orchard never authors contracts.
- Schema-first: adds `Contract`, `ContractStatus` enum, `ContractQuestion` sub-type, `ContractFilter` input, `Query.contract(id)`, and `Query.contracts(filter)`.
- Pure `Fold(events) → map[ContractID]Contract` is the heart of the package — exhaustively unit-tested (12 cases) without IO.
- fsnotify watcher tracks the file *and* its parent directory so a missing log promotes to a real file watch on first CREATE.
- CLI: `orchard query contracts` with `--status` (comma-separated, validated client-side), `--owner-session`, `--owner-agent`, `--parent` filters.

## ACs

- [x] AC1 — schema additions (`Contract`, `ContractStatus`, `ContractQuestion`, `ContractFilter`, `Query.contract`, `Query.contracts`) — `f3990c4`
- [x] AC2 — `make generate` clean — `f3990c4`
- [x] AC3 — provider package layout: `adapter.go` (Stream + Snapshot, stateless), `fold.go` (pure), `provider.go` (`Provider[ContractID, *graphql.Contract]`, in-memory cache, incremental fold), `watcher.go` (fsnotify file + parent dir), `types.go`, `path.go`, `doc.go` — `cfa2718`
- [x] AC4 — `CLAUDE_CONTRACTS_LOG` env override; default `${XDG_STATE_HOME:-$HOME/.local/state}/claude-contracts/contracts.jsonl` — `cfa2718`
- [x] AC5 — missing log → empty list, no error; watcher remains warm via parent-dir attach — `cfa2718`
- [x] AC6 — Resolvers wired (`Query.contract`, `Query.contracts`); server constructs and starts the provider — `1731ba3`
- [x] AC7 — `orchard query contracts --status started` (cobra) mirroring host sibling pattern — `16e7fca`
- [x] AC8 — E2E test in `t.TempDir()`: created → judge_run → delivered → satisfied lifecycle, then mid-test cancel append, asserts subscriber sees invalidation, asserts GraphQL surfaces the new status — `cb75f6a`
- [x] AC9 — `go test ./internal/server/providers/contracts/...` green — verified locally (~2.5s, 14 tests + 1 subtest matrix)
- [x] AC10 — `golangci-lint run` clean for scope (`./internal/server/providers/contracts/... ./internal/cli/query/... ./internal/server/resolvers/...`) — verified locally with `v1.61.0`
- [x] AC11 — PR opened (not draft) targeting `main` ✓

## Notes for reviewers

### Spec discrepancy (flag for transparency)

The briefing's AC list and `references/contracts.md` describe two different shapes:

- **References** (canonical, dated 2026-05-04): three statuses (`started | blocked | delivered`), no judge step, no question lifecycle, no Drew approval gate, no parent contracts.
- **Live plugin JSONL** (`~/.claude/contracts/*.jsonl`): seven non-terminal statuses, judge runs, criterion_added, question_asked/answered/timed_out, cancel ack flow, child_linked.

I mirrored **the live JSONL** because: (a) ADR-011 §11 explicitly defers contracts cleanup to a separate sister, (b) the daemon must read what the plugin actually writes today, and (c) the briefing's AC for `ContractStatus` enum + `ContractQuestion` sub-type only makes sense in the richer shape. Contract `C-2026-05-03-0a0bb5ea` ("tear down claude-contracts to match the canonical") is the open cleanup work; this provider can shrink in lockstep with that sister, and the schema's enum is additive so removing values later is a graceful breaking change.

### Sibling pattern alignment

Mirrors the merged `ws-b-host` PR for layering:

- `Provider[K, V]` interface from `internal/server/adapter/`
- Test-friendly constructor (`NewWithPath`, `NewForTest`) for clock injection
- Compile-time assertion `var _ adapter.Provider[ContractID, *graphql.Contract] = (*Provider)(nil)`
- CLI subcommand mirrors `internal/cli/query/host.go` (canonical query const + `--addr` override)

The watcher draws on the `ws-b-claudeprojects` (PR #386) pattern for fsnotify-on-missing-paths, but stays simpler — contracts is a single file, not a recursive directory.

### Threading + shutdown

`provider.Stop()` closes the underlying fsnotify watcher rather than blocking on context cancellation. This avoids the deadlock where a deferred `Stop()` waits on a context that hasn't yet been cancelled because `cancel()` is itself deferred. Subscribe channels close after the watcher unwinds.

### NO PII

- All test fixtures use `agent-1` / `agent-2`, `session-1` / `session-2`, generic `C-…-deadbeef`/`cafef00d`/`aaaa1111` ids.
- Tests run against `t.TempDir()` only — never touch real `~/.claude/contracts/`.
- Verified by inspection plus the gitleaks pre-commit hook (no leaks across all 5 commits).

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1 -timeout 120s` — green
- [x] `golangci-lint run` for scope — clean
- [x] Manual smoke test: built binary read my real contract from disk via `CLAUDE_CONTRACTS_LOG=…`; `curl POST /graphql 'query { contracts { contractId statement status } }'` returned the expected payload.
- [ ] CI green on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GraphQL queries (`contract` and `contracts`) to retrieve and filter contracts by status, owner session, owner agent, or parent contract.
  * Added CLI command to query contracts with filter options.
  * Contracts now track full lifecycle status and support question tracking with deadlines and blocking indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->