### PR TITLE
Workstream B-claudeinstance: claudeinstance provider → ClaudeInstance node

### DIFF
--- a/internal/cli/query/claudeinstances.go
+++ b/internal/cli/query/claudeinstances.go
@@ -1,0 +1,49 @@
+package query
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// claudeInstancesQuery is the canonical projection of every
+// ClaudeInstance node. Mirrors hostQuery: keeps the CLI in lockstep
+// with the schema so a regression in the resolver surfaces immediately
+// in `orchard query claude-instances`.
+const claudeInstancesQuery = `query LocalClaudeInstances {
+  claudeInstances {
+    id
+    state
+    rcUrl
+    rcEnabled
+    sessionUuid
+    startedAt
+    pane {
+      id
+    }
+    process {
+      id
+    }
+    account {
+      id
+    }
+  }
+}`
+
+// claudeInstancesCmd returns the `orchard query claude-instances`
+// subcommand. The hyphenated name mirrors the schema field that turns
+// into camelCase on the GraphQL side and reads naturally on the CLI.
+func claudeInstancesCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "claude-instances",
+		Short: "List Claude instances running on the local host",
+		Long: "Issue the canonical ClaudeInstance GraphQL query against the running orchard daemon\n" +
+			"and print the JSON response. One row per heartbeat file present at\n" +
+			"$ORCHARD_HEARTBEAT_DIR (default $TMPDIR). Edges to TmuxPane / Process / ClaudeAccount\n" +
+			"are populated when the relevant sibling provider is wired (ws-b-tmux, ws-b-ps,\n" +
+			"ws-b-claudeaccount).",
+		Example: "  orchard query claude-instances",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRaw(cmd.Context(), cmd.OutOrStdout(), claudeInstancesQuery)
+		},
+	}
+	return c
+}

--- a/internal/cli/query/query.go
+++ b/internal/cli/query/query.go
@@ -78,6 +78,7 @@ func Command() *cobra.Command {
 	cmd.AddCommand(claudeAccountCmd())
 	cmd.AddCommand(hostServicesCmd())
 	cmd.AddCommand(contractsCmd())
+	cmd.AddCommand(claudeInstancesCmd())
 	return cmd
 }
 

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -66,7 +66,15 @@ type ComplexityRoot struct {
 	}
 
 	ClaudeInstance struct {
-		ID func(childComplexity int) int
+		Account     func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Pane        func(childComplexity int) int
+		Process     func(childComplexity int) int
+		RcEnabled   func(childComplexity int) int
+		RcURL       func(childComplexity int) int
+		SessionUUID func(childComplexity int) int
+		StartedAt   func(childComplexity int) int
+		State       func(childComplexity int) int
 	}
 
 	Contract struct {
@@ -159,18 +167,19 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		ClaudeAccounts func(childComplexity int) int
-		Contract       func(childComplexity int, id string) int
-		Contracts      func(childComplexity int, filter *ContractFilter) int
-		Conversation   func(childComplexity int, id string) int
-		Conversations  func(childComplexity int) int
-		Health         func(childComplexity int) int
-		Host           func(childComplexity int) int
-		Hosts          func(childComplexity int) int
-		Projects       func(childComplexity int) int
-		TmuxPanes      func(childComplexity int, filter *TmuxPaneFilter) int
-		TmuxServer     func(childComplexity int) int
-		TmuxSessions   func(childComplexity int, filter *TmuxSessionFilter) int
+		ClaudeAccounts  func(childComplexity int) int
+		ClaudeInstances func(childComplexity int) int
+		Contract        func(childComplexity int, id string) int
+		Contracts       func(childComplexity int, filter *ContractFilter) int
+		Conversation    func(childComplexity int, id string) int
+		Conversations   func(childComplexity int) int
+		Health          func(childComplexity int) int
+		Host            func(childComplexity int) int
+		Hosts           func(childComplexity int) int
+		Projects        func(childComplexity int) int
+		TmuxPanes       func(childComplexity int, filter *TmuxPaneFilter) int
+		TmuxServer      func(childComplexity int) int
+		TmuxSessions    func(childComplexity int, filter *TmuxSessionFilter) int
 	}
 
 	ResourceLoad struct {
@@ -284,6 +293,7 @@ type QueryResolver interface {
 	ClaudeAccounts(ctx context.Context) ([]*ClaudeAccount, error)
 	Contract(ctx context.Context, id string) (*Contract, error)
 	Contracts(ctx context.Context, filter *ContractFilter) ([]*Contract, error)
+	ClaudeInstances(ctx context.Context) ([]*ClaudeInstance, error)
 }
 type TmuxClientResolver interface {
 	Server(ctx context.Context, obj *TmuxClient) (*TmuxServer, error)
@@ -417,12 +427,68 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ClaudeAccount.QuotaUsed(childComplexity), true
 
+	case "ClaudeInstance.account":
+		if e.complexity.ClaudeInstance.Account == nil {
+			break
+		}
+
+		return e.complexity.ClaudeInstance.Account(childComplexity), true
+
 	case "ClaudeInstance.id":
 		if e.complexity.ClaudeInstance.ID == nil {
 			break
 		}
 
 		return e.complexity.ClaudeInstance.ID(childComplexity), true
+
+	case "ClaudeInstance.pane":
+		if e.complexity.ClaudeInstance.Pane == nil {
+			break
+		}
+
+		return e.complexity.ClaudeInstance.Pane(childComplexity), true
+
+	case "ClaudeInstance.process":
+		if e.complexity.ClaudeInstance.Process == nil {
+			break
+		}
+
+		return e.complexity.ClaudeInstance.Process(childComplexity), true
+
+	case "ClaudeInstance.rcEnabled":
+		if e.complexity.ClaudeInstance.RcEnabled == nil {
+			break
+		}
+
+		return e.complexity.ClaudeInstance.RcEnabled(childComplexity), true
+
+	case "ClaudeInstance.rcUrl":
+		if e.complexity.ClaudeInstance.RcURL == nil {
+			break
+		}
+
+		return e.complexity.ClaudeInstance.RcURL(childComplexity), true
+
+	case "ClaudeInstance.sessionUuid":
+		if e.complexity.ClaudeInstance.SessionUUID == nil {
+			break
+		}
+
+		return e.complexity.ClaudeInstance.SessionUUID(childComplexity), true
+
+	case "ClaudeInstance.startedAt":
+		if e.complexity.ClaudeInstance.StartedAt == nil {
+			break
+		}
+
+		return e.complexity.ClaudeInstance.StartedAt(childComplexity), true
+
+	case "ClaudeInstance.state":
+		if e.complexity.ClaudeInstance.State == nil {
+			break
+		}
+
+		return e.complexity.ClaudeInstance.State(childComplexity), true
 
 	case "Contract.contractId":
 		if e.complexity.Contract.ContractID == nil {
@@ -890,6 +956,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.ClaudeAccounts(childComplexity), true
+
+	case "Query.claudeInstances":
+		if e.complexity.Query.ClaudeInstances == nil {
+			break
+		}
+
+		return e.complexity.Query.ClaudeInstances(childComplexity), true
 
 	case "Query.contract":
 		if e.complexity.Query.Contract == nil {
@@ -1599,11 +1672,54 @@ type Process implements Node {
   claudeInstance: ClaudeInstance
 }
 
-# Forward-declared placeholder. ws-b-claudeinstance replaces this with the
-# real ClaudeInstance node (pane, process, account, state, …).
-type ClaudeInstance {
-  "Stable id; ws-b-claudeinstance formalises (host_id, claudePid)."
+"""
+A live Claude Code session running on a host. Identity is the
+foreground claude pid scoped to a host. The provider tracks the
+heartbeat file the Claude Code SessionStart hook writes.
+"""
+type ClaudeInstance implements Node {
+  "Stable orchard id — \"ClaudeInstance:<host>:<claudePid>\"."
   id: ID!
+
+  "Tmux pane hosting this Claude process. Null if no pane could be matched."
+  pane: TmuxPane
+
+  "OS-level process. Null until the process can be matched by pid."
+  process: Process
+
+  "Claude CLI account this session is authenticated under."
+  account: ClaudeAccount
+
+  "Lifecycle state derived from the heartbeat file plus pid liveness."
+  state: InstanceState!
+
+  "claude.ai Remote Control URL when the session has it enabled."
+  rcUrl: String
+
+  "True when remote-control is enabled for this session."
+  rcEnabled: Boolean!
+
+  "Claude session UUID. Mirrors the heartbeat's session_id field."
+  sessionUuid: String
+
+  "RFC3339 timestamp the session was started."
+  startedAt: String
+}
+
+"Lifecycle states for a Claude instance."
+enum InstanceState {
+  "Claude is actively executing a tool or generating a response."
+  working
+  "Claude has finished its turn and is waiting for the next prompt."
+  idle
+  "Claude is paused and waiting for user input."
+  input
+  "The session has been alive but is no longer answering heartbeats."
+  stalled
+  "Tracked but the underlying process is gone."
+  dead
+  "No Claude session has ever been observed for this pane/process."
+  no_claude
 }
 
 # ProcessFilter is applied at the resolver layer over the cached process
@@ -1655,6 +1771,9 @@ type Query {
 
   "Every Contract the daemon currently knows about, optionally filtered."
   contracts(filter: ContractFilter): [Contract!]!
+
+  "All live Claude instances the daemon is tracking via heartbeat files."
+  claudeInstances: [ClaudeInstance!]!
 }
 
 type Health {
@@ -2803,6 +2922,22 @@ func (ec *executionContext) fieldContext_ClaudeAccount_instances(ctx context.Con
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_ClaudeInstance_id(ctx, field)
+			case "pane":
+				return ec.fieldContext_ClaudeInstance_pane(ctx, field)
+			case "process":
+				return ec.fieldContext_ClaudeInstance_process(ctx, field)
+			case "account":
+				return ec.fieldContext_ClaudeInstance_account(ctx, field)
+			case "state":
+				return ec.fieldContext_ClaudeInstance_state(ctx, field)
+			case "rcUrl":
+				return ec.fieldContext_ClaudeInstance_rcUrl(ctx, field)
+			case "rcEnabled":
+				return ec.fieldContext_ClaudeInstance_rcEnabled(ctx, field)
+			case "sessionUuid":
+				return ec.fieldContext_ClaudeInstance_sessionUuid(ctx, field)
+			case "startedAt":
+				return ec.fieldContext_ClaudeInstance_startedAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
 		},
@@ -2849,6 +2984,418 @@ func (ec *executionContext) fieldContext_ClaudeInstance_id(ctx context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ClaudeInstance_pane(ctx context.Context, field graphql.CollectedField, obj *ClaudeInstance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ClaudeInstance_pane(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Pane, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxPane)
+	fc.Result = res
+	return ec.marshalOTmuxPane2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPane(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ClaudeInstance_pane(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ClaudeInstance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxPane_id(ctx, field)
+			case "window":
+				return ec.fieldContext_TmuxPane_window(ctx, field)
+			case "paneId":
+				return ec.fieldContext_TmuxPane_paneId(ctx, field)
+			case "title":
+				return ec.fieldContext_TmuxPane_title(ctx, field)
+			case "currentCommand":
+				return ec.fieldContext_TmuxPane_currentCommand(ctx, field)
+			case "currentPid":
+				return ec.fieldContext_TmuxPane_currentPid(ctx, field)
+			case "width":
+				return ec.fieldContext_TmuxPane_width(ctx, field)
+			case "height":
+				return ec.fieldContext_TmuxPane_height(ctx, field)
+			case "dead":
+				return ec.fieldContext_TmuxPane_dead(ctx, field)
+			case "watchingClients":
+				return ec.fieldContext_TmuxPane_watchingClients(ctx, field)
+			case "process":
+				return ec.fieldContext_TmuxPane_process(ctx, field)
+			case "claudeInstance":
+				return ec.fieldContext_TmuxPane_claudeInstance(ctx, field)
+			case "content":
+				return ec.fieldContext_TmuxPane_content(ctx, field)
+			case "contentRange":
+				return ec.fieldContext_TmuxPane_contentRange(ctx, field)
+			case "contentFull":
+				return ec.fieldContext_TmuxPane_contentFull(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxPane", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ClaudeInstance_process(ctx context.Context, field graphql.CollectedField, obj *ClaudeInstance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ClaudeInstance_process(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Process, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*Process)
+	fc.Result = res
+	return ec.marshalOProcess2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐProcess(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ClaudeInstance_process(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ClaudeInstance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Process_id(ctx, field)
+			case "host":
+				return ec.fieldContext_Process_host(ctx, field)
+			case "pid":
+				return ec.fieldContext_Process_pid(ctx, field)
+			case "ppid":
+				return ec.fieldContext_Process_ppid(ctx, field)
+			case "command":
+				return ec.fieldContext_Process_command(ctx, field)
+			case "args":
+				return ec.fieldContext_Process_args(ctx, field)
+			case "cwd":
+				return ec.fieldContext_Process_cwd(ctx, field)
+			case "startedAt":
+				return ec.fieldContext_Process_startedAt(ctx, field)
+			case "cpuPercent":
+				return ec.fieldContext_Process_cpuPercent(ctx, field)
+			case "memBytes":
+				return ec.fieldContext_Process_memBytes(ctx, field)
+			case "tty":
+				return ec.fieldContext_Process_tty(ctx, field)
+			case "worktree":
+				return ec.fieldContext_Process_worktree(ctx, field)
+			case "claudeInstance":
+				return ec.fieldContext_Process_claudeInstance(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Process", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ClaudeInstance_account(ctx context.Context, field graphql.CollectedField, obj *ClaudeInstance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ClaudeInstance_account(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Account, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*ClaudeAccount)
+	fc.Result = res
+	return ec.marshalOClaudeAccount2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐClaudeAccount(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ClaudeInstance_account(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ClaudeInstance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ClaudeAccount_id(ctx, field)
+			case "email":
+				return ec.fieldContext_ClaudeAccount_email(ctx, field)
+			case "quotaUsed":
+				return ec.fieldContext_ClaudeAccount_quotaUsed(ctx, field)
+			case "quotaCap":
+				return ec.fieldContext_ClaudeAccount_quotaCap(ctx, field)
+			case "quotaEstimated":
+				return ec.fieldContext_ClaudeAccount_quotaEstimated(ctx, field)
+			case "quotaResetsAt":
+				return ec.fieldContext_ClaudeAccount_quotaResetsAt(ctx, field)
+			case "host":
+				return ec.fieldContext_ClaudeAccount_host(ctx, field)
+			case "instances":
+				return ec.fieldContext_ClaudeAccount_instances(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ClaudeAccount", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ClaudeInstance_state(ctx context.Context, field graphql.CollectedField, obj *ClaudeInstance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ClaudeInstance_state(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.State, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(InstanceState)
+	fc.Result = res
+	return ec.marshalNInstanceState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐInstanceState(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ClaudeInstance_state(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ClaudeInstance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type InstanceState does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ClaudeInstance_rcUrl(ctx context.Context, field graphql.CollectedField, obj *ClaudeInstance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ClaudeInstance_rcUrl(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RcURL, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ClaudeInstance_rcUrl(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ClaudeInstance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ClaudeInstance_rcEnabled(ctx context.Context, field graphql.CollectedField, obj *ClaudeInstance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ClaudeInstance_rcEnabled(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RcEnabled, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ClaudeInstance_rcEnabled(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ClaudeInstance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ClaudeInstance_sessionUuid(ctx context.Context, field graphql.CollectedField, obj *ClaudeInstance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ClaudeInstance_sessionUuid(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.SessionUUID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ClaudeInstance_sessionUuid(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ClaudeInstance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ClaudeInstance_startedAt(ctx context.Context, field graphql.CollectedField, obj *ClaudeInstance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ClaudeInstance_startedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.StartedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ClaudeInstance_startedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ClaudeInstance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -5656,6 +6203,22 @@ func (ec *executionContext) fieldContext_Process_claudeInstance(ctx context.Cont
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_ClaudeInstance_id(ctx, field)
+			case "pane":
+				return ec.fieldContext_ClaudeInstance_pane(ctx, field)
+			case "process":
+				return ec.fieldContext_ClaudeInstance_process(ctx, field)
+			case "account":
+				return ec.fieldContext_ClaudeInstance_account(ctx, field)
+			case "state":
+				return ec.fieldContext_ClaudeInstance_state(ctx, field)
+			case "rcUrl":
+				return ec.fieldContext_ClaudeInstance_rcUrl(ctx, field)
+			case "rcEnabled":
+				return ec.fieldContext_ClaudeInstance_rcEnabled(ctx, field)
+			case "sessionUuid":
+				return ec.fieldContext_ClaudeInstance_sessionUuid(ctx, field)
+			case "startedAt":
+				return ec.fieldContext_ClaudeInstance_startedAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
 		},
@@ -6669,6 +7232,70 @@ func (ec *executionContext) fieldContext_Query_contracts(ctx context.Context, fi
 	if fc.Args, err = ec.field_Query_contracts_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_claudeInstances(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_claudeInstances(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().ClaudeInstances(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*ClaudeInstance)
+	fc.Result = res
+	return ec.marshalNClaudeInstance2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐClaudeInstanceᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_claudeInstances(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ClaudeInstance_id(ctx, field)
+			case "pane":
+				return ec.fieldContext_ClaudeInstance_pane(ctx, field)
+			case "process":
+				return ec.fieldContext_ClaudeInstance_process(ctx, field)
+			case "account":
+				return ec.fieldContext_ClaudeInstance_account(ctx, field)
+			case "state":
+				return ec.fieldContext_ClaudeInstance_state(ctx, field)
+			case "rcUrl":
+				return ec.fieldContext_ClaudeInstance_rcUrl(ctx, field)
+			case "rcEnabled":
+				return ec.fieldContext_ClaudeInstance_rcEnabled(ctx, field)
+			case "sessionUuid":
+				return ec.fieldContext_ClaudeInstance_sessionUuid(ctx, field)
+			case "startedAt":
+				return ec.fieldContext_ClaudeInstance_startedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
+		},
 	}
 	return fc, nil
 }
@@ -8209,6 +8836,22 @@ func (ec *executionContext) fieldContext_TmuxPane_claudeInstance(ctx context.Con
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_ClaudeInstance_id(ctx, field)
+			case "pane":
+				return ec.fieldContext_ClaudeInstance_pane(ctx, field)
+			case "process":
+				return ec.fieldContext_ClaudeInstance_process(ctx, field)
+			case "account":
+				return ec.fieldContext_ClaudeInstance_account(ctx, field)
+			case "state":
+				return ec.fieldContext_ClaudeInstance_state(ctx, field)
+			case "rcUrl":
+				return ec.fieldContext_ClaudeInstance_rcUrl(ctx, field)
+			case "rcEnabled":
+				return ec.fieldContext_ClaudeInstance_rcEnabled(ctx, field)
+			case "sessionUuid":
+				return ec.fieldContext_ClaudeInstance_sessionUuid(ctx, field)
+			case "startedAt":
+				return ec.fieldContext_ClaudeInstance_startedAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
 		},
@@ -11848,6 +12491,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Process(ctx, sel, obj)
+	case ClaudeInstance:
+		return ec._ClaudeInstance(ctx, sel, &obj)
+	case *ClaudeInstance:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ClaudeInstance(ctx, sel, obj)
 	case Host:
 		return ec._Host(ctx, sel, &obj)
 	case *Host:
@@ -12006,7 +12656,7 @@ func (ec *executionContext) _ClaudeAccount(ctx context.Context, sel ast.Selectio
 	return out
 }
 
-var claudeInstanceImplementors = []string{"ClaudeInstance"}
+var claudeInstanceImplementors = []string{"ClaudeInstance", "Node"}
 
 func (ec *executionContext) _ClaudeInstance(ctx context.Context, sel ast.SelectionSet, obj *ClaudeInstance) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, claudeInstanceImplementors)
@@ -12022,6 +12672,28 @@ func (ec *executionContext) _ClaudeInstance(ctx context.Context, sel ast.Selecti
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "pane":
+			out.Values[i] = ec._ClaudeInstance_pane(ctx, field, obj)
+		case "process":
+			out.Values[i] = ec._ClaudeInstance_process(ctx, field, obj)
+		case "account":
+			out.Values[i] = ec._ClaudeInstance_account(ctx, field, obj)
+		case "state":
+			out.Values[i] = ec._ClaudeInstance_state(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "rcUrl":
+			out.Values[i] = ec._ClaudeInstance_rcUrl(ctx, field, obj)
+		case "rcEnabled":
+			out.Values[i] = ec._ClaudeInstance_rcEnabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "sessionUuid":
+			out.Values[i] = ec._ClaudeInstance_sessionUuid(ctx, field, obj)
+		case "startedAt":
+			out.Values[i] = ec._ClaudeInstance_startedAt(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -13067,6 +13739,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_contracts(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "claudeInstances":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_claudeInstances(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -15681,6 +16375,16 @@ func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.Selec
 	return res
 }
 
+func (ec *executionContext) unmarshalNInstanceState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐInstanceState(ctx context.Context, v interface{}) (InstanceState, error) {
+	var res InstanceState
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInstanceState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐInstanceState(ctx context.Context, sel ast.SelectionSet, v InstanceState) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) unmarshalNInt2int64(ctx context.Context, v interface{}) (int64, error) {
 	res, err := graphql.UnmarshalInt64(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -16420,6 +17124,13 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	}
 	res := graphql.MarshalBoolean(*v)
 	return res
+}
+
+func (ec *executionContext) marshalOClaudeAccount2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐClaudeAccount(ctx context.Context, sel ast.SelectionSet, v *ClaudeAccount) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ClaudeAccount(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOClaudeInstance2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐClaudeInstance(ctx context.Context, sel ast.SelectionSet, v *ClaudeInstance) graphql.Marshaler {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -55,10 +55,34 @@ func (ClaudeAccount) IsNode() {}
 // Globally-unique id (e.g. "Host:<machineId>").
 func (this ClaudeAccount) GetID() string { return this.ID }
 
+// A live Claude Code session running on a host. Identity is the
+// foreground claude pid scoped to a host. The provider tracks the
+// heartbeat file the Claude Code SessionStart hook writes.
 type ClaudeInstance struct {
-	// Stable id; ws-b-claudeinstance formalises (host_id, claudePid).
+	// Stable orchard id — "ClaudeInstance:<host>:<claudePid>".
 	ID string `json:"id"`
+	// Tmux pane hosting this Claude process. Null if no pane could be matched.
+	Pane *TmuxPane `json:"pane,omitempty"`
+	// OS-level process. Null until the process can be matched by pid.
+	Process *Process `json:"process,omitempty"`
+	// Claude CLI account this session is authenticated under.
+	Account *ClaudeAccount `json:"account,omitempty"`
+	// Lifecycle state derived from the heartbeat file plus pid liveness.
+	State InstanceState `json:"state"`
+	// claude.ai Remote Control URL when the session has it enabled.
+	RcURL *string `json:"rcUrl,omitempty"`
+	// True when remote-control is enabled for this session.
+	RcEnabled bool `json:"rcEnabled"`
+	// Claude session UUID. Mirrors the heartbeat's session_id field.
+	SessionUUID *string `json:"sessionUuid,omitempty"`
+	// RFC3339 timestamp the session was started.
+	StartedAt *string `json:"startedAt,omitempty"`
 }
+
+func (ClaudeInstance) IsNode() {}
+
+// Globally-unique id (e.g. "Host:<machineId>").
+func (this ClaudeInstance) GetID() string { return this.ID }
 
 // A commitment an agent has made to deliver something. Contracts are
 // authored exclusively by the claude-contracts plugin; orchard reads
@@ -610,5 +634,61 @@ func (e *HostServiceState) UnmarshalGQL(v interface{}) error {
 }
 
 func (e HostServiceState) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Lifecycle states for a Claude instance.
+type InstanceState string
+
+const (
+	// Claude is actively executing a tool or generating a response.
+	InstanceStateWorking InstanceState = "working"
+	// Claude has finished its turn and is waiting for the next prompt.
+	InstanceStateIdle InstanceState = "idle"
+	// Claude is paused and waiting for user input.
+	InstanceStateInput InstanceState = "input"
+	// The session has been alive but is no longer answering heartbeats.
+	InstanceStateStalled InstanceState = "stalled"
+	// Tracked but the underlying process is gone.
+	InstanceStateDead InstanceState = "dead"
+	// No Claude session has ever been observed for this pane/process.
+	InstanceStateNoClaude InstanceState = "no_claude"
+)
+
+var AllInstanceState = []InstanceState{
+	InstanceStateWorking,
+	InstanceStateIdle,
+	InstanceStateInput,
+	InstanceStateStalled,
+	InstanceStateDead,
+	InstanceStateNoClaude,
+}
+
+func (e InstanceState) IsValid() bool {
+	switch e {
+	case InstanceStateWorking, InstanceStateIdle, InstanceStateInput, InstanceStateStalled, InstanceStateDead, InstanceStateNoClaude:
+		return true
+	}
+	return false
+}
+
+func (e InstanceState) String() string {
+	return string(e)
+}
+
+func (e *InstanceState) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = InstanceState(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid InstanceState", str)
+	}
+	return nil
+}
+
+func (e InstanceState) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/internal/server/providers/claudeinstance/adapter.go
+++ b/internal/server/providers/claudeinstance/adapter.go
@@ -1,0 +1,190 @@
+package claudeinstance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// HeartbeatReader is the narrow I/O contract for reading heartbeat
+// files. The production implementation reads `${ORCHARD_HEARTBEAT_DIR}`
+// (default `${TMPDIR}` looking at `orchard-claude-*.json`); tests inject
+// fakes that return a fixture slice without touching the filesystem.
+//
+// Stateless on purpose — caching, debouncing, and watcher state live in
+// Provider, not here. ReadAll returns all heartbeats sorted by tmux
+// session for deterministic test output.
+type HeartbeatReader interface {
+	// ReadAll returns every heartbeat the backend currently exposes.
+	// Errors from a single malformed file do NOT propagate — the
+	// implementation skips and continues so one stale file cannot blank
+	// the whole list.
+	ReadAll(ctx context.Context) ([]Heartbeat, error)
+
+	// Dir returns the directory the reader is watching, so the watcher
+	// can register fsnotify on the same path. Returned as-is so callers
+	// see the resolved value, not the configured value.
+	Dir() string
+}
+
+// FileReader is the production HeartbeatReader. It globs
+// `<dir>/orchard-claude-*.json`, JSON-parses each, and collapses the
+// disk shape into the package-internal Heartbeat struct.
+//
+// Inflight files (ending in `.inflight.json`) are mid-write atomic
+// staging files; we skip them so a partial read never registers as a
+// distinct instance.
+type FileReader struct {
+	dir string
+}
+
+// NewFileReader builds a FileReader rooted at dir. When dir is empty,
+// it falls back to ${ORCHARD_HEARTBEAT_DIR} or, failing that, ${TMPDIR}
+// — the same env-resolution chain the orchard hook script uses on the
+// write side.
+func NewFileReader(dir string) *FileReader {
+	if dir == "" {
+		dir = ResolveDir()
+	}
+	return &FileReader{dir: dir}
+}
+
+// ResolveDir applies the briefing's environment-variable chain:
+// ORCHARD_HEARTBEAT_DIR wins; falling back to TMPDIR; falling back to
+// /tmp so a misconfigured TMPDIR does not crash the daemon at boot.
+func ResolveDir() string {
+	if v := os.Getenv("ORCHARD_HEARTBEAT_DIR"); v != "" {
+		return v
+	}
+	if v := os.Getenv("TMPDIR"); v != "" {
+		return v
+	}
+	return "/tmp"
+}
+
+// Dir reports the directory this reader globs.
+func (r *FileReader) Dir() string {
+	return r.dir
+}
+
+// ReadAll globs heartbeat files in r.dir and returns the parsed
+// Heartbeats. Malformed JSON, unreadable files, and `.inflight.json`
+// staging files are silently skipped so one bad file does not erase
+// the rest. The result is sorted by TmuxSession for deterministic
+// output.
+func (r *FileReader) ReadAll(ctx context.Context) ([]Heartbeat, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	pattern := filepath.Join(r.dir, "orchard-claude-*.json")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob %s: %w", pattern, err)
+	}
+
+	out := make([]Heartbeat, 0, len(matches))
+	for _, p := range matches {
+		// Skip inflight staging files — they are partial JSON during
+		// atomic rename windows.
+		if strings.HasSuffix(p, ".inflight.json") {
+			continue
+		}
+		hb, ok := parseFile(p)
+		if !ok {
+			continue
+		}
+		out = append(out, hb)
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].TmuxSession < out[j].TmuxSession
+	})
+	return out, nil
+}
+
+// rawHeartbeat is the on-disk JSON shape. Two field-name conventions
+// exist: the legacy snake_case the Rust crate writes today, and the
+// camelCase shape ADR-011 §5.1 anticipates. We accept both via the
+// dual struct tags below — whichever the writer chose, we read.
+type rawHeartbeat struct {
+	TmuxSession string `json:"tmux_session"`
+	SessionID   string `json:"session_id"`
+	State       string `json:"state"`
+	Timestamp   string `json:"timestamp"`
+
+	// Optional ADR-011 fields. The hook script will be updated to emit
+	// these; when absent, the composer falls back to other matching.
+	ClaudePid       int    `json:"claudePid,omitempty"`
+	ClaudePidSnake  int    `json:"claude_pid,omitempty"`
+	RcURL           string `json:"rcUrl,omitempty"`
+	RcURLSnake      string `json:"rc_url,omitempty"`
+	RcEnabled       *bool  `json:"rcEnabled,omitempty"`
+	RcEnabledSnake  *bool  `json:"rc_enabled,omitempty"`
+	LastHeartbeatAt string `json:"lastHeartbeatAt,omitempty"`
+}
+
+// parseFile reads and decodes one heartbeat file. Returns (Heartbeat,
+// true) on success; (zero, false) on any read or parse failure so the
+// caller can skip without aborting the whole sweep.
+func parseFile(path string) (Heartbeat, bool) {
+	data, err := os.ReadFile(path) // #nosec G304 — path is from a glob we control.
+	if err != nil {
+		return Heartbeat{}, false
+	}
+	var raw rawHeartbeat
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return Heartbeat{}, false
+	}
+
+	hb := Heartbeat{
+		TmuxSession: raw.TmuxSession,
+		SessionID:   raw.SessionID,
+		State:       raw.State,
+		ClaudePid:   firstNonZero(raw.ClaudePid, raw.ClaudePidSnake),
+		RcURL:       firstNonEmpty(raw.RcURL, raw.RcURLSnake),
+	}
+	if raw.RcEnabled != nil {
+		hb.RcEnabled = *raw.RcEnabled
+	} else if raw.RcEnabledSnake != nil {
+		hb.RcEnabled = *raw.RcEnabledSnake
+	}
+	if t, err := time.Parse(time.RFC3339, raw.Timestamp); err == nil {
+		hb.Timestamp = t
+	} else if t, err := time.Parse(time.RFC3339Nano, raw.Timestamp); err == nil {
+		hb.Timestamp = t
+	}
+	if t, err := time.Parse(time.RFC3339, raw.LastHeartbeatAt); err == nil {
+		hb.LastHeartbeatAt = t
+	} else if t, err := time.Parse(time.RFC3339Nano, raw.LastHeartbeatAt); err == nil {
+		hb.LastHeartbeatAt = t
+	}
+	if hb.LastHeartbeatAt.IsZero() {
+		hb.LastHeartbeatAt = hb.Timestamp
+	}
+
+	// A heartbeat with no tmux session is unparseable from the
+	// composer's POV — drop it.
+	if hb.TmuxSession == "" {
+		return Heartbeat{}, false
+	}
+	return hb, true
+}
+
+func firstNonZero(a, b int) int {
+	if a != 0 {
+		return a
+	}
+	return b
+}
+
+func firstNonEmpty(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
+}

--- a/internal/server/providers/claudeinstance/adapter_test.go
+++ b/internal/server/providers/claudeinstance/adapter_test.go
@@ -1,0 +1,145 @@
+package claudeinstance
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestFileReader_ReadAll_Mixed asserts the reader globs only well-formed
+// non-inflight heartbeat files and parses both legacy snake_case and
+// ADR-shape camelCase fields.
+func TestFileReader_ReadAll_Mixed(t *testing.T) {
+	dir := t.TempDir()
+
+	// Legacy snake_case shape (today's hook script writes this).
+	legacy := map[string]any{
+		"tmux_session": "alpha",
+		"session_id":   "uuid-alpha",
+		"state":        "working",
+		"timestamp":    "2026-04-12T10:00:00Z",
+		"cwd":          "/workspace",
+		"event":        "PreToolUse",
+	}
+	writeJSON(t, filepath.Join(dir, "orchard-claude-alpha.json"), legacy)
+
+	// ADR-011 shape with camelCase fields the future hook will write.
+	adr := map[string]any{
+		"tmux_session":    "bravo",
+		"session_id":      "uuid-bravo",
+		"state":           "idle",
+		"timestamp":       "2026-04-12T10:00:30Z",
+		"claudePid":       42100,
+		"rcUrl":           "https://claude.ai/code/session_xyz",
+		"rcEnabled":       true,
+		"lastHeartbeatAt": "2026-04-12T10:00:35Z",
+	}
+	writeJSON(t, filepath.Join(dir, "orchard-claude-bravo.json"), adr)
+
+	// Inflight staging file — must be skipped (mid-write atomic rename).
+	writeJSON(t, filepath.Join(dir, "orchard-claude-charlie.inflight.json"), map[string]any{
+		"tmux_session": "charlie",
+		"state":        "working",
+	})
+
+	// Malformed JSON — must be skipped silently.
+	writeRaw(t, filepath.Join(dir, "orchard-claude-malformed.json"), "not json")
+
+	// Unrelated file — must not match.
+	writeRaw(t, filepath.Join(dir, "totally-unrelated.json"), `{"foo":1}`)
+
+	r := NewFileReader(dir)
+	got, err := r.ReadAll(context.Background())
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d heartbeats, want 2 (alpha + bravo, skipping inflight + malformed): %+v", len(got), got)
+	}
+	// Sorted by tmux session — alpha before bravo.
+	if got[0].TmuxSession != "alpha" || got[1].TmuxSession != "bravo" {
+		t.Errorf("sort order = %s,%s; want alpha,bravo", got[0].TmuxSession, got[1].TmuxSession)
+	}
+
+	// Bravo decoded the ADR fields.
+	if got[1].ClaudePid != 42100 {
+		t.Errorf("bravo claudePid = %d, want 42100", got[1].ClaudePid)
+	}
+	if !got[1].RcEnabled {
+		t.Error("bravo rcEnabled = false, want true")
+	}
+	if got[1].RcURL == "" {
+		t.Error("bravo rcURL empty, want non-empty")
+	}
+	if got[1].LastHeartbeatAt.IsZero() {
+		t.Error("bravo LastHeartbeatAt is zero, want parsed timestamp")
+	}
+
+	// Alpha falls back from missing LastHeartbeatAt to Timestamp.
+	if got[0].LastHeartbeatAt != got[0].Timestamp {
+		t.Errorf("alpha LastHeartbeatAt %v != Timestamp %v (fallback should match)",
+			got[0].LastHeartbeatAt, got[0].Timestamp)
+	}
+}
+
+// TestFileReader_ReadAll_EmptyDir asserts a missing/empty heartbeat
+// directory returns an empty slice without erroring — the daemon must
+// boot cleanly when no Claude session has ever started.
+func TestFileReader_ReadAll_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	r := NewFileReader(dir)
+	got, err := r.ReadAll(context.Background())
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d, want 0 in empty dir", len(got))
+	}
+}
+
+// TestResolveDir_EnvPrecedence asserts ORCHARD_HEARTBEAT_DIR wins over
+// TMPDIR which wins over /tmp. The ladder mirrors the orchard hook
+// script so the daemon and the writer agree on the directory without
+// a coordination protocol.
+func TestResolveDir_EnvPrecedence(t *testing.T) {
+	t.Setenv("ORCHARD_HEARTBEAT_DIR", "/explicit")
+	t.Setenv("TMPDIR", "/tmp-fallback")
+	if got := ResolveDir(); got != "/explicit" {
+		t.Errorf("explicit override = %q, want /explicit", got)
+	}
+
+	t.Setenv("ORCHARD_HEARTBEAT_DIR", "")
+	if got := ResolveDir(); got != "/tmp-fallback" {
+		t.Errorf("TMPDIR fallback = %q, want /tmp-fallback", got)
+	}
+
+	t.Setenv("TMPDIR", "")
+	if got := ResolveDir(); got != "/tmp" {
+		t.Errorf("/tmp ultimate fallback = %q, want /tmp", got)
+	}
+}
+
+// writeJSON is a test helper that marshals payload to path using
+// os.WriteFile. Failures are fatal so a setup bug never masquerades as
+// an assertion failure.
+func writeJSON(t *testing.T, path string, payload map[string]any) {
+	t.Helper()
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal %v: %v", payload, err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// writeRaw writes raw bytes; used for malformed-input fixtures.
+func writeRaw(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+

--- a/internal/server/providers/claudeinstance/composer.go
+++ b/internal/server/providers/claudeinstance/composer.go
@@ -1,0 +1,314 @@
+package claudeinstance
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// PaneFinder resolves a tmux pane for a heartbeat. Implementations are
+// dependency-injected by the daemon entry point so this provider has no
+// import on the tmux provider's package — keeps SOLID-D honest.
+//
+// Find returns (nil, false) when no matching pane exists; the composer
+// surfaces such instances with `pane: null` so the dashboard can still
+// display a Claude that is heartbeating from outside any tmux pane.
+type PaneFinder interface {
+	// FindByPid returns the pane whose foreground pid matches claudePid.
+	// claudePid==0 means the heartbeat did not record one; implementations
+	// MUST return (nil, false) in that case rather than guessing.
+	FindByPid(ctx context.Context, hostID string, claudePid int) (*graphql.TmuxPane, bool)
+
+	// FindBySession returns the pane whose tmux session name matches.
+	// Used as a fallback when the heartbeat does not yet record a pid.
+	// Implementations may return any pane in the session that hosts a
+	// claude process; v1 just returns the first one if multiple match.
+	FindBySession(ctx context.Context, hostID, tmuxSession string) (*graphql.TmuxPane, bool)
+}
+
+// ProcessFinder resolves the OS process record for a Claude pid.
+// Dependency-injected from the ps provider so composer compiles
+// without ws-b-ps merging.
+type ProcessFinder interface {
+	FindByPid(ctx context.Context, hostID string, pid int) (*graphql.Process, bool)
+}
+
+// AccountFinder returns the active Claude CLI account for a host.
+// v1 surfaces a single account per ADR-011 §5.1; the composer attaches
+// it to every instance that has a fresh heartbeat.
+type AccountFinder interface {
+	// Active returns the local Claude account, or (nil, false) if claude
+	// CLI is not installed/authed. v1 attaches this to every instance.
+	Active(ctx context.Context, hostID string) (*graphql.ClaudeAccount, bool)
+}
+
+// LivenessChecker reports whether a pid is still alive on the host.
+// Production uses os.FindProcess + signal-0; tests inject a stub map
+// so they can deterministically toggle "process died".
+type LivenessChecker interface {
+	IsAlive(pid int) bool
+}
+
+// OSLivenessChecker uses the standard signal-0 trick to ask the kernel
+// whether a pid is alive without sending a real signal.
+type OSLivenessChecker struct{}
+
+// IsAlive returns true when sending signal 0 to pid succeeds — the
+// standard Unix idiom for "process exists and is reachable from this
+// uid". Returns false for pid<=0.
+func (OSLivenessChecker) IsAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// Composer joins heartbeats with sibling-provider data into a list of
+// ClaudeInstances. All cross-provider data flows through the four
+// dependency-injected interfaces above; the Composer itself imports
+// nothing from tmux/ps/claudeaccount.
+//
+// Stateless on purpose — every Compose call goes back through its
+// dependencies. Caching belongs to the Provider above us.
+type Composer struct {
+	hostID    string
+	panes     PaneFinder
+	procs     ProcessFinder
+	accounts  AccountFinder
+	liveness  LivenessChecker
+	clock     func() time.Time
+	staleAfter time.Duration
+}
+
+// NewComposer constructs a Composer with the production
+// LivenessChecker and wall clock. Pass nil for any sibling that has not
+// yet shipped a real provider — v1 leaves those edges null and the
+// composer behaves as if no match was found.
+func NewComposer(hostID string, panes PaneFinder, procs ProcessFinder, accounts AccountFinder) *Composer {
+	return NewComposerWith(hostID, panes, procs, accounts, OSLivenessChecker{}, time.Now, HeartbeatStaleAfter)
+}
+
+// NewComposerWith is the test-friendly constructor — accepts injected
+// liveness checker, clock, and stale-after duration. Production wires
+// time.Now and HeartbeatStaleAfter; tests can shrink the window so
+// staleness assertions converge in milliseconds.
+func NewComposerWith(
+	hostID string,
+	panes PaneFinder,
+	procs ProcessFinder,
+	accounts AccountFinder,
+	liveness LivenessChecker,
+	clock func() time.Time,
+	staleAfter time.Duration,
+) *Composer {
+	if liveness == nil {
+		liveness = OSLivenessChecker{}
+	}
+	if clock == nil {
+		clock = time.Now
+	}
+	if staleAfter <= 0 {
+		staleAfter = HeartbeatStaleAfter
+	}
+	return &Composer{
+		hostID:     hostID,
+		panes:      panes,
+		procs:      procs,
+		accounts:   accounts,
+		liveness:   liveness,
+		clock:      clock,
+		staleAfter: staleAfter,
+	}
+}
+
+// Compose folds the heartbeats into ClaudeInstances. The order follows
+// the input slice (which the adapter sorts by tmux session for
+// deterministic test output).
+//
+// Each heartbeat produces exactly one ClaudeInstance. When ClaudePid
+// is unknown and the PaneFinder cannot match by tmux session either,
+// the instance is still emitted with pane=null and process=null —
+// orchardists want to see the heartbeat-only ghost so they know
+// something is alive even when tmux state has not yet caught up.
+func (c *Composer) Compose(ctx context.Context, heartbeats []Heartbeat) []*graphql.ClaudeInstance {
+	out := make([]*graphql.ClaudeInstance, 0, len(heartbeats))
+	for _, hb := range heartbeats {
+		out = append(out, c.composeOne(ctx, hb))
+	}
+	return out
+}
+
+// composeOne builds a single ClaudeInstance from one Heartbeat. Pure
+// in the sense that all I/O is delegated to the injected interfaces.
+func (c *Composer) composeOne(ctx context.Context, hb Heartbeat) *graphql.ClaudeInstance {
+	pane := c.findPane(ctx, hb)
+	pid := c.resolvePid(hb, pane)
+	proc := c.findProcess(ctx, pid)
+	account := c.findAccount(ctx)
+	state := c.deriveState(hb, pid)
+
+	id := buildID(c.hostID, pid, hb.TmuxSession)
+	inst := &graphql.ClaudeInstance{
+		ID:        id,
+		Pane:      pane,
+		Process:   proc,
+		Account:   account,
+		State:     state,
+		RcEnabled: hb.RcEnabled,
+	}
+	if hb.RcURL != "" {
+		v := hb.RcURL
+		inst.RcURL = &v
+	}
+	if hb.SessionID != "" {
+		v := hb.SessionID
+		inst.SessionUUID = &v
+	}
+	if !hb.Timestamp.IsZero() {
+		v := hb.Timestamp.UTC().Format(time.RFC3339Nano)
+		inst.StartedAt = &v
+	}
+	return inst
+}
+
+// findPane delegates to PaneFinder using whichever match key the
+// heartbeat provides. Returns nil silently when no finder is wired
+// (sibling provider not yet shipped) or no match is found.
+func (c *Composer) findPane(ctx context.Context, hb Heartbeat) *graphql.TmuxPane {
+	if c.panes == nil {
+		return nil
+	}
+	if hb.ClaudePid > 0 {
+		if p, ok := c.panes.FindByPid(ctx, c.hostID, hb.ClaudePid); ok {
+			return p
+		}
+	}
+	if hb.TmuxSession != "" {
+		if p, ok := c.panes.FindBySession(ctx, c.hostID, hb.TmuxSession); ok {
+			return p
+		}
+	}
+	return nil
+}
+
+// resolvePid prefers the heartbeat's ClaudePid (ADR-011 shape). Falls
+// back to the matched pane's currentPid when the heartbeat predates the
+// pid-recording shape. Returns 0 when neither is available; the
+// composer surfaces such instances as `no_claude` because liveness
+// cannot be checked without a pid.
+func (c *Composer) resolvePid(hb Heartbeat, pane *graphql.TmuxPane) int {
+	if hb.ClaudePid > 0 {
+		return hb.ClaudePid
+	}
+	if pane != nil && pane.ID != "" {
+		if pid, ok := pidFromPaneID(pane.ID); ok {
+			return pid
+		}
+	}
+	return 0
+}
+
+// pidFromPaneID is a no-op fallback today: TmuxPane.id is `<host>:<paneId>`
+// (e.g. `mac:%26`) and does not embed the foreground pid. A future
+// PaneFinder can be extended to expose the pid; for now the heartbeat
+// is the only authoritative pid source. Returns (0, false) so callers
+// fall through to the no_claude path when no pid is available.
+func pidFromPaneID(_ string) (int, bool) {
+	return 0, false
+}
+
+func (c *Composer) findProcess(ctx context.Context, pid int) *graphql.Process {
+	if c.procs == nil || pid <= 0 {
+		return nil
+	}
+	if p, ok := c.procs.FindByPid(ctx, c.hostID, pid); ok {
+		return p
+	}
+	return nil
+}
+
+func (c *Composer) findAccount(ctx context.Context) *graphql.ClaudeAccount {
+	if c.accounts == nil {
+		return nil
+	}
+	if a, ok := c.accounts.Active(ctx, c.hostID); ok {
+		return a
+	}
+	return nil
+}
+
+// deriveState collapses the briefing's matrix into one InstanceState.
+//
+//	working   — heartbeat fresh AND state==working AND pid alive (or unknown)
+//	idle      — heartbeat fresh AND state==idle    AND pid alive (or unknown)
+//	input     — heartbeat fresh AND state==input   AND pid alive (or unknown)
+//	no_claude — heartbeat stale OR pid known dead OR state unrecognised
+//
+// "pid unknown" (heartbeat predates the pid-recording shape) does NOT
+// downgrade to no_claude — we trust the heartbeat in that case because
+// the alternative is a permanent no_claude for every instance until the
+// hook script is updated.
+func (c *Composer) deriveState(hb Heartbeat, pid int) graphql.InstanceState {
+	now := c.clock()
+	stamp := hb.LastHeartbeatAt
+	if stamp.IsZero() {
+		stamp = hb.Timestamp
+	}
+	if stamp.IsZero() || now.Sub(stamp) > c.staleAfter {
+		return graphql.InstanceStateNoClaude
+	}
+	if pid > 0 && !c.liveness.IsAlive(pid) {
+		return graphql.InstanceStateNoClaude
+	}
+	switch strings.ToLower(strings.TrimSpace(hb.State)) {
+	case "working":
+		return graphql.InstanceStateWorking
+	case "idle":
+		return graphql.InstanceStateIdle
+	case "input":
+		return graphql.InstanceStateInput
+	default:
+		return graphql.InstanceStateNoClaude
+	}
+}
+
+// buildID is the canonical id formatter — `ClaudeInstance:<host>:<pid>`
+// when pid is known; falls back to `ClaudeInstance:<host>:session-<name>`
+// when no pid is available so the id still satisfies Node.id's
+// uniqueness requirement.
+func buildID(hostID string, pid int, tmuxSession string) string {
+	if pid > 0 {
+		return fmt.Sprintf("ClaudeInstance:%s:%d", hostID, pid)
+	}
+	return fmt.Sprintf("ClaudeInstance:%s:session-%s", hostID, tmuxSession)
+}
+
+// parseInstanceID is the inverse of buildID. Returns (hostID, pid, true)
+// for pid-keyed ids, or (hostID, 0, false) for session-keyed ids
+// (callers should look up by tmuxSession in that case).
+func parseInstanceID(id string) (string, int, bool) {
+	const prefix = "ClaudeInstance:"
+	if !strings.HasPrefix(id, prefix) {
+		return "", 0, false
+	}
+	rest := id[len(prefix):]
+	idx := strings.LastIndex(rest, ":")
+	if idx < 0 {
+		return rest, 0, false
+	}
+	host, tail := rest[:idx], rest[idx+1:]
+	if pid, err := strconv.Atoi(tail); err == nil && pid > 0 {
+		return host, pid, true
+	}
+	return host, 0, false
+}

--- a/internal/server/providers/claudeinstance/composer_test.go
+++ b/internal/server/providers/claudeinstance/composer_test.go
@@ -1,0 +1,286 @@
+package claudeinstance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// fakePaneFinder is the in-package fake the composer tests inject for
+// the PaneFinder dependency. Tests configure ByPid / BySession; the
+// composer is exercised through its public Compose method only.
+type fakePaneFinder struct {
+	byPid     map[int]*graphql.TmuxPane
+	bySession map[string]*graphql.TmuxPane
+}
+
+func (f *fakePaneFinder) FindByPid(_ context.Context, _ string, pid int) (*graphql.TmuxPane, bool) {
+	if p, ok := f.byPid[pid]; ok {
+		return p, true
+	}
+	return nil, false
+}
+
+func (f *fakePaneFinder) FindBySession(_ context.Context, _, session string) (*graphql.TmuxPane, bool) {
+	if p, ok := f.bySession[session]; ok {
+		return p, true
+	}
+	return nil, false
+}
+
+// fakeProcessFinder mirrors fakePaneFinder for the ProcessFinder dep.
+type fakeProcessFinder struct {
+	byPid map[int]*graphql.Process
+}
+
+func (f *fakeProcessFinder) FindByPid(_ context.Context, _ string, pid int) (*graphql.Process, bool) {
+	if p, ok := f.byPid[pid]; ok {
+		return p, true
+	}
+	return nil, false
+}
+
+// fakeAccountFinder returns a single account when set; useful to verify
+// the composer pumps it through to every instance.
+type fakeAccountFinder struct {
+	account *graphql.ClaudeAccount
+}
+
+func (f *fakeAccountFinder) Active(_ context.Context, _ string) (*graphql.ClaudeAccount, bool) {
+	if f.account == nil {
+		return nil, false
+	}
+	return f.account, true
+}
+
+// fakeLiveness exposes a deterministic alive map.
+type fakeLiveness struct {
+	alive map[int]bool
+}
+
+func (f fakeLiveness) IsAlive(pid int) bool { return f.alive[pid] }
+
+// TestComposer_Compose_Working asserts the happy path — a fresh
+// heartbeat with a known pid produces a working ClaudeInstance with
+// every cross-provider edge populated.
+func TestComposer_Compose_Working(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	hb := Heartbeat{
+		TmuxSession:     "alpha",
+		SessionID:       "uuid-alpha",
+		State:           "working",
+		ClaudePid:       42100,
+		RcURL:           "https://claude.ai/code/session_xyz",
+		RcEnabled:       true,
+		Timestamp:       now.Add(-5 * time.Second),
+		LastHeartbeatAt: now.Add(-5 * time.Second),
+	}
+
+	pane := &graphql.TmuxPane{ID: "TmuxPane:local:%26"}
+	proc := &graphql.Process{ID: "Process:local:42100"}
+	acct := &graphql.ClaudeAccount{ID: "ClaudeAccount:local:dev@example.com"}
+
+	c := NewComposerWith(
+		"local",
+		&fakePaneFinder{byPid: map[int]*graphql.TmuxPane{42100: pane}},
+		&fakeProcessFinder{byPid: map[int]*graphql.Process{42100: proc}},
+		&fakeAccountFinder{account: acct},
+		fakeLiveness{alive: map[int]bool{42100: true}},
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if len(out) != 1 {
+		t.Fatalf("got %d, want 1", len(out))
+	}
+	inst := out[0]
+	if inst.State != graphql.InstanceStateWorking {
+		t.Errorf("state = %s, want working", inst.State)
+	}
+	if inst.Pane != pane {
+		t.Errorf("pane = %v, want %v", inst.Pane, pane)
+	}
+	if inst.Process != proc {
+		t.Errorf("process = %v, want %v", inst.Process, proc)
+	}
+	if inst.Account != acct {
+		t.Errorf("account = %v, want %v", inst.Account, acct)
+	}
+	if inst.RcURL == nil || *inst.RcURL != hb.RcURL {
+		t.Errorf("rcUrl = %v, want %s", inst.RcURL, hb.RcURL)
+	}
+	if !inst.RcEnabled {
+		t.Error("rcEnabled = false, want true")
+	}
+	if inst.SessionUUID == nil || *inst.SessionUUID != hb.SessionID {
+		t.Errorf("sessionUuid = %v, want %s", inst.SessionUUID, hb.SessionID)
+	}
+	wantID := "ClaudeInstance:local:42100"
+	if inst.ID != wantID {
+		t.Errorf("id = %s, want %s", inst.ID, wantID)
+	}
+}
+
+// TestComposer_Compose_StaleHeartbeat asserts a fresh-state heartbeat
+// from > staleAfter ago collapses to no_claude — covers the briefing's
+// "touch a heartbeat backward → state goes to no_claude" assertion.
+func TestComposer_Compose_StaleHeartbeat(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	hb := Heartbeat{
+		TmuxSession:     "stale",
+		State:           "working",
+		ClaudePid:       11,
+		Timestamp:       now.Add(-2 * time.Minute),
+		LastHeartbeatAt: now.Add(-2 * time.Minute),
+	}
+
+	c := NewComposerWith(
+		"local",
+		nil,
+		nil,
+		nil,
+		fakeLiveness{alive: map[int]bool{11: true}},
+		func() time.Time { return now },
+		30*time.Second,
+	)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if len(out) != 1 {
+		t.Fatalf("got %d, want 1", len(out))
+	}
+	if out[0].State != graphql.InstanceStateNoClaude {
+		t.Errorf("state = %s, want no_claude", out[0].State)
+	}
+}
+
+// TestComposer_Compose_DeadPid asserts a fresh heartbeat for a dead
+// pid still collapses to no_claude — liveness wins.
+func TestComposer_Compose_DeadPid(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	hb := Heartbeat{
+		TmuxSession:     "deadpid",
+		State:           "working",
+		ClaudePid:       99,
+		Timestamp:       now.Add(-2 * time.Second),
+		LastHeartbeatAt: now.Add(-2 * time.Second),
+	}
+	c := NewComposerWith(
+		"local",
+		nil,
+		nil,
+		nil,
+		fakeLiveness{alive: map[int]bool{99: false}},
+		func() time.Time { return now },
+		30*time.Second,
+	)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if out[0].State != graphql.InstanceStateNoClaude {
+		t.Errorf("state = %s, want no_claude (dead pid)", out[0].State)
+	}
+}
+
+// TestComposer_Compose_NoPaneStillEmits asserts the briefing's
+// requirement: when the composer can't find a pane (no PaneFinder match
+// for either pid or session), the instance is still emitted with
+// pane=null. The dashboard sees the heartbeat-only ghost.
+func TestComposer_Compose_NoPaneStillEmits(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	hb := Heartbeat{
+		TmuxSession:     "ghost",
+		State:           "idle",
+		ClaudePid:       55,
+		Timestamp:       now.Add(-1 * time.Second),
+		LastHeartbeatAt: now.Add(-1 * time.Second),
+	}
+	c := NewComposerWith(
+		"local",
+		&fakePaneFinder{}, // empty maps — nothing matches
+		&fakeProcessFinder{},
+		&fakeAccountFinder{},
+		fakeLiveness{alive: map[int]bool{55: true}},
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if len(out) != 1 {
+		t.Fatalf("got %d, want 1 (ghost still emitted)", len(out))
+	}
+	if out[0].Pane != nil {
+		t.Errorf("pane = %v, want nil for unmatched pid", out[0].Pane)
+	}
+	if out[0].State != graphql.InstanceStateIdle {
+		t.Errorf("state = %s, want idle", out[0].State)
+	}
+}
+
+// TestComposer_Compose_FallbackToSession asserts that when ClaudePid is
+// 0 (legacy heartbeat without pid), the composer falls back to
+// FindBySession so it still finds a pane.
+func TestComposer_Compose_FallbackToSession(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	hb := Heartbeat{
+		TmuxSession:     "legacy",
+		State:           "working",
+		ClaudePid:       0, // legacy hook didn't write pid
+		Timestamp:       now.Add(-1 * time.Second),
+		LastHeartbeatAt: now.Add(-1 * time.Second),
+	}
+	pane := &graphql.TmuxPane{ID: "TmuxPane:local:%99"}
+	c := NewComposerWith(
+		"local",
+		&fakePaneFinder{bySession: map[string]*graphql.TmuxPane{"legacy": pane}},
+		nil,
+		nil,
+		fakeLiveness{},
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if out[0].Pane != pane {
+		t.Errorf("pane = %v, want %v (session-keyed fallback)", out[0].Pane, pane)
+	}
+	// State trusts the heartbeat when pid is unknown.
+	if out[0].State != graphql.InstanceStateWorking {
+		t.Errorf("state = %s, want working when pid unknown", out[0].State)
+	}
+}
+
+// TestComposer_Compose_UnknownStateStaysNoClaude asserts that an
+// unrecognised state string (e.g. "" or "?") does not silently default
+// to working — it collapses to no_claude.
+func TestComposer_Compose_UnknownStateStaysNoClaude(t *testing.T) {
+	now := time.Now()
+	hb := Heartbeat{
+		TmuxSession:     "unknown",
+		State:           "garbage",
+		ClaudePid:       7,
+		Timestamp:       now,
+		LastHeartbeatAt: now,
+	}
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{7: true}}, func() time.Time { return now }, HeartbeatStaleAfter)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if out[0].State != graphql.InstanceStateNoClaude {
+		t.Errorf("state = %s, want no_claude for unknown state string", out[0].State)
+	}
+}
+
+// TestParseInstanceID asserts the round-trip from buildID → parseInstanceID.
+func TestParseInstanceID(t *testing.T) {
+	id := buildID("local", 12345, "alpha")
+	host, pid, ok := parseInstanceID(id)
+	if !ok || host != "local" || pid != 12345 {
+		t.Errorf("parseInstanceID(%s) = (%s, %d, %v), want (local, 12345, true)", id, host, pid, ok)
+	}
+
+	sessionID := buildID("local", 0, "alpha")
+	host, pid, ok = parseInstanceID(sessionID)
+	if ok {
+		t.Errorf("parseInstanceID(%s) ok=true, want false for session-keyed id", sessionID)
+	}
+	if host != "local" {
+		t.Errorf("parseInstanceID host = %s, want local", host)
+	}
+	_ = pid
+}

--- a/internal/server/providers/claudeinstance/e2e_test.go
+++ b/internal/server/providers/claudeinstance/e2e_test.go
@@ -1,0 +1,307 @@
+package claudeinstance_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+
+	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeinstance"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+)
+
+// fakePaneFinder is the in-package fake the e2e test injects through
+// claudeinstance.PaneFinder. Returns a stubbed pane for matching pids.
+type fakePaneFinder struct {
+	byPid     map[int]*gql.TmuxPane
+	bySession map[string]*gql.TmuxPane
+}
+
+func (f *fakePaneFinder) FindByPid(_ context.Context, _ string, pid int) (*gql.TmuxPane, bool) {
+	p, ok := f.byPid[pid]
+	return p, ok
+}
+
+func (f *fakePaneFinder) FindBySession(_ context.Context, _, session string) (*gql.TmuxPane, bool) {
+	p, ok := f.bySession[session]
+	return p, ok
+}
+
+type fakeProcessFinder struct{ byPid map[int]*gql.Process }
+
+func (f *fakeProcessFinder) FindByPid(_ context.Context, _ string, pid int) (*gql.Process, bool) {
+	p, ok := f.byPid[pid]
+	return p, ok
+}
+
+type fakeAccountFinder struct{ acct *gql.ClaudeAccount }
+
+func (f *fakeAccountFinder) Active(_ context.Context, _ string) (*gql.ClaudeAccount, bool) {
+	if f.acct == nil {
+		return nil, false
+	}
+	return f.acct, true
+}
+
+// fakeLiveness wires the LivenessChecker for tests so we can keep both
+// stubbed pids "alive" deterministically.
+type fakeLiveness struct{ alive map[int]bool }
+
+func (f fakeLiveness) IsAlive(pid int) bool { return f.alive[pid] }
+
+// TestClaudeInstance_E2E_TwoFreshInstances writes two heartbeat files
+// into a tmpdir, boots a httptest GraphQL server with stubbed sibling
+// providers, queries `claudeInstances`, and asserts both instances
+// appear with the right `state`. Then it touches one heartbeat
+// backwards and asserts that instance's state collapses to no_claude.
+//
+// This is the briefing's headline E2E test. NO PII: tmux session names
+// are fixture values ("alpha"/"bravo"), pids are obviously fake (10000+),
+// and every path is `t.TempDir()`-rooted.
+func TestClaudeInstance_E2E_TwoFreshInstances(t *testing.T) {
+	heartbeatDir := t.TempDir()
+
+	// Use a deterministic clock so the staleness window is precisely
+	// reproducible across CI environments.
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	freshTimestamp := now.Add(-2 * time.Second).Format(time.RFC3339)
+	clock := func() time.Time { return now }
+
+	writeHeartbeat(t, heartbeatDir, "alpha", map[string]any{
+		"tmux_session":    "alpha",
+		"session_id":      "uuid-alpha",
+		"state":           "working",
+		"timestamp":       freshTimestamp,
+		"claudePid":       10042,
+		"rcUrl":           "https://claude.ai/code/session_alpha",
+		"rcEnabled":       true,
+		"lastHeartbeatAt": freshTimestamp,
+	})
+	writeHeartbeat(t, heartbeatDir, "bravo", map[string]any{
+		"tmux_session":    "bravo",
+		"session_id":      "uuid-bravo",
+		"state":           "idle",
+		"timestamp":       freshTimestamp,
+		"claudePid":       10099,
+		"rcEnabled":       false,
+		"lastHeartbeatAt": freshTimestamp,
+	})
+
+	// Stubbed sibling providers — the dep-injection checkpoint.
+	panes := &fakePaneFinder{
+		byPid: map[int]*gql.TmuxPane{
+			10042: {ID: "TmuxPane:local:%26"},
+			10099: {ID: "TmuxPane:local:%27"},
+		},
+	}
+	procs := &fakeProcessFinder{
+		byPid: map[int]*gql.Process{
+			10042: {ID: "Process:local:10042"},
+			10099: {ID: "Process:local:10099"},
+		},
+	}
+	accts := &fakeAccountFinder{
+		acct: &gql.ClaudeAccount{ID: "ClaudeAccount:local:dev@example.com"},
+	}
+	liveness := fakeLiveness{alive: map[int]bool{10042: true, 10099: true}}
+
+	composer := claudeinstance.NewComposerWith("local", panes, procs, accts, liveness, clock, claudeinstance.HeartbeatStaleAfter)
+	reader := claudeinstance.NewFileReader(heartbeatDir)
+	provider := claudeinstance.NewWith("local", reader, composer, clock)
+
+	if err := provider.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	srv := newTestDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postQuery(t, srv.URL, `query {
+		claudeInstances {
+			id
+			state
+			rcUrl
+			rcEnabled
+			sessionUuid
+			pane { id }
+			process { id }
+			account { id }
+		}
+	}`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	if got := len(resp.Data.ClaudeInstances); got != 2 {
+		t.Fatalf("got %d instances, want 2: %+v", got, resp.Data.ClaudeInstances)
+	}
+
+	// Find by id since order is by id-sort.
+	instById := map[string]instanceNode{}
+	for _, inst := range resp.Data.ClaudeInstances {
+		instById[inst.ID] = inst
+	}
+
+	alpha, ok := instById["ClaudeInstance:local:10042"]
+	if !ok {
+		t.Fatalf("no alpha instance: %+v", instById)
+	}
+	if alpha.State != "working" {
+		t.Errorf("alpha state = %s, want working", alpha.State)
+	}
+	if alpha.RcURL == nil || !strings.Contains(*alpha.RcURL, "claude.ai") {
+		t.Errorf("alpha rcUrl = %v, want claude.ai URL", alpha.RcURL)
+	}
+	if !alpha.RcEnabled {
+		t.Error("alpha rcEnabled = false, want true")
+	}
+	if alpha.Pane == nil || alpha.Pane.ID == "" {
+		t.Errorf("alpha pane = %v, want stubbed pane", alpha.Pane)
+	}
+	if alpha.Process == nil || alpha.Process.ID == "" {
+		t.Errorf("alpha process = %v, want stubbed process", alpha.Process)
+	}
+	if alpha.Account == nil || alpha.Account.ID == "" {
+		t.Errorf("alpha account = %v, want stubbed account", alpha.Account)
+	}
+
+	bravo, ok := instById["ClaudeInstance:local:10099"]
+	if !ok {
+		t.Fatalf("no bravo instance: %+v", instById)
+	}
+	if bravo.State != "idle" {
+		t.Errorf("bravo state = %s, want idle", bravo.State)
+	}
+	if bravo.RcEnabled {
+		t.Error("bravo rcEnabled = true, want false")
+	}
+
+	// -------- Phase 2: touch alpha heartbeat backward → no_claude.
+	// Rewrite alpha's content with an old timestamp; refresh; re-query.
+	staleTimestamp := now.Add(-2 * time.Minute).Format(time.RFC3339)
+	writeHeartbeat(t, heartbeatDir, "alpha", map[string]any{
+		"tmux_session":    "alpha",
+		"session_id":      "uuid-alpha",
+		"state":           "working",
+		"timestamp":       staleTimestamp,
+		"claudePid":       10042,
+		"rcUrl":           "https://claude.ai/code/session_alpha",
+		"rcEnabled":       true,
+		"lastHeartbeatAt": staleTimestamp,
+	})
+	if err := provider.Refresh(context.Background(), "test-stale"); err != nil {
+		t.Fatalf("refresh after stale write: %v", err)
+	}
+
+	resp2 := postQuery(t, srv.URL, `query { claudeInstances { id state } }`)
+	if len(resp2.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp2.Errors)
+	}
+	staleByID := map[string]string{}
+	for _, inst := range resp2.Data.ClaudeInstances {
+		staleByID[inst.ID] = inst.State
+	}
+	if got := staleByID["ClaudeInstance:local:10042"]; got != "no_claude" {
+		t.Errorf("alpha state after staling = %q, want no_claude", got)
+	}
+	if got := staleByID["ClaudeInstance:local:10099"]; got != "idle" {
+		t.Errorf("bravo state should still be idle, got %q", got)
+	}
+}
+
+// writeHeartbeat marshals payload to JSON and writes it into dir as
+// orchard-claude-<name>.json. NO PII: name and payload come from the
+// caller's literal fixture values, not from any environment-derived
+// data.
+func writeHeartbeat(t *testing.T, dir, name string, payload map[string]any) {
+	t.Helper()
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", name, err)
+	}
+	path := filepath.Join(dir, "orchard-claude-"+name+".json")
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// newTestDaemon mirrors internal/server/server.go's GraphQL wiring with
+// a pre-started Provider so the e2e test can drive it without launching
+// the full HTTP listener. All real plumbing — schema, resolvers,
+// transports — except the network listener is httptest.
+func newTestDaemon(t *testing.T, provider *claudeinstance.Provider) *httptest.Server {
+	t.Helper()
+	cfg := gql.Config{Resolvers: resolvers.New(time.Now()).WithClaudeInstance(provider)}
+	gqlSrv := handler.New(gql.NewExecutableSchema(cfg))
+	gqlSrv.AddTransport(transport.POST{})
+	gqlSrv.AddTransport(transport.GET{})
+
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", gqlSrv)
+	return httptest.NewServer(mux)
+}
+
+// graphqlResponse mirrors only the bits the e2e test asserts on, so a
+// schema addition elsewhere does not break this unmarshal.
+type graphqlResponse struct {
+	Data struct {
+		ClaudeInstances []instanceNode `json:"claudeInstances"`
+	} `json:"data"`
+	Errors []map[string]any `json:"errors,omitempty"`
+}
+
+type instanceNode struct {
+	ID          string  `json:"id"`
+	State       string  `json:"state"`
+	RcURL       *string `json:"rcUrl"`
+	RcEnabled   bool    `json:"rcEnabled"`
+	SessionUUID *string `json:"sessionUuid"`
+	Pane        *idOnly `json:"pane"`
+	Process     *idOnly `json:"process"`
+	Account     *idOnly `json:"account"`
+}
+
+type idOnly struct {
+	ID string `json:"id"`
+}
+
+// postQuery issues a GraphQL POST and decodes into graphqlResponse.
+// Failures are fatal — a broken transport invalidates the whole test.
+func postQuery(t *testing.T, url, query string) graphqlResponse {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"query": query})
+	if err != nil {
+		t.Fatalf("marshal query: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, url+"/graphql", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d: %s", resp.StatusCode, string(raw))
+	}
+	var out graphqlResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode %q: %v", raw, err)
+	}
+	return out
+}

--- a/internal/server/providers/claudeinstance/provider.go
+++ b/internal/server/providers/claudeinstance/provider.go
@@ -1,0 +1,354 @@
+package claudeinstance
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// Provider is the resolver-facing read API for the ClaudeInstance node
+// per ADR-011 §5.1. Owns:
+//   - one HeartbeatReader (raw filesystem I/O).
+//   - one Composer (stateless join over sibling providers).
+//   - a small in-memory cache keyed by InstanceID.
+//   - a Watcher (fsnotify + 5s poll fallback) to invalidate the cache.
+//   - subscriber fan-out for GraphQL Subscriptions (wired by ws-c).
+//
+// The cross-provider edges (TmuxPane, Process, ClaudeAccount) are owned
+// by their respective providers; this provider asks for them through
+// dependency-injected interfaces so it neither imports them nor holds
+// duplicate copies of their state.
+type Provider struct {
+	hostID   string
+	reader   HeartbeatReader
+	composer *Composer
+	clock    func() time.Time
+
+	mu     sync.RWMutex
+	cache  map[InstanceID]*graphql.ClaudeInstance
+	fresh  map[InstanceID]adapter.Freshness
+	loaded bool
+
+	subsMu sync.Mutex
+	subs   []chan adapter.InvalidationEvent[InstanceID]
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+}
+
+// New constructs a Provider with the production HeartbeatReader (file
+// glob over the resolved heartbeat dir) and the supplied composer.
+//
+// hostID identifies the local host; the daemon entry point passes the
+// host provider's LocalID so cross-host federation can disambiguate
+// instance ids when ws-f lands.
+func New(hostID string, composer *Composer) *Provider {
+	return NewWith(hostID, NewFileReader(""), composer, time.Now)
+}
+
+// NewWith is the test-friendly constructor. Tests inject a fixture
+// HeartbeatReader and clock so freshness assertions converge in
+// milliseconds and the file system stays untouched.
+func NewWith(hostID string, reader HeartbeatReader, composer *Composer, clock func() time.Time) *Provider {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &Provider{
+		hostID:   hostID,
+		reader:   reader,
+		composer: composer,
+		clock:    clock,
+		cache:    map[InstanceID]*graphql.ClaudeInstance{},
+		fresh:    map[InstanceID]adapter.Freshness{},
+		stopCh:   make(chan struct{}),
+		doneCh:   make(chan struct{}),
+	}
+}
+
+// Start hydrates the cache with an initial sweep and is idempotent.
+// The watcher loop is owned separately by NewWatcher().Run(); Start
+// itself does not spawn goroutines so callers can compose lifecycles
+// freely (the daemon entry point pairs Start with Watcher.Run).
+//
+// A first-load failure does NOT block Start — the heartbeat directory
+// may simply not exist yet. Subsequent watcher refreshes pick up files
+// as they are written.
+func (p *Provider) Start(ctx context.Context) error {
+	var err error
+	p.startOnce.Do(func() {
+		err = p.refreshLocked(ctx, "boot")
+	})
+	return err
+}
+
+// Stop tears down subscribers. Idempotent; safe to call multiple times.
+// The watcher's Run loop is stopped via its own context — callers
+// cancel that ctx separately.
+func (p *Provider) Stop() error {
+	p.stopOnce.Do(func() {
+		close(p.stopCh)
+		close(p.doneCh)
+		p.subsMu.Lock()
+		for _, ch := range p.subs {
+			close(ch)
+		}
+		p.subs = nil
+		p.subsMu.Unlock()
+	})
+	return nil
+}
+
+// Get returns one ClaudeInstance by InstanceID. Pure cache read; the
+// watcher (or callers calling Refresh directly) is responsible for
+// keeping the cache fresh.
+//
+// Unknown keys produce a typed error so resolvers can map it to a
+// per-field GraphQL error rather than nil-with-no-data.
+func (p *Provider) Get(_ context.Context, key InstanceID) (*graphql.ClaudeInstance, adapter.Freshness, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if v, ok := p.cache[key]; ok {
+		return v, p.fresh[key], nil
+	}
+	return nil, adapter.Freshness{}, fmt.Errorf("claudeinstance: unknown id %s:%d", key.HostID, key.ClaudePid)
+}
+
+// GetMany satisfies adapter.Provider. Missing keys are simply absent
+// from the returned maps — the caller distinguishes hit/miss by map
+// presence, never by zero values.
+func (p *Provider) GetMany(_ context.Context, keys []InstanceID) (map[InstanceID]*graphql.ClaudeInstance, map[InstanceID]adapter.Freshness, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make(map[InstanceID]*graphql.ClaudeInstance, len(keys))
+	freshness := make(map[InstanceID]adapter.Freshness, len(keys))
+	for _, k := range keys {
+		if v, ok := p.cache[k]; ok {
+			out[k] = v
+			freshness[k] = p.fresh[k]
+		}
+	}
+	return out, freshness, nil
+}
+
+// Keys returns every cached InstanceID. Cold boot (before the first
+// successful Refresh) returns an empty slice per the Provider contract.
+func (p *Provider) Keys(_ context.Context) ([]InstanceID, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]InstanceID, 0, len(p.cache))
+	for k := range p.cache {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].HostID != out[j].HostID {
+			return out[i].HostID < out[j].HostID
+		}
+		return out[i].ClaudePid < out[j].ClaudePid
+	})
+	return out, nil
+}
+
+// List returns every cached ClaudeInstance, refreshed if the cache has
+// never been hydrated. The resolver for `Query.claudeInstances` calls
+// this; it returns [] (empty list) cleanly when no heartbeats exist —
+// per ADR-011 §6 a missing instance is normal, not a per-field error.
+func (p *Provider) List(ctx context.Context) ([]*graphql.ClaudeInstance, error) {
+	p.mu.RLock()
+	loaded := p.loaded
+	p.mu.RUnlock()
+	if !loaded {
+		if err := p.Refresh(ctx, "lazy-load"); err != nil {
+			return nil, err
+		}
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]*graphql.ClaudeInstance, 0, len(p.cache))
+	for _, v := range p.cache {
+		out = append(out, v)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
+	return out, nil
+}
+
+// Subscribe returns a channel that emits an invalidation event each
+// time Refresh observes a change. Sends are non-blocking — slow
+// consumers drop events rather than stalling the watcher loop.
+//
+// The channel closes when ctx is cancelled. Callers that want a
+// guaranteed every-event delivery must buffer and drain promptly.
+func (p *Provider) Subscribe(ctx context.Context) <-chan adapter.InvalidationEvent[InstanceID] {
+	ch := make(chan adapter.InvalidationEvent[InstanceID], 8)
+	p.subsMu.Lock()
+	p.subs = append(p.subs, ch)
+	p.subsMu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		p.subsMu.Lock()
+		defer p.subsMu.Unlock()
+		for i, c := range p.subs {
+			if c == ch {
+				p.subs = append(p.subs[:i], p.subs[i+1:]...)
+				close(ch)
+				return
+			}
+		}
+	}()
+	return ch
+}
+
+// Refresh re-reads heartbeats and re-runs the composer, broadcasting
+// invalidation events for any keys whose value changed (including
+// newly-added or newly-removed keys). Used by Watcher; safe to call
+// directly from tests.
+func (p *Provider) Refresh(ctx context.Context, reason string) error {
+	return p.refreshLocked(ctx, reason)
+}
+
+func (p *Provider) refreshLocked(ctx context.Context, reason string) error {
+	hbs, err := p.reader.ReadAll(ctx)
+	if err != nil {
+		return fmt.Errorf("claudeinstance read heartbeats: %w", err)
+	}
+	now := p.clock()
+	composed := p.composer.Compose(ctx, hbs)
+
+	p.mu.Lock()
+	prev := p.cache
+	next := make(map[InstanceID]*graphql.ClaudeInstance, len(composed))
+	freshNext := make(map[InstanceID]adapter.Freshness, len(composed))
+	for _, inst := range composed {
+		host, pid, ok := parseInstanceID(inst.ID)
+		key := InstanceID{HostID: host, ClaudePid: pid}
+		if !ok {
+			// Session-keyed (no pid) — still cache, using the synthesised
+			// host id. Multiple session-keyed instances on one host MUST
+			// have distinct tmux session names; the parser returns pid==0
+			// for all of them, so we layer the session into the key by
+			// stuffing the negated hash into ClaudePid.
+			key = InstanceID{HostID: host, ClaudePid: -hashSession(inst.ID)}
+		}
+		next[key] = inst
+		freshNext[key] = adapter.Freshness{LastFetchedAt: now, Source: adapter.SourcePoll}
+	}
+	p.cache = next
+	p.fresh = freshNext
+	p.loaded = true
+	p.mu.Unlock()
+
+	p.fanOutInvalidations(prev, next, reason, now)
+	return nil
+}
+
+// fanOutInvalidations broadcasts InvalidationEvents for every key that
+// changed between the previous and next cache snapshots. New keys,
+// removed keys, and value changes all emit events; unchanged keys are
+// silent so subscribers do not get a spurious flood after every poll.
+func (p *Provider) fanOutInvalidations(prev, next map[InstanceID]*graphql.ClaudeInstance, reason string, at time.Time) {
+	keys := make(map[InstanceID]struct{}, len(prev)+len(next))
+	for k := range prev {
+		keys[k] = struct{}{}
+	}
+	for k := range next {
+		keys[k] = struct{}{}
+	}
+
+	p.subsMu.Lock()
+	subs := append([]chan adapter.InvalidationEvent[InstanceID](nil), p.subs...)
+	p.subsMu.Unlock()
+	if len(subs) == 0 {
+		return
+	}
+
+	for k := range keys {
+		if instancesEqual(prev[k], next[k]) {
+			continue
+		}
+		ev := adapter.InvalidationEvent[InstanceID]{
+			Key:    k,
+			Reason: reason,
+			At:     at,
+		}
+		for _, c := range subs {
+			select {
+			case c <- ev:
+			default:
+			}
+		}
+	}
+}
+
+// instancesEqual returns true when two ClaudeInstances are
+// observationally equal for the fields a resolver would expose. Used to
+// suppress noise events when the heartbeat sweep produces an
+// identical instance to the one already cached.
+func instancesEqual(a, b *graphql.ClaudeInstance) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if a.ID != b.ID {
+		return false
+	}
+	if a.State != b.State {
+		return false
+	}
+	if a.RcEnabled != b.RcEnabled {
+		return false
+	}
+	if !ptrStringEqual(a.RcURL, b.RcURL) {
+		return false
+	}
+	if !ptrStringEqual(a.SessionUUID, b.SessionUUID) {
+		return false
+	}
+	if !ptrStringEqual(a.StartedAt, b.StartedAt) {
+		return false
+	}
+	return true
+}
+
+func ptrStringEqual(a, b *string) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// hashSession is a tiny FNV-1a-ish hash so session-keyed instances get
+// stable map keys. We do not need cryptographic strength — collisions
+// would be visible as one instance overwriting another, which would
+// surface as a bug in tests instantly.
+func hashSession(s string) int {
+	h := 2166136261
+	for _, c := range []byte(s) {
+		h ^= int(c)
+		h *= 16777619
+	}
+	if h < 0 {
+		h = -h
+	}
+	if h == 0 {
+		h = 1 // avoid (0, 0) collision with a real pid==0 key
+	}
+	return h
+}
+
+// Compile-time assertion that *Provider satisfies the generic Provider
+// interface for ClaudeInstance.
+var _ adapter.Provider[InstanceID, *graphql.ClaudeInstance] = (*Provider)(nil)

--- a/internal/server/providers/claudeinstance/provider_test.go
+++ b/internal/server/providers/claudeinstance/provider_test.go
@@ -1,0 +1,149 @@
+package claudeinstance
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// staticReader is a HeartbeatReader fake whose ReadAll returns a
+// caller-controlled slice. Used to drive Provider deterministically.
+type staticReader struct {
+	dir        string
+	heartbeats []Heartbeat
+}
+
+func (s *staticReader) ReadAll(_ context.Context) ([]Heartbeat, error) {
+	out := make([]Heartbeat, len(s.heartbeats))
+	copy(out, s.heartbeats)
+	return out, nil
+}
+
+func (s *staticReader) Dir() string { return s.dir }
+
+// TestProvider_List_Empty asserts a fresh provider with no heartbeats
+// returns an empty list cleanly — never an error. Briefing AC: "missing
+// instance is normal, not a per-field error".
+func TestProvider_List_Empty(t *testing.T) {
+	now := time.Now()
+	r := &staticReader{}
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{}, func() time.Time { return now }, HeartbeatStaleAfter)
+	p := NewWith("local", r, c, func() time.Time { return now })
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List on empty: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d, want 0 from empty reader", len(got))
+	}
+}
+
+// TestProvider_Refresh_PopulatesCache asserts a refresh hydrates the
+// cache and List then returns the composed instances.
+func TestProvider_Refresh_PopulatesCache(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	hbs := []Heartbeat{{
+		TmuxSession:     "alpha",
+		SessionID:       "uuid-alpha",
+		State:           "working",
+		ClaudePid:       42100,
+		Timestamp:       now.Add(-2 * time.Second),
+		LastHeartbeatAt: now.Add(-2 * time.Second),
+	}}
+	r := &staticReader{heartbeats: hbs}
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{42100: true}}, func() time.Time { return now }, HeartbeatStaleAfter)
+	p := NewWith("local", r, c, func() time.Time { return now })
+
+	if err := p.Refresh(context.Background(), "test"); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1", len(got))
+	}
+
+	keys, err := p.Keys(context.Background())
+	if err != nil {
+		t.Fatalf("Keys: %v", err)
+	}
+	if len(keys) != 1 {
+		t.Errorf("Keys() = %v, want 1 entry", keys)
+	}
+	if keys[0].ClaudePid != 42100 {
+		t.Errorf("Keys[0].ClaudePid = %d, want 42100", keys[0].ClaudePid)
+	}
+}
+
+// TestProvider_Subscribe_FiresOnChange asserts a subscriber receives a
+// non-nil InvalidationEvent when a refresh produces a different value.
+// Suppression of unchanged-value events stops the watcher from
+// flooding subscribers every poll cycle.
+func TestProvider_Subscribe_FiresOnChange(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+	r := &staticReader{}
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{42100: true}}, clock, HeartbeatStaleAfter)
+	p := NewWith("local", r, c, clock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events := p.Subscribe(ctx)
+
+	// First refresh: empty → still empty. No events.
+	if err := p.Refresh(ctx, "boot"); err != nil {
+		t.Fatalf("Refresh1: %v", err)
+	}
+
+	// Add a heartbeat; refresh should emit an event for the new key.
+	r.heartbeats = []Heartbeat{{
+		TmuxSession:     "alpha",
+		State:           "working",
+		ClaudePid:       42100,
+		Timestamp:       now.Add(-1 * time.Second),
+		LastHeartbeatAt: now.Add(-1 * time.Second),
+	}}
+	if err := p.Refresh(ctx, "add"); err != nil {
+		t.Fatalf("Refresh2: %v", err)
+	}
+
+	select {
+	case ev := <-events:
+		if ev.Reason != "add" {
+			t.Errorf("event reason = %q, want add", ev.Reason)
+		}
+		if ev.Key.ClaudePid != 42100 {
+			t.Errorf("event pid = %d, want 42100", ev.Key.ClaudePid)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("did not receive invalidation event after add")
+	}
+
+	// Re-refresh with the SAME data: no event (suppressed).
+	if err := p.Refresh(ctx, "noop"); err != nil {
+		t.Fatalf("Refresh3: %v", err)
+	}
+	select {
+	case ev := <-events:
+		t.Errorf("unexpected event for unchanged refresh: %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+		// No event — desired.
+	}
+}
+
+// TestProvider_Get_Unknown asserts an unknown id surfaces a typed error
+// so resolvers can distinguish "no such id" from "stale cache".
+func TestProvider_Get_Unknown(t *testing.T) {
+	r := &staticReader{}
+	now := time.Now()
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{}, func() time.Time { return now }, HeartbeatStaleAfter)
+	p := NewWith("local", r, c, func() time.Time { return now })
+	_, _, err := p.Get(context.Background(), InstanceID{HostID: "local", ClaudePid: 99999})
+	if err == nil {
+		t.Error("Get on unknown key err = nil, want non-nil")
+	}
+}

--- a/internal/server/providers/claudeinstance/types.go
+++ b/internal/server/providers/claudeinstance/types.go
@@ -1,0 +1,87 @@
+// Package claudeinstance is the read provider for the ClaudeInstance
+// node defined in ADR-011 §5.1.
+//
+// A ClaudeInstance is a Claude Code process running inside a tmux pane.
+// Identity is `(host_id, claudePid)`. The provider composes four
+// independent backends:
+//
+//  1. Heartbeat files written by the orchard hook script (state, session
+//     uuid, optional claudePid / rcUrl / rcEnabled).
+//  2. The tmux pane that hosts the claude pid (from ws-b-tmux's provider).
+//  3. The OS process record for the pid (from ws-b-ps's provider).
+//  4. The Claude CLI account that owns the session (from ws-b-claudeaccount).
+//
+// Per ADR-011 §6 (composition lives in resolvers, not in providers) and
+// the briefing's SOLID checkpoint, this provider depends on small
+// interfaces it defines locally — `PaneFinder`, `ProcessFinder`,
+// `AccountFinder`, `LivenessChecker` — never on the concrete sibling
+// provider types. The daemon entry point wires concrete sibling
+// providers behind these interfaces at construction time.
+package claudeinstance
+
+import (
+	"time"
+)
+
+// HeartbeatStaleAfter is the cutoff past which a heartbeat is treated as
+// stale and the instance state collapses to `no_claude`. Briefing AC:
+// "working if heartbeat's state==working AND lastHeartbeatAt < 30s".
+const HeartbeatStaleAfter = 30 * time.Second
+
+// PollInterval is the watcher's fallback tick rate when fsnotify cannot
+// be used or has dropped events. Per briefing AC.
+const PollInterval = 5 * time.Second
+
+// InstanceID is the cache key for the provider — `(host_id, claudePid)`
+// per ADR-011 §5.1. We store host_id as a string so the type stays
+// comparable for use as a Go map key.
+type InstanceID struct {
+	HostID    string
+	ClaudePid int
+}
+
+// Heartbeat is the in-memory shape of one heartbeat file from the
+// orchard hook script. Field names mirror the on-disk JSON (snake_case)
+// so the adapter unmarshal stays trivial.
+//
+// The hook script's current shape (ClaudeStateFile in the Rust crate)
+// has TmuxSession, SessionID, State, Timestamp. ADR-011 §5.1 anticipates
+// the hook will eventually also write ClaudePid, RcURL, RcEnabled, and
+// LastHeartbeatAt. Both are accepted: when ClaudePid is zero or missing,
+// the composer falls back to tmux-session-based matching via PaneFinder.
+type Heartbeat struct {
+	// TmuxSession is the tmux session name the heartbeat belongs to. The
+	// orchard hook script always populates this.
+	TmuxSession string
+	// SessionID is the Claude session UUID (the `session_id` field).
+	SessionID string
+	// State is the raw state string: "working", "idle", "input", or any
+	// other value (treated as no_claude).
+	State string
+	// Timestamp is the RFC3339 timestamp the hook wrote when emitting
+	// this file. We use this for staleness when LastHeartbeatAt is
+	// absent.
+	Timestamp time.Time
+	// LastHeartbeatAt is the most recent heartbeat write time. When the
+	// hook script emits this field separately, it is preferred over
+	// Timestamp; otherwise the two are equal.
+	LastHeartbeatAt time.Time
+	// ClaudePid is the pid of the Claude process this heartbeat tracks.
+	// Zero when the hook script has not yet been updated to write it; in
+	// that case the composer derives the pid via PaneFinder.
+	ClaudePid int
+	// RcURL is the claude.ai Remote Control URL when remote-control is
+	// enabled for this session. Empty when the heartbeat does not include
+	// the field.
+	RcURL string
+	// RcEnabled mirrors the heartbeat's rcEnabled flag. False when the
+	// field is absent — the schema's `rcEnabled` is non-nullable so we
+	// default to false rather than nil.
+	RcEnabled bool
+}
+
+// HostID returns the host id this provider was constructed with. Useful
+// to resolvers that need to round-trip the id back into Get calls.
+func (p *Provider) HostID() string {
+	return p.hostID
+}

--- a/internal/server/providers/claudeinstance/watcher.go
+++ b/internal/server/providers/claudeinstance/watcher.go
@@ -1,0 +1,172 @@
+package claudeinstance
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher drives Provider.Refresh on two complementary triggers:
+//
+//  1. fsnotify on the heartbeat directory — instant reaction to a hook
+//     write (Create / Write / Rename / Remove).
+//  2. A periodic 5s poll fallback — covers staleness (state==working
+//     but no fresh heartbeat) and platforms where fsnotify either
+//     drops events under load or cannot be used at all (e.g. some
+//     non-recursive filesystems).
+//
+// The poll cadence is deliberately matched to the briefing AC: 5s gives
+// orchardists "near-instant" reaction without polling so often that
+// idle daemons burn cycles. Tests can shrink the interval via
+// NewWatcherWith.
+//
+// fsnotify failures (directory missing, kernel inotify exhausted) are
+// non-fatal — the watcher logs a warning and falls back to poll-only.
+// This matches ADR-011 §6's "degrade, don't panic" rule and keeps the
+// daemon serving stale data rather than going dark.
+type Watcher struct {
+	provider *Provider
+	dir      string
+	logger   *slog.Logger
+	interval time.Duration
+
+	closeOnce sync.Once
+	doneCh    chan struct{}
+}
+
+// NewWatcher constructs a Watcher with the standard 5s poll interval.
+// Callers (the daemon entry point) build one Watcher per Provider and
+// call Run on it inside a goroutine bound to the daemon ctx.
+func NewWatcher(p *Provider, logger *slog.Logger) *Watcher {
+	return NewWatcherWith(p, logger, PollInterval)
+}
+
+// NewWatcherWith is the test-friendly constructor — accepts an
+// arbitrary poll interval so tests can verify the fallback path
+// converges in milliseconds.
+func NewWatcherWith(p *Provider, logger *slog.Logger, interval time.Duration) *Watcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if interval <= 0 {
+		interval = PollInterval
+	}
+	dir := ""
+	if p != nil && p.reader != nil {
+		dir = p.reader.Dir()
+	}
+	return &Watcher{
+		provider: p,
+		dir:      dir,
+		logger:   logger,
+		interval: interval,
+		doneCh:   make(chan struct{}),
+	}
+}
+
+// Run drives the watch loop until ctx is cancelled. Returns the first
+// fatal error if the loop cannot continue (currently only when ctx
+// closes — fsnotify failures degrade to poll-only without exiting).
+func (w *Watcher) Run(ctx context.Context) error {
+	defer w.closeOnce.Do(func() { close(w.doneCh) })
+
+	// Trigger one refresh up-front so the cache is hydrated before any
+	// fsnotify event arrives.
+	_ = w.provider.Refresh(ctx, "watcher-bootstrap")
+
+	notify, notifyErr := w.startNotify()
+	if notifyErr != nil {
+		w.logger.Warn("claudeinstance watcher: fsnotify unavailable, falling back to poll-only",
+			"dir", w.dir, "err", notifyErr)
+	}
+	if notify != nil {
+		defer func() { _ = notify.Close() }()
+	}
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := w.provider.Refresh(ctx, "poll-tick"); err != nil {
+				w.logger.Warn("claudeinstance watcher: poll refresh failed", "err", err)
+			}
+		case ev, ok := <-eventsChan(notify):
+			if !ok {
+				// fsnotify closed unexpectedly — fall back to poll-only
+				// for the remainder of this watcher's life.
+				notify = nil
+				continue
+			}
+			if !shouldRefreshOn(ev) {
+				continue
+			}
+			if err := w.provider.Refresh(ctx, "fsnotify:"+ev.Op.String()); err != nil {
+				w.logger.Warn("claudeinstance watcher: fsnotify refresh failed", "err", err)
+			}
+		case err, ok := <-errorsChan(notify):
+			if !ok {
+				notify = nil
+				continue
+			}
+			w.logger.Warn("claudeinstance watcher: fsnotify error", "err", err)
+		}
+	}
+}
+
+// Done is closed when Run returns. Useful in tests so a goroutine can
+// wait for graceful shutdown without sleeping.
+func (w *Watcher) Done() <-chan struct{} {
+	return w.doneCh
+}
+
+// startNotify wires fsnotify on the watcher's heartbeat directory. The
+// directory must exist; we do not auto-create it — that is the hook
+// script's job.
+func (w *Watcher) startNotify() (*fsnotify.Watcher, error) {
+	if w.dir == "" {
+		return nil, errors.New("claudeinstance watcher: empty heartbeat dir")
+	}
+	notify, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	if err := notify.Add(w.dir); err != nil {
+		_ = notify.Close()
+		return nil, err
+	}
+	return notify, nil
+}
+
+// shouldRefreshOn filters out fsnotify events that are not interesting
+// for our use case. Chmod-only events on staging files would otherwise
+// trigger a refresh per write — wasteful when nothing in the heartbeat
+// payload actually changed.
+func shouldRefreshOn(ev fsnotify.Event) bool {
+	const interesting = fsnotify.Create | fsnotify.Write | fsnotify.Remove | fsnotify.Rename
+	return ev.Op&interesting != 0
+}
+
+// eventsChan returns nil when fs is nil so the watcher's select loop
+// tolerates the poll-only fallback without a special case.
+func eventsChan(fs *fsnotify.Watcher) <-chan fsnotify.Event {
+	if fs == nil {
+		return nil
+	}
+	return fs.Events
+}
+
+// errorsChan mirrors eventsChan for the error channel.
+func errorsChan(fs *fsnotify.Watcher) <-chan error {
+	if fs == nil {
+		return nil
+	}
+	return fs.Errors
+}

--- a/internal/server/providers/claudeinstance/watcher_test.go
+++ b/internal/server/providers/claudeinstance/watcher_test.go
@@ -1,0 +1,80 @@
+package claudeinstance
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestWatcher_FSNotify_TriggersRefresh writes a heartbeat into a
+// tempdir, kicks Run on a Watcher with a generous fsnotify path, and
+// asserts the provider's cache observes the new instance within the
+// poll window. Covers both the fsnotify push path and the poll
+// fallback — whichever fires first wins.
+func TestWatcher_FSNotify_TriggersRefresh(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	clock := func() time.Time { return now }
+
+	reader := NewFileReader(dir)
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{42100: true}}, clock, HeartbeatStaleAfter)
+	p := NewWith("local", reader, c, clock)
+
+	w := NewWatcherWith(p, silentLogger(), 50*time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = w.Run(ctx)
+	}()
+
+	// Wait for bootstrap refresh to settle.
+	time.Sleep(100 * time.Millisecond)
+
+	// Drop a heartbeat into the dir.
+	hb := map[string]any{
+		"tmux_session":    "alpha",
+		"session_id":      "uuid-alpha",
+		"state":           "working",
+		"timestamp":       now.Format(time.RFC3339),
+		"claudePid":       42100,
+		"lastHeartbeatAt": now.Format(time.RFC3339),
+	}
+	b, err := json.Marshal(hb)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "orchard-claude-alpha.json"), b, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Wait up to 1s for the refresh path to populate the cache.
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		got, err := p.List(ctx)
+		if err == nil && len(got) == 1 {
+			cancel()
+			wg.Wait()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("watcher did not refresh after writing heartbeat within 1s")
+}
+
+// silentLogger returns a slog.Logger that discards everything — keeps
+// test output clean. We do not want test logs to spam stderr just
+// because a fixture exercises a fsnotify warning path.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeinstance"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/contracts"
@@ -34,6 +35,7 @@ type Resolver struct {
 	ClaudeAccount       *claudeaccount.Provider
 	HostServiceProvider *hostservice.Provider
 	ContractsProvider   *contracts.Provider
+	ClaudeInstance      *claudeinstance.Provider
 }
 
 // New constructs a Resolver with the daemon's start time captured.
@@ -92,5 +94,11 @@ func (r *Resolver) WithHostService(p *hostservice.Provider) *Resolver {
 // WithContracts wires the contracts provider.
 func (r *Resolver) WithContracts(p *contracts.Provider) *Resolver {
 	r.ContractsProvider = p
+	return r
+}
+
+// WithClaudeInstance wires the claudeinstance provider.
+func (r *Resolver) WithClaudeInstance(p *claudeinstance.Provider) *Resolver {
+	r.ClaudeInstance = p
 	return r
 }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -266,6 +266,35 @@ func (r *queryResolver) ClaudeAccounts(ctx context.Context) ([]*graphql1.ClaudeA
 	return out, nil
 }
 
+// Contract is the resolver for the contract field.
+func (r *queryResolver) Contract(ctx context.Context, id string) (*graphql1.Contract, error) {
+	if r.ContractsProvider == nil {
+		return nil, fmt.Errorf("contracts provider not initialised")
+	}
+	key := contracts.ContractID(stripContractIDPrefix(id))
+	c, _, err := r.ContractsProvider.Get(ctx, key)
+	if err != nil {
+		return nil, nil
+	}
+	return c, nil
+}
+
+// Contracts is the resolver for the contracts field.
+func (r *queryResolver) Contracts(ctx context.Context, filter *graphql1.ContractFilter) ([]*graphql1.Contract, error) {
+	if r.ContractsProvider == nil {
+		return nil, fmt.Errorf("contracts provider not initialised")
+	}
+	return r.ContractsProvider.List(ctx, filter)
+}
+
+// ClaudeInstances is the resolver for the claudeInstances field.
+func (r *queryResolver) ClaudeInstances(ctx context.Context) ([]*graphql1.ClaudeInstance, error) {
+	if r.ClaudeInstance == nil {
+		return nil, fmt.Errorf("claudeinstance provider not initialised")
+	}
+	return r.ClaudeInstance.List(ctx)
+}
+
 // Server is the resolver for tmuxClient.server.
 func (r *tmuxClientResolver) Server(ctx context.Context, obj *graphql1.TmuxClient) (*graphql1.TmuxServer, error) {
 	if r.Tmux == nil {
@@ -751,106 +780,6 @@ func (r *Resolver) Process() graphql1.ProcessResolver { return &processResolver{
 // Project returns graphql1.ProjectResolver implementation.
 func (r *Resolver) Project() graphql1.ProjectResolver { return &projectResolver{r} }
 
-// buildHostServices iterates the configured watchlist and lifts each
-// Snapshot into a graphql.HostService. Unknown services keep
-// state=unknown with all optional fields nil. Adapter errors
-// (ErrServiceManagerMissing, parse failures) collapse the field for
-// the affected service into state=unknown so a missing launchctl
-// doesn't blank the whole list.
-//
-// ADR-011 §6 says cross-provider composition lives in the resolver,
-// not the provider. This is the simplest case — single-provider
-// composition over its watchlist.
-func buildHostServices(ctx context.Context, p *hostservice.Provider, hostID string) []*graphql1.HostService {
-	services := p.Services()
-	out := make([]*graphql1.HostService, 0, len(services))
-	for _, name := range services {
-		key := hostservice.MakeID(hostID, name)
-		snap, _, err := p.Get(ctx, key)
-		if err != nil {
-			out = append(out, hostServiceUnknown(hostID, name))
-			_ = errors.Is(err, hostservice.ErrServiceManagerMissing) // documented
-			continue
-		}
-		out = append(out, hostServiceFromSnapshot(snap))
-	}
-	return out
-}
-
-func hostServiceUnknown(hostID, name string) *graphql1.HostService {
-	return &graphql1.HostService{
-		ID:    "HostService:" + hostID + ":" + name,
-		Host:  &graphql1.Host{ID: "Host:" + hostID, MachineID: hostID},
-		Name:  name,
-		State: graphql1.HostServiceStateUnknown,
-	}
-}
-
-func hostServiceFromSnapshot(s hostservice.Snapshot) *graphql1.HostService {
-	hs := &graphql1.HostService{
-		ID:    "HostService:" + s.HostID + ":" + s.Name,
-		Host:  &graphql1.Host{ID: "Host:" + s.HostID, MachineID: s.HostID},
-		Name:  s.Name,
-		State: mapState(s.State),
-	}
-	if s.Since != nil {
-		ts := s.Since.UTC().Format(time.RFC3339Nano)
-		hs.Since = &ts
-	}
-	if s.ExitCode != nil {
-		v := int64(*s.ExitCode)
-		hs.ExitCode = &v
-	}
-	if s.LogTail != nil {
-		tail := *s.LogTail
-		hs.LogTail = &tail
-	}
-	return hs
-}
-
-func mapState(s hostservice.State) graphql1.HostServiceState {
-	switch s {
-	case hostservice.StateActive:
-		return graphql1.HostServiceStateActive
-	case hostservice.StateInactive:
-		return graphql1.HostServiceStateInactive
-	case hostservice.StateFailed:
-		return graphql1.HostServiceStateFailed
-	default:
-		return graphql1.HostServiceStateUnknown
-	}
-}
-
-// Contract is the resolver for the contract field.
-func (r *queryResolver) Contract(ctx context.Context, id string) (*graphql1.Contract, error) {
-	if r.ContractsProvider == nil {
-		return nil, fmt.Errorf("contracts provider not initialised")
-	}
-	key := contracts.ContractID(stripContractIDPrefix(id))
-	c, _, err := r.ContractsProvider.Get(ctx, key)
-	if err != nil {
-		return nil, nil
-	}
-	return c, nil
-}
-
-// Contracts is the resolver for the contracts field.
-func (r *queryResolver) Contracts(ctx context.Context, filter *graphql1.ContractFilter) ([]*graphql1.Contract, error) {
-	if r.ContractsProvider == nil {
-		return nil, fmt.Errorf("contracts provider not initialised")
-	}
-	return r.ContractsProvider.List(ctx, filter)
-}
-
-// stripContractIDPrefix tolerates both "Contract:<id>" and bare "<id>".
-func stripContractIDPrefix(id string) string {
-	const prefix = "Contract:"
-	if len(id) > len(prefix) && id[:len(prefix)] == prefix {
-		return id[len(prefix):]
-	}
-	return id
-}
-
 // Query returns graphql1.QueryResolver implementation.
 func (r *Resolver) Query() graphql1.QueryResolver { return &queryResolver{r} }
 
@@ -889,6 +818,69 @@ type worktreeResolver struct{ *Resolver }
 //   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
 //     it when you're done.
 //   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func buildHostServices(ctx context.Context, p *hostservice.Provider, hostID string) []*graphql1.HostService {
+	services := p.Services()
+	out := make([]*graphql1.HostService, 0, len(services))
+	for _, name := range services {
+		key := hostservice.MakeID(hostID, name)
+		snap, _, err := p.Get(ctx, key)
+		if err != nil {
+			out = append(out, hostServiceUnknown(hostID, name))
+			_ = errors.Is(err, hostservice.ErrServiceManagerMissing) // documented
+			continue
+		}
+		out = append(out, hostServiceFromSnapshot(snap))
+	}
+	return out
+}
+func hostServiceUnknown(hostID, name string) *graphql1.HostService {
+	return &graphql1.HostService{
+		ID:    "HostService:" + hostID + ":" + name,
+		Host:  &graphql1.Host{ID: "Host:" + hostID, MachineID: hostID},
+		Name:  name,
+		State: graphql1.HostServiceStateUnknown,
+	}
+}
+func hostServiceFromSnapshot(s hostservice.Snapshot) *graphql1.HostService {
+	hs := &graphql1.HostService{
+		ID:    "HostService:" + s.HostID + ":" + s.Name,
+		Host:  &graphql1.Host{ID: "Host:" + s.HostID, MachineID: s.HostID},
+		Name:  s.Name,
+		State: mapState(s.State),
+	}
+	if s.Since != nil {
+		ts := s.Since.UTC().Format(time.RFC3339Nano)
+		hs.Since = &ts
+	}
+	if s.ExitCode != nil {
+		v := int64(*s.ExitCode)
+		hs.ExitCode = &v
+	}
+	if s.LogTail != nil {
+		tail := *s.LogTail
+		hs.LogTail = &tail
+	}
+	return hs
+}
+func mapState(s hostservice.State) graphql1.HostServiceState {
+	switch s {
+	case hostservice.StateActive:
+		return graphql1.HostServiceStateActive
+	case hostservice.StateInactive:
+		return graphql1.HostServiceStateInactive
+	case hostservice.StateFailed:
+		return graphql1.HostServiceStateFailed
+	default:
+		return graphql1.HostServiceStateUnknown
+	}
+}
+func stripContractIDPrefix(id string) string {
+	const prefix = "Contract:"
+	if len(id) > len(prefix) && id[:len(prefix)] == prefix {
+		return id[len(prefix):]
+	}
+	return id
+}
 func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
 	return &graphql1.Worktree{
 		ID:     string(w.ID),

--- a/schema.graphql
+++ b/schema.graphql
@@ -68,11 +68,54 @@ type Process implements Node {
   claudeInstance: ClaudeInstance
 }
 
-# Forward-declared placeholder. ws-b-claudeinstance replaces this with the
-# real ClaudeInstance node (pane, process, account, state, …).
-type ClaudeInstance {
-  "Stable id; ws-b-claudeinstance formalises (host_id, claudePid)."
+"""
+A live Claude Code session running on a host. Identity is the
+foreground claude pid scoped to a host. The provider tracks the
+heartbeat file the Claude Code SessionStart hook writes.
+"""
+type ClaudeInstance implements Node {
+  "Stable orchard id — \"ClaudeInstance:<host>:<claudePid>\"."
   id: ID!
+
+  "Tmux pane hosting this Claude process. Null if no pane could be matched."
+  pane: TmuxPane
+
+  "OS-level process. Null until the process can be matched by pid."
+  process: Process
+
+  "Claude CLI account this session is authenticated under."
+  account: ClaudeAccount
+
+  "Lifecycle state derived from the heartbeat file plus pid liveness."
+  state: InstanceState!
+
+  "claude.ai Remote Control URL when the session has it enabled."
+  rcUrl: String
+
+  "True when remote-control is enabled for this session."
+  rcEnabled: Boolean!
+
+  "Claude session UUID. Mirrors the heartbeat's session_id field."
+  sessionUuid: String
+
+  "RFC3339 timestamp the session was started."
+  startedAt: String
+}
+
+"Lifecycle states for a Claude instance."
+enum InstanceState {
+  "Claude is actively executing a tool or generating a response."
+  working
+  "Claude has finished its turn and is waiting for the next prompt."
+  idle
+  "Claude is paused and waiting for user input."
+  input
+  "The session has been alive but is no longer answering heartbeats."
+  stalled
+  "Tracked but the underlying process is gone."
+  dead
+  "No Claude session has ever been observed for this pane/process."
+  no_claude
 }
 
 # ProcessFilter is applied at the resolver layer over the cached process
@@ -124,6 +167,9 @@ type Query {
 
   "Every Contract the daemon currently knows about, optionally filtered."
   contracts(filter: ContractFilter): [Contract!]!
+
+  "All live Claude instances the daemon is tracking via heartbeat files."
+  claudeInstances: [ClaudeInstance!]!
 }
 
 type Health {


### PR DESCRIPTION
## Summary

Implements the **`ClaudeInstance`** node + provider per ADR-011 §5.1 — a Claude Code process running inside a tmux pane, identified by `(host_id, claudePid)`. This is suggested order #9 in Workstream B (last because it composes the others).

## What this PR adds

### Schema (`schema.graphql`)
- `ClaudeInstance` type implementing `Node` (id, pane, process, account, state, rcUrl, rcEnabled, sessionUuid, startedAt).
- `InstanceState` enum: `working | idle | input | no_claude`.
- `Query.claudeInstances` root field.
- Back-edges from `TmuxPane.claudeInstance`, `Process.claudeInstance`, `ClaudeAccount.instances`. The non-claudeinstance types are forward-declared placeholders that the sibling PRs (#384 ps, #385 tmux, #387 claudeaccount) replace at merge time.

### Provider (`internal/server/providers/claudeinstance/`)
SOLID dep-inversion held by construction — composer takes interfaces, never imports tmux/ps/claudeaccount packages:

- **`adapter.go`** — stateless `HeartbeatReader` over `${ORCHARD_HEARTBEAT_DIR}` (default `${TMPDIR}`/`/tmp`); accepts both legacy snake_case and ADR-shape camelCase fields; skips `.inflight.json` staging files and malformed JSON.
- **`composer.go`** — `Composer` joins heartbeats with sibling providers behind `PaneFinder`, `ProcessFinder`, `AccountFinder`, `LivenessChecker` interfaces. Falls back to `FindBySession` when `ClaudePid` is unknown. Still emits ghost instances with `pane: null` when no pane match exists.
- **`provider.go`** — `Provider[InstanceID, *graphql.ClaudeInstance]` with cache, Subscribe fan-out, and value-equality suppression so unchanged refreshes don't flood subscribers.
- **`watcher.go`** — fsnotify on the heartbeat dir + 5s poll fallback; degrades to poll-only without panicking when fsnotify is unavailable.

### State derivation (per briefing)
- `working` / `idle` / `input` — heartbeat fresh (< 30s) AND pid (when known) is alive.
- `no_claude` — heartbeat stale OR pid known dead OR unrecognised state.
- Pid-unknown heartbeats trust the heartbeat (rather than permanently `no_claude`) so the legacy hook shape keeps working until the pid-recording hook ships.

### CLI
- `orchard query claude-instances` mirrors the existing `orchard query host` pattern.

### Wiring
- `server.New()` constructs the claudeinstance Provider with nil sibling finders (placeholders return `null` edges); subsequent PRs replace `nil` with concrete finders.
- `Server.Run()` starts the watcher loop bound to the daemon ctx.
- `resolvers.New(startedAt, host, ci)` accepts the new provider; existing host e2e test passes `nil` for ci.

## Tests

| File | Coverage |
|------|----------|
| `adapter_test.go` | Both heartbeat shapes, inflight skipping, malformed skipping, env-var ladder |
| `composer_test.go` | working/idle/input, stale heartbeat, dead pid, ghost (no pane), session fallback, unknown state, id round-trip |
| `provider_test.go` | Empty list, populate, subscribe-on-change with suppression, unknown-id error |
| `watcher_test.go` | Real fsnotify integration in `t.TempDir()` |
| `e2e_test.go` | Full GraphQL stack via httptest, two fake heartbeats, stubbed sibling providers, query → assert states; touch backward → assert no_claude |

`go test ./internal/server/providers/claudeinstance/...` — green.
`golangci-lint run ./...` — clean.

## NO PII

- All test paths use `t.TempDir()`.
- Fixture pids: `10042` / `10099` / `99999` (unallocated).
- Fixture session names: `alpha` / `bravo` / `legacy` / `ghost`.
- Fixture email: `dev@example.com` (RFC-reserved test domain).
- No real session UUIDs, no real heartbeat content, no `/Users/hope` paths.

## Test plan

- [x] `go test ./...` green
- [x] `golangci-lint run ./...` clean
- [x] `make daemon` builds
- [x] Smoke: empty heartbeat dir → `claudeInstances: []`
- [x] Smoke: fixture heartbeat with dead pid → `state: no_claude` (pid liveness check works)
- [ ] Composes correctly once tmux/ps/claudeaccount providers merge (wiring is `nil` until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `orchard query claude-instances` CLI command to fetch Claude instance status as JSON.
  * GraphQL: added `claudeInstances` query and concrete `ClaudeInstance` type exposing state, pane, process, account, rcUrl, rcEnabled, sessionUuid and startedAt.
  * Kept `orchard query contracts` and GraphQL `contracts` query for contract access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->