### PR TITLE
feat(gh): pass-through Query.gh(query, variables) (resolves #418)

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -170,3 +170,11 @@ models:
   Time:
     model:
       - github.com/99designs/gqlgen/graphql.Time
+
+  # JSON scalar binds to gqlgen's Any marshaller, which round-trips any
+  # JSON-shaped value (`map[string]any`, `[]any`, primitives) verbatim.
+  # Used by Query.gh to forward GitHub GraphQL responses without imposing
+  # an orchard-side schema (issue #418).
+  JSON:
+    model:
+      - github.com/99designs/gqlgen/graphql.Any

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -225,6 +225,7 @@ type ComplexityRoot struct {
 		Contracts       func(childComplexity int, filter *ContractFilter) int
 		Conversation    func(childComplexity int, id string) int
 		Conversations   func(childComplexity int) int
+		Gh              func(childComplexity int, query string, variables interface{}) int
 		Health          func(childComplexity int) int
 		Host            func(childComplexity int) int
 		Hosts           func(childComplexity int) int
@@ -376,6 +377,7 @@ type QueryResolver interface {
 	PullRequests(ctx context.Context, repo string, state *PullRequestState) ([]*PullRequest, error)
 	Issues(ctx context.Context, repo string, state *IssueState) ([]*Issue, error)
 	WorkflowRuns(ctx context.Context, repo string) ([]*WorkflowRun, error)
+	Gh(ctx context.Context, query string, variables interface{}) (interface{}, error)
 	Node(ctx context.Context, id string) (Node, error)
 }
 type SubscriptionResolver interface {
@@ -1361,6 +1363,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Conversations(childComplexity), true
 
+	case "Query.gh":
+		if e.complexity.Query.Gh == nil {
+			break
+		}
+
+		args, err := ec.field_Query_gh_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Gh(childComplexity, args["query"].(string), args["variables"].(interface{})), true
+
 	case "Query.health":
 		if e.complexity.Query.Health == nil {
 			break
@@ -2172,6 +2186,14 @@ interface Node {
 "RFC 3339 timestamp string. Mapped to Go's time.Time."
 scalar Time
 
+"""
+Opaque JSON value — any GraphQL-compatible type, marshalled verbatim.
+Used by ` + "`" + `Query.gh` + "`" + ` to forward GitHub GraphQL responses without imposing
+an orchard-side schema on them. Callers deserialise against their
+knowledge of GitHub's schema.
+"""
+scalar JSON
+
 # Process is an OS-level process surfaced via the ` + "`" + `ps` + "`" + ` adapter.
 type Process implements Node {
   "Stable id formatted as ` + "`" + `<host>:<pid>` + "`" + `."
@@ -2325,6 +2347,23 @@ type Query {
 
   "Workflow runs on a GitHub repository. ` + "`" + `repo` + "`" + ` is ` + "`" + `owner/name` + "`" + `."
   workflowRuns(repo: String!): [WorkflowRun!]
+
+  """
+  Forward an arbitrary GraphQL query to GitHub's API using the daemon's
+  configured gh credentials. The ` + "`" + `query` + "`" + ` argument is a GitHub-schema
+  GraphQL document (string); the returned JSON is GitHub's full envelope
+  including the ` + "`" + `data` + "`" + ` and any ` + "`" + `errors` + "`" + ` keys.
+
+  Pass-through is read-only by design: it is exposed as a Query field,
+  not a Mutation, so callers cannot bypass orchardist guardrails by
+  routing mutations through the daemon. Auth, rate limiting, and base
+  URL come from the gh provider; callers do not pass tokens.
+
+  Federation: peers can call ` + "`" + `gh` + "`" + ` through the peerproxy surface. The
+  result is opaque JSON on the orchard side — the consumer typecheks
+  against GitHub's schema directly.
+  """
+  gh(query: String!, variables: JSON): JSON
 
   """
   Generic node lookup by globally-unique id. Returns the node if it
@@ -3090,6 +3129,30 @@ func (ec *executionContext) field_Query_conversation_args(ctx context.Context, r
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_gh_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["query"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["query"] = arg0
+	var arg1 interface{}
+	if tmp, ok := rawArgs["variables"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("variables"))
+		arg1, err = ec.unmarshalOJSON2interface(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["variables"] = arg1
 	return args, nil
 }
 
@@ -10022,6 +10085,64 @@ func (ec *executionContext) fieldContext_Query_workflowRuns(ctx context.Context,
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_workflowRuns_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_gh(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_gh(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Gh(rctx, fc.Args["query"].(string),
+			func() interface{} {
+				if fc.Args["variables"] == nil {
+					return nil
+				}
+				return fc.Args["variables"].(interface{})
+			}())
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(interface{})
+	fc.Result = res
+	return ec.marshalOJSON2interface(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_gh(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type JSON does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_gh_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -17772,6 +17893,25 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "gh":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_gh(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "node":
 			field := field
 
@@ -21644,6 +21784,22 @@ func (ec *executionContext) marshalOIssueState2ᚖgithubᚗcomᚋdrewdrewthisᚋ
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) unmarshalOJSON2interface(ctx context.Context, v interface{}) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalAny(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOJSON2interface(ctx context.Context, sel ast.SelectionSet, v interface{}) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	res := graphql.MarshalAny(v)
+	return res
 }
 
 func (ec *executionContext) marshalONode2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐNode(ctx context.Context, sel ast.SelectionSet, v Node) graphql.Marshaler {

--- a/internal/server/providers/gh/graphql.go
+++ b/internal/server/providers/gh/graphql.go
@@ -1,0 +1,128 @@
+package gh
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// graphqlPath is the GitHub GraphQL endpoint path appended to the
+// REST BaseURL. GitHub's GraphQL surface is hosted at the same origin
+// as the REST API (`https://api.github.com/graphql`); GHES users
+// resolve `<host>/api/graphql` via their GH_API_BASE_URL override.
+const graphqlPath = "/graphql"
+
+// GraphQL POSTs an arbitrary GraphQL query to GitHub's API and returns
+// the full JSON envelope verbatim — `data`, `errors`, and any
+// extensions GitHub attaches.
+//
+// The query string is opaque to the client: we do not parse it, do
+// not introspect it, and do not validate it against any schema. GitHub
+// validates server-side; validation errors surface as entries in the
+// returned envelope's `errors` array, not as a Go error.
+//
+// Go-error returns are reserved for the things callers cannot recover
+// from at the resolver layer: network failure, auth failure (401),
+// rate limit (X-RateLimit-Remaining: 0 + 403), or non-2xx HTTP without
+// a JSON body. Anything else — including GraphQL-level `errors` —
+// rides through as part of the returned envelope so callers see what
+// GitHub said verbatim.
+//
+// `variables` may be nil for queries that take no variables; callers
+// pass a `map[string]any` keyed by GraphQL variable name.
+func (c *Client) GraphQL(ctx context.Context, query string, variables map[string]any) (json.RawMessage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if c == nil {
+		return nil, errors.New("gh client not initialised")
+	}
+	if strings.TrimSpace(query) == "" {
+		return nil, fmt.Errorf("graphql: empty query")
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"query":     query,
+		"variables": variables,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal graphql request: %w", err)
+	}
+
+	full := c.BaseURL + graphqlPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, full, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build graphql request: %w", err)
+	}
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	// GitHub's GraphQL endpoint requires the JSON content type and
+	// honours the same User-Agent / API-Version headers the REST path
+	// uses; the Accept header is application/json (NOT the REST media
+	// type — keeping the same string would still work, but JSON is the
+	// canonical choice for GraphQL).
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if ua := c.UserAgent; ua != "" {
+		req.Header.Set("User-Agent", ua)
+	}
+
+	resp, err := c.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("github POST %s: %w", graphqlPath, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Mirror the REST path's rate-limit + auth shaping so the resolver
+	// sees the same typed errors regardless of which GitHub surface the
+	// query hit.
+	if remaining := resp.Header.Get("X-RateLimit-Remaining"); remaining == "0" && resp.StatusCode == http.StatusForbidden {
+		var resetAt int64
+		if rs := resp.Header.Get("X-RateLimit-Reset"); rs != "" {
+			if v, perr := strconv.ParseInt(rs, 10, 64); perr == nil {
+				resetAt = v
+			}
+		}
+		return nil, &ErrRateLimitedT{ResetAt: resetAt}
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, ErrNotAuthenticated
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read graphql body: %w", err)
+	}
+
+	// Non-2xx without a JSON body is a transport-level failure; bubble
+	// it up. GitHub's GraphQL endpoint normally returns 200 even when
+	// the query has errors (they go into `errors[]`), so any non-2xx
+	// here is operationally interesting.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(raw))
+		if len(msg) > 4096 {
+			msg = msg[:4096]
+		}
+		return nil, &httpError{
+			Status:   resp.StatusCode,
+			Message:  msg,
+			Endpoint: graphqlPath,
+		}
+	}
+
+	// Validate the response is JSON-shaped before handing back; a 200
+	// with non-JSON content is a GitHub bug, but we should not crash
+	// the resolver if it ever happens.
+	if !json.Valid(raw) {
+		return nil, fmt.Errorf("graphql: non-JSON response from %s", graphqlPath)
+	}
+	return json.RawMessage(raw), nil
+}

--- a/internal/server/providers/gh/graphql_test.go
+++ b/internal/server/providers/gh/graphql_test.go
@@ -1,0 +1,198 @@
+package gh
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubGraphQLServer mounts an httptest.NewTLSServer that handles
+// /graphql with a caller-controlled handler and rejects every other
+// path so misrouted clients fail loudly. Returned alongside an
+// http.Client whose RootCAs trust the self-signed cert.
+func stubGraphQLServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *http.Client) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", handler)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request to %s", r.URL.Path)
+		http.NotFound(w, r)
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+
+	pool := srv.Client().Transport.(*http.Transport).TLSClientConfig.RootCAs
+	c := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+	return srv, c
+}
+
+func newClientForGraphQLTest(t *testing.T, srv *httptest.Server, httpc *http.Client) *Client {
+	t.Helper()
+	c := NewClient(srv.URL, "test-token-fixture")
+	c.HTTP = httpc
+	return c
+}
+
+// TestGraphQL_Verbatim_Envelope confirms the client returns GitHub's
+// envelope as-is. The handler returns a hand-crafted `{ data, errors }`
+// response and we assert both halves survive round-trip without any
+// orchard-side rewriting.
+func TestGraphQL_Verbatim_Envelope(t *testing.T) {
+	want := `{"data":{"repository":{"pullRequest":{"mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}}},"errors":[{"message":"deprecated field","path":["repository","pullRequest","oldField"]}]}`
+	srv, httpc := stubGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("got method %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token-fixture" {
+			t.Errorf("Authorization = %q, want Bearer test-token-fixture", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, want)
+	})
+	c := newClientForGraphQLTest(t, srv, httpc)
+	got, err := c.GraphQL(context.Background(), "{ viewer { login } }", nil)
+	if err != nil {
+		t.Fatalf("GraphQL: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("envelope:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestGraphQL_VariablesForwarded confirms the variables map is encoded
+// into the request body alongside the query.
+func TestGraphQL_VariablesForwarded(t *testing.T) {
+	srv, httpc := stubGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.Query != "query($n: Int!) { foo(n: $n) }" {
+			t.Errorf("query = %q", body.Query)
+		}
+		if body.Variables["n"] != float64(7) {
+			t.Errorf("variables[n] = %v, want 7", body.Variables["n"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"foo":42}}`)
+	})
+	c := newClientForGraphQLTest(t, srv, httpc)
+	if _, err := c.GraphQL(context.Background(),
+		"query($n: Int!) { foo(n: $n) }",
+		map[string]any{"n": 7},
+	); err != nil {
+		t.Fatalf("GraphQL: %v", err)
+	}
+}
+
+// TestGraphQL_Unauthorized maps a 401 from GitHub onto the typed
+// ErrNotAuthenticated, mirroring the REST path. This is what the
+// resolver layer turns into a per-field GraphQL error.
+func TestGraphQL_Unauthorized(t *testing.T) {
+	srv, httpc := stubGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, `{"message":"Bad credentials"}`)
+	})
+	c := newClientForGraphQLTest(t, srv, httpc)
+	_, err := c.GraphQL(context.Background(), "{ viewer { login } }", nil)
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Fatalf("err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
+// TestGraphQL_RateLimited converts a 403 + X-RateLimit-Remaining: 0
+// into the typed ErrRateLimitedT, mirroring the REST path.
+func TestGraphQL_RateLimited(t *testing.T) {
+	srv, httpc := stubGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", "1234567890")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"message":"API rate limit exceeded"}`)
+	})
+	c := newClientForGraphQLTest(t, srv, httpc)
+	_, err := c.GraphQL(context.Background(), "{ viewer { login } }", nil)
+	if !IsRateLimited(err) {
+		t.Fatalf("err = %v, want ErrRateLimitedT", err)
+	}
+}
+
+// TestGraphQL_GitHubErrorsRideThrough confirms that GitHub-level
+// GraphQL errors (200 OK, errors[] populated) come back inside the
+// envelope rather than as a Go error. This is the load-bearing
+// invariant of pass-through.
+func TestGraphQL_GitHubErrorsRideThrough(t *testing.T) {
+	srv, httpc := stubGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":null,"errors":[{"message":"Field 'nope' doesn't exist on type 'Query'","locations":[{"line":1,"column":3}]}]}`)
+	})
+	c := newClientForGraphQLTest(t, srv, httpc)
+	raw, err := c.GraphQL(context.Background(), "{ nope }", nil)
+	if err != nil {
+		t.Fatalf("GraphQL returned go-error for graphql-error response: %v", err)
+	}
+	if !strings.Contains(string(raw), "Field 'nope' doesn't exist") {
+		t.Fatalf("envelope did not preserve graphql error: %s", raw)
+	}
+}
+
+// TestGraphQL_NonJSON_Response surfaces a Go error when GitHub returns
+// 200 with a body that isn't valid JSON. This should never happen but
+// the resolver should not crash if it does.
+func TestGraphQL_NonJSON_Response(t *testing.T) {
+	srv, httpc := stubGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = io.WriteString(w, `<html>oops</html>`)
+	})
+	c := newClientForGraphQLTest(t, srv, httpc)
+	_, err := c.GraphQL(context.Background(), "{ viewer { login } }", nil)
+	if err == nil {
+		t.Fatalf("expected error on non-JSON response, got nil")
+	}
+}
+
+// TestGraphQL_EmptyQuery rejects an empty query string before
+// attempting the network round-trip. Cheap defensive guard.
+func TestGraphQL_EmptyQuery(t *testing.T) {
+	c := NewClient("https://example.invalid", "tok")
+	_, err := c.GraphQL(context.Background(), "   ", nil)
+	if err == nil || !strings.Contains(err.Error(), "empty query") {
+		t.Fatalf("err = %v, want empty-query error", err)
+	}
+}
+
+// TestGraphQL_Non2xxNonAuth surfaces other non-2xx statuses through
+// the typed httpError. This catches GitHub returning 5xx / 502 from a
+// transient outage — the resolver should see a clear error.
+func TestGraphQL_Non2xxNonAuth(t *testing.T) {
+	srv, httpc := stubGraphQLServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, `bad gateway`)
+	})
+	c := newClientForGraphQLTest(t, srv, httpc)
+	_, err := c.GraphQL(context.Background(), "{ viewer { login } }", nil)
+	if err == nil {
+		t.Fatalf("expected error on 502, got nil")
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Errorf("err did not mention status: %v", err)
+	}
+}

--- a/internal/server/providers/gh/passthrough_e2e_test.go
+++ b/internal/server/providers/gh/passthrough_e2e_test.go
@@ -1,0 +1,217 @@
+// E2E coverage for `Query.gh(query, variables)` — the GitHub GraphQL
+// pass-through introduced in issue #418.
+//
+// The shape is the same as gh_e2e_test.go: a stubbed GitHub GraphQL
+// endpoint (httptest.NewTLSServer), a fake `gh auth token` shellout,
+// and a daemon httptest.Server with the gh provider wired in. The
+// query under test rides through the orchard daemon and lands on our
+// stub; assertions cover envelope round-trip + variable forwarding.
+package gh_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
+)
+
+// stubGraphQLAPI mounts /graphql on a TLS server. The handler captures
+// the inbound request so the test can assert on what the daemon sent
+// to GitHub. Other paths fail loudly.
+func stubGraphQLAPI(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", handler)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request to %s", r.URL.Path)
+		http.NotFound(w, r)
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestGH_E2E_Passthrough_QueryRoundTrip drives a GraphQL query through
+// the orchard daemon → gh provider → stub GitHub. Asserts the daemon
+// forwards the query verbatim and returns GitHub's envelope as opaque
+// JSON.
+func TestGH_E2E_Passthrough_QueryRoundTrip(t *testing.T) {
+	installFakeGH(t)
+
+	const inboundQuery = `{ repository(owner:"alice", name:"repo") { pullRequest(number:42) { mergeStateStatus reviewDecision } } }`
+	const upstreamBody = `{"data":{"repository":{"pullRequest":{"mergeStateStatus":"CLEAN","reviewDecision":"APPROVED"}}}}`
+
+	api := stubGraphQLAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("upstream method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token-fixture" {
+			t.Errorf("upstream auth header = %q", got)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		var body struct {
+			Query     string `json:"query"`
+			Variables any    `json:"variables"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode upstream body: %v", err)
+		}
+		if body.Query != inboundQuery {
+			t.Errorf("upstream query = %q, want %q", body.Query, inboundQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, upstreamBody)
+	})
+	tlsClient := httpClientForTLS(t, api)
+
+	auth := gh.NewCommandAuthSource()
+	provider := newGHProviderForTest(t, api.URL, auth, tlsClient)
+
+	srv := newDaemon(t, provider)
+	defer srv.Close()
+
+	// Caller-side query: daemon's `gh` field with the GitHub query as
+	// the `query` argument. JSON-escape it for embedding in the outer
+	// query string.
+	escaped, _ := json.Marshal(inboundQuery)
+	outer := `query { gh(query: ` + string(escaped) + `) }`
+
+	raw := postQueryRaw(t, srv.URL, outer)
+	var resp struct {
+		Data struct {
+			Gh map[string]any `json:"gh"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode response: %v -- %s", err, raw)
+	}
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+
+	// Walk the returned envelope; the daemon must have forwarded
+	// GitHub's `data` payload verbatim, untouched.
+	data, ok := resp.Data.Gh["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("envelope missing data: %+v", resp.Data.Gh)
+	}
+	repo, _ := data["repository"].(map[string]any)
+	pr, _ := repo["pullRequest"].(map[string]any)
+	if pr["mergeStateStatus"] != "CLEAN" {
+		t.Errorf("mergeStateStatus = %v, want CLEAN", pr["mergeStateStatus"])
+	}
+	if pr["reviewDecision"] != "APPROVED" {
+		t.Errorf("reviewDecision = %v, want APPROVED", pr["reviewDecision"])
+	}
+}
+
+// TestGH_E2E_Passthrough_VariablesForwarded confirms variables flow
+// from the outer query, through the resolver, into the upstream POST
+// body. Without this the JSON scalar wiring is silently broken.
+func TestGH_E2E_Passthrough_VariablesForwarded(t *testing.T) {
+	installFakeGH(t)
+
+	api := stubGraphQLAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var body struct {
+			Query     string         `json:"query"`
+			Variables map[string]any `json:"variables"`
+		}
+		if err := json.Unmarshal(raw, &body); err != nil {
+			t.Fatalf("decode upstream body: %v", err)
+		}
+		if body.Variables["owner"] != "alice" {
+			t.Errorf("variables[owner] = %v, want alice", body.Variables["owner"])
+		}
+		if body.Variables["number"] != float64(42) {
+			t.Errorf("variables[number] = %v, want 42", body.Variables["number"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":{"ok":true}}`)
+	})
+	tlsClient := httpClientForTLS(t, api)
+
+	auth := gh.NewCommandAuthSource()
+	provider := newGHProviderForTest(t, api.URL, auth, tlsClient)
+	srv := newDaemon(t, provider)
+	defer srv.Close()
+
+	const outer = `query GhWithVars($q: String!, $v: JSON) { gh(query: $q, variables: $v) }`
+	const inner = `query($owner:String!,$number:Int!){ repository(owner:$owner) { pullRequest(number:$number) { id } } }`
+	body, _ := json.Marshal(map[string]any{
+		"query": outer,
+		"variables": map[string]any{
+			"q": inner,
+			"v": map[string]any{"owner": "alice", "number": 42},
+		},
+	})
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, srv.URL+"/graphql", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status %d: %s", resp.StatusCode, raw)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(raw), `"ok":true`) {
+		t.Fatalf("response missing data: %s", raw)
+	}
+}
+
+// TestGH_E2E_Passthrough_ErrorsRideThrough confirms GitHub-level
+// GraphQL errors come back in the envelope's `errors[]` array — they
+// MUST NOT be promoted to a per-field error on the orchard side, or
+// callers can't distinguish 'GitHub said no' from 'orchard couldn't
+// reach GitHub'.
+func TestGH_E2E_Passthrough_ErrorsRideThrough(t *testing.T) {
+	installFakeGH(t)
+
+	api := stubGraphQLAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"data":null,"errors":[{"message":"Field 'nope' doesn't exist on type 'Query'"}]}`)
+	})
+	tlsClient := httpClientForTLS(t, api)
+
+	auth := gh.NewCommandAuthSource()
+	provider := newGHProviderForTest(t, api.URL, auth, tlsClient)
+	srv := newDaemon(t, provider)
+	defer srv.Close()
+
+	escaped, _ := json.Marshal(`{ nope }`)
+	outer := `query { gh(query: ` + string(escaped) + `) }`
+
+	raw := postQueryRaw(t, srv.URL, outer)
+	var resp struct {
+		Data struct {
+			Gh map[string]any `json:"gh"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors,omitempty"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Errors) > 0 {
+		t.Fatalf("orchard reported a per-field error for a github-level graphql error: %+v", resp.Errors)
+	}
+	errs, ok := resp.Data.Gh["errors"].([]any)
+	if !ok || len(errs) == 0 {
+		t.Fatalf("envelope missing github errors: %+v", resp.Data.Gh)
+	}
+	first, _ := errs[0].(map[string]any)
+	if !strings.Contains(first["message"].(string), "Field 'nope'") {
+		t.Errorf("error message lost: %v", first)
+	}
+}

--- a/internal/server/providers/gh/provider.go
+++ b/internal/server/providers/gh/provider.go
@@ -2,7 +2,9 @@ package gh
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -400,6 +402,28 @@ func (p *Provider) GetRepository(ctx context.Context, owner, name string) (Repos
 		return Repository{}, err
 	}
 	return c.GetRepo(ctx, owner, name)
+}
+
+// GraphQL forwards an arbitrary GraphQL query to GitHub's API and
+// returns the parsed `{ data, errors, extensions }` envelope as a Go
+// map. Backed by Client.GraphQL, which never caches: query strings are
+// arbitrary, so caching by query+variables would be both surprising
+// and easily defeated. Per-resolver auth/rate-limit shaping mirrors
+// the REST path (issue #418).
+func (p *Provider) GraphQL(ctx context.Context, query string, variables map[string]any) (map[string]any, error) {
+	c, err := p.httpClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := c.GraphQL(ctx, query, variables)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode graphql envelope: %w", err)
+	}
+	return out, nil
 }
 
 // Subscribe returns a channel that receives invalidation events when

--- a/internal/server/resolvers/gh.go
+++ b/internal/server/resolvers/gh.go
@@ -91,6 +91,45 @@ func (r *queryResolver) queryWorkflowRunsResolver(ctx context.Context, repo stri
 	return out, nil
 }
 
+// queryGhResolver implements `Query.gh(query, variables)` — the
+// pass-through into GitHub's GraphQL API. Issue #418.
+//
+// The `variables` argument arrives as `interface{}` because the JSON
+// scalar can carry any shape. Two valid shapes: nil (no variables) or
+// a `map[string]any` keyed by GraphQL variable name. Anything else is
+// a caller bug; reject it as a per-field error rather than panicking.
+//
+// Auth-not-bootstrapped returns the typed `errGHNotConfigured` /
+// `gh.ErrNotAuthenticated` so the resolver layer surfaces it as a
+// per-field GraphQL error (the rest of the schema keeps resolving).
+// GitHub-level GraphQL errors ride through inside the returned envelope
+// — they are not Go errors here.
+func (r *queryResolver) queryGhResolver(ctx context.Context, query string, variables interface{}) (interface{}, error) {
+	if r.GH == nil {
+		return nil, errGHNotConfigured
+	}
+	vars, err := coerceGhVariables(variables)
+	if err != nil {
+		return nil, err
+	}
+	return r.GH.GraphQL(ctx, query, vars)
+}
+
+// coerceGhVariables narrows the JSON-scalar input to the shape the gh
+// client wants. nil is allowed (no variables); a `map[string]any` is
+// the happy path. We tolerate `nil` from an absent argument; anything
+// else is a misuse of the field that should surface clearly rather
+// than smuggle a typed-cast panic into the resolver.
+func coerceGhVariables(v interface{}) (map[string]any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	if m, ok := v.(map[string]any); ok {
+		return m, nil
+	}
+	return nil, fmt.Errorf("gh: variables must be a JSON object or null, got %T", v)
+}
+
 // projectPullRequestsResolver implements `Project.pullRequests(state)`.
 //
 // Resolves the project's `origin` remote → `owner/repo` and delegates

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -339,6 +339,11 @@ func (r *queryResolver) WorkflowRuns(ctx context.Context, repo string) ([]*graph
 	return r.queryWorkflowRunsResolver(ctx, repo)
 }
 
+// Gh is the resolver for the gh field.
+func (r *queryResolver) Gh(ctx context.Context, query string, variables interface{}) (interface{}, error) {
+	return r.queryGhResolver(ctx, query, variables)
+}
+
 // Node is the resolver for the node field.
 //
 // The id's host segment selects the dispatch path: when it matches a

--- a/schema.graphql
+++ b/schema.graphql
@@ -27,6 +27,14 @@ interface Node {
 "RFC 3339 timestamp string. Mapped to Go's time.Time."
 scalar Time
 
+"""
+Opaque JSON value — any GraphQL-compatible type, marshalled verbatim.
+Used by `Query.gh` to forward GitHub GraphQL responses without imposing
+an orchard-side schema on them. Callers deserialise against their
+knowledge of GitHub's schema.
+"""
+scalar JSON
+
 # Process is an OS-level process surfaced via the `ps` adapter.
 type Process implements Node {
   "Stable id formatted as `<host>:<pid>`."
@@ -180,6 +188,23 @@ type Query {
 
   "Workflow runs on a GitHub repository. `repo` is `owner/name`."
   workflowRuns(repo: String!): [WorkflowRun!]
+
+  """
+  Forward an arbitrary GraphQL query to GitHub's API using the daemon's
+  configured gh credentials. The `query` argument is a GitHub-schema
+  GraphQL document (string); the returned JSON is GitHub's full envelope
+  including the `data` and any `errors` keys.
+
+  Pass-through is read-only by design: it is exposed as a Query field,
+  not a Mutation, so callers cannot bypass orchardist guardrails by
+  routing mutations through the daemon. Auth, rate limiting, and base
+  URL come from the gh provider; callers do not pass tokens.
+
+  Federation: peers can call `gh` through the peerproxy surface. The
+  result is opaque JSON on the orchard side — the consumer typecheks
+  against GitHub's schema directly.
+  """
+  gh(query: String!, variables: JSON): JSON
 
   """
   Generic node lookup by globally-unique id. Returns the node if it


### PR DESCRIPTION
## Summary

Adds `Query.gh(query: String!, variables: JSON): JSON` — an opaque GraphQL pass-through into GitHub's API using the daemon's existing gh credentials. Query string is forwarded verbatim; GitHub's full envelope (`data` + `errors` + `extensions`) returned as JSON without any orchard-side rewriting.

Lets consumers reach the full GitHub schema (mergeStateStatus, reviewDecision, labels, statusCheckRollup, ad-hoc orchardist queries, future fields) without forcing schema bumps on the daemon every time.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] 8 unit tests in `graphql_test.go` (verbatim envelope, variables forwarded, 401, 429, GitHub-level errors ride through, non-JSON, empty query, 5xx)
- [x] 3 e2e tests in `passthrough_e2e_test.go` (round-trip through daemon, variable forwarding via JSON scalar, GitHub errors preserved end-to-end)
- [ ] Manual smoke: \`orchard query 'gh(query: \"{ viewer { login } }\")'\` once the new query subcommand exists (deferred)

## Design notes

- **Read-only**: \`Query\` field, not \`Mutation\`. Mutation pass-through would bypass orchardist guardrails.
- **No caching**: query strings are arbitrary; caching by query+variables would be both surprising and trivially defeated.
- **Auth/rate-limit shaping**: 401 maps to \`ErrNotAuthenticated\`, 403 + \`X-RateLimit-Remaining: 0\` maps to \`ErrRateLimitedT\` — mirrors the REST path so the resolver surfaces identical per-field errors.
- **GitHub-level errors ride through**: \`errors[]\` in the envelope come back inside the JSON, NOT promoted to a per-field GraphQL error on orchard. Load-bearing invariant: callers must distinguish 'GitHub said no' from 'orchard couldn't reach GitHub'.
- **Federation**: peers can call this through the existing peerproxy surface. Untyped on the orchard side — peer that consumes the response does the typing against GitHub's schema directly.

## Files

- \`schema.graphql\` — \`scalar JSON\` + \`Query.gh\` field
- \`gqlgen.yml\` — JSON binds to \`graphql.Any\`
- \`internal/server/providers/gh/graphql.go\` (new) — \`Client.GraphQL\`
- \`internal/server/providers/gh/provider.go\` — \`Provider.GraphQL\` wrapper
- \`internal/server/resolvers/gh.go\` — \`queryGhResolver\` + \`coerceGhVariables\`
- \`internal/server/resolvers/schema.resolvers.go\` — thin shim
- \`internal/server/graphql/generated.go\` — gqlgen regen
- \`internal/server/providers/gh/{graphql_test.go,passthrough_e2e_test.go}\` (new) — tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub GraphQL query passthrough field that enables forwarding of arbitrary GraphQL queries to GitHub's API with optional variables, using the daemon's configured credentials, and returns the response as opaque JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->