### PR TITLE
fix(daemon): probe 127.0.0.1 in daemon status (resolves #405)

### DIFF
--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -290,9 +290,17 @@ func runStatus(w io.Writer) error {
 }
 
 // probeHealth fetches /health and returns the reported uptime in seconds.
+//
+// Issue #405: Go's HTTP client resolves `localhost` via the system
+// resolver, which on IPv6-enabled Linux boxes returns `::1` first.
+// The daemon's default listener binds 127.0.0.1 (IPv4 only), so the
+// probe sees `dial tcp [::1]:7777: connection refused` and `daemon
+// status` reports a false negative even when the daemon is healthy.
+// We rewrite a leading `localhost` to `127.0.0.1` so the probe
+// targets the same address space the listener uses.
 func probeHealth() (int64, error) {
 	client := &http.Client{Timeout: 2 * time.Second}
-	resp, err := client.Get("http://" + server.DefaultAddr + "/health")
+	resp, err := client.Get("http://" + probeAddr(server.DefaultAddr) + "/health")
 	if err != nil {
 		return 0, err
 	}
@@ -309,6 +317,22 @@ func probeHealth() (int64, error) {
 		return 0, fmt.Errorf("decode: %w", err)
 	}
 	return payload.UptimeS, nil
+}
+
+// probeAddr rewrites a `host:port` so the health probe doesn't go
+// through the system resolver. Specifically: a leading `localhost`
+// becomes `127.0.0.1`. Any other host (explicit `127.0.0.1`, an
+// `--addr 0.0.0.0:8000` override, an FQDN, an IP literal) is returned
+// unchanged. This is the only place we need this rewrite — production
+// HTTP clients can resolve normally.
+func probeAddr(addr string) string {
+	if strings.HasPrefix(addr, "localhost:") {
+		return "127.0.0.1:" + strings.TrimPrefix(addr, "localhost:")
+	}
+	if addr == "localhost" {
+		return "127.0.0.1"
+	}
+	return addr
 }
 
 // claudeprojectsRoot returns the directory the daemon should watch for

--- a/internal/cli/daemon/probe_test.go
+++ b/internal/cli/daemon/probe_test.go
@@ -1,0 +1,61 @@
+// Tests for probeAddr — the helper that rewrites the health-probe
+// target address to avoid Go's IPv6-first resolution of `localhost`.
+// Resolves issue #405.
+
+package daemon
+
+import "testing"
+
+func TestProbeAddr_LocalhostWithPortBecomes127(t *testing.T) {
+	got := probeAddr("localhost:7777")
+	if got != "127.0.0.1:7777" {
+		t.Errorf("probeAddr(localhost:7777) = %q, want 127.0.0.1:7777", got)
+	}
+}
+
+func TestProbeAddr_BareLocalhostBecomes127(t *testing.T) {
+	got := probeAddr("localhost")
+	if got != "127.0.0.1" {
+		t.Errorf("probeAddr(localhost) = %q, want 127.0.0.1", got)
+	}
+}
+
+func TestProbeAddr_ExplicitIP4PassesThrough(t *testing.T) {
+	got := probeAddr("127.0.0.1:7777")
+	if got != "127.0.0.1:7777" {
+		t.Errorf("probeAddr(127.0.0.1:7777) = %q, want unchanged", got)
+	}
+}
+
+func TestProbeAddr_ZeroAddrPassesThrough(t *testing.T) {
+	// `--addr 0.0.0.0:8000` is a valid override. We don't rewrite it
+	// because the daemon probably bound 0.0.0.0 deliberately.
+	got := probeAddr("0.0.0.0:8000")
+	if got != "0.0.0.0:8000" {
+		t.Errorf("probeAddr(0.0.0.0:8000) = %q, want unchanged", got)
+	}
+}
+
+func TestProbeAddr_FqdnPassesThrough(t *testing.T) {
+	got := probeAddr("orchard.internal:7777")
+	if got != "orchard.internal:7777" {
+		t.Errorf("probeAddr(orchard.internal:7777) = %q, want unchanged", got)
+	}
+}
+
+func TestProbeAddr_IPv6BracketPassesThrough(t *testing.T) {
+	// IPv6 listener address is its own choice; don't rewrite.
+	got := probeAddr("[::1]:7777")
+	if got != "[::1]:7777" {
+		t.Errorf("probeAddr([::1]:7777) = %q, want unchanged", got)
+	}
+}
+
+func TestProbeAddr_LocalhostPrefixOnHostnameNotRewritten(t *testing.T) {
+	// Pathological hostname `localhost.example.com:7777` should not
+	// match — only the exact `localhost:` prefix triggers rewriting.
+	got := probeAddr("localhost.example.com:7777")
+	if got != "localhost.example.com:7777" {
+		t.Errorf("probeAddr(localhost.example.com:7777) = %q, want unchanged", got)
+	}
+}


### PR DESCRIPTION
## Summary

\`bin/orchard daemon status\` reports \`health probe failed: dial tcp [::1]:7777: connection refused\` on IPv6-enabled Linux boxes even when the daemon is healthy. Go's HTTP client resolves \`localhost\` via the system resolver and tries \`::1\` first; the daemon binds 127.0.0.1 (IPv4) by default, so the probe sees a connection refusal.

Resolves **#405**.

## Fix

\`probeAddr()\` rewrites a leading \`localhost:\` to \`127.0.0.1:\` so the probe targets the listener's actual address. Other addresses pass through unchanged:

- \`0.0.0.0:8000\` (deliberate \`--addr\` override)
- FQDNs like \`orchard.internal:7777\`
- IPv6 literals like \`[::1]:7777\`
- Substring-only hostnames like \`localhost.example.com:7777\`

Only the exact \`localhost:\` prefix (or bare \`localhost\`) triggers the rewrite.

## Tests

7 unit tests in \`internal/cli/daemon/probe_test.go\`:
- \`localhost:7777\` → \`127.0.0.1:7777\`
- \`localhost\` → \`127.0.0.1\`
- \`127.0.0.1:7777\` (passthrough)
- \`0.0.0.0:8000\` (passthrough)
- \`orchard.internal:7777\` (passthrough)
- \`[::1]:7777\` (passthrough)
- \`localhost.example.com:7777\` (passthrough — guards against accidentally rewriting hostnames that *contain* "localhost")

## Test plan

- [ ] CI green
- [ ] Merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon health check reliability by fixing localhost resolution behavior that could incorrectly report connection failures.

* **Tests**
  * Added comprehensive test coverage for health check address handling across various address formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #127