### PR TITLE
refactor(tui): start_create_worktree calls worktree-core (ADR-013 step 4)

### DIFF
--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -2051,32 +2051,14 @@ impl App {
         std::thread::spawn(move || {
             let worktree_path = crate::paths::derive_local_worktree_path(&repo_root, &branch);
 
-            // Try creating a new branch; fall back to checking out an existing one.
-            let new_branch_result = Command::new("git")
-                .args(["worktree", "add", "-b", &branch, &worktree_path])
-                .current_dir(&repo_root)
-                .output();
-
-            let add_ok = matches!(new_branch_result, Ok(out) if out.status.success());
-
-            if !add_ok {
-                // Branch may already exist — try checking it out directly.
-                let out = Command::new("git")
-                    .args(["worktree", "add", &worktree_path, &branch])
-                    .current_dir(&repo_root)
-                    .output();
-                match out {
-                    Ok(o) if o.status.success() => {}
-                    Ok(o) => {
-                        let stderr = String::from_utf8_lossy(&o.stderr);
-                        let _ = tx.send(AppMsg::CreateWorktreeErr(stderr.trim().to_string()));
-                        return;
-                    }
-                    Err(e) => {
-                        let _ = tx.send(AppMsg::CreateWorktreeErr(format!("{e}")));
-                        return;
-                    }
-                }
+            // Delegate the new-branch-then-fallback dance to worktree-core.
+            // The shared library is the single source of truth for git worktree
+            // mutation; the TUI just collects intent and reports outcomes.
+            if let Err(e) =
+                worktree_core::create_worktree(Path::new(&repo_root), &branch, &worktree_path)
+            {
+                let _ = tx.send(AppMsg::CreateWorktreeErr(format!("{e}")));
+                return;
             }
 
             // Run setup script if configured.


### PR DESCRIPTION
## Summary

Replaces the inlined `git worktree add -b` / fall-back-to-existing-branch dance in the TUI's `start_create_worktree` with a single call to `worktree_core::create_worktree`. The TUI keeps its setup-script execution, tmux session creation, and channel plumbing — those are orchard-specific concerns — but the git mutation itself flows through the shared library.

This is **step 4 of 6** in [ADR-013](docs/adr/013-orchard-cli-ecosystem.md): "Migrate TUI dialogs to call worktree-core directly. Delete the duplicate mutation logic in tui/dialogs.rs."

## What changed

- `crates/orchard/src/tui/mod.rs::start_create_worktree` — 26 lines of inlined git plumbing → 7 lines of `worktree_core::create_worktree(...)`. Behavior preserved: same try-new-branch / fall-back-to-existing sequence, same error semantics (stderr surfaced into `AppMsg::CreateWorktreeErr`).

## What didn't change (and why)

- **Path derivation** stays in `crates/orchard/src/paths.rs::derive_local_worktree_path`. It produces a different layout (`<parent>/worktrees/worktree-<sanitized-slug>`) than `orchard-worktree`'s `<repo_root>/.worktrees/<simple-slug>`. Consolidating these is a separate question — tracked in **#446**.
- **`tui/worktree_ops.rs::delete_task_row`** already calls `worktree_core::remove_worktree` (since step 1).

## Tests

- 1439 orchard lib tests pass
- worktree-core, dispatcher, orchard-worktree all unchanged and green
- Pre-existing flakes in #439 confirmed unrelated

## Phase 1 status

Steps 1-3 already merged. With this PR, step 4 ships. Steps remaining:

- **Step 5**: rename Go binary `orchard` → `orchard-daemon`; update install scripts so `/usr/local/bin/orchard` is the dispatcher.
- **Step 6**: namespace remaining flat verbs (`heal`, `refresh`, `watch`, `chat`, `sessions`, `setup-remote`, `webhook-serve`, `hook-enrich`) with backwards-compat aliases.

## Test plan

- [ ] CI green
- [ ] /prove-it + /review pass
- [ ] Merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved worktree creation logic by centralizing it through an internal utility function, reducing code duplication and enhancing maintainability. Error handling and messaging remain consistent with existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #4