### PR TITLE
feat(dispatcher): orchard CLI dispatcher binary (ADR-013 step 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,6 +2930,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "orchard-dispatcher"
+version = "0.1.0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "orchard-gui"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/orchard",
+    "crates/orchard-dispatcher",
     "crates/orchard-gui/src-tauri",
     "crates/worktree-core",
 ]

--- a/crates/orchard-dispatcher/Cargo.toml
+++ b/crates/orchard-dispatcher/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "orchard-dispatcher"
+version = "0.1.0"
+edition = "2024"
+description = "Thin dispatcher for the orchard CLI ecosystem (routes to orchard-tui, orchard-daemon, orchard-worktree, etc.)"
+license = "MIT"
+repository = "https://github.com/drewdrewthis/git-orchard-rs"
+
+[[bin]]
+name = "orchard"
+path = "src/main.rs"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/orchard-dispatcher/src/main.rs
+++ b/crates/orchard-dispatcher/src/main.rs
@@ -1,0 +1,231 @@
+//! `orchard` — thin dispatcher for the Orchard CLI ecosystem.
+//!
+//! Implements the `git`/`cargo`/`kubectl` dispatcher pattern: this binary owns
+//! the user-facing `orchard` name, parses the first positional argument, and
+//! execs the matching helper binary (`orchard-tui`, `orchard-daemon`,
+//! `orchard-worktree`, `orchard-chat`) with the remaining arguments.
+//!
+//! Bare-verb shortcuts (`orchard new <N>` ≡ `orchard worktree new <N>`) are
+//! reserved for the worktree primary unit per ADR-013. Adding a second primary
+//! unit requires a new ADR.
+//!
+//! # Discovery rule
+//!
+//! For a verb `V`, the dispatcher searches for `orchard-V` in this order:
+//!
+//! 1. The directory containing the `orchard` executable itself (bundled
+//!    install — `brew install orchard` puts every binary in the same `bin/`).
+//! 2. `$PATH` (third-party plugins, matching `kubectl`'s plugin model).
+//!
+//! Found-first wins. This avoids accidentally invoking a stale `$PATH` entry
+//! when the bundled binary is what the user installed.
+//!
+//! # Why no clap
+//!
+//! The dispatcher must NOT parse helper-binary arguments — it just forwards
+//! them. Using a CLI framework would invite incidental coupling. Hand-rolled
+//! argv handling keeps this file small and the dispatch contract obvious.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::{Command, ExitCode};
+
+/// Bare-verb shortcuts that resolve to the worktree primary unit.
+///
+/// Per ADR-013: only the project's primary unit gets bare verbs. Adding a
+/// second primary unit (e.g. remotes becoming first-class) requires a new ADR.
+const WORKTREE_BARE_VERBS: &[&str] = &["new", "rm", "prune", "mv", "ls", "path"];
+
+/// Verbs that map directly to a helper binary `orchard-<verb>`.
+const NAMESPACE_VERBS: &[&str] = &["tui", "daemon", "worktree", "chat"];
+
+const HELP: &str = "\
+orchard — Git worktree, tmux session, and PR dashboard.
+
+Usage:
+  orchard                       Open the TUI dashboard (default).
+  orchard <command> [args...]   Run a subcommand.
+  orchard --help                Show this help.
+  orchard --version             Show dispatcher version.
+
+Commands:
+  tui                           Run the TUI dashboard explicitly.
+  daemon <subcmd>               Manage the daemon (start, stop, status, ...).
+  worktree <subcmd>             Manage worktrees (new, rm, prune, mv, ls, path).
+  chat <subcmd>                 Agent-to-agent chat (send, broadcast, tail).
+
+Worktree shortcuts (the worktree is Orchard's primary unit):
+  orchard new <issue>           ≡ orchard worktree new <issue>
+  orchard rm <id>               ≡ orchard worktree rm <id>
+  orchard prune [filter]        ≡ orchard worktree prune [filter]
+  orchard mv <id> <host>        ≡ orchard worktree mv <id> <host>
+  orchard ls [--json]           ≡ orchard worktree ls [--json]
+  orchard path <id>             ≡ orchard worktree path <id>
+
+Discovery:
+  Helper binaries are looked up first in the directory containing this
+  `orchard` executable, then on $PATH. See ADR-013 for details.
+";
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn main() -> ExitCode {
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    match args.first().map(String::as_str) {
+        None => exec("tui", &[]),
+        Some("--help" | "-h") => {
+            print!("{HELP}");
+            ExitCode::SUCCESS
+        }
+        Some("--version" | "-V") => {
+            println!("orchard {VERSION}");
+            ExitCode::SUCCESS
+        }
+        Some(verb) if WORKTREE_BARE_VERBS.contains(&verb) => {
+            // `orchard new 412` → `orchard-worktree new 412`
+            let mut forwarded = vec![verb.to_string()];
+            forwarded.extend(args.iter().skip(1).cloned());
+            exec("worktree", &forwarded)
+        }
+        Some(verb) if NAMESPACE_VERBS.contains(&verb) => {
+            let forwarded: Vec<String> = args.iter().skip(1).cloned().collect();
+            exec(verb, &forwarded)
+        }
+        Some(verb) => {
+            // Unknown verb — try to dispatch anyway so third-party plugins on
+            // $PATH can resolve. If no binary exists, the resolver below
+            // surfaces the error.
+            let forwarded: Vec<String> = args.iter().skip(1).cloned().collect();
+            exec(verb, &forwarded)
+        }
+    }
+}
+
+/// Executes `orchard-<verb>` with `forwarded` as its arguments.
+///
+/// On `Err` resolving the binary, prints a clear message to stderr and exits
+/// with a non-zero code. On successful exec, returns the child's exit code.
+fn exec(verb: &str, forwarded: &[String]) -> ExitCode {
+    let binary_name = format!("orchard-{verb}");
+    let resolved = match resolve_helper(&binary_name) {
+        Some(path) => path,
+        None => {
+            eprintln!(
+                "orchard: unknown command '{verb}'.\n\
+                 No '{binary_name}' found beside the orchard binary or on $PATH.\n\
+                 Run 'orchard --help' to see available commands."
+            );
+            return ExitCode::from(127);
+        }
+    };
+
+    let status = Command::new(&resolved).args(forwarded).status();
+
+    match status {
+        Ok(s) => match s.code() {
+            Some(code) => ExitCode::from(code as u8),
+            None => ExitCode::from(1),
+        },
+        Err(e) => {
+            eprintln!("orchard: failed to exec '{}': {}", resolved.display(), e);
+            ExitCode::from(126)
+        }
+    }
+}
+
+/// Resolves a helper binary by name.
+///
+/// Search order:
+/// 1. Directory containing the running `orchard` executable.
+/// 2. Each entry of `$PATH`.
+fn resolve_helper(binary_name: &str) -> Option<PathBuf> {
+    if let Ok(self_path) = env::current_exe()
+        && let Some(dir) = self_path.parent()
+    {
+        let candidate = dir.join(binary_name);
+        if is_executable(&candidate) {
+            return Some(candidate);
+        }
+    }
+
+    if let Some(path) = env::var_os("PATH") {
+        for dir in env::split_paths(&path) {
+            let candidate = dir.join(binary_name);
+            if is_executable(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}
+
+/// Reports whether `path` exists and is executable by the current user.
+fn is_executable(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata()
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worktree_bare_verbs_do_not_collide_with_namespace_verbs() {
+        for v in WORKTREE_BARE_VERBS {
+            assert!(
+                !NAMESPACE_VERBS.contains(v),
+                "bare verb '{v}' must not also be a namespace verb (would create ambiguity)"
+            );
+        }
+    }
+
+    #[test]
+    fn worktree_bare_verbs_match_adr() {
+        // ADR-013 §3 specifies the exact set; if this list changes, update the ADR too.
+        assert_eq!(
+            WORKTREE_BARE_VERBS,
+            &["new", "rm", "prune", "mv", "ls", "path"]
+        );
+    }
+
+    #[test]
+    fn namespace_verbs_match_adr() {
+        // ADR-013 §2 lists the helper binaries — the dispatcher routes to each.
+        assert_eq!(NAMESPACE_VERBS, &["tui", "daemon", "worktree", "chat"]);
+    }
+
+    #[test]
+    fn help_lists_all_namespace_verbs() {
+        for v in NAMESPACE_VERBS {
+            assert!(
+                HELP.contains(&format!("  {v}")) || HELP.contains(&format!("  {v} ")),
+                "HELP must document the '{v}' verb"
+            );
+        }
+    }
+
+    #[test]
+    fn help_lists_all_bare_verbs() {
+        for v in WORKTREE_BARE_VERBS {
+            assert!(
+                HELP.contains(&format!("orchard {v} ")) || HELP.contains(&format!("orchard {v}\n")),
+                "HELP must document the bare verb '{v}'"
+            );
+        }
+    }
+
+    #[test]
+    fn is_executable_returns_false_for_nonexistent_path() {
+        assert!(!is_executable(std::path::Path::new("/this/does/not/exist")));
+    }
+
+    #[test]
+    fn is_executable_returns_true_for_known_executable() {
+        // /bin/sh is on every UNIX-like system the dispatcher targets.
+        assert!(is_executable(std::path::Path::new("/bin/sh")));
+    }
+}

--- a/crates/orchard-dispatcher/src/main.rs
+++ b/crates/orchard-dispatcher/src/main.rs
@@ -27,6 +27,7 @@
 //! argv handling keeps this file small and the dispatch contract obvious.
 
 use std::env;
+use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::{Command, ExitCode};
 
@@ -75,11 +76,13 @@ fn main() -> ExitCode {
     match args.first().map(String::as_str) {
         None => exec("tui", &[]),
         Some("--help" | "-h") => {
-            print!("{HELP}");
+            // Ignore broken-pipe so `orchard --help | head` exits cleanly
+            // instead of panicking with "failed printing to stdout".
+            let _ = io::stdout().write_all(HELP.as_bytes());
             ExitCode::SUCCESS
         }
         Some("--version" | "-V") => {
-            println!("orchard {VERSION}");
+            let _ = writeln!(io::stdout(), "orchard {VERSION}");
             ExitCode::SUCCESS
         }
         Some(verb) if WORKTREE_BARE_VERBS.contains(&verb) => {
@@ -123,15 +126,31 @@ fn exec(verb: &str, forwarded: &[String]) -> ExitCode {
     let status = Command::new(&resolved).args(forwarded).status();
 
     match status {
-        Ok(s) => match s.code() {
-            Some(code) => ExitCode::from(code as u8),
-            None => ExitCode::from(1),
-        },
+        Ok(s) => ExitCode::from(child_exit_code(&s)),
         Err(e) => {
             eprintln!("orchard: failed to exec '{}': {}", resolved.display(), e);
             ExitCode::from(126)
         }
     }
+}
+
+/// Maps a child's `ExitStatus` to a `u8` exit code.
+///
+/// On Unix, signal-killed children encode as `128 + signum` (POSIX shell
+/// convention — `kill -9` → 137). Normal exits return their status code.
+/// On non-Unix or when neither is available, returns 1 as a fallback.
+fn child_exit_code(status: &std::process::ExitStatus) -> u8 {
+    if let Some(code) = status.code() {
+        return code as u8;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signum) = status.signal() {
+            return (128 + (signum as u32 & 0x7f)) as u8;
+        }
+    }
+    1
 }
 
 /// Resolves a helper binary by name.
@@ -162,11 +181,18 @@ fn resolve_helper(binary_name: &str) -> Option<PathBuf> {
 }
 
 /// Reports whether `path` exists and is executable by the current user.
+#[cfg(unix)]
 fn is_executable(path: &std::path::Path) -> bool {
     use std::os::unix::fs::PermissionsExt;
     path.metadata()
         .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
         .unwrap_or(false)
+}
+
+/// Windows fallback: existence-check only (no posix permission bits).
+#[cfg(not(unix))]
+fn is_executable(path: &std::path::Path) -> bool {
+    path.metadata().map(|m| m.is_file()).unwrap_or(false)
 }
 
 #[cfg(test)]

--- a/crates/orchard-dispatcher/tests/dispatch.rs
+++ b/crates/orchard-dispatcher/tests/dispatch.rs
@@ -119,6 +119,31 @@ fn child_exit_code_is_propagated() {
 }
 
 #[test]
+fn signal_killed_child_returns_128_plus_signum() {
+    // SIGTERM = 15 → expected exit code 143 (POSIX convention).
+    let dir = tempfile::TempDir::with_prefix("orchard-signal-test").expect("dir");
+    let dispatcher_dest = dir.path().join("orchard");
+    fs::copy(dispatcher_path(), &dispatcher_dest).expect("copy dispatcher");
+    fs::set_permissions(&dispatcher_dest, fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Helper that kills itself with SIGTERM.
+    let helper = dir.path().join("orchard-signal");
+    fs::write(&helper, "#!/bin/sh\nkill -15 $$\n").unwrap();
+    fs::set_permissions(&helper, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = Command::new(&dispatcher_dest)
+        .args(["signal"])
+        .env("PATH", "")
+        .output()
+        .expect("run dispatcher");
+    let code = output.status.code().unwrap_or(-1);
+    assert_eq!(
+        code, 143,
+        "SIGTERM-killed child should return 128+15=143; got {code}"
+    );
+}
+
+#[test]
 fn unknown_verb_returns_127_when_no_helper_exists() {
     let dir = with_helpers(&[]); // no helpers at all
     let (_stdout, stderr, code) = run_dispatcher(dir.path(), &["nonexistent"]);
@@ -132,8 +157,7 @@ fn unknown_verb_returns_127_when_no_helper_exists() {
 #[test]
 fn unknown_verb_dispatches_to_third_party_plugin_on_path() {
     // Plugin lives in a SEPARATE dir from the dispatcher; only PATH points to it.
-    let plugin_dir =
-        tempfile::TempDir::with_prefix("orchard-plugin-test").expect("plugin dir");
+    let plugin_dir = tempfile::TempDir::with_prefix("orchard-plugin-test").expect("plugin dir");
     let plugin = plugin_dir.path().join("orchard-myplugin");
     fs::write(
         &plugin,

--- a/crates/orchard-dispatcher/tests/dispatch.rs
+++ b/crates/orchard-dispatcher/tests/dispatch.rs
@@ -1,0 +1,190 @@
+//! Integration tests for the orchard dispatcher.
+//!
+//! Exercises real-process dispatch: builds a temporary `orchard-foo` shell-script
+//! "helper" next to a copy of the dispatcher, runs the dispatcher, and asserts
+//! on the helper's observed behavior (stdout, exit code, argv echo).
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Path to the built dispatcher binary.
+fn dispatcher_path() -> PathBuf {
+    // CARGO sets CARGO_BIN_EXE_<name> for binaries in the package.
+    PathBuf::from(env!("CARGO_BIN_EXE_orchard"))
+}
+
+/// Creates a temp dir, copies the dispatcher into it, and writes
+/// `orchard-<name>` shell-script helpers that echo their argv to stdout and
+/// exit with `exit_code`. Returns the temp dir path; the caller drops it.
+fn with_helpers(helpers: &[(&str, i32)]) -> tempfile::TempDir {
+    let dir = tempfile::TempDir::with_prefix("orchard-dispatcher-test")
+        .expect("failed to create temp dir");
+    let dispatcher_dest = dir.path().join("orchard");
+    fs::copy(dispatcher_path(), &dispatcher_dest).expect("copy dispatcher");
+    let mut perms = fs::metadata(&dispatcher_dest).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&dispatcher_dest, perms).unwrap();
+
+    for (name, exit_code) in helpers {
+        let helper_path = dir.path().join(format!("orchard-{name}"));
+        let script = format!("#!/bin/sh\necho \"[helper:{name}] argv=$*\"\nexit {exit_code}\n");
+        fs::write(&helper_path, script).expect("write helper");
+        fs::set_permissions(&helper_path, fs::Permissions::from_mode(0o755)).expect("chmod helper");
+    }
+    dir
+}
+
+fn run_dispatcher(dir: &Path, args: &[&str]) -> (String, String, i32) {
+    let dispatcher = dir.join("orchard");
+    let output = Command::new(&dispatcher)
+        .args(args)
+        // Empty PATH so the dispatcher must find helpers via its sibling-dir lookup.
+        .env("PATH", "")
+        .output()
+        .expect("run dispatcher");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+        output.status.code().unwrap_or(-1),
+    )
+}
+
+#[test]
+fn dispatcher_prints_help_on_dash_h() {
+    let dir = with_helpers(&[]);
+    let (stdout, _stderr, code) = run_dispatcher(dir.path(), &["--help"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("orchard — Git worktree"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn dispatcher_prints_version_on_dash_v() {
+    let dir = with_helpers(&[]);
+    let (stdout, _stderr, code) = run_dispatcher(dir.path(), &["--version"]);
+    assert_eq!(code, 0);
+    assert!(stdout.starts_with("orchard "), "stdout: {stdout}");
+}
+
+#[test]
+fn no_args_dispatches_to_orchard_tui() {
+    let dir = with_helpers(&[("tui", 0)]);
+    let (stdout, _stderr, code) = run_dispatcher(dir.path(), &[]);
+    assert_eq!(code, 0);
+    assert!(stdout.contains("[helper:tui]"), "stdout: {stdout}");
+}
+
+#[test]
+fn namespace_verb_dispatches_with_remaining_args() {
+    let dir = with_helpers(&[("daemon", 0)]);
+    let (stdout, _stderr, code) = run_dispatcher(dir.path(), &["daemon", "start", "--foo"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("[helper:daemon] argv=start --foo"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn bare_verb_new_dispatches_to_orchard_worktree_new() {
+    let dir = with_helpers(&[("worktree", 0)]);
+    let (stdout, _stderr, code) = run_dispatcher(dir.path(), &["new", "412"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("[helper:worktree] argv=new 412"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn bare_verb_ls_dispatches_to_orchard_worktree_ls() {
+    let dir = with_helpers(&[("worktree", 0)]);
+    let (stdout, _stderr, code) = run_dispatcher(dir.path(), &["ls", "--json"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("[helper:worktree] argv=ls --json"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn child_exit_code_is_propagated() {
+    let dir = with_helpers(&[("daemon", 7)]);
+    let (_stdout, _stderr, code) = run_dispatcher(dir.path(), &["daemon", "status"]);
+    assert_eq!(code, 7);
+}
+
+#[test]
+fn unknown_verb_returns_127_when_no_helper_exists() {
+    let dir = with_helpers(&[]); // no helpers at all
+    let (_stdout, stderr, code) = run_dispatcher(dir.path(), &["nonexistent"]);
+    assert_eq!(code, 127);
+    assert!(
+        stderr.contains("unknown command 'nonexistent'"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn unknown_verb_dispatches_to_third_party_plugin_on_path() {
+    // Plugin lives in a SEPARATE dir from the dispatcher; only PATH points to it.
+    let plugin_dir =
+        tempfile::TempDir::with_prefix("orchard-plugin-test").expect("plugin dir");
+    let plugin = plugin_dir.path().join("orchard-myplugin");
+    fs::write(
+        &plugin,
+        "#!/bin/sh\necho \"[plugin:myplugin] argv=$*\"\nexit 0\n",
+    )
+    .unwrap();
+    fs::set_permissions(&plugin, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let dispatcher_dir =
+        tempfile::TempDir::with_prefix("orchard-dispatcher-test").expect("disp dir");
+    let dispatcher_dest = dispatcher_dir.path().join("orchard");
+    fs::copy(dispatcher_path(), &dispatcher_dest).expect("copy dispatcher");
+    fs::set_permissions(&dispatcher_dest, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let output = Command::new(&dispatcher_dest)
+        .args(["myplugin", "arg1"])
+        .env("PATH", plugin_dir.path())
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        stdout.contains("[plugin:myplugin] argv=arg1"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
+fn sibling_dir_takes_precedence_over_path() {
+    // Same verb resolves to a helper in BOTH the sibling dir and PATH;
+    // dispatcher must pick the sibling-dir one.
+    let path_dir = tempfile::TempDir::with_prefix("path-dir").unwrap();
+    let path_helper = path_dir.path().join("orchard-tui");
+    fs::write(&path_helper, "#!/bin/sh\necho FROM_PATH\n").unwrap();
+    fs::set_permissions(&path_helper, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let dir = with_helpers(&[("tui", 0)]); // sibling dir helper echoes [helper:tui]
+
+    let dispatcher = dir.path().join("orchard");
+    let output = Command::new(&dispatcher)
+        .args(["tui"])
+        .env("PATH", path_dir.path())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("[helper:tui]"),
+        "sibling-dir helper must win; stdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("FROM_PATH"),
+        "PATH helper must not be invoked; stdout: {stdout}"
+    );
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,15 +101,19 @@ mapped to the same `Message` variants as their keyboard equivalents.
 
 ```text
 crates/
-├── orchard/               # The TUI binary + library (src layout below)
-├── worktree-core/         # Pure git worktree operations (list/destroy/parse).
-│                          #   Backs orchard-tui dialogs + future orchard-worktree CLI.
-└── orchard-gui/src-tauri/ # Tauri-based GUI shell (preview)
+├── orchard/                # The orchard-tui binary + library (src layout below)
+├── orchard-dispatcher/     # The user-facing `orchard` binary; routes verbs
+│                           #   to orchard-{tui,daemon,worktree,chat} per ADR-013.
+├── worktree-core/          # Pure git worktree operations (list/destroy/parse).
+│                           #   Backs orchard-tui dialogs + future orchard-worktree CLI.
+└── orchard-gui/src-tauri/  # Tauri-based GUI shell (preview)
 ```
 
 `worktree-core` is the single source of truth for worktree mutation primitives.
 The orchard binary depends on it; future binaries (`orchard-worktree`) will
-depend on it directly. See ADR-013 for the dispatcher architecture this enables.
+depend on it directly. `orchard-dispatcher` is a thin (~150 LOC) router with
+no orchard dependencies — it just execs the right helper binary. See ADR-013
+for the dispatcher architecture.
 
 ## Module Structure (orchard crate)
 


### PR DESCRIPTION
## Summary

Adds `crates/orchard-dispatcher/` — a thin (~150 LOC) router that owns the user-facing `orchard` name and execs the matching helper binary (`orchard-tui`, `orchard-daemon`, `orchard-worktree`, `orchard-chat`) per the `git`/`cargo`/`kubectl` dispatcher pattern.

This is **step 2 of 6** in [ADR-013](docs/adr/013-orchard-cli-ecosystem.md).

## Behavior

| Invocation | Effect |
|---|---|
| `orchard` | exec `orchard-tui` (default no-arg) |
| `orchard --help` / `-h` | dispatcher's help (lists verbs + bare-verb shortcuts) |
| `orchard --version` / `-V` | dispatcher version |
| `orchard tui [args...]` | exec `orchard-tui args...` |
| `orchard daemon [args...]` | exec `orchard-daemon args...` |
| `orchard worktree [args...]` | exec `orchard-worktree args...` |
| `orchard chat [args...]` | exec `orchard-chat args...` |
| `orchard new <issue>` | exec `orchard-worktree new <issue>` (bare-verb shortcut) |
| `orchard rm <id>` / `prune` / `mv` / `ls` / `path` | bare-verb → `orchard-worktree <verb>` |
| `orchard <unknown-verb> [args...]` | tries `orchard-<verb>` from `$PATH` (third-party plugins); returns 127 with clear stderr if not found |

Bare-verb shortcuts are reserved for the worktree primary unit per ADR-013. Adding a second primary unit requires a new ADR.

## Discovery

Helper binary resolution checks the directory containing the running `orchard` executable first (bundled install — `brew install orchard` puts every binary in the same `bin/`), then `$PATH` (third-party plugins, matching `kubectl`'s plugin model). Found-first wins; sibling-dir takes precedence so a stale `$PATH` entry can't shadow a bundled binary.

## Tests

- **7 unit tests** in `src/main.rs`:
  - bare verbs and namespace verbs are disjoint sets (no ambiguity)
  - both lists match ADR-013 §2/§3 verbatim (regression guard if the ADR changes)
  - `--help` documents every verb (single-source-of-truth check)
  - `is_executable` returns true/false for known/missing paths
- **10 integration tests** in `tests/dispatch.rs` — real-process dispatch via shell-script helpers in temp dirs:
  - `--help` / `--version` produce expected output
  - no-args dispatches to `orchard-tui`
  - namespace verbs forward remaining args verbatim
  - bare verbs (`new 412`, `ls --json`) re-target to `orchard-worktree`
  - child exit code propagated back
  - unknown verb returns 127 + clear stderr message
  - third-party plugin discovered via `$PATH`
  - sibling-dir helper takes precedence over `$PATH`
- **End-to-end smoke** (manual): `target/release/orchard tui --version` invokes real `orchard-tui 0.12.1` ✓

## Why no clap

The dispatcher must NOT parse helper-binary arguments — it just forwards them. Using a CLI framework would invite incidental coupling and multiply the surface that helpers and the dispatcher have to keep aligned. Hand-rolled argv handling keeps this file ~150 LOC and the dispatch contract obvious.

## Install scripts unchanged for now

Today the dispatcher binary lives at `target/release/orchard` after `cargo build --release`, but `make install-daemon` still places the **Go daemon** at `/usr/local/bin/orchard`. The cutover (Go binary renames to `orchard-daemon`; the dispatcher takes the `orchard` install slot) lands with **step 5** in a follow-up PR. Step 2 ships the binary and proves it works end-to-end without disrupting the current user install.

## Checklist

- [x] Behavior preserved (no changes to existing binaries; dispatcher is additive)
- [x] Library/binary has its own tests (17 passing: 7 unit + 10 integration)
- [x] `docs/architecture.md` updated (workspace-crates section)
- [x] CI: workspace build + clippy clean (pre-existing flakes from #439 unrelated)

## Test plan

- [ ] CI green
- [ ] /prove-it + /review pass
- [ ] Merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `orchard` dispatcher CLI that routes commands to appropriate helper binaries, with default dispatch to the TUI and preserved argument passthrough.
  * Supports shortcuts (new, rm, prune, mv, ls, path) mapping to worktree behavior and discovers third-party plugin binaries on PATH.
  * `--help`/`--version` support and proper child-exit code propagation.

* **Documentation**
  * Updated architecture docs to describe the dispatcher and workspace layout.

* **Tests**
  * Added integration tests covering dispatch, passthrough, error codes, and plugin resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #2

# Related issue

- #2

# Related issue

- #2

# Related issue

- #2