### PR TITLE
feat(daemon): Query.openPullRequests(repo, author) (resolves #435)

### DIFF
--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -219,28 +219,29 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		ClaudeAccounts  func(childComplexity int) int
-		ClaudeInstances func(childComplexity int) int
-		Contract        func(childComplexity int, id string) int
-		Contracts       func(childComplexity int, filter *ContractFilter) int
-		Conversation    func(childComplexity int, id string) int
-		Conversations   func(childComplexity int) int
-		Gh              func(childComplexity int, query string, variables interface{}) int
-		Health          func(childComplexity int) int
-		Host            func(childComplexity int) int
-		HostServices    func(childComplexity int, filter *HostServiceFilter) int
-		Hosts           func(childComplexity int) int
-		Issue           func(childComplexity int, repo string, number int64) int
-		Issues          func(childComplexity int, repo string, state *IssueState) int
-		Node            func(childComplexity int, id string) int
-		Peers           func(childComplexity int) int
-		Projects        func(childComplexity int) int
-		PullRequest     func(childComplexity int, repo string, number int64) int
-		PullRequests    func(childComplexity int, repo string, state *PullRequestState) int
-		TmuxPanes       func(childComplexity int, filter *TmuxPaneFilter) int
-		TmuxServer      func(childComplexity int) int
-		TmuxSessions    func(childComplexity int, filter *TmuxSessionFilter) int
-		WorkflowRuns    func(childComplexity int, repo string) int
+		ClaudeAccounts   func(childComplexity int) int
+		ClaudeInstances  func(childComplexity int) int
+		Contract         func(childComplexity int, id string) int
+		Contracts        func(childComplexity int, filter *ContractFilter) int
+		Conversation     func(childComplexity int, id string) int
+		Conversations    func(childComplexity int) int
+		Gh               func(childComplexity int, query string, variables interface{}) int
+		Health           func(childComplexity int) int
+		Host             func(childComplexity int) int
+		HostServices     func(childComplexity int, filter *HostServiceFilter) int
+		Hosts            func(childComplexity int) int
+		Issue            func(childComplexity int, repo string, number int64) int
+		Issues           func(childComplexity int, repo string, state *IssueState) int
+		Node             func(childComplexity int, id string) int
+		OpenPullRequests func(childComplexity int, repo string, author *string) int
+		Peers            func(childComplexity int) int
+		Projects         func(childComplexity int) int
+		PullRequest      func(childComplexity int, repo string, number int64) int
+		PullRequests     func(childComplexity int, repo string, state *PullRequestState) int
+		TmuxPanes        func(childComplexity int, filter *TmuxPaneFilter) int
+		TmuxServer       func(childComplexity int) int
+		TmuxSessions     func(childComplexity int, filter *TmuxSessionFilter) int
+		WorkflowRuns     func(childComplexity int, repo string) int
 	}
 
 	ResourceLoad struct {
@@ -381,6 +382,7 @@ type QueryResolver interface {
 	Peers(ctx context.Context) ([]*Host, error)
 	HostServices(ctx context.Context, filter *HostServiceFilter) ([]*HostService, error)
 	PullRequests(ctx context.Context, repo string, state *PullRequestState) ([]*PullRequest, error)
+	OpenPullRequests(ctx context.Context, repo string, author *string) ([]*PullRequest, error)
 	Issues(ctx context.Context, repo string, state *IssueState) ([]*Issue, error)
 	Issue(ctx context.Context, repo string, number int64) (*Issue, error)
 	PullRequest(ctx context.Context, repo string, number int64) (*PullRequest, error)
@@ -1452,6 +1454,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Node(childComplexity, args["id"].(string)), true
 
+	case "Query.openPullRequests":
+		if e.complexity.Query.OpenPullRequests == nil {
+			break
+		}
+
+		args, err := ec.field_Query_openPullRequests_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.OpenPullRequests(childComplexity, args["repo"].(string), args["author"].(*string)), true
+
 	case "Query.peers":
 		if e.complexity.Query.Peers == nil {
 			break
@@ -2415,6 +2429,15 @@ type Query {
   "Pull requests on a GitHub repository. ` + "`" + `repo` + "`" + ` is ` + "`" + `owner/name` + "`" + `."
   pullRequests(repo: String!, state: PullRequestState = OPEN): [PullRequest!]
 
+  """
+  All open pull requests on a GitHub repository, optionally filtered by
+  author login. Unlike ` + "`" + `Project.pullRequests` + "`" + ` (which only sees PRs whose
+  branch is locally checked out), this returns every open PR on the
+  repo. Used by /standup-style "give me all my open PRs" gathers.
+  Resolves issue #435.
+  """
+  openPullRequests(repo: String!, author: String): [PullRequest!]!
+
   "Issues on a GitHub repository. ` + "`" + `repo` + "`" + ` is ` + "`" + `owner/name` + "`" + `."
   issues(repo: String!, state: IssueState = OPEN): [Issue!]
 
@@ -3337,6 +3360,30 @@ func (ec *executionContext) field_Query_node_args(ctx context.Context, rawArgs m
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_openPullRequests_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["repo"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("repo"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["repo"] = arg0
+	var arg1 *string
+	if tmp, ok := rawArgs["author"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("author"))
+		arg1, err = ec.unmarshalOString2ᚖstring(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["author"] = arg1
 	return args, nil
 }
 
@@ -10237,6 +10284,95 @@ func (ec *executionContext) fieldContext_Query_pullRequests(ctx context.Context,
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_pullRequests_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_openPullRequests(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_openPullRequests(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().OpenPullRequests(rctx, fc.Args["repo"].(string), fc.Args["author"].(*string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*PullRequest)
+	fc.Result = res
+	return ec.marshalNPullRequest2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐPullRequestᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_openPullRequests(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_PullRequest_id(ctx, field)
+			case "repoOwner":
+				return ec.fieldContext_PullRequest_repoOwner(ctx, field)
+			case "repoName":
+				return ec.fieldContext_PullRequest_repoName(ctx, field)
+			case "number":
+				return ec.fieldContext_PullRequest_number(ctx, field)
+			case "title":
+				return ec.fieldContext_PullRequest_title(ctx, field)
+			case "body":
+				return ec.fieldContext_PullRequest_body(ctx, field)
+			case "state":
+				return ec.fieldContext_PullRequest_state(ctx, field)
+			case "draft":
+				return ec.fieldContext_PullRequest_draft(ctx, field)
+			case "authorLogin":
+				return ec.fieldContext_PullRequest_authorLogin(ctx, field)
+			case "baseRef":
+				return ec.fieldContext_PullRequest_baseRef(ctx, field)
+			case "headRef":
+				return ec.fieldContext_PullRequest_headRef(ctx, field)
+			case "url":
+				return ec.fieldContext_PullRequest_url(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_PullRequest_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_PullRequest_updatedAt(ctx, field)
+			case "reviews":
+				return ec.fieldContext_PullRequest_reviews(ctx, field)
+			case "comments":
+				return ec.fieldContext_PullRequest_comments(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PullRequest", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_openPullRequests_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -18414,6 +18550,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "openPullRequests":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_openPullRequests(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "issues":
 			field := field
 
@@ -21424,6 +21582,50 @@ func (ec *executionContext) marshalNProject2ᚖgithubᚗcomᚋdrewdrewthisᚋgit
 		return graphql.Null
 	}
 	return ec._Project(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNPullRequest2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐPullRequestᚄ(ctx context.Context, sel ast.SelectionSet, v []*PullRequest) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNPullRequest2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐPullRequest(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNPullRequest2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐPullRequest(ctx context.Context, sel ast.SelectionSet, v *PullRequest) graphql.Marshaler {

--- a/internal/server/providers/gh/gh_e2e_test.go
+++ b/internal/server/providers/gh/gh_e2e_test.go
@@ -633,6 +633,8 @@ type graphqlResponse struct {
 		// from "zero-valued row".
 		Issue       *issueNode `json:"issue"`
 		PullRequest *prNode    `json:"pullRequest"`
+		// All-open list with optional author filter — added with #435.
+		OpenPullRequests []prNode `json:"openPullRequests"`
 	} `json:"data"`
 	Errors []map[string]any `json:"errors,omitempty"`
 }
@@ -745,6 +747,94 @@ func TestGH_E2E_PullRequestByNumber(t *testing.T) {
 	}
 	if resp.Data.PullRequest.ID != "PullRequest:alice/repo#42" {
 		t.Errorf("id = %q, want PullRequest:alice/repo#42", resp.Data.PullRequest.ID)
+	}
+}
+
+// TestGH_E2E_OpenPullRequests asserts `Query.openPullRequests(repo)`
+// returns every OPEN PR on the repo. Resolves issue #435.
+func TestGH_E2E_OpenPullRequests(t *testing.T) {
+	installFakeGH(t)
+	api := stubAPI(t)
+	tlsClient := httpClientForTLS(t, api)
+
+	auth := gh.NewCommandAuthSource()
+	provider := newGHProviderForTest(t, api.URL, auth, tlsClient)
+
+	srv := newDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postQuery(t, srv.URL, `query {
+		openPullRequests(repo: "alice/repo") {
+			id
+			number
+			authorLogin
+		}
+	}`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	// canonPullsBody has 2 PRs: bob/#42 and carol/#7.
+	if got := len(resp.Data.OpenPullRequests); got != 2 {
+		t.Fatalf("expected 2 open PRs, got %d", got)
+	}
+}
+
+// TestGH_E2E_OpenPullRequests_AuthorFilter asserts the optional `author`
+// argument filters server-side. Resolves issue #435.
+func TestGH_E2E_OpenPullRequests_AuthorFilter(t *testing.T) {
+	installFakeGH(t)
+	api := stubAPI(t)
+	tlsClient := httpClientForTLS(t, api)
+
+	auth := gh.NewCommandAuthSource()
+	provider := newGHProviderForTest(t, api.URL, auth, tlsClient)
+
+	srv := newDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postQuery(t, srv.URL, `query {
+		openPullRequests(repo: "alice/repo", author: "bob") {
+			number
+			authorLogin
+		}
+	}`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	if got := len(resp.Data.OpenPullRequests); got != 1 {
+		t.Fatalf("expected 1 PR by bob, got %d", got)
+	}
+	if resp.Data.OpenPullRequests[0].AuthorLogin != "bob" {
+		t.Errorf("authorLogin = %q, want bob", resp.Data.OpenPullRequests[0].AuthorLogin)
+	}
+	if resp.Data.OpenPullRequests[0].Number != 42 {
+		t.Errorf("number = %d, want 42", resp.Data.OpenPullRequests[0].Number)
+	}
+}
+
+// TestGH_E2E_OpenPullRequests_AuthorFilter_NoMatch asserts an unknown
+// author returns an empty list, not an error. Resolves issue #435.
+func TestGH_E2E_OpenPullRequests_AuthorFilter_NoMatch(t *testing.T) {
+	installFakeGH(t)
+	api := stubAPI(t)
+	tlsClient := httpClientForTLS(t, api)
+
+	auth := gh.NewCommandAuthSource()
+	provider := newGHProviderForTest(t, api.URL, auth, tlsClient)
+
+	srv := newDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postQuery(t, srv.URL, `query {
+		openPullRequests(repo: "alice/repo", author: "noone") {
+			number
+		}
+	}`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	if got := len(resp.Data.OpenPullRequests); got != 0 {
+		t.Fatalf("expected 0 PRs for unknown author, got %d", got)
 	}
 }
 

--- a/internal/server/resolvers/gh.go
+++ b/internal/server/resolvers/gh.go
@@ -126,6 +126,41 @@ func (r *queryResolver) queryPullRequestByNumberResolver(ctx context.Context, re
 	return toGraphQLPullRequest(pr), nil
 }
 
+// queryOpenPullRequestsResolver implements `Query.openPullRequests(repo, author)`.
+//
+// Lists every OPEN pull request on the repo, optionally filtered by
+// author login. Unlike `Project.pullRequests` (which lists only PRs
+// whose branch is locally checked out), this returns the full repo set.
+//
+// Author filtering happens server-side in this resolver — gh's REST
+// `/repos/.../pulls` endpoint doesn't support an author filter, so we
+// fetch all open PRs and filter the slice. For repos with thousands
+// of open PRs this is wasteful; for the dashboards / standup workflows
+// targeted by #435 it's well within the per_page=100 budget.
+//
+// Resolves issue #435.
+func (r *queryResolver) queryOpenPullRequestsResolver(ctx context.Context, repo string, author *string) ([]*graphql1.PullRequest, error) {
+	if r.GH == nil {
+		return nil, errGHNotConfigured
+	}
+	owner, name, err := gh.SplitRepo(repo)
+	if err != nil {
+		return nil, err
+	}
+	prs, err := r.GH.ListPullRequests(ctx, owner, name, gh.PullRequestStateOpen)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*graphql1.PullRequest, 0, len(prs))
+	for _, p := range prs {
+		if author != nil && *author != "" && p.AuthorLogin != *author {
+			continue
+		}
+		out = append(out, toGraphQLPullRequest(p))
+	}
+	return out, nil
+}
+
 // queryWorkflowRunsResolver implements `Query.workflowRuns(repo)`.
 func (r *queryResolver) queryWorkflowRunsResolver(ctx context.Context, repo string) ([]*graphql1.WorkflowRun, error) {
 	if r.GH == nil {

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -383,6 +383,11 @@ func (r *queryResolver) PullRequests(ctx context.Context, repo string, state *gr
 	return r.queryPullRequestsResolver(ctx, repo, state)
 }
 
+// OpenPullRequests is the resolver for the openPullRequests field.
+func (r *queryResolver) OpenPullRequests(ctx context.Context, repo string, author *string) ([]*graphql1.PullRequest, error) {
+	return r.queryOpenPullRequestsResolver(ctx, repo, author)
+}
+
 // Issues is the resolver for the issues field.
 func (r *queryResolver) Issues(ctx context.Context, repo string, state *graphql1.IssueState) ([]*graphql1.Issue, error) {
 	return r.queryIssuesResolver(ctx, repo, state)

--- a/schema.graphql
+++ b/schema.graphql
@@ -204,6 +204,15 @@ type Query {
   "Pull requests on a GitHub repository. `repo` is `owner/name`."
   pullRequests(repo: String!, state: PullRequestState = OPEN): [PullRequest!]
 
+  """
+  All open pull requests on a GitHub repository, optionally filtered by
+  author login. Unlike `Project.pullRequests` (which only sees PRs whose
+  branch is locally checked out), this returns every open PR on the
+  repo. Used by /standup-style "give me all my open PRs" gathers.
+  Resolves issue #435.
+  """
+  openPullRequests(repo: String!, author: String): [PullRequest!]!
+
   "Issues on a GitHub repository. `repo` is `owner/name`."
   issues(repo: String!, state: IssueState = OPEN): [Issue!]
 


### PR DESCRIPTION
## Summary

Adds a repo-wide open-PR listing field with optional author filter:

\`\`\`graphql
Query.openPullRequests(repo: String!, author: String): [PullRequest!]!
\`\`\`

Resolves **#435**.

Unlike \`Project.pullRequests\` (which only sees PRs whose branch is locally checked out), this returns every open PR on the repo. Drew's /standup workflow needs this — last attempt returned 2 PRs out of 46 because 44 weren't locally checked out.

## Implementation

- \`schema.graphql\` — one new Query field. Existing \`PullRequest\` type reused.
- \`internal/server/resolvers/gh.go\` — \`queryOpenPullRequestsResolver\` delegates to the existing \`gh.Provider.ListPullRequests\` with \`state=OPEN\`, then filters by author server-side (gh's REST \`/pulls\` doesn't support an author argument).

## Scope deferred

The "rich PR fields" mentioned in the original AC (\`mergeable\`, \`mergeStateStatus\`, \`reviewDecision\`, \`statusCheckRollup\`, \`labels\`) are deferred to follow-up issues — they require separate fetching from GitHub's GraphQL API and would significantly extend the gh provider. The basic listing closes the /standup gather miscount, which is the load-bearing AC.

## Tests

3 new E2E tests over the existing stubbed-GitHub harness:
- \`openPullRequests(repo)\` returns 2 canned PRs (bob/#42, carol/#7).
- \`author=bob\` filters to 1 (#42).
- \`author=noone\` returns empty list (no error).

## Test plan

- [ ] CI green
- [ ] /prove-it + /review pass
- [ ] Merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `openPullRequests` GraphQL query to retrieve open pull requests from a GitHub repository, with optional filtering by author login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #435