### PR TITLE
fix: nodeChanged dispatches by id-prefix to owning provider (resolves #396)

### DIFF
--- a/internal/server/resolvers/loader_bridge.go
+++ b/internal/server/resolvers/loader_bridge.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/loaders"
@@ -89,6 +90,44 @@ func projectTmuxPane(p tmuxprovider.Pane) *graphql1.TmuxPane {
 		PaneID: p.Key.PaneID,
 	}
 }
+
+// projectWindowAtomic mirrors `projectWindow` in schema.resolvers.go so
+// node.resolvers.go can build a TmuxWindow value without depending on
+// the schema-level helper (gqlgen routinely shuffles those).
+func projectWindowAtomic(w tmuxprovider.Window) *graphql1.TmuxWindow {
+	return &graphql1.TmuxWindow{
+		ID:    "TmuxWindow:" + string(w.Key.Host) + ":" + w.Key.Session + ":" + strconv.Itoa(w.Key.Index),
+		Index: int64(w.Key.Index),
+	}
+}
+
+// projectClientAtomic mirrors `projectClient` in schema.resolvers.go.
+func projectClientAtomic(c tmuxprovider.Client) *graphql1.TmuxClient {
+	return &graphql1.TmuxClient{
+		ID: "TmuxClient:" + string(c.Key.Host) + ":" + c.Key.ClientName,
+	}
+}
+
+// findTmuxWindow scans the tmux provider's window snapshot for the
+// window matching (host, session, index). Returns ok=false when no match.
+func findTmuxWindow(p *tmuxprovider.Provider, host, session string, index int) (tmuxprovider.Window, bool) {
+	if p == nil {
+		return tmuxprovider.Window{}, false
+	}
+	w, ok := p.Snapshot().Windows[tmuxprovider.WindowKey{Host: tmuxprovider.HostID(host), Session: session, Index: index}]
+	return w, ok
+}
+
+// findTmuxClient scans the tmux provider's client snapshot for the
+// client matching (host, name).
+func findTmuxClient(p *tmuxprovider.Provider, host, name string) (tmuxprovider.Client, bool) {
+	if p == nil {
+		return tmuxprovider.Client{}, false
+	}
+	c, ok := p.Snapshot().Clients[tmuxprovider.ClientKey{Host: tmuxprovider.HostID(host), ClientName: name}]
+	return c, ok
+}
+
 
 // findTmuxSession scans the tmux provider's session snapshot for the
 // session matching (host, name). Returns ok=false when no match.

--- a/internal/server/resolvers/node.resolvers.go
+++ b/internal/server/resolvers/node.resolvers.go
@@ -7,8 +7,14 @@ import (
 	"strings"
 
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
+	claudeinstanceprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeinstance"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/contracts"
+	ghprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	hostprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
 	psprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 )
 
@@ -24,10 +30,32 @@ func resolveNode(ctx context.Context, r *Resolver, id string) (graphql1.Node, er
 	switch {
 	case strings.HasPrefix(id, "Host:"):
 		return resolveHostNode(ctx, r, id)
+	case strings.HasPrefix(id, "HostService:"):
+		return resolveHostServiceNode(ctx, r, id)
+	case strings.HasPrefix(id, "Conversation:"):
+		return resolveConversationNode(ctx, r, id)
+	case strings.HasPrefix(id, "ClaudeAccount:"):
+		return resolveClaudeAccountNode(ctx, r, id)
+	case strings.HasPrefix(id, "ClaudeInstance:"):
+		return resolveClaudeInstanceNode(ctx, r, id)
+	case strings.HasPrefix(id, "Contract:"):
+		return resolveContractNode(ctx, r, id)
+	case strings.HasPrefix(id, "TmuxServer:"):
+		return resolveTmuxServerNode(ctx, r, id)
 	case strings.HasPrefix(id, "TmuxSession:"):
 		return resolveTmuxSessionNode(ctx, r, id)
+	case strings.HasPrefix(id, "TmuxWindow:"):
+		return resolveTmuxWindowNode(ctx, r, id)
 	case strings.HasPrefix(id, "TmuxPane:"):
 		return resolveTmuxPaneNode(ctx, r, id)
+	case strings.HasPrefix(id, "TmuxClient:"):
+		return resolveTmuxClientNode(ctx, r, id)
+	case strings.HasPrefix(id, "PullRequest:"):
+		return resolvePullRequestNode(ctx, r, id)
+	case strings.HasPrefix(id, "Issue:"):
+		return resolveIssueNode(ctx, r, id)
+	case strings.HasPrefix(id, "WorkflowRun:"):
+		return resolveWorkflowRunNode(ctx, r, id)
 	}
 	if isProcessID(id) {
 		return resolveProcessNode(ctx, r, id)
@@ -150,6 +178,188 @@ func resolveTmuxPaneNode(_ context.Context, r *Resolver, id string) (graphql1.No
 	return *projectTmuxPane(p), nil
 }
 
+func resolveTmuxServerNode(_ context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.Tmux == nil {
+		return nil, fmt.Errorf("tmux provider not configured")
+	}
+	host, socketPath, ok := splitTmuxServerID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed tmux server id %q", id)
+	}
+	if string(r.Tmux.Host()) != host {
+		return nil, nil
+	}
+	info := r.Tmux.Server()
+	if info.SocketPath != socketPath {
+		return nil, nil
+	}
+	return *projectServer(r.Tmux.Host(), info), nil
+}
+
+func resolveTmuxWindowNode(_ context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.Tmux == nil {
+		return nil, fmt.Errorf("tmux provider not configured")
+	}
+	host, session, idx, ok := splitTmuxWindowID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed tmux window id %q", id)
+	}
+	if string(r.Tmux.Host()) != host {
+		return nil, nil
+	}
+	w, found := findTmuxWindow(r.Tmux, host, session, idx)
+	if !found {
+		return nil, nil
+	}
+	return *projectWindowAtomic(w), nil
+}
+
+func resolveTmuxClientNode(_ context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.Tmux == nil {
+		return nil, fmt.Errorf("tmux provider not configured")
+	}
+	host, name, ok := splitTmuxClientID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed tmux client id %q", id)
+	}
+	if string(r.Tmux.Host()) != host {
+		return nil, nil
+	}
+	c, found := findTmuxClient(r.Tmux, host, name)
+	if !found {
+		return nil, nil
+	}
+	return *projectClientAtomic(c), nil
+}
+
+func resolveConversationNode(ctx context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.ClaudeProjects == nil {
+		return nil, fmt.Errorf("claudeprojects provider not configured")
+	}
+	uuid := strings.TrimPrefix(id, "Conversation:")
+	if uuid == "" {
+		return nil, nil
+	}
+	keys, err := r.ClaudeProjects.Keys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, k := range keys {
+		if k.SessionUUID != uuid {
+			continue
+		}
+		c, _, gerr := r.ClaudeProjects.Get(ctx, k)
+		if gerr != nil {
+			return nil, nil
+		}
+		return *r.ClaudeProjects.ToGraphQL(c), nil
+	}
+	return nil, nil
+}
+
+func resolveClaudeAccountNode(ctx context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.ClaudeAccount == nil {
+		return nil, fmt.Errorf("claudeaccount provider not configured")
+	}
+	host, email, ok := splitClaudeAccountID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed claude account id %q", id)
+	}
+	a, _, err := r.ClaudeAccount.Get(ctx, claudeaccount.AccountID{HostID: host, Email: email})
+	if err != nil {
+		return nil, nil
+	}
+	return *r.ClaudeAccount.ToGraphQL(a), nil
+}
+
+func resolveClaudeInstanceNode(ctx context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.ClaudeInstance == nil {
+		return nil, fmt.Errorf("claudeinstance provider not configured")
+	}
+	host, pid, ok := parseClaudeInstanceID(id)
+	if !ok {
+		// Session-keyed id — fall through to a List+match.
+		return findClaudeInstanceByID(ctx, r.ClaudeInstance, id)
+	}
+	inst, _, err := r.ClaudeInstance.Get(ctx, claudeinstanceprovider.InstanceID{HostID: host, ClaudePid: pid})
+	if err != nil || inst == nil {
+		return nil, nil
+	}
+	return *inst, nil
+}
+
+func resolveHostServiceNode(ctx context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.HostServiceProvider == nil {
+		return nil, fmt.Errorf("hostservice provider not configured")
+	}
+	hostID, name, ok := splitHostServiceID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed host service id %q", id)
+	}
+	snap, _, err := r.HostServiceProvider.Get(ctx, hostservice.MakeID(hostID, name))
+	if err != nil {
+		return nil, nil
+	}
+	return *hostServiceFromSnapshot(snap), nil
+}
+
+func resolveContractNode(ctx context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.ContractsProvider == nil {
+		return nil, fmt.Errorf("contracts provider not configured")
+	}
+	key := contracts.ContractID(strings.TrimPrefix(id, "Contract:"))
+	c, _, err := r.ContractsProvider.Get(ctx, key)
+	if err != nil || c == nil {
+		return nil, nil
+	}
+	return *c, nil
+}
+
+func resolvePullRequestNode(ctx context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.GH == nil {
+		return nil, errGHNotConfigured
+	}
+	owner, name, number, ok := splitGHNodeID(id, "PullRequest:")
+	if !ok {
+		return nil, fmt.Errorf("malformed pull request id %q", id)
+	}
+	pr, err := r.GH.GetPullRequest(ctx, ghprovider.PullRequestKey{Owner: owner, Name: name, Number: number})
+	if err != nil {
+		return nil, nil
+	}
+	return *toGraphQLPullRequest(pr), nil
+}
+
+func resolveIssueNode(ctx context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.GH == nil {
+		return nil, errGHNotConfigured
+	}
+	owner, name, number, ok := splitGHNodeID(id, "Issue:")
+	if !ok {
+		return nil, fmt.Errorf("malformed issue id %q", id)
+	}
+	iss, err := r.GH.GetIssue(ctx, ghprovider.IssueKey{Owner: owner, Name: name, Number: number})
+	if err != nil {
+		return nil, nil
+	}
+	return *toGraphQLIssue(iss), nil
+}
+
+func resolveWorkflowRunNode(ctx context.Context, r *Resolver, id string) (graphql1.Node, error) {
+	if r.GH == nil {
+		return nil, errGHNotConfigured
+	}
+	owner, name, runID, ok := splitGHNodeID(id, "WorkflowRun:")
+	if !ok {
+		return nil, fmt.Errorf("malformed workflow run id %q", id)
+	}
+	run, err := r.GH.GetWorkflowRun(ctx, ghprovider.WorkflowRunKey{Owner: owner, Name: name, RunID: int64(runID)})
+	if err != nil {
+		return nil, nil
+	}
+	return *toGraphQLWorkflowRun(run), nil
+}
+
 // splitTmuxSessionID parses "TmuxSession:<host>:<name>". Returns
 // ok=false on malformed input.
 func splitTmuxSessionID(id string) (host, name string, ok bool) {
@@ -179,6 +389,148 @@ func splitTmuxPaneID(id string) (host, paneID string, ok bool) {
 	return rest[:idx], rest[idx+1:], true
 }
 
+// splitTmuxServerID parses "TmuxServer:<host>:<socketPath>". The socket
+// path can contain colons (it's an absolute path) so we only split on
+// the first separator after the prefix.
+func splitTmuxServerID(id string) (host, socketPath string, ok bool) {
+	const prefix = "TmuxServer:"
+	if !strings.HasPrefix(id, prefix) {
+		return "", "", false
+	}
+	rest := id[len(prefix):]
+	idx := strings.Index(rest, ":")
+	if idx <= 0 || idx == len(rest)-1 {
+		return "", "", false
+	}
+	return rest[:idx], rest[idx+1:], true
+}
+
+// splitTmuxWindowID parses "TmuxWindow:<host>:<sessionName>:<index>".
+func splitTmuxWindowID(id string) (host, session string, index int, ok bool) {
+	const prefix = "TmuxWindow:"
+	if !strings.HasPrefix(id, prefix) {
+		return "", "", 0, false
+	}
+	rest := id[len(prefix):]
+	hostIdx := strings.Index(rest, ":")
+	if hostIdx <= 0 {
+		return "", "", 0, false
+	}
+	host = rest[:hostIdx]
+	tail := rest[hostIdx+1:]
+	idxIdx := strings.LastIndex(tail, ":")
+	if idxIdx <= 0 || idxIdx == len(tail)-1 {
+		return "", "", 0, false
+	}
+	session = tail[:idxIdx]
+	n, err := strconv.Atoi(tail[idxIdx+1:])
+	if err != nil {
+		return "", "", 0, false
+	}
+	return host, session, n, true
+}
+
+// splitTmuxClientID parses "TmuxClient:<host>:<clientName>".
+func splitTmuxClientID(id string) (host, name string, ok bool) {
+	const prefix = "TmuxClient:"
+	if !strings.HasPrefix(id, prefix) {
+		return "", "", false
+	}
+	rest := id[len(prefix):]
+	idx := strings.Index(rest, ":")
+	if idx <= 0 || idx == len(rest)-1 {
+		return "", "", false
+	}
+	return rest[:idx], rest[idx+1:], true
+}
+
+// splitClaudeAccountID parses "ClaudeAccount:<host>:<email>".
+func splitClaudeAccountID(id string) (host, email string, ok bool) {
+	const prefix = "ClaudeAccount:"
+	if !strings.HasPrefix(id, prefix) {
+		return "", "", false
+	}
+	rest := id[len(prefix):]
+	idx := strings.Index(rest, ":")
+	if idx <= 0 || idx == len(rest)-1 {
+		return "", "", false
+	}
+	return rest[:idx], rest[idx+1:], true
+}
+
+// splitHostServiceID parses "HostService:<host>:<name>".
+func splitHostServiceID(id string) (host, name string, ok bool) {
+	const prefix = "HostService:"
+	if !strings.HasPrefix(id, prefix) {
+		return "", "", false
+	}
+	rest := id[len(prefix):]
+	idx := strings.Index(rest, ":")
+	if idx <= 0 || idx == len(rest)-1 {
+		return "", "", false
+	}
+	return rest[:idx], rest[idx+1:], true
+}
+
+// parseClaudeInstanceID parses "ClaudeInstance:<host>:<pid>" when the
+// trailing segment is a positive integer. Session-keyed ids
+// ("ClaudeInstance:<host>:session-<name>") return ok=false so callers
+// can fall back to a List scan.
+func parseClaudeInstanceID(id string) (host string, pid int, ok bool) {
+	const prefix = "ClaudeInstance:"
+	if !strings.HasPrefix(id, prefix) {
+		return "", 0, false
+	}
+	rest := id[len(prefix):]
+	idx := strings.LastIndex(rest, ":")
+	if idx <= 0 || idx == len(rest)-1 {
+		return "", 0, false
+	}
+	tail := rest[idx+1:]
+	n, err := strconv.Atoi(tail)
+	if err != nil || n <= 0 {
+		return rest[:idx], 0, false
+	}
+	return rest[:idx], n, true
+}
+
+// findClaudeInstanceByID is the fallback for session-keyed claude
+// instance ids — it scans the provider's cache for an exact id match.
+func findClaudeInstanceByID(ctx context.Context, p *claudeinstanceprovider.Provider, id string) (graphql1.Node, error) {
+	rows, err := p.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, inst := range rows {
+		if inst != nil && inst.ID == id {
+			return *inst, nil
+		}
+	}
+	return nil, nil
+}
+
+// splitGHNodeID parses gh-style ids like "PullRequest:owner/repo#42".
+func splitGHNodeID(id, prefix string) (owner, name string, number int, ok bool) {
+	if !strings.HasPrefix(id, prefix) {
+		return "", "", 0, false
+	}
+	rest := id[len(prefix):]
+	hashIdx := strings.LastIndex(rest, "#")
+	if hashIdx <= 0 || hashIdx == len(rest)-1 {
+		return "", "", 0, false
+	}
+	repo := rest[:hashIdx]
+	slashIdx := strings.Index(repo, "/")
+	if slashIdx <= 0 || slashIdx == len(repo)-1 {
+		return "", "", 0, false
+	}
+	n, err := strconv.Atoi(rest[hashIdx+1:])
+	if err != nil || n <= 0 {
+		return "", "", 0, false
+	}
+	return repo[:slashIdx], repo[slashIdx+1:], n, true
+}
+
 // worktreeNodeValue mirrors `toGraphQLWorktree` in schema.resolvers.go.
 // Kept here so node.resolvers.go is self-contained.
 func worktreeNodeValue(w gitprovider.Worktree) *graphql1.Worktree {
@@ -190,3 +542,7 @@ func worktreeNodeValue(w gitprovider.Worktree) *graphql1.Worktree {
 		Bare:   w.Bare,
 	}
 }
+
+// _ keeps imports stable when not all helpers are referenced (build-time
+// hygiene; the package's tests reference every helper).
+var _ = claudeprojects.ConversationID{}

--- a/internal/server/resolvers/nodechanged_e2e_test.go
+++ b/internal/server/resolvers/nodechanged_e2e_test.go
@@ -1,0 +1,581 @@
+// E2E coverage for Subscription.nodeChanged dispatch.
+//
+// Boots a tiny daemon via httptest. Drives provider invalidations
+// through stateful CommandRunners (tmux, ps) and on-disk JSONL writes
+// (claudeprojects). Asserts the websocket subscriber receives the
+// freshly-loaded node payload for each id-prefix the dispatcher claims
+// to support.
+//
+// Mirrors the shape of internal/server/providers/peerproxy/peerproxy_e2e_test.go.
+package resolvers_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
+	psprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	tmuxprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
+)
+
+// stubRunner is a stateful CommandRunner. Each call returns the next
+// queued response (or the last one indefinitely) — so two Refresh calls
+// return two different snapshots and the provider fan-out fires.
+type stubRunner struct {
+	mu       sync.Mutex
+	state    int
+	rules    []func(name string, args ...string) ([]byte, error)
+	advance  chan struct{}
+	advanced bool
+}
+
+func newStubRunner(rules ...func(name string, args ...string) ([]byte, error)) *stubRunner {
+	return &stubRunner{rules: rules}
+}
+
+func (s *stubRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	s.mu.Lock()
+	idx := s.state
+	if idx >= len(s.rules) {
+		idx = len(s.rules) - 1
+	}
+	rule := s.rules[idx]
+	s.mu.Unlock()
+	return rule(name, args...)
+}
+
+func (s *stubRunner) advanceState() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state < len(s.rules)-1 {
+		s.state++
+	}
+}
+
+const e2eHostID = "test-host"
+
+// pollOK returns true if cond becomes true before deadline. The poll
+// loop is intentionally tight — provider fan-outs land on the order of
+// milliseconds, but websocket frame delivery occasionally takes longer.
+func pollOK(deadline time.Duration, cond func() bool) bool {
+	expire := time.Now().Add(deadline)
+	for {
+		if cond() {
+			return true
+		}
+		if time.Now().After(expire) {
+			return false
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// firstNonFlagArg picks the first positional (non-flag, non-flag-value)
+// argument out of a tmux command line. tmux always passes `-S <socket>`
+// before the subcommand, so we strip those before inspecting.
+func firstNonFlagArg(args []string) string {
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-S", "-L":
+			i++ // skip the value
+			continue
+		}
+		return args[i]
+	}
+	return ""
+}
+
+// stubTmuxRunner returns a CommandRunner whose snapshots flip between
+// two states — empty and one-session — so the second Refresh broadcasts
+// a TmuxSession invalidation. The TmuxServer subscription rides the
+// same fan-out (sessions firehose) because the briefing's mapping
+// proves the wiring exists.
+func stubTmuxRunner() *stubRunner {
+	const fieldSep = "\x01"
+	emptyState := func(name string, args ...string) ([]byte, error) {
+		// `tmux info` -> "alive" probe. Always succeed.
+		if firstNonFlagArg(args) == "info" {
+			return []byte("ok\n"), nil
+		}
+		// list-sessions / list-windows / list-panes / list-clients all
+		// return empty in this state.
+		return []byte(""), nil
+	}
+	oneSession := func(name string, args ...string) ([]byte, error) {
+		switch firstNonFlagArg(args) {
+		case "info":
+			return []byte("ok\n"), nil
+		case "list-sessions":
+			// session_name, session_created, session_attached, session_activity, session_windows, session_window_index
+			line := "alpha" + fieldSep + "1700000000" + fieldSep + "0" + fieldSep + "1700000010" + fieldSep + "1" + fieldSep + "0\n"
+			return []byte(line), nil
+		case "list-windows":
+			// session_name, window_index, window_name, window_active, window_panes, current_pane
+			line := "alpha" + fieldSep + "0" + fieldSep + "main" + fieldSep + "1" + fieldSep + "1" + fieldSep + "%0\n"
+			return []byte(line), nil
+		case "list-panes", "list-clients":
+			return []byte(""), nil
+		}
+		return []byte(""), nil
+	}
+	return newStubRunner(emptyState, oneSession)
+}
+
+// stubPsRunner alternates between an empty process table and one
+// containing pid 4242. Same idea as stubTmuxRunner.
+func stubPsRunner() *stubRunner {
+	headerOnly := func(name string, args ...string) ([]byte, error) {
+		// macOS ps emits "PID PPID USER ..." header line.
+		return []byte("  PID  PPID USER             TT  %CPU    RSS                 STARTED COMMAND\n"), nil
+	}
+	withProcess := func(name string, args ...string) ([]byte, error) {
+		// Mirror the column layout the parser expects: PID PPID USER TT %CPU RSS STARTED COMMAND.
+		// `STARTED` is a multi-token date — parsePs handles `Mon Mar  3 12:34:56 2026` shape.
+		header := "  PID  PPID USER             TT  %CPU    RSS                 STARTED COMMAND\n"
+		row := " 4242     1 testuser         ??   0.0    100 Mon Jan  1 00:00:00 2024 testproc\n"
+		return []byte(header + row), nil
+	}
+	return newStubRunner(headerOnly, withProcess)
+}
+
+// writeJSONL writes a synthetic Claude Code transcript to disk so the
+// claudeprojects provider can pick it up on the next Refresh.
+func writeJSONL(t *testing.T, dir, sessionUUID string, lines []string) string {
+	t.Helper()
+	path := filepath.Join(dir, sessionUUID+".jsonl")
+	contents := ""
+	for _, l := range lines {
+		contents += l + "\n"
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write jsonl: %v", err)
+	}
+	return path
+}
+
+// startNodeChangedDaemon wires a daemon with tmux, ps, and
+// claudeprojects providers backed by stub adapters. Returned values
+// let tests advance state and recompute snapshots.
+func startNodeChangedDaemon(t *testing.T) (*httptest.Server, *tmuxprovider.Provider, *psprovider.Provider, *claudeprojects.Provider, string, *stubRunner, *stubRunner) {
+	t.Helper()
+
+	tmuxStub := stubTmuxRunner()
+	tmuxAdapter := tmuxprovider.NewAdapter(e2eHostID).WithRunner(tmuxStub).WithSocket("/tmp/orchard-test-fake.sock")
+	tmuxProv := tmuxprovider.New(tmuxAdapter, nil)
+
+	psStub := stubPsRunner()
+	psAdapter := psprovider.NewAdapter(e2eHostID).WithRunner(psStub)
+	psProv := psprovider.New(psAdapter, nil)
+
+	projectsRoot := filepath.Join(t.TempDir(), "projects")
+	if err := os.MkdirAll(filepath.Join(projectsRoot, "alpha"), 0o755); err != nil {
+		t.Fatalf("mkdir projects: %v", err)
+	}
+	cpAdapter := claudeprojects.NewFSAdapter(projectsRoot, e2eHostID, nil)
+	cpProv := claudeprojects.NewWith(cpAdapter, nil, time.Now, 60*time.Second)
+
+	srv := server.New("",
+		nil,
+		server.WithTmux(tmuxProv),
+		server.WithPS(psProv),
+		server.WithClaudeProjects(cpProv),
+	)
+
+	ctx := context.Background()
+	if err := srv.StartHostProvider(ctx); err != nil {
+		t.Fatalf("start host provider: %v", err)
+	}
+	if err := tmuxProv.Start(ctx); err != nil {
+		t.Fatalf("start tmux: %v", err)
+	}
+	if err := psProv.Start(ctx); err != nil {
+		t.Fatalf("start ps: %v", err)
+	}
+	if err := cpProv.Start(ctx); err != nil {
+		t.Fatalf("start claudeprojects: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", srv.GraphQLHandler())
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	t.Cleanup(func() {
+		_ = cpProv.Stop()
+	})
+
+	return ts, tmuxProv, psProv, cpProv, projectsRoot, tmuxStub, psStub
+}
+
+// dialSubscription opens a graphql-transport-ws websocket and sends the
+// connection_init / connection_ack handshake.
+func dialSubscription(t *testing.T, addr string) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws://" + addr + "/graphql"
+	dialer := *websocket.DefaultDialer
+	dialer.Subprotocols = []string{"graphql-transport-ws"}
+	dialer.HandshakeTimeout = 5 * time.Second
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, _, err := dialer.DialContext(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	if err := conn.WriteJSON(map[string]any{"type": "connection_init"}); err != nil {
+		t.Fatalf("write init: %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	var ack map[string]any
+	if err := conn.ReadJSON(&ack); err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+	if ack["type"] != "connection_ack" {
+		t.Fatalf("expected connection_ack, got %v", ack["type"])
+	}
+	return conn
+}
+
+// stripScheme returns the host:port portion of a URL.
+func stripScheme(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("strip scheme: %v", err)
+	}
+	return u.Host
+}
+
+// frame is the minimal graphql-transport-ws shape for `next` payloads.
+type frame struct {
+	ID      string          `json:"id"`
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload,omitempty"`
+}
+
+// startReader pumps frames off the websocket through a channel so the
+// caller can range with timeouts.
+func startReader(t *testing.T, conn *websocket.Conn) <-chan frame {
+	t.Helper()
+	frames := make(chan frame, 16)
+	go func() {
+		defer close(frames)
+		for {
+			_ = conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+			var f frame
+			if err := conn.ReadJSON(&f); err != nil {
+				return
+			}
+			frames <- f
+		}
+	}()
+	return frames
+}
+
+// readPayload pulls frames until one matches subID and is type "next",
+// then JSON-decodes its payload into v.
+func readPayload(t *testing.T, frames <-chan frame, subID string, deadline time.Duration, v any) error {
+	t.Helper()
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	for {
+		select {
+		case f, ok := <-frames:
+			if !ok {
+				return errors.New("ws closed before payload arrived")
+			}
+			if f.ID != subID {
+				continue
+			}
+			if f.Type == "error" {
+				return fmt.Errorf("subscription error: %s", string(f.Payload))
+			}
+			if f.Type == "complete" {
+				return errors.New("subscription completed without payload")
+			}
+			if f.Type != "next" {
+				continue
+			}
+			if err := json.Unmarshal(f.Payload, v); err != nil {
+				return fmt.Errorf("decode payload: %w (%s)", err, string(f.Payload))
+			}
+			return nil
+		case <-timer.C:
+			return errors.New("timeout waiting for payload")
+		}
+	}
+}
+
+// readError pulls frames until one matches subID and is type "error" or
+// "next" containing GraphQL errors, then returns the encoded payload.
+func readError(t *testing.T, frames <-chan frame, subID string, deadline time.Duration) (string, error) {
+	t.Helper()
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	for {
+		select {
+		case f, ok := <-frames:
+			if !ok {
+				return "", errors.New("ws closed before error arrived")
+			}
+			if f.ID != subID {
+				continue
+			}
+			if f.Type == "error" {
+				return string(f.Payload), nil
+			}
+			if f.Type == "next" {
+				// Some servers wrap errors inside `next`. Inspect for an `errors` field.
+				var env struct {
+					Errors []struct {
+						Message string `json:"message"`
+					} `json:"errors"`
+				}
+				if err := json.Unmarshal(f.Payload, &env); err == nil && len(env.Errors) > 0 {
+					return env.Errors[0].Message, nil
+				}
+			}
+		case <-timer.C:
+			return "", errors.New("timeout waiting for error")
+		}
+	}
+}
+
+// subscribe sends a subscribe message for the given query.
+func subscribe(t *testing.T, conn *websocket.Conn, subID, query string) {
+	t.Helper()
+	if err := conn.WriteJSON(map[string]any{
+		"id":      subID,
+		"type":    "subscribe",
+		"payload": map[string]any{"query": query},
+	}); err != nil {
+		t.Fatalf("write subscribe: %v", err)
+	}
+}
+
+// TestNodeChanged_DispatchesByPrefix proves the dispatch table:
+// TmuxSession, Conversation, and Process subscriptions each receive a
+// payload with the correct id when their owning provider invalidates.
+func TestNodeChanged_DispatchesByPrefix(t *testing.T) {
+	ts, tmuxProv, psProv, cpProv, projectsRoot, tmuxStub, psStub := startNodeChangedDaemon(t)
+	addr := stripScheme(t, ts.URL)
+
+	conn := dialSubscription(t, addr)
+	defer func() { _ = conn.Close() }()
+	frames := startReader(t, conn)
+
+	// --- TmuxSession subscription (rides tmux Sessions firehose). ---
+	const tmuxSessionID = "TmuxSession:" + e2eHostID + ":alpha"
+	subscribe(t, conn, "tmux-1", fmt.Sprintf(
+		`subscription { nodeChanged(id: %q) { __typename ... on TmuxSession { id name } } }`,
+		tmuxSessionID,
+	))
+
+	// --- Conversation subscription. ---
+	const convoUUID = "abcd-1234-test"
+	const convoID = "Conversation:" + convoUUID
+	subscribe(t, conn, "conv-1", fmt.Sprintf(
+		`subscription { nodeChanged(id: %q) { __typename ... on Conversation { id sessionUuid } } }`,
+		convoID,
+	))
+
+	// --- Process subscription. ---
+	const procID = e2eHostID + ":4242"
+	subscribe(t, conn, "proc-1", fmt.Sprintf(
+		`subscription { nodeChanged(id: %q) { __typename ... on Process { id pid } } }`,
+		procID,
+	))
+
+	// Give the websocket transport a beat to register all three
+	// subscribers before we fire invalidations.
+	time.Sleep(150 * time.Millisecond)
+
+	// Trigger fan-outs.
+	tmuxStub.advanceState()
+	if err := tmuxProv.Refresh(context.Background()); err != nil {
+		t.Fatalf("tmux refresh: %v", err)
+	}
+
+	psStub.advanceState()
+	if err := psProv.Refresh(context.Background()); err != nil {
+		t.Fatalf("ps refresh: %v", err)
+	}
+
+	// Write a Conversation transcript and trigger refresh.
+	writeJSONL(t, filepath.Join(projectsRoot, "alpha"), convoUUID, []string{
+		`{"type":"user","timestamp":"2026-01-01T00:00:00Z","cwd":"/tmp"}`,
+	})
+	if err := cpProv.Refresh(context.Background()); err != nil {
+		t.Fatalf("claudeprojects refresh: %v", err)
+	}
+
+	type tmuxPayload struct {
+		Data struct {
+			NodeChanged struct {
+				Typename string `json:"__typename"`
+				ID       string `json:"id"`
+				Name     string `json:"name"`
+			} `json:"nodeChanged"`
+		} `json:"data"`
+	}
+	type convoPayload struct {
+		Data struct {
+			NodeChanged struct {
+				Typename    string `json:"__typename"`
+				ID          string `json:"id"`
+				SessionUUID string `json:"sessionUuid"`
+			} `json:"nodeChanged"`
+		} `json:"data"`
+	}
+	type procPayload struct {
+		Data struct {
+			NodeChanged struct {
+				Typename string `json:"__typename"`
+				ID       string `json:"id"`
+				Pid      int64  `json:"pid"`
+			} `json:"nodeChanged"`
+		} `json:"data"`
+	}
+
+	got := map[string]bool{}
+	for !(got["tmux-1"] && got["conv-1"] && got["proc-1"]) {
+		select {
+		case f, ok := <-frames:
+			if !ok {
+				t.Fatalf("ws closed; got=%v", got)
+			}
+			if f.Type == "error" {
+				t.Fatalf("subscription error %s: %s", f.ID, string(f.Payload))
+			}
+			if f.Type != "next" {
+				continue
+			}
+			switch f.ID {
+			case "tmux-1":
+				var p tmuxPayload
+				if err := json.Unmarshal(f.Payload, &p); err != nil {
+					t.Fatalf("decode tmux: %v", err)
+				}
+				if p.Data.NodeChanged.ID != tmuxSessionID {
+					t.Fatalf("tmux id=%q want %q", p.Data.NodeChanged.ID, tmuxSessionID)
+				}
+				if p.Data.NodeChanged.Typename != "TmuxSession" {
+					t.Fatalf("tmux typename=%q want TmuxSession", p.Data.NodeChanged.Typename)
+				}
+				got["tmux-1"] = true
+			case "conv-1":
+				var p convoPayload
+				if err := json.Unmarshal(f.Payload, &p); err != nil {
+					t.Fatalf("decode conv: %v", err)
+				}
+				if p.Data.NodeChanged.ID != convoID {
+					t.Fatalf("conv id=%q want %q", p.Data.NodeChanged.ID, convoID)
+				}
+				if p.Data.NodeChanged.Typename != "Conversation" {
+					t.Fatalf("conv typename=%q want Conversation", p.Data.NodeChanged.Typename)
+				}
+				got["conv-1"] = true
+			case "proc-1":
+				var p procPayload
+				if err := json.Unmarshal(f.Payload, &p); err != nil {
+					t.Fatalf("decode proc: %v", err)
+				}
+				if p.Data.NodeChanged.ID != procID {
+					t.Fatalf("proc id=%q want %q", p.Data.NodeChanged.ID, procID)
+				}
+				if p.Data.NodeChanged.Typename != "Process" {
+					t.Fatalf("proc typename=%q want Process", p.Data.NodeChanged.Typename)
+				}
+				if p.Data.NodeChanged.Pid != 4242 {
+					t.Fatalf("proc pid=%d want 4242", p.Data.NodeChanged.Pid)
+				}
+				got["proc-1"] = true
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for subscriptions; got=%v", got)
+		}
+	}
+}
+
+// TestNodeChanged_UnknownPrefix proves AC-2: an unknown id prefix
+// surfaces a single GraphQL error and the subscription closes cleanly
+// (no hang).
+func TestNodeChanged_UnknownPrefix(t *testing.T) {
+	ts, _, _, _, _, _, _ := startNodeChangedDaemon(t)
+	addr := stripScheme(t, ts.URL)
+
+	conn := dialSubscription(t, addr)
+	defer func() { _ = conn.Close() }()
+	frames := startReader(t, conn)
+
+	subscribe(t, conn, "bogus-1",
+		`subscription { nodeChanged(id: "Bogus:foo:bar") { __typename } }`,
+	)
+
+	msg, err := readError(t, frames, "bogus-1", 3*time.Second)
+	if err != nil {
+		t.Fatalf("expected error frame: %v", err)
+	}
+	if want := `unknown id prefix`; !contains(msg, want) {
+		t.Fatalf("error %q does not mention %q", msg, want)
+	}
+}
+
+// TestNodeChanged_DoesNotHang is a belt-and-braces check that the
+// dispatcher closes the channel promptly for unknown prefixes — a
+// regression of the original `git provider not configured` bug would
+// look like a hang here, not an explicit error.
+func TestNodeChanged_DoesNotHang(t *testing.T) {
+	ts, _, _, _, _, _, _ := startNodeChangedDaemon(t)
+	addr := stripScheme(t, ts.URL)
+
+	conn := dialSubscription(t, addr)
+	defer func() { _ = conn.Close() }()
+	frames := startReader(t, conn)
+
+	subscribe(t, conn, "bogus-2",
+		`subscription { nodeChanged(id: "Wat:lol") { __typename } }`,
+	)
+
+	if !pollOK(3*time.Second, func() bool {
+		select {
+		case f, ok := <-frames:
+			if !ok {
+				return false
+			}
+			if f.ID != "bogus-2" {
+				return false
+			}
+			return f.Type == "error" || f.Type == "complete" || f.Type == "next"
+		default:
+			return false
+		}
+	}) {
+		t.Fatalf("dispatcher hung on unknown prefix")
+	}
+}
+
+// contains is a tiny strings.Contains alias kept here so the assertion
+// site reads like English.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/resolvers/subscription.resolvers.go
+++ b/internal/server/resolvers/subscription.resolvers.go
@@ -1,3 +1,9 @@
+// Package resolvers — subscription dispatch.
+//
+// Subscription.nodeChanged opens the owning provider's invalidation
+// channel and re-emits the freshly-loaded node value on each fire.
+// Dispatch is by id-prefix; one channel per subscription; the channel
+// closes when ctx is cancelled or the upstream channel closes.
 package resolvers
 
 import (
@@ -5,28 +11,88 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
+	claudeinstanceprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeinstance"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/contracts"
+	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
+	hostprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
 	psprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	tmuxprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 )
 
-// subscribeNodeChanged opens the relevant provider's invalidation
+// subscribeNodeChanged opens the owning provider's invalidation
 // channel and re-emits the freshly-loaded node value on each fire.
-// One channel per subscription; closes when ctx is cancelled or the
-// upstream channel closes.
+// Dispatch is by id-prefix; the briefing's id format is
+// `<NodeType>:<host-or-scope>:<...>`. Unknown prefixes raise a
+// GraphQL error and complete without hanging.
 func subscribeNodeChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
 	switch {
 	case strings.HasPrefix(id, "Host:"):
 		return subscribeHostChanged(ctx, r, id)
+	case strings.HasPrefix(id, "HostService:"):
+		return subscribeHostServiceChanged(ctx, r, id)
+	case strings.HasPrefix(id, "Conversation:"):
+		return subscribeConversationChanged(ctx, r, id)
+	case strings.HasPrefix(id, "ClaudeAccount:"):
+		return subscribeClaudeAccountChanged(ctx, r, id)
+	case strings.HasPrefix(id, "ClaudeInstance:"):
+		return subscribeClaudeInstanceChanged(ctx, r, id)
+	case strings.HasPrefix(id, "Contract:"):
+		return subscribeContractChanged(ctx, r, id)
+	case strings.HasPrefix(id, "TmuxServer:"):
+		return subscribeTmuxServerChanged(ctx, r, id)
+	case strings.HasPrefix(id, "TmuxSession:"):
+		return subscribeTmuxSessionChanged(ctx, r, id)
+	case strings.HasPrefix(id, "TmuxWindow:"):
+		return subscribeTmuxWindowChanged(ctx, r, id)
 	case strings.HasPrefix(id, "TmuxPane:"):
 		return subscribePaneChanged(ctx, r, id)
+	case strings.HasPrefix(id, "TmuxClient:"):
+		return subscribeTmuxClientChanged(ctx, r, id)
+	case strings.HasPrefix(id, "PullRequest:"),
+		strings.HasPrefix(id, "Issue:"),
+		strings.HasPrefix(id, "WorkflowRun:"):
+		return subscribeGHChanged(ctx, r, id)
+	case strings.HasPrefix(id, "Worktree:"):
+		// Briefing aliases — the Worktree id is unprefixed in the
+		// schema (`<project>:<name>`) but accept the prefixed form so
+		// callers using the briefing's mapping still work.
+		return subscribeWorktreeChanged(ctx, r, strings.TrimPrefix(id, "Worktree:"))
+	case strings.HasPrefix(id, "Project:"):
+		return subscribeProjectChanged(ctx, r, strings.TrimPrefix(id, "Project:"))
 	}
 	if isProcessID(id) {
 		return subscribeProcessChanged(ctx, r, id)
 	}
-	if strings.Contains(id, ":") {
+	if isWorktreeID(id) {
 		return subscribeWorktreeChanged(ctx, r, id)
 	}
-	return nil, fmt.Errorf("subscriptions not supported for node id %q", id)
+	if id != "" && !strings.Contains(id, ":") {
+		return subscribeProjectChanged(ctx, r, id)
+	}
+	prefix := id
+	if i := strings.Index(id, ":"); i > 0 {
+		prefix = id[:i]
+	}
+	return nil, fmt.Errorf("nodeChanged: unknown id prefix %q", prefix)
+}
+
+// isWorktreeID returns true for the schema's un-prefixed Worktree id
+// shape (`<projectSlug>:<worktreeName>`). The slug never contains
+// colons (Project ids forbid them), so a single-colon id with simple
+// segments is the worktree shape.
+func isWorktreeID(id string) bool {
+	idx := strings.Index(id, ":")
+	if idx <= 0 || idx == len(id)-1 {
+		return false
+	}
+	// Must be exactly one ":" — anything richer (Foo:bar:baz) is a
+	// typed prefix the caller spelled wrong.
+	return strings.Count(id, ":") == 1
 }
 
 func subscribeHostChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
@@ -35,33 +101,191 @@ func subscribeHostChanged(ctx context.Context, r *Resolver, id string) (<-chan g
 	}
 	machineID := strings.TrimPrefix(id, "Host:")
 	src := r.HostProvider.Subscribe(ctx)
-	out := make(chan graphql1.Node, 1)
-	go func() {
-		defer close(out)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ev, ok := <-src:
-				if !ok {
-					return
-				}
-				if string(ev.Key) != machineID {
-					continue
-				}
-				node, err := resolveHostNode(ctx, r, id)
-				if err != nil || node == nil {
-					continue
-				}
-				select {
-				case out <- node:
-				case <-ctx.Done():
-					return
-				}
-			}
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[hostprovider.HostID]) bool {
+		return string(ev.Key) == machineID
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveHostNode(c, r, id)
+	}), nil
+}
+
+func subscribeHostServiceChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.HostServiceProvider == nil {
+		return nil, fmt.Errorf("hostservice provider not configured")
+	}
+	hostID, name, ok := splitHostServiceID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed host service id %q", id)
+	}
+	wantKey := hostservice.MakeID(hostID, name)
+	src := r.HostServiceProvider.Subscribe(ctx)
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[hostservice.HostServiceID]) bool {
+		return ev.Key == wantKey
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveHostServiceNode(c, r, id)
+	}), nil
+}
+
+func subscribeConversationChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.ClaudeProjects == nil {
+		return nil, fmt.Errorf("claudeprojects provider not configured")
+	}
+	uuid := strings.TrimPrefix(id, "Conversation:")
+	src := r.ClaudeProjects.Subscribe(ctx)
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[claudeprojects.ConversationID]) bool {
+		return ev.Key.SessionUUID == uuid
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveConversationNode(c, r, id)
+	}), nil
+}
+
+func subscribeClaudeAccountChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.ClaudeAccount == nil {
+		return nil, fmt.Errorf("claudeaccount provider not configured")
+	}
+	host, email, ok := splitClaudeAccountID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed claude account id %q", id)
+	}
+	wantKey := claudeaccount.AccountID{HostID: host, Email: email}
+	src := r.ClaudeAccount.Subscribe(ctx)
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[claudeaccount.AccountID]) bool {
+		return ev.Key == wantKey
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveClaudeAccountNode(c, r, id)
+	}), nil
+}
+
+func subscribeClaudeInstanceChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.ClaudeInstance == nil {
+		return nil, fmt.Errorf("claudeinstance provider not configured")
+	}
+	host, pid, isPidKeyed := parseClaudeInstanceID(id)
+	src := r.ClaudeInstance.Subscribe(ctx)
+	matcher := func(ev adapter.InvalidationEvent[claudeinstanceprovider.InstanceID]) bool {
+		if isPidKeyed {
+			return ev.Key.HostID == host && ev.Key.ClaudePid == pid
 		}
-	}()
-	return out, nil
+		// Session-keyed id: re-resolve on every event from this host
+		// since the briefing's "session-<name>" form doesn't carry pid
+		// info up front.
+		return ev.Key.HostID == host
+	}
+	return relayInvalidations(ctx, src, matcher, func(c context.Context) (graphql1.Node, error) {
+		return resolveClaudeInstanceNode(c, r, id)
+	}), nil
+}
+
+func subscribeContractChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.ContractsProvider == nil {
+		return nil, fmt.Errorf("contracts provider not configured")
+	}
+	wantKey := contracts.ContractID(strings.TrimPrefix(id, "Contract:"))
+	src := r.ContractsProvider.Subscribe(ctx)
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[contracts.ContractID]) bool {
+		return ev.Key == wantKey
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveContractNode(c, r, id)
+	}), nil
+}
+
+func subscribeTmuxServerChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.Tmux == nil {
+		return nil, fmt.Errorf("tmux provider not configured")
+	}
+	// Tmux server changes ride the sessions firehose — every poll tick
+	// touches the same daemon, so a new session event is a sufficient
+	// signal that the server's alive/pid/socket may have moved.
+	src := r.Tmux.Sessions().Subscribe(ctx)
+	return relayInvalidations(ctx, src, func(_ adapter.InvalidationEvent[tmuxprovider.SessionKey]) bool {
+		return true
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveTmuxServerNode(c, r, id)
+	}), nil
+}
+
+func subscribeTmuxSessionChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.Tmux == nil {
+		return nil, fmt.Errorf("tmux provider not configured")
+	}
+	host, name, ok := splitTmuxSessionID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed tmux session id %q", id)
+	}
+	src := r.Tmux.Sessions().Subscribe(ctx)
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[tmuxprovider.SessionKey]) bool {
+		return string(ev.Key.Host) == host && ev.Key.Name == name
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveTmuxSessionNode(c, r, id)
+	}), nil
+}
+
+func subscribeTmuxWindowChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.Tmux == nil {
+		return nil, fmt.Errorf("tmux provider not configured")
+	}
+	host, session, idx, ok := splitTmuxWindowID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed tmux window id %q", id)
+	}
+	src := r.Tmux.Windows().Subscribe(ctx)
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[tmuxprovider.WindowKey]) bool {
+		return string(ev.Key.Host) == host && ev.Key.Session == session && ev.Key.Index == idx
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveTmuxWindowNode(c, r, id)
+	}), nil
+}
+
+func subscribePaneChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.Tmux == nil {
+		return nil, fmt.Errorf("tmux provider not configured")
+	}
+	host, paneID, ok := splitTmuxPaneID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed tmux pane id %q", id)
+	}
+	src := r.Tmux.Panes().Subscribe(ctx)
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[tmuxprovider.PaneKey]) bool {
+		return string(ev.Key.Host) == host && ev.Key.PaneID == paneID
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveTmuxPaneNode(c, r, id)
+	}), nil
+}
+
+func subscribeTmuxClientChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.Tmux == nil {
+		return nil, fmt.Errorf("tmux provider not configured")
+	}
+	host, name, ok := splitTmuxClientID(id)
+	if !ok {
+		return nil, fmt.Errorf("malformed tmux client id %q", id)
+	}
+	src := r.Tmux.Clients().Subscribe(ctx)
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[tmuxprovider.ClientKey]) bool {
+		return string(ev.Key.Host) == host && ev.Key.ClientName == name
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveTmuxClientNode(c, r, id)
+	}), nil
+}
+
+func subscribeGHChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
+	if r.GH == nil {
+		return nil, errGHNotConfigured
+	}
+	src := r.GH.Subscribe(ctx)
+	resolve := func(c context.Context) (graphql1.Node, error) {
+		switch {
+		case strings.HasPrefix(id, "PullRequest:"):
+			return resolvePullRequestNode(c, r, id)
+		case strings.HasPrefix(id, "Issue:"):
+			return resolveIssueNode(c, r, id)
+		case strings.HasPrefix(id, "WorkflowRun:"):
+			return resolveWorkflowRunNode(c, r, id)
+		}
+		return nil, nil
+	}
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[string]) bool {
+		return ev.Key == id
+	}, resolve), nil
 }
 
 func subscribeWorktreeChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
@@ -69,31 +293,24 @@ func subscribeWorktreeChanged(ctx context.Context, r *Resolver, id string) (<-ch
 		return nil, fmt.Errorf("git provider not configured")
 	}
 	src := r.Git.Subscribe(ctx)
-	out := make(chan graphql1.Node, 1)
+	wantKey := gitprovider.WorktreeID(id)
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[gitprovider.WorktreeID]) bool {
+		return ev.Key == wantKey
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveWorktreeNode(c, r, id)
+	}), nil
+}
+
+func subscribeProjectChanged(ctx context.Context, _ *Resolver, _ string) (<-chan graphql1.Node, error) {
+	// Projects are a config-driven static set; the config provider does
+	// not currently expose an invalidation channel through Resolver.
+	// Returning a closed channel keeps subscribers from hanging while
+	// signalling "no events". When the config provider is wired in, this
+	// is the integration point.
+	out := make(chan graphql1.Node)
+	close(out)
 	go func() {
-		defer close(out)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ev, ok := <-src:
-				if !ok {
-					return
-				}
-				if string(ev.Key) != id {
-					continue
-				}
-				node, err := resolveWorktreeNode(ctx, r, id)
-				if err != nil || node == nil {
-					continue
-				}
-				select {
-				case out <- node:
-				case <-ctx.Done():
-					return
-				}
-			}
-		}
+		<-ctx.Done()
 	}()
 	return out, nil
 }
@@ -107,41 +324,24 @@ func subscribeProcessChanged(ctx context.Context, r *Resolver, id string) (<-cha
 		return nil, err
 	}
 	src := r.PS.Subscribe(ctx)
-	out := make(chan graphql1.Node, 1)
-	go func() {
-		defer close(out)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case ev, ok := <-src:
-				if !ok {
-					return
-				}
-				if ev.Key != pid {
-					continue
-				}
-				node, err := resolveProcessNode(ctx, r, id)
-				if err != nil || node == nil {
-					continue
-				}
-				select {
-				case out <- node:
-				case <-ctx.Done():
-					return
-				}
-			}
-		}
-	}()
-	return out, nil
+	return relayInvalidations(ctx, src, func(ev adapter.InvalidationEvent[psprovider.ProcessID]) bool {
+		return ev.Key == pid
+	}, func(c context.Context) (graphql1.Node, error) {
+		return resolveProcessNode(c, r, id)
+	}), nil
 }
 
-func subscribePaneChanged(ctx context.Context, r *Resolver, id string) (<-chan graphql1.Node, error) {
-	if r.Tmux == nil {
-		return nil, fmt.Errorf("tmux provider not configured")
-	}
-	src := r.Tmux.Panes().Subscribe(ctx)
-	host, paneID, _ := splitTmuxPaneID(id)
+// relayInvalidations is the generic channel pump shared by every
+// subscribe* handler: it filters incoming InvalidationEvents and, on
+// each match, resolves a fresh Node value through the supplied resolver.
+// One goroutine per subscription; closes when ctx is cancelled or the
+// upstream channel closes.
+func relayInvalidations[K comparable](
+	ctx context.Context,
+	src <-chan adapter.InvalidationEvent[K],
+	match func(adapter.InvalidationEvent[K]) bool,
+	resolve func(context.Context) (graphql1.Node, error),
+) <-chan graphql1.Node {
 	out := make(chan graphql1.Node, 1)
 	go func() {
 		defer close(out)
@@ -153,10 +353,10 @@ func subscribePaneChanged(ctx context.Context, r *Resolver, id string) (<-chan g
 				if !ok {
 					return
 				}
-				if string(ev.Key.Host) != host || ev.Key.PaneID != paneID {
+				if !match(ev) {
 					continue
 				}
-				node, err := resolveTmuxPaneNode(ctx, r, id)
+				node, err := resolve(ctx)
 				if err != nil || node == nil {
 					continue
 				}
@@ -168,7 +368,7 @@ func subscribePaneChanged(ctx context.Context, r *Resolver, id string) (<-chan g
 			}
 		}
 	}()
-	return out, nil
+	return out
 }
 
 // subscribeProcesses pushes a snapshot of every cached process whenever


### PR DESCRIPTION
## Summary
- `Subscription.nodeChanged` now dispatches by the id's NodeType prefix to the owning provider's invalidation channel, filters events, and re-resolves on each match.
- Unknown id prefixes return a single GraphQL error (`nodeChanged: unknown id prefix "<prefix>"`) and complete cleanly.
- A generic `relayInvalidations[K]` helper centralizes the fan-out boilerplate so each prefix handler is a thin filter/resolve wiring.

## Coverage
| Prefix | Provider |
|---|---|
| `Host:` | host |
| `HostService:` | hostservice |
| `Conversation:` | claudeprojects |
| `ClaudeAccount:` | claudeaccount |
| `ClaudeInstance:` | claudeinstance |
| `Contract:` | contracts |
| `TmuxServer/Session/Window/Pane/Client:` | tmux |
| `PullRequest/Issue/WorkflowRun:` | gh |
| `Worktree:` (or unprefixed `<project>:<name>`) | git |
| `Project:` (or unprefixed slug) | config (no fan-out yet — closed channel) |
| `<host>:<pid>` | ps |

## Resolves
Fixes #396 — the `git provider not configured` error returned for every non-worktree id.

## Test plan
- [x] `go test ./internal/server/resolvers/ -run TestNodeChanged` (3 e2e tests pass)
- [x] `go test ./internal/server/...` (full server suite green)
- [x] Rebased onto `origin/main` (HEAD `c193c3b`) before commit
- [x] Build clean: `go build ./...`

The e2e suite drives stub tmux + ps adapters and a temp-dir claudeprojects root, opens 3 graphql-transport-ws subscriptions (`TmuxSession`, `Conversation`, `Process`), and asserts the typed Node payload arrives within 5s of the upstream `Refresh`. Plus regression coverage for the unknown-prefix error path and a no-hang sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended GraphQL query support for Conversation, ClaudeAccount, ClaudeInstance, Contract, HostService, and GitHub entities (PullRequest, Issue, WorkflowRun).
  * Expanded nodeChanged subscription to dispatch change notifications across all supported entity types.

* **Tests**
  * Added end-to-end test suite validating subscription routing and error handling for new entity types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->