### PR TITLE
fix(peerproxy): HTTPS/WSS + add-peer CLI + drop peer_secret

### DIFF
--- a/internal/cli/config/add_peer.go
+++ b/internal/cli/config/add_peer.go
@@ -1,0 +1,262 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/orchpaths"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
+)
+
+// peeredFile is the on-disk view of ~/.config/orchard/config.json that
+// `add-peer` cares about. It tracks `version` + `projects` (owned by the
+// projects-config provider) plus the `peers` key peerproxy consumes.
+// Any other top-level keys — including legacy `peer_secret` from configs
+// written before issue #412 — round-trip via the `Extras` catch-all so
+// they aren't silently dropped on rewrite.
+type peeredFile struct {
+	Version  int                        `json:"version,omitempty"`
+	Projects json.RawMessage            `json:"projects,omitempty"`
+	Peers    []peerproxy.PeerConfig     `json:"peers,omitempty"`
+	Extras   map[string]json.RawMessage `json:"-"`
+}
+
+// MarshalJSON re-emits the canonical fields followed by any unknown
+// fields stored in Extras. Output order is: version, projects, peers,
+// then extras alphabetically.
+func (f peeredFile) MarshalJSON() ([]byte, error) {
+	out := map[string]json.RawMessage{}
+	if f.Version != 0 {
+		b, err := json.Marshal(f.Version)
+		if err != nil {
+			return nil, err
+		}
+		out["version"] = b
+	}
+	if len(f.Projects) > 0 {
+		out["projects"] = f.Projects
+	}
+	if len(f.Peers) > 0 {
+		b, err := json.Marshal(f.Peers)
+		if err != nil {
+			return nil, err
+		}
+		out["peers"] = b
+	}
+	for k, v := range f.Extras {
+		if _, taken := out[k]; taken {
+			continue
+		}
+		out[k] = v
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON pulls the canonical fields and stashes any other
+// top-level keys in Extras so we don't drop them on rewrite.
+func (f *peeredFile) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	f.Extras = map[string]json.RawMessage{}
+	for k, v := range raw {
+		switch k {
+		case "version":
+			if err := json.Unmarshal(v, &f.Version); err != nil {
+				return err
+			}
+		case "projects":
+			f.Projects = v
+		case "peers":
+			if err := json.Unmarshal(v, &f.Peers); err != nil {
+				return err
+			}
+		default:
+			f.Extras[k] = v
+		}
+	}
+	return nil
+}
+
+// addPeerCmd wires `orchard config add-peer` into the cobra tree.
+//
+//	orchard config add-peer --name <name> --address <host[:port]> [--tls]
+func addPeerCmd() *cobra.Command {
+	var (
+		name    string
+		address string
+		tls     bool
+	)
+	c := &cobra.Command{
+		Use:   "add-peer",
+		Short: "Append a peer to ~/.config/orchard/config.json",
+		Long: "Validate the supplied name + address, append a peer entry,\n" +
+			"and rely on the running daemon's fsnotify watcher to pick up\n" +
+			"the change. Pass --tls (or use an `https://`/`wss://` address)\n" +
+			"for TLS-fronted peers.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAddPeer(cmd.OutOrStdout(), name, address, tls)
+		},
+	}
+	c.Flags().StringVar(&name, "name", "", "peer identifier (matches node-id host segment)")
+	c.Flags().StringVar(&address, "address", "", "host[:port] (or https://host for TLS)")
+	c.Flags().BoolVar(&tls, "tls", false, "speak HTTPS/WSS to this peer")
+	return c
+}
+
+// runAddPeer is the testable core. Validates flags, mutates the file,
+// writes atomically. Returns an error if name/address are missing or
+// the peer already exists.
+func runAddPeer(w io.Writer, name, address string, tls bool) error {
+	name = strings.TrimSpace(name)
+	address = strings.TrimSpace(address)
+	if name == "" {
+		return fmt.Errorf("--name is required")
+	}
+	if address == "" {
+		return fmt.Errorf("--address is required")
+	}
+
+	cfgPath, err := orchpaths.ConfigFile()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		return fmt.Errorf("ensure config dir: %w", err)
+	}
+
+	file, err := loadOrInitPeeredFile(cfgPath)
+	if err != nil {
+		return err
+	}
+
+	// Reject duplicate names — add-peer is strictly an append. Update
+	// flows belong to a future `update-peer`.
+	for _, existing := range file.Peers {
+		if existing.Name == name {
+			return fmt.Errorf("peer %q already exists; remove or rename it first", name)
+		}
+	}
+
+	normalised := normalisePeerInput(name, address, tls)
+	if normalised.Address == "" {
+		return fmt.Errorf("address %q has no host component", address)
+	}
+
+	file.Peers = append(file.Peers, normalised)
+	if file.Version == 0 {
+		file.Version = 1
+	}
+
+	if err := writePeeredFileAtomic(cfgPath, file); err != nil {
+		return err
+	}
+	scheme := "http/ws"
+	if normalised.TLS {
+		scheme = "https/wss"
+	}
+	fmt.Fprintf(w, "added peer %s (%s, %s) to %s\n",
+		normalised.Name, normalised.Address, scheme, cfgPath)
+	return nil
+}
+
+// normalisePeerInput mirrors peerproxy.normalise's per-row behaviour
+// without going through file I/O. Strips any scheme prefix from address
+// and flips TLS true on `https://`/`wss://`.
+func normalisePeerInput(name, address string, tls bool) peerproxy.PeerConfig {
+	host, schemeTLS := splitAddressForCLI(address)
+	return peerproxy.PeerConfig{
+		Name:    strings.TrimSpace(name),
+		Address: host,
+		TLS:     tls || schemeTLS,
+	}
+}
+
+// splitAddressForCLI is a thin wrapper around the same logic peerproxy
+// uses. Kept local to avoid adding a new exported surface; the two
+// are covered by their own unit tests.
+func splitAddressForCLI(raw string) (string, bool) {
+	rest := strings.TrimSpace(raw)
+	tls := false
+	switch {
+	case strings.HasPrefix(strings.ToLower(rest), "https://"):
+		rest = rest[len("https://"):]
+		tls = true
+	case strings.HasPrefix(strings.ToLower(rest), "wss://"):
+		rest = rest[len("wss://"):]
+		tls = true
+	case strings.HasPrefix(strings.ToLower(rest), "http://"):
+		rest = rest[len("http://"):]
+	case strings.HasPrefix(strings.ToLower(rest), "ws://"):
+		rest = rest[len("ws://"):]
+	}
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		rest = rest[:i]
+	}
+	return strings.TrimSpace(rest), tls
+}
+
+// loadOrInitPeeredFile reads cfgPath. A missing file yields an empty
+// peeredFile with version=1 so add-peer also serves as implicit init.
+func loadOrInitPeeredFile(cfgPath string) (peeredFile, error) {
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return peeredFile{Version: 1, Extras: map[string]json.RawMessage{}}, nil
+		}
+		return peeredFile{}, fmt.Errorf("read %s: %w", cfgPath, err)
+	}
+	if len(data) == 0 {
+		return peeredFile{Version: 1, Extras: map[string]json.RawMessage{}}, nil
+	}
+	var f peeredFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		return peeredFile{}, fmt.Errorf("parse %s: %w", cfgPath, err)
+	}
+	if f.Version == 0 {
+		f.Version = 1
+	}
+	if f.Extras == nil {
+		f.Extras = map[string]json.RawMessage{}
+	}
+	return f, nil
+}
+
+// writePeeredFileAtomic writes f via tmp + rename so fsnotify observes
+// a single atomic event (matches add-repo's writer).
+func writePeeredFileAtomic(cfgPath string, f peeredFile) error {
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(cfgPath), ".config.*.json")
+	if err != nil {
+		return fmt.Errorf("create tmp: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, cfgPath); err != nil {
+		cleanup()
+		return fmt.Errorf("rename %s → %s: %w", tmpName, cfgPath, err)
+	}
+	return nil
+}

--- a/internal/cli/config/add_peer_test.go
+++ b/internal/cli/config/add_peer_test.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
+)
+
+// readPeeredConfig is a test helper — round-trip the on-disk JSON back
+// into peeredFile so assertions can read both projects and peer fields.
+func readPeeredConfig(t *testing.T, dir string) peeredFile {
+	t.Helper()
+	cfgPath := filepath.Join(dir, "config", "orchard", "config.json")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var f peeredFile
+	if err := json.Unmarshal(data, &f); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	return f
+}
+
+func TestAddPeer_EmptyConfig_AllFlags(t *testing.T) {
+	dir := setHomeForTest(t)
+	var buf bytes.Buffer
+	if err := runAddPeer(&buf, "peer-1", "10.0.0.1:7777", true); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	cfg := readPeeredConfig(t, dir)
+	if len(cfg.Peers) != 1 {
+		t.Fatalf("want 1 peer, got %d", len(cfg.Peers))
+	}
+	want := peerproxy.PeerConfig{Name: "peer-1", Address: "10.0.0.1:7777", TLS: true}
+	if cfg.Peers[0] != want {
+		t.Errorf("peer mismatch: got %+v, want %+v", cfg.Peers[0], want)
+	}
+	if cfg.Version != 1 {
+		t.Errorf("version = %d, want 1", cfg.Version)
+	}
+}
+
+func TestAddPeer_RequiresName(t *testing.T) {
+	setHomeForTest(t)
+	var buf bytes.Buffer
+	err := runAddPeer(&buf, "", "10.0.0.1:7777", false)
+	if err == nil || !strings.Contains(err.Error(), "name") {
+		t.Fatalf("expected name-required error, got %v", err)
+	}
+}
+
+func TestAddPeer_RequiresAddress(t *testing.T) {
+	setHomeForTest(t)
+	var buf bytes.Buffer
+	err := runAddPeer(&buf, "peer-1", "", false)
+	if err == nil || !strings.Contains(err.Error(), "address") {
+		t.Fatalf("expected address-required error, got %v", err)
+	}
+}
+
+func TestAddPeer_DuplicateNameFails(t *testing.T) {
+	setHomeForTest(t)
+	var buf bytes.Buffer
+	if err := runAddPeer(&buf, "peer-1", "10.0.0.1:7777", false); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	err := runAddPeer(&buf, "peer-1", "10.0.0.2:7778", false)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected duplicate error, got %v", err)
+	}
+}
+
+func TestAddPeer_HTTPSAddressFlipsTLS(t *testing.T) {
+	dir := setHomeForTest(t)
+	var buf bytes.Buffer
+	if err := runAddPeer(&buf, "peer-1", "https://graphql.peer.example", false); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	cfg := readPeeredConfig(t, dir)
+	if len(cfg.Peers) != 1 {
+		t.Fatalf("want 1 peer, got %d", len(cfg.Peers))
+	}
+	got := cfg.Peers[0]
+	if got.Address != "graphql.peer.example" {
+		t.Errorf("address = %q, want stripped host", got.Address)
+	}
+	if !got.TLS {
+		t.Errorf("expected TLS=true after https:// prefix")
+	}
+}
+
+// Verify that legacy `peer_secret` keys in pre-#412 configs round-trip
+// through the Extras catch-all instead of being silently dropped.
+func TestAddPeer_PreservesLegacyPeerSecret(t *testing.T) {
+	dir := setHomeForTest(t)
+	cfgPath := filepath.Join(dir, "config", "orchard", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	const body = `{"version": 1, "peer_secret": "legacy-shhh"}`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := runAddPeer(&buf, "peer-1", "10.0.0.1:7777", false); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if raw["peer_secret"] != "legacy-shhh" {
+		t.Errorf("legacy peer_secret dropped: %v", raw["peer_secret"])
+	}
+}
+
+func TestAddPeer_PreservesExistingProjects(t *testing.T) {
+	dir := setHomeForTest(t)
+	cfgPath := filepath.Join(dir, "config", "orchard", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	const body = `{
+		"version": 1,
+		"projects": [
+			{"id": "alpha", "directory": "/tmp/alpha", "name": "Alpha"}
+		]
+	}`
+	if err := os.WriteFile(cfgPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	var buf bytes.Buffer
+	if err := runAddPeer(&buf, "peer-1", "10.0.0.1:7777", false); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	projects, ok := raw["projects"].([]any)
+	if !ok || len(projects) != 1 {
+		t.Fatalf("projects clobbered: %v", raw["projects"])
+	}
+	peers, ok := raw["peers"].([]any)
+	if !ok || len(peers) != 1 {
+		t.Fatalf("peer not written: %v", raw["peers"])
+	}
+}

--- a/internal/cli/config/config.go
+++ b/internal/cli/config/config.go
@@ -31,7 +31,7 @@ func Command() *cobra.Command {
 		Short: "Manage orchard configuration files",
 		Long:  "Initialise and edit ~/.config/orchard/config.json. The running daemon reflects changes via fsnotify.",
 	}
-	cmd.AddCommand(initCmd(), addRepoCmd())
+	cmd.AddCommand(initCmd(), addRepoCmd(), addPeerCmd())
 	return cmd
 }
 

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -175,7 +175,6 @@ func runStart(parentCtx context.Context, addr string) error {
 		server.WithContracts(contracts.New(logger)),
 		server.WithGh(ghProvider),
 		server.WithPeerProxy(peerProvider),
-		server.WithPeerSecret(fedCfg.PeerSecret),
 		server.WithLocalEvents(localEvents),
 	}
 	if hsvc != nil {

--- a/internal/cli/daemon/daemon_test.go
+++ b/internal/cli/daemon/daemon_test.go
@@ -218,7 +218,6 @@ func TestDaemonWiring_AllProvidersBoot(t *testing.T) {
 		server.WithClaudeInstance(claudeInstance),
 		server.WithContracts(contracts.New(logger)),
 		server.WithPeerProxy(peerProvider),
-		server.WithPeerSecret(fedCfg.PeerSecret),
 		server.WithLocalEvents(localEvents),
 	)
 	ts := httptest.NewServer(srv.HTTPHandler())

--- a/internal/server/providers/peerproxy/client.go
+++ b/internal/server/providers/peerproxy/client.go
@@ -20,11 +20,6 @@ import (
 // subprotocol) is intentionally not implemented.
 const graphqlTransportWSProtocol = "graphql-transport-ws"
 
-// authHeader is the HTTP / WebSocket header carrying the shared-secret
-// bearer. Centralised so the client and the server-side middleware
-// stay in lockstep.
-const authHeader = "Authorization"
-
 // QueryResult is the payload of a single GraphQL response. The Data
 // field is left as a json.RawMessage so callers can decode into the
 // concrete shape they expect.
@@ -68,9 +63,14 @@ type GraphQLError struct {
 // Lifecycle: NewClient is cheap (no I/O). The websocket is opened on
 // the first Subscribe() call and reused across subsequent calls. Close
 // tears it down; subsequent Subscribe() calls reopen.
+//
+// When tls is true the client speaks HTTPS for queries and WSS for
+// subscriptions; the underlying http.Client and websocket.Dialer carry
+// the TLS configuration the caller supplied (system trust store by
+// default — production code MUST verify certificates).
 type Client struct {
 	address    string
-	secret     string
+	tls        bool
 	httpClient *http.Client
 	dialer     *websocket.Dialer
 	now        func() time.Time
@@ -89,17 +89,21 @@ type Client struct {
 	writeMu sync.Mutex
 }
 
-// NewClient constructs a Client targeting `host:port` with the given
-// shared secret. The secret may be empty (local-dev mode); in that case
-// no Authorization header is sent.
-func NewClient(address, secret string) *Client {
-	return newClient(address, secret, http.DefaultClient, websocket.DefaultDialer, time.Now)
+// NewClient constructs a Client targeting `host:port`. When tls is true
+// the client speaks HTTPS/WSS using the default trust store — callers
+// needing a custom tls.Config can construct via newClient with a
+// configured http.Client + websocket.Dialer.
+//
+// No bearer-secret is supported: peer authentication is delegated to
+// the transport (TLS + boxd-fronted endpoint allowlists). See issue #412.
+func NewClient(address string, tls bool) *Client {
+	return newClient(address, tls, http.DefaultClient, websocket.DefaultDialer, time.Now)
 }
 
 // newClient is the test-friendly constructor. Production callers go
 // through NewClient; tests inject a stub HTTP client (httptest), a
 // configured dialer (httptest.NewServer URL), and a frozen clock.
-func newClient(address, secret string, httpc *http.Client, dialer *websocket.Dialer, clock func() time.Time) *Client {
+func newClient(address string, tls bool, httpc *http.Client, dialer *websocket.Dialer, clock func() time.Time) *Client {
 	if httpc == nil {
 		httpc = http.DefaultClient
 	}
@@ -116,7 +120,7 @@ func newClient(address, secret string, httpc *http.Client, dialer *websocket.Dia
 	}
 	return &Client{
 		address:    address,
-		secret:     secret,
+		tls:        tls,
 		httpClient: httpc,
 		dialer:     &d,
 		now:        clock,
@@ -132,10 +136,10 @@ func (c *Client) Address() string { return c.address }
 // Used for transparent node-lookup proxying — Subscribe() is for
 // long-lived streams.
 //
-// The remote endpoint is `http://<address>/graphql`; HTTPS is not
-// supported in v1. Workstream F operates on a trusted localhost-only
-// LAN — the shared secret is the security boundary, not transport
-// encryption.
+// The endpoint URL is `<scheme>://<address>/graphql` where scheme is
+// `https` when the client was constructed with tls=true (boxd-fronted
+// peers) and `http` otherwise (trusted-LAN peers — the LAN itself is
+// then the security boundary).
 func (c *Client) Query(ctx context.Context, query string, variables map[string]any) (QueryResult, error) {
 	body, err := json.Marshal(map[string]any{
 		"query":     query,
@@ -149,9 +153,6 @@ func (c *Client) Query(ctx context.Context, query string, variables map[string]a
 		return QueryResult{}, fmt.Errorf("new request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if c.secret != "" {
-		req.Header.Set(authHeader, "Bearer "+c.secret)
-	}
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return QueryResult{}, fmt.Errorf("http: %w", err)
@@ -160,9 +161,6 @@ func (c *Client) Query(ctx context.Context, query string, variables map[string]a
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return QueryResult{}, fmt.Errorf("read body: %w", err)
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		return QueryResult{}, fmt.Errorf("unauthorized: peer rejected shared secret")
 	}
 	if resp.StatusCode/100 != 2 {
 		return QueryResult{}, fmt.Errorf("http status %d: %s", resp.StatusCode, string(raw))
@@ -270,11 +268,7 @@ func (c *Client) ensureConn(ctx context.Context) error {
 	c.mu.Unlock()
 
 	once.Do(func() {
-		hdr := http.Header{}
-		if c.secret != "" {
-			hdr.Set(authHeader, "Bearer "+c.secret)
-		}
-		conn, _, err := c.dialer.DialContext(ctx, c.wsURL(), hdr)
+		conn, _, err := c.dialer.DialContext(ctx, c.wsURL(), nil)
 		if err != nil {
 			c.mu.Lock()
 			c.connErr = fmt.Errorf("dial %s: %w", c.wsURL(), err)
@@ -286,9 +280,6 @@ func (c *Client) ensureConn(ctx context.Context) error {
 		// server → connection_ack. The server may attach a payload to
 		// the ack; we ignore it in v1.
 		init := map[string]any{"type": "connection_init"}
-		if c.secret != "" {
-			init["payload"] = map[string]any{"authToken": c.secret}
-		}
 		if err := c.writeJSON(conn, init); err != nil {
 			_ = conn.Close()
 			c.mu.Lock()
@@ -441,11 +432,19 @@ func (c *Client) writeJSON(conn *websocket.Conn, v any) error {
 }
 
 func (c *Client) httpURL() string {
-	u := url.URL{Scheme: "http", Host: c.address, Path: "/graphql"}
+	scheme := "http"
+	if c.tls {
+		scheme = "https"
+	}
+	u := url.URL{Scheme: scheme, Host: c.address, Path: "/graphql"}
 	return u.String()
 }
 
 func (c *Client) wsURL() string {
-	u := url.URL{Scheme: "ws", Host: c.address, Path: "/graphql"}
+	scheme := "ws"
+	if c.tls {
+		scheme = "wss"
+	}
+	u := url.URL{Scheme: scheme, Host: c.address, Path: "/graphql"}
 	return u.String()
 }

--- a/internal/server/providers/peerproxy/config.go
+++ b/internal/server/providers/peerproxy/config.go
@@ -15,24 +15,32 @@ import (
 // must match the prefix in node ids the resolvers want to forward
 // (e.g. a node id `TmuxPane:peer-1:%26` is routed to the peer with
 // Name == "peer-1"). Address is the host:port of the remote orchard
-// daemon's GraphQL endpoint (without scheme — the client picks ws/wss
-// based on TLS configuration).
+// daemon's GraphQL endpoint (no scheme — the scheme is selected by the
+// TLS field). For convenience, users may write a full URL like
+// `https://graphql.host.example` in the config; normalise() strips the
+// scheme and flips TLS to true automatically.
+//
+// TLS controls the wire protocol: when true the client speaks HTTPS for
+// queries and WSS for subscriptions, and verifies certs against the
+// system trust store. Default false preserves the original plaintext
+// transport for trusted-LAN deployments.
 type PeerConfig struct {
 	Name    string `json:"name"`
 	Address string `json:"address"`
+	TLS     bool   `json:"tls,omitempty"`
 }
 
 // FederationConfig is the slice of the daemon's on-disk config that
 // peerproxy cares about. It lives next to the existing project list in
-// ~/.config/orchard/config.json under the `peers` and `peer_secret`
-// keys; older configs without these keys yield an empty list and an
-// empty secret (local-dev mode — no auth required).
+// ~/.config/orchard/config.json under the `peers` key; older configs
+// without it yield an empty list (no peers configured).
 //
 // The struct is intentionally tolerant of unknown fields so workstreams
-// can grow the config schema without breaking peerproxy.
+// can grow the config schema without breaking peerproxy. In particular,
+// any legacy `peer_secret` key is ignored — the bearer-secret guard was
+// removed in favour of TLS + boxd-fronted auth (issue #412).
 type FederationConfig struct {
-	Peers      []PeerConfig `json:"peers"`
-	PeerSecret string       `json:"peer_secret"`
+	Peers []PeerConfig `json:"peers"`
 }
 
 // LoadFederationConfig reads cfgPath and extracts the federation slice.
@@ -60,22 +68,64 @@ func LoadFederationConfig(cfgPath string) (FederationConfig, error) {
 // the list is well-formed. The first entry for a given Name wins —
 // later duplicates are silently dropped (consistent with how the
 // projects list de-dupes by directory).
+//
+// The Address field is stripped of any leading scheme (`http://`,
+// `https://`, `ws://`, `wss://`); when an `https://` or `wss://` prefix
+// is detected the TLS bit is implicitly set to true so users who paste
+// a URL get HTTPS without an extra flag. An explicit TLS=true in the
+// config is honoured even when the Address is bare host:port.
 func (f FederationConfig) normalise() FederationConfig {
-	out := FederationConfig{PeerSecret: strings.TrimSpace(f.PeerSecret)}
+	out := FederationConfig{}
 	seen := make(map[string]struct{}, len(f.Peers))
 	for _, p := range f.Peers {
 		name := strings.TrimSpace(p.Name)
-		addr := strings.TrimSpace(p.Address)
-		if name == "" || addr == "" {
+		raw := strings.TrimSpace(p.Address)
+		if name == "" || raw == "" {
 			continue
 		}
 		if _, dup := seen[name]; dup {
 			continue
 		}
 		seen[name] = struct{}{}
-		out.Peers = append(out.Peers, PeerConfig{Name: name, Address: addr})
+		host, tls := splitAddress(raw)
+		if host == "" {
+			continue
+		}
+		out.Peers = append(out.Peers, PeerConfig{
+			Name:    name,
+			Address: host,
+			TLS:     p.TLS || tls,
+		})
 	}
 	return out
+}
+
+// splitAddress parses a peer address that may carry a scheme prefix.
+// Returns the bare `host` or `host:port` plus a TLS hint:
+//   - `https://h` or `wss://h` → (h, true)
+//   - `http://h` or `ws://h`   → (h, false)
+//   - `h:port` or `h`          → (h:port, false)  (TLS unchanged)
+//
+// Trailing slashes and any path components are dropped so the URL
+// builder in client.go can append `/graphql` cleanly.
+func splitAddress(raw string) (host string, tls bool) {
+	rest := raw
+	switch {
+	case strings.HasPrefix(strings.ToLower(rest), "https://"):
+		rest = rest[len("https://"):]
+		tls = true
+	case strings.HasPrefix(strings.ToLower(rest), "wss://"):
+		rest = rest[len("wss://"):]
+		tls = true
+	case strings.HasPrefix(strings.ToLower(rest), "http://"):
+		rest = rest[len("http://"):]
+	case strings.HasPrefix(strings.ToLower(rest), "ws://"):
+		rest = rest[len("ws://"):]
+	}
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		rest = rest[:i]
+	}
+	return strings.TrimSpace(rest), tls
 }
 
 // PeerByName returns the configured peer with the given name, or false

--- a/internal/server/providers/peerproxy/config_test.go
+++ b/internal/server/providers/peerproxy/config_test.go
@@ -12,7 +12,7 @@ func TestLoadFederationConfig_MissingFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil err for missing file, got %v", err)
 	}
-	if len(cfg.Peers) != 0 || cfg.PeerSecret != "" {
+	if len(cfg.Peers) != 0 {
 		t.Fatalf("expected empty config, got %+v", cfg)
 	}
 }
@@ -44,7 +44,7 @@ func TestLoadFederationConfig_RoundTrip(t *testing.T) {
 			{"name": "peer-1", "address": "duplicate-dropped"},
 			{"name": "peer-2", "address": "127.0.0.1:7778"}
 		],
-		"peer_secret": "  shhh  "
+		"peer_secret": "  legacy-ignored  "
 	}`
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
@@ -53,9 +53,8 @@ func TestLoadFederationConfig_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if cfg.PeerSecret != "shhh" {
-		t.Fatalf("expected trimmed secret 'shhh', got %q", cfg.PeerSecret)
-	}
+	// `peer_secret` is a removed field (see issue #412); LoadFederationConfig
+	// must tolerate it in legacy configs without erroring.
 	if len(cfg.Peers) != 2 {
 		t.Fatalf("expected 2 peers after dedupe/blank-drop, got %v", cfg.Peers)
 	}
@@ -73,5 +72,75 @@ func TestLoadFederationConfig_RoundTrip(t *testing.T) {
 	}
 	if _, ok := cfg.PeerByName("peer-3"); ok {
 		t.Fatalf("peer-3 lookup should have failed")
+	}
+}
+
+// TestLoadFederationConfig_TLSAndSchemes covers AC-1 (explicit TLS
+// flag preserved) and AC-4 (scheme prefixes implicitly set TLS and are
+// stripped from the stored Address).
+func TestLoadFederationConfig_TLSAndSchemes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	const body = `{
+		"peers": [
+			{"name": "plain",    "address": "127.0.0.1:7777"},
+			{"name": "explicit", "address": "10.0.0.1:7777", "tls": true},
+			{"name": "https",    "address": "https://graphql.peer.example/"},
+			{"name": "wss",      "address": "wss://graphql.peer.example"},
+			{"name": "http",     "address": "http://localhost:8080/graphql"},
+			{"name": "mixed",    "address": "https://peer.example", "tls": false}
+		]
+	}`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg, err := LoadFederationConfig(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	want := []PeerConfig{
+		{Name: "plain", Address: "127.0.0.1:7777"},
+		{Name: "explicit", Address: "10.0.0.1:7777", TLS: true},
+		{Name: "https", Address: "graphql.peer.example", TLS: true},
+		{Name: "wss", Address: "graphql.peer.example", TLS: true},
+		{Name: "http", Address: "localhost:8080"},
+		// `tls=false` in JSON does not undo the implicit `https://` flip:
+		// scheme prefix wins. Users who paste a URL get TLS regardless.
+		{Name: "mixed", Address: "peer.example", TLS: true},
+	}
+	if len(cfg.Peers) != len(want) {
+		t.Fatalf("got %d peers, want %d: %+v", len(cfg.Peers), len(want), cfg.Peers)
+	}
+	for i, p := range cfg.Peers {
+		if p != want[i] {
+			t.Fatalf("peer[%d] = %+v, want %+v", i, p, want[i])
+		}
+	}
+}
+
+// TestSplitAddress isolates the URL-stripping helper used by normalise
+// so AC-4 has a focused regression net.
+func TestSplitAddress(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantHost string
+		wantTLS  bool
+	}{
+		{"127.0.0.1:7777", "127.0.0.1:7777", false},
+		{"localhost", "localhost", false},
+		{"http://localhost:8080", "localhost:8080", false},
+		{"http://localhost:8080/graphql", "localhost:8080", false},
+		{"ws://peer.example", "peer.example", false},
+		{"https://graphql.peer.example", "graphql.peer.example", true},
+		{"HTTPS://graphql.peer.example", "graphql.peer.example", true},
+		{"wss://graphql.peer.example/graphql", "graphql.peer.example", true},
+		{"https://graphql.peer.example/", "graphql.peer.example", true},
+	}
+	for _, tc := range cases {
+		gotHost, gotTLS := splitAddress(tc.in)
+		if gotHost != tc.wantHost || gotTLS != tc.wantTLS {
+			t.Errorf("splitAddress(%q) = (%q, %v); want (%q, %v)",
+				tc.in, gotHost, gotTLS, tc.wantHost, tc.wantTLS)
+		}
 	}
 }

--- a/internal/server/providers/peerproxy/doc.go
+++ b/internal/server/providers/peerproxy/doc.go
@@ -12,16 +12,18 @@
 //	              fans the watcher channel out as InvalidationEvent.
 //	client.go   — websocket + HTTP transport; speaks the
 //	              graphql-transport-ws subprotocol for subscriptions
-//	              and POSTs JSON for one-shot queries. Owns the
-//	              shared-secret bearer header.
-//	config.go   — loads peer addresses + shared secret from
+//	              and POSTs JSON for one-shot queries. HTTPS/WSS
+//	              enabled per-peer via `tls: true` in config.
+//	config.go   — loads peer addresses from
 //	              ~/.config/orchard/config.json. Read-only.
 //
-// Auth (§11): the client attaches `Authorization: Bearer <secret>` to
-// every websocket open and HTTP request when a non-empty secret is
-// configured. The server side mirrors this — when `peer_secret` is set
-// in config the daemon enforces the bearer; when unset, no auth is
-// required (local-dev escape hatch).
+// Auth: peer authentication is delegated to the transport. For TLS-enabled
+// peers (e.g. boxd-fronted endpoints), the transport-level allowlist on
+// the boxd subdomain is the security boundary. For plaintext peers, the
+// LAN itself is the boundary. The daemon does not implement an
+// application-level bearer-secret guard — that approach was removed in
+// issue #412 because the operational complexity (CLI auth lockout,
+// fsnotify reload edge cases) outweighed the security gain over TLS.
 //
 // Failure model: the adapter never silently swallows errors. A failed
 // websocket open marks the peer unreachable, the next dashboard query

--- a/internal/server/providers/peerproxy/peerproxy_e2e_test.go
+++ b/internal/server/providers/peerproxy/peerproxy_e2e_test.go
@@ -14,6 +14,7 @@ package peerproxy_test
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 	"time"
 
@@ -31,10 +31,7 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
 )
 
-const (
-	remoteName  = "remote-host"
-	sharedToken = "test-secret-shhh"
-)
+const remoteName = "remote-host"
 
 // orchardFixture wraps an httptest.Server bound to a peerproxy-aware
 // orchard daemon plus the LocalInvalidator the test uses to inject
@@ -45,18 +42,32 @@ type orchardFixture struct {
 	events *peerproxy.LocalInvalidator
 }
 
+// fixtureOpts tunes startOrchard for TLS variants and TLS-config
+// injection. Plain federation tests use the zero value.
+type fixtureOpts struct {
+	tlsServer bool
+	tlsConfig *tls.Config
+}
+
 // startOrchard boots an orchard daemon attached to httptest. fedCfg is
-// the federation slice (peers + peer_secret); pass an empty FederationConfig
-// for a "leaf" daemon that has no peers of its own.
+// the federation slice (peers); pass an empty FederationConfig for a
+// "leaf" daemon that has no peers of its own.
 func startOrchard(t *testing.T, fedCfg peerproxy.FederationConfig) *orchardFixture {
+	return startOrchardOpts(t, fedCfg, fixtureOpts{})
+}
+
+func startOrchardOpts(t *testing.T, fedCfg peerproxy.FederationConfig, opts fixtureOpts) *orchardFixture {
 	t.Helper()
 	logger := slog.Default()
-	peerProvider := peerproxy.NewProvider(fedCfg, logger)
+	provOpts := []peerproxy.ProviderOption{}
+	if opts.tlsConfig != nil {
+		provOpts = append(provOpts, peerproxy.WithTLSConfig(opts.tlsConfig))
+	}
+	peerProvider := peerproxy.NewProvider(fedCfg, logger, provOpts...)
 	localEvents := peerproxy.NewLocalInvalidator()
 
 	srv := server.New("", logger,
 		server.WithPeerProxy(peerProvider),
-		server.WithPeerSecret(fedCfg.PeerSecret),
 		server.WithLocalEvents(localEvents),
 	)
 
@@ -74,7 +85,12 @@ func startOrchard(t *testing.T, fedCfg peerproxy.FederationConfig) *orchardFixtu
 
 	mux := http.NewServeMux()
 	mux.Handle("/graphql", srv.GraphQLHandler())
-	ts := httptest.NewServer(mux)
+	var ts *httptest.Server
+	if opts.tlsServer {
+		ts = httptest.NewTLSServer(mux)
+	} else {
+		ts = httptest.NewServer(mux)
+	}
 	t.Cleanup(ts.Close)
 
 	addr, err := stripScheme(ts.URL)
@@ -99,8 +115,9 @@ func stripScheme(rawURL string) (string, error) {
 }
 
 // graphQLPost issues a single POST against the fixture and returns the
-// decoded envelope. Authorization header is attached when secret != "".
-func graphQLPost(t *testing.T, fix *orchardFixture, secret, query string) map[string]any {
+// decoded envelope. Uses the fixture's own http.Client so TLS-fronted
+// fixtures (httptest.NewTLSServer) accept the self-signed cert.
+func graphQLPost(t *testing.T, fix *orchardFixture, query string) map[string]any {
 	t.Helper()
 	body, err := json.Marshal(map[string]string{"query": query})
 	if err != nil {
@@ -111,10 +128,7 @@ func graphQLPost(t *testing.T, fix *orchardFixture, secret, query string) map[st
 		t.Fatalf("new request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if secret != "" {
-		req.Header.Set("Authorization", "Bearer "+secret)
-	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := fix.srv.Client().Do(req)
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
@@ -137,9 +151,8 @@ func graphQLPost(t *testing.T, fix *orchardFixture, secret, query string) map[st
 // peer, polls until the local probe succeeds, then asserts
 // `host.peers[*].reachable == true`.
 func TestPeers_Reachable(t *testing.T) {
-	remote := startOrchard(t, peerproxy.FederationConfig{PeerSecret: sharedToken})
+	remote := startOrchard(t, peerproxy.FederationConfig{})
 	local := startOrchard(t, peerproxy.FederationConfig{
-		PeerSecret: sharedToken,
 		Peers: []peerproxy.PeerConfig{
 			{Name: remoteName, Address: remote.addr},
 		},
@@ -150,7 +163,7 @@ func TestPeers_Reachable(t *testing.T) {
 	// supervisor's first probe lands the answer flips to true.
 	deadline := time.Now().Add(5 * time.Second)
 	for {
-		envelope := graphQLPost(t, local, sharedToken,
+		envelope := graphQLPost(t, local,
 			`{ host { peers { id reachable } } }`)
 		errs, _ := envelope["errors"].([]any)
 		if len(errs) > 0 {
@@ -175,30 +188,13 @@ func TestPeers_Reachable(t *testing.T) {
 	}
 }
 
-// TestPeers_AuthRequired confirms the bearer middleware rejects
-// requests missing the configured secret. Belt-and-braces for §11.
-func TestPeers_AuthRequired(t *testing.T) {
-	fix := startOrchard(t, peerproxy.FederationConfig{PeerSecret: sharedToken})
-	resp, err := http.Post(fix.srv.URL+"/graphql", "application/json",
-		strings.NewReader(`{"query":"{ __typename }"}`))
-	if err != nil {
-		t.Fatalf("post: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusUnauthorized {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("expected 401, got %d: %s", resp.StatusCode, body)
-	}
-}
-
 // TestNode_ProxiedLookup queries `node(id: "TmuxPane:<remote>:%26")`
 // against the local daemon and asserts the response was forwarded —
 // the typename + id come back from the remote, not from a local
 // fallback.
 func TestNode_ProxiedLookup(t *testing.T) {
-	remote := startOrchard(t, peerproxy.FederationConfig{PeerSecret: sharedToken})
+	remote := startOrchard(t, peerproxy.FederationConfig{})
 	local := startOrchard(t, peerproxy.FederationConfig{
-		PeerSecret: sharedToken,
 		Peers: []peerproxy.PeerConfig{
 			{Name: remoteName, Address: remote.addr},
 		},
@@ -206,7 +202,7 @@ func TestNode_ProxiedLookup(t *testing.T) {
 
 	const wantID = "TmuxPane:remote-host:%fake"
 	query := fmt.Sprintf(`{ node(id: %q) { __typename id } }`, wantID)
-	envelope := graphQLPost(t, local, sharedToken, query)
+	envelope := graphQLPost(t, local, query)
 	if errs, ok := envelope["errors"].([]any); ok && len(errs) > 0 {
 		t.Fatalf("graphql errors: %v", errs)
 	}
@@ -228,17 +224,14 @@ func TestNode_ProxiedLookup(t *testing.T) {
 // fires a synthetic invalidation on the remote's LocalInvalidator.
 // The subscriber must observe the touched node within the timeout.
 func TestSubscription_PeerTunnel(t *testing.T) {
-	remote := startOrchard(t, peerproxy.FederationConfig{PeerSecret: sharedToken})
+	remote := startOrchard(t, peerproxy.FederationConfig{})
 	local := startOrchard(t, peerproxy.FederationConfig{
-		PeerSecret: sharedToken,
 		Peers: []peerproxy.PeerConfig{
 			{Name: remoteName, Address: remote.addr},
 		},
 	})
 
 	wsURL := "ws://" + local.addr + "/graphql"
-	hdr := http.Header{}
-	hdr.Set("Authorization", "Bearer "+sharedToken)
 
 	dialer := *websocket.DefaultDialer
 	dialer.Subprotocols = []string{"graphql-transport-ws"}
@@ -247,7 +240,7 @@ func TestSubscription_PeerTunnel(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	conn, _, err := dialer.DialContext(ctx, wsURL, hdr)
+	conn, _, err := dialer.DialContext(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial local ws: %v", err)
 	}
@@ -357,7 +350,7 @@ func TestSubscription_PeerTunnel(t *testing.T) {
 func TestNode_UnknownPeer(t *testing.T) {
 	local := startOrchard(t, peerproxy.FederationConfig{}) // no peers
 
-	envelope := graphQLPost(t, local, "",
+	envelope := graphQLPost(t, local,
 		`{ node(id: "TmuxPane:not-a-peer:%abc") { __typename id } }`)
 	if errs, ok := envelope["errors"].([]any); ok && len(errs) > 0 {
 		t.Fatalf("graphql errors: %v", errs)
@@ -370,6 +363,113 @@ func TestNode_UnknownPeer(t *testing.T) {
 	if node["id"] != "TmuxPane:not-a-peer:%abc" {
 		t.Fatalf("expected echoed id, got %v", node["id"])
 	}
+}
+
+// TestPeers_TLS_ReachableAndProxiedLookup is the AC-5 coverage for
+// HTTPS/WSS support: a TLS-fronted "remote" daemon, a "local" daemon
+// configured with `tls=true` for that peer, and the same `host.peers`
+// + `node(id)` round-trips that the plain-HTTP suite exercises.
+//
+// The remote uses `httptest.NewTLSServer` (self-signed cert). The local
+// daemon's peerproxy is given the corresponding *tls.Config so its
+// dialer accepts the test cert — this MUST stay test-scoped:
+// production code never sets InsecureSkipVerify.
+func TestPeers_TLS_ReachableAndProxiedLookup(t *testing.T) {
+	remote := startOrchardOpts(t,
+		peerproxy.FederationConfig{},
+		fixtureOpts{tlsServer: true},
+	)
+	clientTLS := tlsConfigFromTestServer(remote.srv)
+	local := startOrchardOpts(t,
+		peerproxy.FederationConfig{
+			Peers: []peerproxy.PeerConfig{
+				{Name: remoteName, Address: remote.addr, TLS: true},
+			},
+		},
+		fixtureOpts{tlsConfig: clientTLS},
+	)
+
+	// Wait until the local supervisor's HTTPS probe of the remote lands.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		envelope := graphQLPost(t, local,
+			`{ host { peers { id reachable } } }`)
+		if errs, _ := envelope["errors"].([]any); len(errs) > 0 {
+			t.Fatalf("graphql errors: %v", errs)
+		}
+		data, _ := envelope["data"].(map[string]any)
+		host, _ := data["host"].(map[string]any)
+		peers, _ := host["peers"].([]any)
+		if len(peers) == 1 {
+			peer := peers[0].(map[string]any)
+			if peer["reachable"] == true {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("TLS peer never reachable; envelope=%v", envelope)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Proxied node lookup over HTTPS.
+	const wantID = "TmuxPane:remote-host:%fake"
+	q := fmt.Sprintf(`{ node(id: %q) { __typename id } }`, wantID)
+	envelope := graphQLPost(t, local, q)
+	if errs, _ := envelope["errors"].([]any); len(errs) > 0 {
+		t.Fatalf("graphql errors: %v", errs)
+	}
+	data, _ := envelope["data"].(map[string]any)
+	node, _ := data["node"].(map[string]any)
+	if node == nil {
+		t.Fatalf("expected node, got %v", data)
+	}
+	if node["id"] != wantID {
+		t.Fatalf("expected echoed id %q, got %v", wantID, node["id"])
+	}
+}
+
+// TestPeers_TLS_WSSHandshake confirms the local supervisor's
+// `peerproxy.Client.Subscribe` upgrades to WSS against the TLS-fronted
+// remote. Once the supervisor's subscription is registered on the
+// remote's LocalInvalidator, we know the WSS handshake + connection_init
+// completed — covering AC-2's wsURL() change end-to-end.
+func TestPeers_TLS_WSSHandshake(t *testing.T) {
+	remote := startOrchardOpts(t,
+		peerproxy.FederationConfig{},
+		fixtureOpts{tlsServer: true},
+	)
+	clientTLS := tlsConfigFromTestServer(remote.srv)
+	_ = startOrchardOpts(t,
+		peerproxy.FederationConfig{
+			Peers: []peerproxy.PeerConfig{
+				{Name: remoteName, Address: remote.addr, TLS: true},
+			},
+		},
+		fixtureOpts{tlsConfig: clientTLS},
+	)
+
+	if !waitForCondition(5*time.Second, func() bool {
+		return remote.events.SubscriberCount() >= 1
+	}) {
+		t.Fatalf("expected ≥1 upstream WSS subscription on remote, saw %d",
+			remote.events.SubscriberCount())
+	}
+}
+
+// tlsConfigFromTestServer extracts a *tls.Config that trusts ts's
+// self-signed cert. This is the standard httptest pattern — `ts.Client()`
+// returns an http.Client whose Transport's TLSClientConfig has the
+// test CA in its RootCAs pool. Cloning it gives peerproxy a config it
+// can install on its own dialer.
+func tlsConfigFromTestServer(ts *httptest.Server) *tls.Config {
+	tr, ok := ts.Client().Transport.(*http.Transport)
+	if !ok || tr.TLSClientConfig == nil {
+		// Fallback for older httptest internals — accept the test cert
+		// only. Production code MUST NOT do this.
+		return &tls.Config{InsecureSkipVerify: true} //nolint:gosec // test-only
+	}
+	return tr.TLSClientConfig.Clone()
 }
 
 // waitForCondition polls fn until it returns true or the timeout fires.

--- a/internal/server/providers/peerproxy/provider.go
+++ b/internal/server/providers/peerproxy/provider.go
@@ -2,10 +2,14 @@ package peerproxy
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"sync"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 // InvalidationEvent is the resolver-facing notification that a node on
@@ -42,6 +46,28 @@ type Provider struct {
 	closed      bool
 }
 
+// ProviderOption configures a Provider at construction time. The only
+// option today (`WithTLSConfig`) lets callers — most importantly tests
+// against `httptest.NewTLSServer` — supply a custom *tls.Config without
+// having to override `http.DefaultClient` globally.
+type ProviderOption func(*providerOptions)
+
+type providerOptions struct {
+	tlsConfig *tls.Config
+}
+
+// WithTLSConfig overrides the *tls.Config the Provider's per-peer
+// Clients use when peer.TLS is true. Production code should leave this
+// unset (the default trust store applies); tests pass the cert bundle
+// from `httptest.NewTLSServer().Client().Transport` so the self-signed
+// cert is accepted.
+//
+// Callers MUST NOT set `InsecureSkipVerify: true` outside tests — the
+// daemon's only defence against MITM on a TLS peer is cert verification.
+func WithTLSConfig(cfg *tls.Config) ProviderOption {
+	return func(o *providerOptions) { o.tlsConfig = cfg }
+}
+
 // NewProvider constructs a provider from a fully-loaded
 // FederationConfig. The provider does not read the config file itself;
 // the daemon owns the config-loading lifecycle.
@@ -49,9 +75,13 @@ type Provider struct {
 // Each peer gets its own Client — websocket multiplexing is per-
 // connection, and one connection per peer keeps the failure model
 // simple.
-func NewProvider(cfg FederationConfig, logger *slog.Logger) *Provider {
+func NewProvider(cfg FederationConfig, logger *slog.Logger, opts ...ProviderOption) *Provider {
 	if logger == nil {
 		logger = slog.Default()
+	}
+	options := providerOptions{}
+	for _, opt := range opts {
+		opt(&options)
 	}
 	p := &Provider{
 		logger:   logger,
@@ -60,11 +90,26 @@ func NewProvider(cfg FederationConfig, logger *slog.Logger) *Provider {
 		subs:     map[chan InvalidationEvent]struct{}{},
 	}
 	for _, peer := range cfg.Peers {
-		client := NewClient(peer.Address, cfg.PeerSecret)
+		client := buildClient(peer, options.tlsConfig)
 		p.adapters[peer.Name] = NewPeerAdapter(peer, client)
 		p.clients[peer.Name] = client
 	}
 	return p
+}
+
+// buildClient assembles a per-peer Client. When peer.TLS is true and
+// tlsCfg is non-nil, the resulting http.Client + websocket.Dialer share
+// the supplied tls.Config; otherwise the package defaults apply.
+func buildClient(peer PeerConfig, tlsCfg *tls.Config) *Client {
+	if !peer.TLS || tlsCfg == nil {
+		return NewClient(peer.Address, peer.TLS)
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsCfg
+	httpc := &http.Client{Transport: transport}
+	dialer := *websocket.DefaultDialer
+	dialer.TLSClientConfig = tlsCfg
+	return newClient(peer.Address, peer.TLS, httpc, &dialer, time.Now)
 }
 
 // Start kicks off the per-peer probe + subscription goroutines. Safe

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,8 +13,10 @@
 // Workstream D-gh: WithGh wires the gh provider; Run() calls Start to prime
 // the auth bootstrap (failure is non-fatal — gh-derived fields surface
 // per-field GraphQL errors when auth is unavailable).
-// Workstream F: WithPeerProxy attaches the federation provider; the GraphQL
-// handler is wrapped in a bearer-secret middleware when peer_secret is set.
+// Workstream F: WithPeerProxy attaches the federation provider. Peer
+// authentication is delegated to the transport (TLS + boxd subdomain
+// allowlists); the daemon does not enforce a bearer-secret guard
+// (issue #412).
 package server
 
 import (
@@ -26,7 +28,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql/handler"
@@ -72,7 +73,6 @@ type Server struct {
 	contracts      *contracts.Provider
 	gh             *gh.Provider
 	peerProxy      *peerproxy.Provider
-	peerSecret     string
 	localEvents    *peerproxy.LocalInvalidator
 }
 
@@ -178,16 +178,6 @@ func WithPeerProxy(p *peerproxy.Provider) Option {
 	}
 }
 
-// WithPeerSecret enables the bearer-secret guard on /graphql. When the
-// secret is the empty string the middleware is a no-op (local-dev mode);
-// any non-empty value requires inbound requests to carry
-// `Authorization: Bearer <secret>`.
-func WithPeerSecret(secret string) Option {
-	return func(s *Server, _ *resolvers.Resolver) {
-		s.peerSecret = strings.TrimSpace(secret)
-	}
-}
-
 // WithLocalEvents wires a LocalInvalidator into the resolver so the
 // federation `Subscription.peer(host: "*")` field can fan local node
 // updates out to upstream peers.
@@ -224,7 +214,7 @@ func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 
 	mux := http.NewServeMux()
 	mux.Handle("/health", healthHandler(startedAt))
-	mux.Handle("/graphql", srv.bearerGuard(graphqlHandlerFor(res)))
+	mux.Handle("/graphql", graphqlHandlerFor(res))
 
 	srv.httpSrv = &http.Server{
 		Addr:              addr,
@@ -255,10 +245,11 @@ func (s *Server) StartHostProvider(ctx context.Context) error {
 }
 
 // GraphQLHandler returns a fresh handler bound to the server's resolver.
-// The handler honours the configured peer secret — call sites that need
-// an unguarded handler should use the resolver directly.
+// Tests that need to mount the handler with custom middleware should
+// call this and wrap the result; production wires the handler via the
+// daemon's mux in New().
 func (s *Server) GraphQLHandler() http.Handler {
-	return s.bearerGuard(graphqlHandlerFor(s.resolver))
+	return graphqlHandlerFor(s.resolver)
 }
 
 // Run starts providers, the HTTP server, and blocks until ctx is cancelled.
@@ -406,25 +397,3 @@ func graphqlHandlerFor(res *resolvers.Resolver) http.Handler {
 	return srv
 }
 
-// bearerGuard wraps next so that requests carrying the wrong (or no)
-// `Authorization: Bearer <secret>` header are rejected with 401. When
-// the configured secret is empty the middleware passes through, keeping
-// local-dev mode auth-free per the §11 backwards-compat rule.
-//
-// The header check applies uniformly to POST queries and the websocket
-// upgrade handshake — gorilla's Upgrader rejects requests it never
-// sees, so the middleware short-circuiting before delegation is the
-// only place we enforce the check.
-func (s *Server) bearerGuard(next http.Handler) http.Handler {
-	if s.peerSecret == "" {
-		return next
-	}
-	want := "Bearer " + s.peerSecret
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != want {
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}


### PR DESCRIPTION
## Summary

Three rolled-up peerproxy changes:
- **HTTPS/WSS support** for boxd-fronted peers — `PeerConfig.tls` flag, scheme-prefix-flips-TLS, `WithTLSConfig` option for tests (resolves #407)
- **`orchard config add-peer` CLI** — mirrors `add-repo` with `--name --address [--tls]`, fsnotify-friendly atomic write (resolves #411)
- **Drop `peer_secret` entirely** per YAGNI: lockout-prone, TLS already covers boxd, LAN is the boundary for plain peers (resolves #412)

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `peerproxy_e2e_test.go` covers AC-1 (TLS reachable + proxied node lookup), AC-2 (WSS handshake), and the existing plain-HTTP suite
- [x] `add_peer_test.go` covers happy path, duplicate rejection, https-flips-TLS, project preservation, legacy-peer_secret-tolerance
- [x] `config_test.go` covers TLS-and-schemes round trip + splitAddress unit cases
- [ ] Manual: `orchard config add-peer --name boxd-or-374 --address graphql.or-374.boxd.sh --tls` should land cleanly on a daemon already configured for fsnotify reload (deferred to post-merge boxd push)

## Notes for reviewers

- `peer_secret` removal is intentional and broad: middleware deleted, header writes deleted, `--secret` flag deleted. Issue #412 has the YAGNI rationale.
- Legacy configs with `peer_secret` set are still accepted — `LoadFederationConfig` silently ignores the key, `add-peer` round-trips it through Extras. No migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `orchard config add-peer` CLI command to configure federation peers
  * Peer configuration now supports TLS for secure connections
  * Peer addresses are automatically normalized with scheme detection (HTTP/HTTPS/WS/WSS)

* **Tests**
  * Added comprehensive test coverage for peer configuration and TLS handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->