### PR TITLE
feat(schema): top-level Query.peers + hostServices(filter:) (resolves #425)

### DIFF
--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -228,9 +228,11 @@ type ComplexityRoot struct {
 		Gh              func(childComplexity int, query string, variables interface{}) int
 		Health          func(childComplexity int) int
 		Host            func(childComplexity int) int
+		HostServices    func(childComplexity int, filter *HostServiceFilter) int
 		Hosts           func(childComplexity int) int
 		Issues          func(childComplexity int, repo string, state *IssueState) int
 		Node            func(childComplexity int, id string) int
+		Peers           func(childComplexity int) int
 		Projects        func(childComplexity int) int
 		PullRequests    func(childComplexity int, repo string, state *PullRequestState) int
 		TmuxPanes       func(childComplexity int, filter *TmuxPaneFilter) int
@@ -374,6 +376,8 @@ type QueryResolver interface {
 	Contract(ctx context.Context, id string) (*Contract, error)
 	Contracts(ctx context.Context, filter *ContractFilter) ([]*Contract, error)
 	ClaudeInstances(ctx context.Context) ([]*ClaudeInstance, error)
+	Peers(ctx context.Context) ([]*Host, error)
+	HostServices(ctx context.Context, filter *HostServiceFilter) ([]*HostService, error)
 	PullRequests(ctx context.Context, repo string, state *PullRequestState) ([]*PullRequest, error)
 	Issues(ctx context.Context, repo string, state *IssueState) ([]*Issue, error)
 	WorkflowRuns(ctx context.Context, repo string) ([]*WorkflowRun, error)
@@ -1389,6 +1393,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Host(childComplexity), true
 
+	case "Query.hostServices":
+		if e.complexity.Query.HostServices == nil {
+			break
+		}
+
+		args, err := ec.field_Query_hostServices_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.HostServices(childComplexity, args["filter"].(*HostServiceFilter)), true
+
 	case "Query.hosts":
 		if e.complexity.Query.Hosts == nil {
 			break
@@ -1419,6 +1435,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Node(childComplexity, args["id"].(string)), true
+
+	case "Query.peers":
+		if e.complexity.Query.Peers == nil {
+			break
+		}
+
+		return e.complexity.Query.Peers(childComplexity), true
 
 	case "Query.projects":
 		if e.complexity.Query.Projects == nil {
@@ -2055,6 +2078,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	ec := executionContext{rc, e, 0, 0, make(chan graphql.DeferredResult)}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputContractFilter,
+		ec.unmarshalInputHostServiceFilter,
 		ec.unmarshalInputProcessFilter,
 		ec.unmarshalInputTmuxPaneFilter,
 		ec.unmarshalInputTmuxSessionFilter,
@@ -2338,6 +2362,27 @@ type Query {
 
   "All live Claude instances the daemon is tracking via heartbeat files."
   claudeInstances: [ClaudeInstance!]!
+
+  """
+  All peer hosts known to this daemon, flattened across ` + "`" + `hosts[*].peers` + "`" + `.
+
+  Sugar for the common case where callers want every peer without
+  traversing the (currently single-element) ` + "`" + `hosts` + "`" + ` list. Equivalent to
+  ` + "`" + `{ hosts { peers { ... } } }` + "`" + ` with dedup by ` + "`" + `id` + "`" + `. The local host is not
+  itself a peer — it is ` + "`" + `Query.host` + "`" + `.
+  """
+  peers: [Host!]!
+
+  """
+  All host services known to this daemon, flattened across
+  ` + "`" + `hosts[*].hostServices` + "`" + ` and optionally filtered. Filter clauses are
+  AND-combined when multiple are set.
+
+  Sugar for the common case where callers want every service without
+  traversing ` + "`" + `hosts` + "`" + `. Per-host scoping is still available via
+  ` + "`" + `Host.hostServices` + "`" + `.
+  """
+  hostServices(filter: HostServiceFilter): [HostService!]!
 
   "Pull requests on a GitHub repository. ` + "`" + `repo` + "`" + ` is ` + "`" + `owner/name` + "`" + `."
   pullRequests(repo: String!, state: PullRequestState = OPEN): [PullRequest!]
@@ -2712,6 +2757,23 @@ input TmuxSessionFilter {
 
   "Only include sessions with active-attached clients within the freshness window."
   activeAttachedOnly: Boolean
+}
+
+"""
+Filter for ` + "`" + `Query.hostServices` + "`" + `. AND-combined when multiple are set.
+
+` + "`" + `host` + "`" + ` matches a ` + "`" + `Host.machineId` + "`" + `. ` + "`" + `name` + "`" + ` is an exact-match service
+name (no glob, no substring). ` + "`" + `state` + "`" + ` filters by lifecycle state.
+"""
+input HostServiceFilter {
+  "Match services on this host machine id."
+  host: String
+
+  "Exact service name (e.g. \"com.gitorchard.orchard\")."
+  name: String
+
+  "Lifecycle state."
+  state: HostServiceState
 }
 
 "Filter for ` + "`" + `Query.tmuxPanes` + "`" + `. AND-combined when multiple are set."
@@ -3153,6 +3215,21 @@ func (ec *executionContext) field_Query_gh_args(ctx context.Context, rawArgs map
 		}
 	}
 	args["variables"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_hostServices_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *HostServiceFilter
+	if tmp, ok := rawArgs["filter"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("filter"))
+		arg0, err = ec.unmarshalOHostServiceFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceFilter(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["filter"] = arg0
 	return args, nil
 }
 
@@ -9847,6 +9924,147 @@ func (ec *executionContext) fieldContext_Query_claudeInstances(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_peers(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_peers(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Peers(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*Host)
+	fc.Result = res
+	return ec.marshalNHost2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_peers(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Host_id(ctx, field)
+			case "machineId":
+				return ec.fieldContext_Host_machineId(ctx, field)
+			case "hostname":
+				return ec.fieldContext_Host_hostname(ctx, field)
+			case "os":
+				return ec.fieldContext_Host_os(ctx, field)
+			case "kernel":
+				return ec.fieldContext_Host_kernel(ctx, field)
+			case "address":
+				return ec.fieldContext_Host_address(ctx, field)
+			case "reachable":
+				return ec.fieldContext_Host_reachable(ctx, field)
+			case "resourceLoad":
+				return ec.fieldContext_Host_resourceLoad(ctx, field)
+			case "lastSeenAt":
+				return ec.fieldContext_Host_lastSeenAt(ctx, field)
+			case "peers":
+				return ec.fieldContext_Host_peers(ctx, field)
+			case "processes":
+				return ec.fieldContext_Host_processes(ctx, field)
+			case "hostServices":
+				return ec.fieldContext_Host_hostServices(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_hostServices(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_hostServices(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().HostServices(rctx, fc.Args["filter"].(*HostServiceFilter))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*HostService)
+	fc.Result = res
+	return ec.marshalNHostService2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_hostServices(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_HostService_id(ctx, field)
+			case "host":
+				return ec.fieldContext_HostService_host(ctx, field)
+			case "name":
+				return ec.fieldContext_HostService_name(ctx, field)
+			case "state":
+				return ec.fieldContext_HostService_state(ctx, field)
+			case "since":
+				return ec.fieldContext_HostService_since(ctx, field)
+			case "exitCode":
+				return ec.fieldContext_HostService_exitCode(ctx, field)
+			case "logTail":
+				return ec.fieldContext_HostService_logTail(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type HostService", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_hostServices_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_pullRequests(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_pullRequests(ctx, field)
 	if err != nil {
@@ -16033,6 +16251,47 @@ func (ec *executionContext) unmarshalInputContractFilter(ctx context.Context, ob
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputHostServiceFilter(ctx context.Context, obj interface{}) (HostServiceFilter, error) {
+	var it HostServiceFilter
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"host", "name", "state"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "host":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("host"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Host = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "state":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("state"))
+			data, err := ec.unmarshalOHostServiceState2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceState(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.State = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputProcessFilter(ctx context.Context, obj interface{}) (ProcessFilter, error) {
 	var it ProcessFilter
 	asMap := map[string]interface{}{}
@@ -17824,6 +18083,50 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_claudeInstances(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "peers":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_peers(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "hostServices":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_hostServices(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -21604,6 +21907,30 @@ func (ec *executionContext) marshalOFloat2ᚖfloat64(ctx context.Context, sel as
 	}
 	res := graphql.MarshalFloatContext(*v)
 	return graphql.WrapContextMarshaler(ctx, res)
+}
+
+func (ec *executionContext) unmarshalOHostServiceFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceFilter(ctx context.Context, v interface{}) (*HostServiceFilter, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputHostServiceFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOHostServiceState2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceState(ctx context.Context, v interface{}) (*HostServiceState, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(HostServiceState)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOHostServiceState2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceState(ctx context.Context, sel ast.SelectionSet, v *HostServiceState) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) unmarshalOID2ᚖstring(ctx context.Context, v interface{}) (*string, error) {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -255,6 +255,19 @@ func (HostService) IsNode() {}
 // Globally-unique id (e.g. "Host:<machineId>").
 func (this HostService) GetID() string { return this.ID }
 
+// Filter for `Query.hostServices`. AND-combined when multiple are set.
+//
+// `host` matches a `Host.machineId`. `name` is an exact-match service
+// name (no glob, no substring). `state` filters by lifecycle state.
+type HostServiceFilter struct {
+	// Match services on this host machine id.
+	Host *string `json:"host,omitempty"`
+	// Exact service name (e.g. "com.gitorchard.orchard").
+	Name *string `json:"name,omitempty"`
+	// Lifecycle state.
+	State *HostServiceState `json:"state,omitempty"`
+}
+
 // An issue on a GitHub repository. Pull requests are excluded.
 type Issue struct {
 	ID          string          `json:"id"`

--- a/internal/server/providers/peerproxy/peerproxy_e2e_test.go
+++ b/internal/server/providers/peerproxy/peerproxy_e2e_test.go
@@ -188,6 +188,67 @@ func TestPeers_Reachable(t *testing.T) {
 	}
 }
 
+// TestQueryPeers_TopLevel boots a local daemon with one configured
+// peer and asserts the top-level `Query.peers` aggregate returns that
+// peer without traversing `hosts`. This is the AC for #425: callers
+// should not have to thread through `hosts[0].peers`.
+func TestQueryPeers_TopLevel(t *testing.T) {
+	remote := startOrchard(t, peerproxy.FederationConfig{})
+	local := startOrchard(t, peerproxy.FederationConfig{
+		Peers: []peerproxy.PeerConfig{
+			{Name: remoteName, Address: remote.addr},
+		},
+	})
+
+	// Poll the top-level `peers` field — same flat shape as
+	// `tmuxSessions` and `claudeInstances`. Local has one peer, so the
+	// flat aggregate must surface exactly that peer.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		envelope := graphQLPost(t, local,
+			`{ peers { id hostname address reachable } }`)
+		if errs, ok := envelope["errors"].([]any); ok && len(errs) > 0 {
+			t.Fatalf("graphql errors: %v", errs)
+		}
+		data, _ := envelope["data"].(map[string]any)
+		peers, _ := data["peers"].([]any)
+		if len(peers) == 1 {
+			peer := peers[0].(map[string]any)
+			if peer["id"] != "Host:"+remoteName {
+				t.Fatalf("unexpected peer id %v", peer["id"])
+			}
+			if peer["hostname"] != remoteName {
+				t.Fatalf("unexpected hostname %v", peer["hostname"])
+			}
+			if peer["reachable"] == true {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("top-level peers never surfaced reachable peer; envelope=%v", envelope)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// TestQueryHostServices_TopLevel asserts `Query.hostServices` returns
+// the same shape as `host.hostServices` on a daemon with no
+// hostservice provider wired (defaulting to an empty list). Even with
+// no services the flat field must not error.
+func TestQueryHostServices_TopLevel(t *testing.T) {
+	local := startOrchard(t, peerproxy.FederationConfig{})
+
+	envelope := graphQLPost(t, local,
+		`{ hostServices { id name state } }`)
+	if errs, ok := envelope["errors"].([]any); ok && len(errs) > 0 {
+		t.Fatalf("graphql errors: %v", errs)
+	}
+	data, _ := envelope["data"].(map[string]any)
+	if _, ok := data["hostServices"].([]any); !ok {
+		t.Fatalf("expected hostServices array, got %v", data)
+	}
+}
+
 // TestNode_ProxiedLookup queries `node(id: "TmuxPane:<remote>:%26")`
 // against the local daemon and asserts the response was forwarded —
 // the typename + id come back from the remote, not from a local

--- a/internal/server/resolvers/host_aggregation.go
+++ b/internal/server/resolvers/host_aggregation.go
@@ -1,0 +1,39 @@
+// Helpers used by the top-level aggregate resolvers (Query.peers,
+// Query.hostServices). Kept separate from schema.resolvers.go so gqlgen
+// does not rewrite them when the schema regenerates.
+package resolvers
+
+import (
+	"strings"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// hostServiceMatchesFilter applies a HostServiceFilter to a single
+// HostService. A nil filter matches everything. Multiple filter fields
+// are AND-combined.
+//
+// `host` matches `Host.machineId` exactly. `name` is exact-match.
+// `state` is the lifecycle enum.
+func hostServiceMatchesFilter(svc *graphql1.HostService, filter *graphql1.HostServiceFilter) bool {
+	if filter == nil || svc == nil {
+		return svc != nil
+	}
+	if filter.Host != nil {
+		want := strings.TrimSpace(*filter.Host)
+		got := ""
+		if svc.Host != nil {
+			got = svc.Host.MachineID
+		}
+		if want != got {
+			return false
+		}
+	}
+	if filter.Name != nil && *filter.Name != svc.Name {
+		return false
+	}
+	if filter.State != nil && *filter.State != svc.State {
+		return false
+	}
+	return true
+}

--- a/internal/server/resolvers/host_aggregation_test.go
+++ b/internal/server/resolvers/host_aggregation_test.go
@@ -1,0 +1,104 @@
+package resolvers
+
+import (
+	"testing"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// strPtr returns a pointer to the given string. Local helper to keep the
+// test cases short.
+func strPtr(s string) *string { return &s }
+
+// statePtr returns a pointer to the given HostServiceState.
+func statePtr(s graphql1.HostServiceState) *graphql1.HostServiceState { return &s }
+
+// fixtureHostService builds a HostService bound to a host with the given
+// machine id, name, and state.
+func fixtureHostService(host, name string, state graphql1.HostServiceState) *graphql1.HostService {
+	return &graphql1.HostService{
+		ID:    "HostService:" + host + ":" + name,
+		Host:  &graphql1.Host{ID: "Host:" + host, MachineID: host},
+		Name:  name,
+		State: state,
+	}
+}
+
+func TestHostServiceMatchesFilter_NilFilter(t *testing.T) {
+	svc := fixtureHostService("local", "orchard", graphql1.HostServiceStateActive)
+	if !hostServiceMatchesFilter(svc, nil) {
+		t.Fatal("nil filter should pass-through")
+	}
+}
+
+func TestHostServiceMatchesFilter_NilService(t *testing.T) {
+	if hostServiceMatchesFilter(nil, nil) {
+		t.Fatal("nil service must never match")
+	}
+}
+
+func TestHostServiceMatchesFilter_HostMatch(t *testing.T) {
+	svc := fixtureHostService("local-machine", "orchard", graphql1.HostServiceStateActive)
+	if !hostServiceMatchesFilter(svc, &graphql1.HostServiceFilter{Host: strPtr("local-machine")}) {
+		t.Fatal("host match must keep the service")
+	}
+	if hostServiceMatchesFilter(svc, &graphql1.HostServiceFilter{Host: strPtr("other")}) {
+		t.Fatal("non-matching host must drop the service")
+	}
+}
+
+func TestHostServiceMatchesFilter_NameExactMatch(t *testing.T) {
+	svc := fixtureHostService("local", "com.gitorchard.orchard", graphql1.HostServiceStateActive)
+	if !hostServiceMatchesFilter(svc, &graphql1.HostServiceFilter{Name: strPtr("com.gitorchard.orchard")}) {
+		t.Fatal("exact name match must keep")
+	}
+	if hostServiceMatchesFilter(svc, &graphql1.HostServiceFilter{Name: strPtr("orchard")}) {
+		t.Fatal("substring name must NOT match (filter is exact)")
+	}
+}
+
+func TestHostServiceMatchesFilter_State(t *testing.T) {
+	svc := fixtureHostService("local", "orchard", graphql1.HostServiceStateFailed)
+	if !hostServiceMatchesFilter(svc, &graphql1.HostServiceFilter{State: statePtr(graphql1.HostServiceStateFailed)}) {
+		t.Fatal("matching state must keep")
+	}
+	if hostServiceMatchesFilter(svc, &graphql1.HostServiceFilter{State: statePtr(graphql1.HostServiceStateActive)}) {
+		t.Fatal("non-matching state must drop")
+	}
+}
+
+func TestHostServiceMatchesFilter_AndCombined(t *testing.T) {
+	svc := fixtureHostService("local", "com.gitorchard.orchard", graphql1.HostServiceStateActive)
+	all := &graphql1.HostServiceFilter{
+		Host:  strPtr("local"),
+		Name:  strPtr("com.gitorchard.orchard"),
+		State: statePtr(graphql1.HostServiceStateActive),
+	}
+	if !hostServiceMatchesFilter(svc, all) {
+		t.Fatal("all filters matching should keep")
+	}
+	mismatch := &graphql1.HostServiceFilter{
+		Host:  strPtr("local"),
+		Name:  strPtr("com.gitorchard.orchard"),
+		State: statePtr(graphql1.HostServiceStateInactive),
+	}
+	if hostServiceMatchesFilter(svc, mismatch) {
+		t.Fatal("any non-matching field should drop (AND semantics)")
+	}
+}
+
+func TestHostServiceMatchesFilter_HostMissingHostRef(t *testing.T) {
+	// A HostService without a host ref (defensive — shouldn't happen in
+	// practice) does not match a host filter.
+	svc := &graphql1.HostService{
+		ID:    "HostService:?:orphan",
+		Name:  "orphan",
+		State: graphql1.HostServiceStateUnknown,
+	}
+	if hostServiceMatchesFilter(svc, &graphql1.HostServiceFilter{Host: strPtr("local")}) {
+		t.Fatal("orphaned service must not satisfy a host filter")
+	}
+	if !hostServiceMatchesFilter(svc, nil) {
+		t.Fatal("orphaned service still matches a nil filter")
+	}
+}

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Peers is the resolver for the peers field.
-func (r *hostResolver) Peers(_ context.Context, obj *graphql1.Host) ([]*graphql1.Host, error) {
+func (r *hostResolver) Peers(ctx context.Context, obj *graphql1.Host) ([]*graphql1.Host, error) {
 	if r.PeerProxy == nil {
 		return []*graphql1.Host{}, nil
 	}
@@ -324,6 +324,60 @@ func (r *queryResolver) ClaudeInstances(ctx context.Context) ([]*graphql1.Claude
 	return r.ClaudeInstance.List(ctx)
 }
 
+// Peers is the resolver for the peers field.
+func (r *queryResolver) Peers(ctx context.Context) ([]*graphql1.Host, error) {
+	hosts, err := r.Query().Hosts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	hostRes := r.Resolver.Host()
+	seen := make(map[string]struct{})
+	out := make([]*graphql1.Host, 0)
+	for _, h := range hosts {
+		peers, err := hostRes.Peers(ctx, h)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range peers {
+			if p == nil {
+				continue
+			}
+			if _, dup := seen[p.ID]; dup {
+				continue
+			}
+			seen[p.ID] = struct{}{}
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// HostServices is the resolver for the hostServices field.
+func (r *queryResolver) HostServices(ctx context.Context, filter *graphql1.HostServiceFilter) ([]*graphql1.HostService, error) {
+	hosts, err := r.Query().Hosts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{})
+	out := make([]*graphql1.HostService, 0)
+	for _, h := range hosts {
+		for _, svc := range h.HostServices {
+			if svc == nil {
+				continue
+			}
+			if !hostServiceMatchesFilter(svc, filter) {
+				continue
+			}
+			if _, dup := seen[svc.ID]; dup {
+				continue
+			}
+			seen[svc.ID] = struct{}{}
+			out = append(out, svc)
+		}
+	}
+	return out, nil
+}
+
 // PullRequests is the resolver for the pullRequests field.
 func (r *queryResolver) PullRequests(ctx context.Context, repo string, state *graphql1.PullRequestState) ([]*graphql1.PullRequest, error) {
 	return r.queryPullRequestsResolver(ctx, repo, state)
@@ -345,15 +399,6 @@ func (r *queryResolver) Gh(ctx context.Context, query string, variables interfac
 }
 
 // Node is the resolver for the node field.
-//
-// The id's host segment selects the dispatch path: when it matches a
-// configured peer, the peerproxy provider forwards the lookup to that
-// remote daemon and the response is materialised back into a stub
-// Node carrying the typename + id. Otherwise the lookup falls through
-// to the local providers via resolveNode; ids whose host segment
-// matches no configured peer and no local provider also return a
-// best-effort stub so callers see a sensible answer instead of an
-// error.
 func (r *queryResolver) Node(ctx context.Context, id string) (graphql1.Node, error) {
 	if r.PeerProxy != nil {
 		host := peerproxy.HostFromNodeID(id)
@@ -417,38 +462,6 @@ func (r *subscriptionResolver) Peer(ctx context.Context, host string) (<-chan gr
 			}
 			select {
 			case out <- projected:
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-	return out, nil
-}
-
-func (r *subscriptionResolver) streamLocalEvents(ctx context.Context) (<-chan graphql1.Node, error) {
-	if r.LocalEvents == nil {
-		out := make(chan graphql1.Node)
-		go func() {
-			<-ctx.Done()
-			close(out)
-		}()
-		return out, nil
-	}
-	stream := r.LocalEvents.Subscribe(ctx)
-	out := make(chan graphql1.Node, 16)
-	go func() {
-		defer close(out)
-		for ev := range stream {
-			id := string(ev.NodeID)
-			if id == "" {
-				continue
-			}
-			node, err := projectLocalInvalidation(id)
-			if err != nil || node == nil {
-				continue
-			}
-			select {
-			case out <- node:
 			case <-ctx.Done():
 				return
 			}
@@ -984,6 +997,37 @@ type worktreeResolver struct{ *Resolver }
 //   - When renaming or deleting a resolver the old code will be put in here. You can safely delete
 //     it when you're done.
 //   - You have helper methods in this file. Move them out to keep these resolver files clean.
+func (r *subscriptionResolver) streamLocalEvents(ctx context.Context) (<-chan graphql1.Node, error) {
+	if r.LocalEvents == nil {
+		out := make(chan graphql1.Node)
+		go func() {
+			<-ctx.Done()
+			close(out)
+		}()
+		return out, nil
+	}
+	stream := r.LocalEvents.Subscribe(ctx)
+	out := make(chan graphql1.Node, 16)
+	go func() {
+		defer close(out)
+		for ev := range stream {
+			id := string(ev.NodeID)
+			if id == "" {
+				continue
+			}
+			node, err := projectLocalInvalidation(id)
+			if err != nil || node == nil {
+				continue
+			}
+			select {
+			case out <- node:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}
 func buildHostServices(ctx context.Context, p *hostservice.Provider, hostID string) []*graphql1.HostService {
 	services := p.Services()
 	out := make([]*graphql1.HostService, 0, len(services))

--- a/schema.graphql
+++ b/schema.graphql
@@ -180,6 +180,27 @@ type Query {
   "All live Claude instances the daemon is tracking via heartbeat files."
   claudeInstances: [ClaudeInstance!]!
 
+  """
+  All peer hosts known to this daemon, flattened across `hosts[*].peers`.
+
+  Sugar for the common case where callers want every peer without
+  traversing the (currently single-element) `hosts` list. Equivalent to
+  `{ hosts { peers { ... } } }` with dedup by `id`. The local host is not
+  itself a peer — it is `Query.host`.
+  """
+  peers: [Host!]!
+
+  """
+  All host services known to this daemon, flattened across
+  `hosts[*].hostServices` and optionally filtered. Filter clauses are
+  AND-combined when multiple are set.
+
+  Sugar for the common case where callers want every service without
+  traversing `hosts`. Per-host scoping is still available via
+  `Host.hostServices`.
+  """
+  hostServices(filter: HostServiceFilter): [HostService!]!
+
   "Pull requests on a GitHub repository. `repo` is `owner/name`."
   pullRequests(repo: String!, state: PullRequestState = OPEN): [PullRequest!]
 
@@ -553,6 +574,23 @@ input TmuxSessionFilter {
 
   "Only include sessions with active-attached clients within the freshness window."
   activeAttachedOnly: Boolean
+}
+
+"""
+Filter for `Query.hostServices`. AND-combined when multiple are set.
+
+`host` matches a `Host.machineId`. `name` is an exact-match service
+name (no glob, no substring). `state` filters by lifecycle state.
+"""
+input HostServiceFilter {
+  "Match services on this host machine id."
+  host: String
+
+  "Exact service name (e.g. \"com.gitorchard.orchard\")."
+  name: String
+
+  "Lifecycle state."
+  state: HostServiceState
 }
 
 "Filter for `Query.tmuxPanes`. AND-combined when multiple are set."


### PR DESCRIPTION
## Summary
- Added top-level `Query.peers: [Host!]!` and `Query.hostServices(filter: HostServiceFilter): [HostService!]!` so federation/service queries don't have to thread through `hosts[0].something`. Flat aggregates match `tmuxSessions` / `claudeInstances`.
- Defined `HostServiceFilter { host, name, state }` (AND-combined) for resolver-layer filtering.
- Resolvers aggregate via the existing `Query.hosts` + `Host.peers` / `Host.hostServices` resolvers with dedup by id. Future multi-host expansion is host-loop-friendly.
- Backward compatible: existing `{ hosts { peers { ... } } }` and `{ hosts { hostServices { ... } } }` queries are untouched.

## Test plan
- [x] Unit tests for the filter helper — host/name/state semantics + AND-combination + nil cases (`internal/server/resolvers/host_aggregation_test.go`)
- [x] E2E test for top-level `{ peers { ... } }` against a configured peer via the peerproxy fixture (`internal/server/providers/peerproxy/peerproxy_e2e_test.go`)
- [x] E2E smoke test for top-level `{ hostServices { ... } }` returns an array
- [x] Manual `curl` against a freshly-built daemon confirmed all five filter combinations (none / name / state / host / non-matching host) and that nested `hosts { peers { ... } }` still works
- [x] `go vet` and `go test ./...` clean
- [x] `cargo build -p orchard` clean (Rust TUI re-derived schema.json unchanged — its wire format is JsonOutput, not GraphQL introspection)
- [x] `go run github.com/99designs/gqlgen generate` produces the committed `generated.go` / `models_gen.go` cleanly (one stale multi-line Go doc comment on the existing `Query.Node` resolver had to collapse to its single-line form so gqlgen's resolver-rewriter could roundtrip the file — schema docs already cover the same content)

Resolves #425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new root-level GraphQL query for peers, aggregating peer hosts across all hosts.
  * Added new root-level GraphQL query for host services with optional filtering by host identifier, service name, and state.

* **Tests**
  * Added end-to-end tests verifying the new peer and host services queries.
  * Added unit tests for service filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #425