### PR TITLE
feat(daemon): Query.issue/pullRequest by number (resolves #436)

### DIFF
--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -230,10 +230,12 @@ type ComplexityRoot struct {
 		Host            func(childComplexity int) int
 		HostServices    func(childComplexity int, filter *HostServiceFilter) int
 		Hosts           func(childComplexity int) int
+		Issue           func(childComplexity int, repo string, number int64) int
 		Issues          func(childComplexity int, repo string, state *IssueState) int
 		Node            func(childComplexity int, id string) int
 		Peers           func(childComplexity int) int
 		Projects        func(childComplexity int) int
+		PullRequest     func(childComplexity int, repo string, number int64) int
 		PullRequests    func(childComplexity int, repo string, state *PullRequestState) int
 		TmuxPanes       func(childComplexity int, filter *TmuxPaneFilter) int
 		TmuxServer      func(childComplexity int) int
@@ -380,6 +382,8 @@ type QueryResolver interface {
 	HostServices(ctx context.Context, filter *HostServiceFilter) ([]*HostService, error)
 	PullRequests(ctx context.Context, repo string, state *PullRequestState) ([]*PullRequest, error)
 	Issues(ctx context.Context, repo string, state *IssueState) ([]*Issue, error)
+	Issue(ctx context.Context, repo string, number int64) (*Issue, error)
+	PullRequest(ctx context.Context, repo string, number int64) (*PullRequest, error)
 	WorkflowRuns(ctx context.Context, repo string) ([]*WorkflowRun, error)
 	Gh(ctx context.Context, query string, variables interface{}) (interface{}, error)
 	Node(ctx context.Context, id string) (Node, error)
@@ -1412,6 +1416,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Hosts(childComplexity), true
 
+	case "Query.issue":
+		if e.complexity.Query.Issue == nil {
+			break
+		}
+
+		args, err := ec.field_Query_issue_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.Issue(childComplexity, args["repo"].(string), args["number"].(int64)), true
+
 	case "Query.issues":
 		if e.complexity.Query.Issues == nil {
 			break
@@ -1449,6 +1465,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.Projects(childComplexity), true
+
+	case "Query.pullRequest":
+		if e.complexity.Query.PullRequest == nil {
+			break
+		}
+
+		args, err := ec.field_Query_pullRequest_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.PullRequest(childComplexity, args["repo"].(string), args["number"].(int64)), true
 
 	case "Query.pullRequests":
 		if e.complexity.Query.PullRequests == nil {
@@ -2390,6 +2418,22 @@ type Query {
   "Issues on a GitHub repository. ` + "`" + `repo` + "`" + ` is ` + "`" + `owner/name` + "`" + `."
   issues(repo: String!, state: IssueState = OPEN): [Issue!]
 
+  """
+  Look up a single issue by repo + number. Resolves null when the issue
+  doesn't exist, the daemon isn't authenticated against GitHub, or the
+  repo isn't accessible. Use this for "is this number still open?"
+  cross-references against numbers from external sources (Slack lists,
+  comments, docs) — replaces ad-hoc ` + "`" + `gh api repos/.../issues/N` + "`" + `
+  shellouts. Resolves issue #436.
+  """
+  issue(repo: String!, number: Int!): Issue
+
+  """
+  Look up a single pull request by repo + number. Same shape as
+  ` + "`" + `issue(...)` + "`" + `. Returns null when not found. Resolves issue #436.
+  """
+  pullRequest(repo: String!, number: Int!): PullRequest
+
   "Workflow runs on a GitHub repository. ` + "`" + `repo` + "`" + ` is ` + "`" + `owner/name` + "`" + `."
   workflowRuns(repo: String!): [WorkflowRun!]
 
@@ -3233,6 +3277,30 @@ func (ec *executionContext) field_Query_hostServices_args(ctx context.Context, r
 	return args, nil
 }
 
+func (ec *executionContext) field_Query_issue_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["repo"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("repo"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["repo"] = arg0
+	var arg1 int64
+	if tmp, ok := rawArgs["number"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("number"))
+		arg1, err = ec.unmarshalNInt2int64(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["number"] = arg1
+	return args, nil
+}
+
 func (ec *executionContext) field_Query_issues_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -3269,6 +3337,30 @@ func (ec *executionContext) field_Query_node_args(ctx context.Context, rawArgs m
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_pullRequest_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["repo"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("repo"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["repo"] = arg0
+	var arg1 int64
+	if tmp, ok := rawArgs["number"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("number"))
+		arg1, err = ec.unmarshalNInt2int64(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["number"] = arg1
 	return args, nil
 }
 
@@ -10223,6 +10315,170 @@ func (ec *executionContext) fieldContext_Query_issues(ctx context.Context, field
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_issues_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_issue(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_issue(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Issue(rctx, fc.Args["repo"].(string), fc.Args["number"].(int64))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*Issue)
+	fc.Result = res
+	return ec.marshalOIssue2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssue(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_issue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Issue_id(ctx, field)
+			case "repoOwner":
+				return ec.fieldContext_Issue_repoOwner(ctx, field)
+			case "repoName":
+				return ec.fieldContext_Issue_repoName(ctx, field)
+			case "number":
+				return ec.fieldContext_Issue_number(ctx, field)
+			case "title":
+				return ec.fieldContext_Issue_title(ctx, field)
+			case "body":
+				return ec.fieldContext_Issue_body(ctx, field)
+			case "state":
+				return ec.fieldContext_Issue_state(ctx, field)
+			case "authorLogin":
+				return ec.fieldContext_Issue_authorLogin(ctx, field)
+			case "url":
+				return ec.fieldContext_Issue_url(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Issue_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Issue_updatedAt(ctx, field)
+			case "comments":
+				return ec.fieldContext_Issue_comments(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Issue", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_issue_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_pullRequest(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_pullRequest(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().PullRequest(rctx, fc.Args["repo"].(string), fc.Args["number"].(int64))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*PullRequest)
+	fc.Result = res
+	return ec.marshalOPullRequest2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐPullRequest(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_pullRequest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_PullRequest_id(ctx, field)
+			case "repoOwner":
+				return ec.fieldContext_PullRequest_repoOwner(ctx, field)
+			case "repoName":
+				return ec.fieldContext_PullRequest_repoName(ctx, field)
+			case "number":
+				return ec.fieldContext_PullRequest_number(ctx, field)
+			case "title":
+				return ec.fieldContext_PullRequest_title(ctx, field)
+			case "body":
+				return ec.fieldContext_PullRequest_body(ctx, field)
+			case "state":
+				return ec.fieldContext_PullRequest_state(ctx, field)
+			case "draft":
+				return ec.fieldContext_PullRequest_draft(ctx, field)
+			case "authorLogin":
+				return ec.fieldContext_PullRequest_authorLogin(ctx, field)
+			case "baseRef":
+				return ec.fieldContext_PullRequest_baseRef(ctx, field)
+			case "headRef":
+				return ec.fieldContext_PullRequest_headRef(ctx, field)
+			case "url":
+				return ec.fieldContext_PullRequest_url(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_PullRequest_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_PullRequest_updatedAt(ctx, field)
+			case "reviews":
+				return ec.fieldContext_PullRequest_reviews(ctx, field)
+			case "comments":
+				return ec.fieldContext_PullRequest_comments(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PullRequest", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_pullRequest_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -18177,6 +18433,44 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "issue":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_issue(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "pullRequest":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_pullRequest(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "workflowRuns":
 			field := field
 
@@ -22050,6 +22344,13 @@ func (ec *executionContext) marshalOIssue2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgi
 	return ret
 }
 
+func (ec *executionContext) marshalOIssue2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssue(ctx context.Context, sel ast.SelectionSet, v *Issue) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Issue(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOIssueComment2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssueCommentᚄ(ctx context.Context, sel ast.SelectionSet, v []*IssueComment) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -22196,6 +22497,13 @@ func (ec *executionContext) marshalOPullRequest2ᚕᚖgithubᚗcomᚋdrewdrewthi
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalOPullRequest2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐPullRequest(ctx context.Context, sel ast.SelectionSet, v *PullRequest) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._PullRequest(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOPullRequestReview2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐPullRequestReviewᚄ(ctx context.Context, sel ast.SelectionSet, v []*PullRequestReview) graphql.Marshaler {

--- a/internal/server/providers/gh/errors.go
+++ b/internal/server/providers/gh/errors.go
@@ -48,3 +48,15 @@ type httpError struct {
 func (e *httpError) Error() string {
 	return fmt.Sprintf("github %s returned %d: %s", e.Endpoint, e.Status, e.Message)
 }
+
+// IsNotFound reports whether `err` is a GitHub API 404. Callers use this
+// to distinguish "this number doesn't exist" from other failures so a
+// `null` response can be returned cleanly (for `Query.issue(repo,
+// number)` and `Query.pullRequest(repo, number)`).
+func IsNotFound(err error) bool {
+	var h *httpError
+	if errors.As(err, &h) {
+		return h.Status == 404
+	}
+	return false
+}

--- a/internal/server/providers/gh/errors_test.go
+++ b/internal/server/providers/gh/errors_test.go
@@ -1,0 +1,45 @@
+package gh
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestIsNotFound covers the IsNotFound helper added with #436 — the
+// resolver layer uses it to translate GitHub 404s into a `null` GraphQL
+// response (rather than a per-field error) for `Query.issue` /
+// `Query.pullRequest` lookups.
+func TestIsNotFound_OnHTTP404(t *testing.T) {
+	err := &httpError{Status: 404, Message: "not found", Endpoint: "/repos/x/y/issues/9999"}
+	if !IsNotFound(err) {
+		t.Errorf("IsNotFound(404 httpError) = false, want true")
+	}
+}
+
+func TestIsNotFound_OnHTTP500(t *testing.T) {
+	err := &httpError{Status: 500, Message: "boom", Endpoint: "/repos/x/y/issues/1"}
+	if IsNotFound(err) {
+		t.Errorf("IsNotFound(500 httpError) = true, want false (only 404 counts)")
+	}
+}
+
+func TestIsNotFound_OnWrappedHTTP404(t *testing.T) {
+	inner := &httpError{Status: 404}
+	wrapped := fmt.Errorf("layer 2: %w", inner)
+	if !IsNotFound(wrapped) {
+		t.Errorf("IsNotFound on wrapped 404 = false, want true (errors.As must unwrap)")
+	}
+}
+
+func TestIsNotFound_OnUnrelatedError(t *testing.T) {
+	if IsNotFound(errors.New("anything")) {
+		t.Errorf("IsNotFound on plain error = true, want false")
+	}
+}
+
+func TestIsNotFound_OnNil(t *testing.T) {
+	if IsNotFound(nil) {
+		t.Errorf("IsNotFound(nil) = true, want false")
+	}
+}

--- a/internal/server/providers/gh/gh_e2e_test.go
+++ b/internal/server/providers/gh/gh_e2e_test.go
@@ -624,10 +624,15 @@ func newDaemon(t *testing.T, p *gh.Provider) *httptest.Server {
 // in the Data field for the query it ran; missing fields are zero-valued.
 type graphqlResponse struct {
 	Data struct {
-		PullRequests []prNode      `json:"pullRequests"`
-		Issues       []issueNode   `json:"issues"`
-		WorkflowRuns []runNode     `json:"workflowRuns"`
-		Health       *healthNode   `json:"health"`
+		PullRequests []prNode    `json:"pullRequests"`
+		Issues       []issueNode `json:"issues"`
+		WorkflowRuns []runNode   `json:"workflowRuns"`
+		Health       *healthNode `json:"health"`
+		// Singular look-ups by number — added with #436. Nullable on the
+		// wire; pointer on this side so tests can distinguish "no row"
+		// from "zero-valued row".
+		Issue       *issueNode `json:"issue"`
+		PullRequest *prNode    `json:"pullRequest"`
 	} `json:"data"`
 	Errors []map[string]any `json:"errors,omitempty"`
 }
@@ -651,6 +656,7 @@ type issueNode struct {
 	Number int    `json:"number"`
 	Title  string `json:"title"`
 	State  string `json:"state"`
+	URL    string `json:"url"`
 }
 
 type runNode struct {
@@ -663,6 +669,83 @@ type runNode struct {
 
 type healthNode struct {
 	Status string `json:"status"`
+}
+
+// TestGH_E2E_IssueByNumber asserts `Query.issue(repo, number)` returns
+// the canned issue. Resolves issue #436.
+func TestGH_E2E_IssueByNumber(t *testing.T) {
+	installFakeGH(t)
+	api := stubAPI(t)
+	tlsClient := httpClientForTLS(t, api)
+
+	auth := gh.NewCommandAuthSource()
+	provider := newGHProviderForTest(t, api.URL, auth, tlsClient)
+
+	srv := newDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postQuery(t, srv.URL, `query {
+		issue(repo: "alice/repo", number: 100) {
+			id
+			number
+			title
+			state
+			url
+		}
+	}`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	if resp.Data.Issue == nil {
+		t.Fatalf("expected non-null issue, got null")
+	}
+	if resp.Data.Issue.Number != 100 {
+		t.Errorf("number = %d, want 100", resp.Data.Issue.Number)
+	}
+	if resp.Data.Issue.ID != "Issue:alice/repo#100" {
+		t.Errorf("id = %q, want Issue:alice/repo#100", resp.Data.Issue.ID)
+	}
+	if resp.Data.Issue.State != "OPEN" {
+		t.Errorf("state = %q, want OPEN", resp.Data.Issue.State)
+	}
+}
+
+// TestGH_E2E_PullRequestByNumber asserts `Query.pullRequest(repo, number)`
+// returns the canned PR. Resolves issue #436.
+func TestGH_E2E_PullRequestByNumber(t *testing.T) {
+	installFakeGH(t)
+	api := stubAPI(t)
+	tlsClient := httpClientForTLS(t, api)
+
+	auth := gh.NewCommandAuthSource()
+	provider := newGHProviderForTest(t, api.URL, auth, tlsClient)
+
+	srv := newDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postQuery(t, srv.URL, `query {
+		pullRequest(repo: "alice/repo", number: 42) {
+			id
+			number
+			title
+			state
+			authorLogin
+			baseRef
+			headRef
+		}
+	}`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	if resp.Data.PullRequest == nil {
+		t.Fatalf("expected non-null pullRequest, got null")
+	}
+	if resp.Data.PullRequest.Number != 42 {
+		t.Errorf("number = %d, want 42", resp.Data.PullRequest.Number)
+	}
+	if resp.Data.PullRequest.ID != "PullRequest:alice/repo#42" {
+		t.Errorf("id = %q, want PullRequest:alice/repo#42", resp.Data.PullRequest.ID)
+	}
 }
 
 func postQuery(t *testing.T, url, query string) graphqlResponse {

--- a/internal/server/resolvers/gh.go
+++ b/internal/server/resolvers/gh.go
@@ -71,6 +71,61 @@ func (r *queryResolver) queryIssuesResolver(ctx context.Context, repo string, st
 	return out, nil
 }
 
+// queryIssueByNumberResolver implements `Query.issue(repo, number)`.
+//
+// Resolves null when the issue isn't found (404), the daemon isn't
+// authenticated, or the repo is otherwise inaccessible. The "not found"
+// case must be `(nil, nil)` so GraphQL surfaces it as `null` rather
+// than as a per-field error — this lets callers cross-reference numbers
+// without errors propagating into otherwise-healthy responses.
+//
+// Resolves issue #436.
+func (r *queryResolver) queryIssueByNumberResolver(ctx context.Context, repo string, number int64) (*graphql1.Issue, error) {
+	if r.GH == nil {
+		return nil, errGHNotConfigured
+	}
+	owner, name, err := gh.SplitRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	issue, err := r.GH.GetIssue(ctx, gh.IssueKey{
+		Owner:  owner,
+		Name:   name,
+		Number: int(number),
+	})
+	if err != nil {
+		if gh.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return toGraphQLIssue(issue), nil
+}
+
+// queryPullRequestByNumberResolver implements `Query.pullRequest(repo, number)`.
+// Same shape as `queryIssueByNumberResolver`. Resolves issue #436.
+func (r *queryResolver) queryPullRequestByNumberResolver(ctx context.Context, repo string, number int64) (*graphql1.PullRequest, error) {
+	if r.GH == nil {
+		return nil, errGHNotConfigured
+	}
+	owner, name, err := gh.SplitRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	pr, err := r.GH.GetPullRequest(ctx, gh.PullRequestKey{
+		Owner:  owner,
+		Name:   name,
+		Number: int(number),
+	})
+	if err != nil {
+		if gh.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return toGraphQLPullRequest(pr), nil
+}
+
 // queryWorkflowRunsResolver implements `Query.workflowRuns(repo)`.
 func (r *queryResolver) queryWorkflowRunsResolver(ctx context.Context, repo string) ([]*graphql1.WorkflowRun, error) {
 	if r.GH == nil {

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -388,6 +388,16 @@ func (r *queryResolver) Issues(ctx context.Context, repo string, state *graphql1
 	return r.queryIssuesResolver(ctx, repo, state)
 }
 
+// Issue is the resolver for the issue field.
+func (r *queryResolver) Issue(ctx context.Context, repo string, number int64) (*graphql1.Issue, error) {
+	return r.queryIssueByNumberResolver(ctx, repo, number)
+}
+
+// PullRequest is the resolver for the pullRequest field.
+func (r *queryResolver) PullRequest(ctx context.Context, repo string, number int64) (*graphql1.PullRequest, error) {
+	return r.queryPullRequestByNumberResolver(ctx, repo, number)
+}
+
 // WorkflowRuns is the resolver for the workflowRuns field.
 func (r *queryResolver) WorkflowRuns(ctx context.Context, repo string) ([]*graphql1.WorkflowRun, error) {
 	return r.queryWorkflowRunsResolver(ctx, repo)

--- a/schema.graphql
+++ b/schema.graphql
@@ -207,6 +207,22 @@ type Query {
   "Issues on a GitHub repository. `repo` is `owner/name`."
   issues(repo: String!, state: IssueState = OPEN): [Issue!]
 
+  """
+  Look up a single issue by repo + number. Resolves null when the issue
+  doesn't exist, the daemon isn't authenticated against GitHub, or the
+  repo isn't accessible. Use this for "is this number still open?"
+  cross-references against numbers from external sources (Slack lists,
+  comments, docs) — replaces ad-hoc `gh api repos/.../issues/N`
+  shellouts. Resolves issue #436.
+  """
+  issue(repo: String!, number: Int!): Issue
+
+  """
+  Look up a single pull request by repo + number. Same shape as
+  `issue(...)`. Returns null when not found. Resolves issue #436.
+  """
+  pullRequest(repo: String!, number: Int!): PullRequest
+
   "Workflow runs on a GitHub repository. `repo` is `owner/name`."
   workflowRuns(repo: String!): [WorkflowRun!]
 


### PR DESCRIPTION
## Summary

Adds two singular look-up fields to the daemon's GraphQL surface:

```graphql
Query.issue(repo: String!, number: Int!): Issue
Query.pullRequest(repo: String!, number: Int!): PullRequest
```

Resolves **#436**.

Both fields resolve `null` when the row doesn't exist (404 from GitHub), the daemon isn't authenticated, or the repo isn't accessible. Use them for "is this number still open?" cross-references against numbers from external sources (Slack lists, comments, docs) — replacing ad-hoc \`gh api repos/.../issues/N\` shellouts that hit REST rate limits and trigger the daemon-first nudge.

## Implementation

- \`schema.graphql\` — two new Query fields. Existing \`Issue\` and \`PullRequest\` types reused (no new types).
- \`internal/server/resolvers/gh.go\` — \`queryIssueByNumberResolver\` and \`queryPullRequestByNumberResolver\` delegate to the existing \`gh.Provider.GetIssue\` / \`GetPullRequest\` methods.
- \`internal/server/providers/gh/errors.go\` — new \`IsNotFound(err)\` helper that pattern-matches \`httpError{Status: 404}\` via \`errors.As\`. The resolver uses this to translate 404 → \`null\`.

## Tests

- **5 unit tests** for \`IsNotFound\`: 404 hit, 500 miss, wrapped 404 (errors.As unwrap), unrelated error, nil.
- **2 E2E tests** over the existing stubbed-GitHub harness:
  - \`Query.issue(repo, number)\` returns the canned issue with correct \`Issue:owner/repo#number\` id.
  - \`Query.pullRequest(repo, number)\` returns the canned PR.

The 404 → null contract is exercised by the unit tests. Integration-level NotFound coverage is harder because the test stub's catch-all \`/\` handler fails the test on unexpected paths.

## Why this matters now

This unblocks Phase 2 of the cli-tui-daemon-lane: the focus-driven sort needs "is this number still open?" lookups so the dashboard can highlight rows whose linked issue/PR has changed state externally.

## Test plan

- [ ] CI green
- [ ] /prove-it + /review pass
- [ ] Merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `issue` and `pullRequest` GraphQL queries to retrieve individual issues and pull requests by repository and item number, returning `null` for not-found scenarios.

* **Tests**
  * Added unit and end-to-end tests validating the new queries, error detection, and resource lookup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #436