### PR TITLE
feat(cli): pretty-print GraphQL validation errors (resolves #398)

### DIFF
--- a/internal/cli/query/pretty_errors_test.go
+++ b/internal/cli/query/pretty_errors_test.go
@@ -1,0 +1,83 @@
+// Tests for prettyGraphQLErrors — the helper that turns a GraphQL
+// validation-error envelope into operator-friendly text. Resolves #398.
+
+package query
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPrettyGraphQLErrors_SingleErrorWithLocation(t *testing.T) {
+	body := []byte(`{"errors":[{"message":"Cannot query field \"services\" on type \"Host\". Did you mean \"hostServices\"?","locations":[{"line":1,"column":16}]}],"data":null}`)
+	got := prettyGraphQLErrors(body)
+	wantSubstrs := []string{
+		`Cannot query field "services" on type "Host"`,
+		`Did you mean "hostServices"?`,
+		"at line 1, col 16",
+	}
+	for _, want := range wantSubstrs {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestPrettyGraphQLErrors_MultipleErrorsAreSeparated(t *testing.T) {
+	body := []byte(`{"errors":[
+		{"message":"first error","locations":[{"line":1,"column":1}]},
+		{"message":"second error","locations":[{"line":2,"column":5}]}
+	]}`)
+	got := prettyGraphQLErrors(body)
+	if !strings.Contains(got, "first error") {
+		t.Errorf("missing first error: %s", got)
+	}
+	if !strings.Contains(got, "second error") {
+		t.Errorf("missing second error: %s", got)
+	}
+	if !strings.Contains(got, "line 2, col 5") {
+		t.Errorf("missing second location: %s", got)
+	}
+}
+
+func TestPrettyGraphQLErrors_NoLocations(t *testing.T) {
+	body := []byte(`{"errors":[{"message":"server is angry"}]}`)
+	got := prettyGraphQLErrors(body)
+	if !strings.HasPrefix(got, "error: server is angry") {
+		t.Errorf("got: %q", got)
+	}
+	if strings.Contains(got, "at line") {
+		t.Errorf("should not synthesise a fake location: %s", got)
+	}
+}
+
+func TestPrettyGraphQLErrors_PathRendered(t *testing.T) {
+	body := []byte(`{"errors":[{"message":"resolver panic","path":["pullRequests",2,"reviews"]}]}`)
+	got := prettyGraphQLErrors(body)
+	if !strings.Contains(got, "path: pullRequests.2.reviews") {
+		t.Errorf("path not rendered: %s", got)
+	}
+}
+
+func TestPrettyGraphQLErrors_EmptyErrorsArrayReturnsEmpty(t *testing.T) {
+	body := []byte(`{"errors":[],"data":{"foo":"bar"}}`)
+	if got := prettyGraphQLErrors(body); got != "" {
+		t.Errorf("expected empty string for empty errors[], got: %q", got)
+	}
+}
+
+func TestPrettyGraphQLErrors_NonJsonReturnsEmpty(t *testing.T) {
+	body := []byte("not json at all")
+	if got := prettyGraphQLErrors(body); got != "" {
+		t.Errorf("expected empty for non-JSON body, got: %q", got)
+	}
+}
+
+func TestPrettyGraphQLErrors_NoErrorsFieldReturnsEmpty(t *testing.T) {
+	// Healthy response — no `errors` key. Helper must return "" so the
+	// caller knows there's nothing to pretty-print.
+	body := []byte(`{"data":{"health":{"status":"ok"}}}`)
+	if got := prettyGraphQLErrors(body); got != "" {
+		t.Errorf("expected empty for error-less body, got: %q", got)
+	}
+}

--- a/internal/cli/query/query.go
+++ b/internal/cli/query/query.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -181,6 +182,9 @@ func postGraphQLWithVars(ctx context.Context, query string, variables map[string
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
+		if pretty := prettyGraphQLErrors(data); pretty != "" {
+			return nil, fmt.Errorf("daemon returned %d:\n%s", resp.StatusCode, pretty)
+		}
 		return nil, fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(data))
 	}
 	return data, nil
@@ -211,9 +215,61 @@ func postGraphQL(ctx context.Context, query string) ([]byte, error) {
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
+		if pretty := prettyGraphQLErrors(data); pretty != "" {
+			return nil, fmt.Errorf("daemon returned %d:\n%s", resp.StatusCode, pretty)
+		}
 		return nil, fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(data))
 	}
 	return data, nil
+}
+
+// prettyGraphQLErrors decodes a GraphQL error body and returns a
+// human-readable rendering, or "" if the body isn't a recognisable
+// GraphQL error envelope. Each error message is followed by its
+// `locations` (line:col) when present.
+//
+// Resolves issue #398. Today's raw 422 dumps `{"errors":[{...}]}` JSON,
+// which forces operators to eyeball line/column. The new format reads
+//
+//	error: Cannot query field "services" on type "Host". Did you mean "hostServices"?
+//	  at line 1, col 16
+//
+// — readable in a terminal without copy/pasting through `jq`.
+func prettyGraphQLErrors(body []byte) string {
+	var env struct {
+		Errors []struct {
+			Message   string `json:"message"`
+			Locations []struct {
+				Line   int `json:"line"`
+				Column int `json:"column"`
+			} `json:"locations"`
+			Path []any `json:"path"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return ""
+	}
+	if len(env.Errors) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, e := range env.Errors {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		fmt.Fprintf(&b, "error: %s\n", e.Message)
+		for _, loc := range e.Locations {
+			fmt.Fprintf(&b, "  at line %d, col %d\n", loc.Line, loc.Column)
+		}
+		if len(e.Path) > 0 {
+			parts := make([]string, 0, len(e.Path))
+			for _, p := range e.Path {
+				parts = append(parts, fmt.Sprintf("%v", p))
+			}
+			fmt.Fprintf(&b, "  path: %s\n", strings.Join(parts, "."))
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // SetDaemonURLForTest overrides the daemon URL. Tests that drive the


### PR DESCRIPTION
## Summary

Adds \`prettyGraphQLErrors()\` to \`internal/cli/query\`: when the daemon returns 422 (or any non-200 with a recognisable GraphQL error envelope), the CLI renders each error message + its line/column instead of dumping raw JSON.

Resolves **#398**.

## Before / After

\`\`\`
# Before
\$ orchard query --raw '{ host { services } }'
Error: daemon returned 422: {"errors":[{"message":"Cannot query field \"services\" on type \"Host\". Did you mean \"hostServices\"?","locations":[{"line":1,"column":16}]}],"data":null}

# After
\$ orchard query --raw '{ host { services } }'
Error: daemon returned 422:
error: Cannot query field "services" on type "Host". Did you mean "hostServices"?
  at line 1, col 16
\`\`\`

## Implementation

- \`prettyGraphQLErrors(body)\` decodes a \`{"errors":[...]}\` envelope into a multi-line operator-friendly rendering. Handles missing \`locations\` and an optional \`path\`.
- Falls back to the raw-dump path when the body isn't a GraphQL error envelope (e.g. plain HTTP error from a misconfigured proxy).
- Both \`postGraphQL()\` and \`postGraphQLWithVars()\` use the helper.

## Tests

7 unit tests:
- single error + location
- multiple errors
- no locations
- path field rendered
- empty errors array → empty string
- non-JSON body → empty string
- healthy response (no errors key) → empty string

## Test plan

- [ ] CI green
- [ ] /prove-it + /review pass
- [ ] Merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for failed GraphQL requests with improved formatting, now displaying detailed error information including location and path data for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #398