### PR TITLE
docs(schema): correct TmuxPane.currentCommand documentation (resolves #399)

### DIFF
--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -2737,7 +2737,24 @@ type TmuxPane implements Node {
   "Pane title (tmux ` + "`" + `pane_title` + "`" + `)."
   title: String!
 
-  "Foreground command basename (tmux ` + "`" + `pane_current_command` + "`" + `, e.g. 'claude', 'zsh')."
+  """
+  Foreground command name as reported by ` + "`" + `tmux #{pane_current_command}` + "`" + `.
+  This is **whatever string tmux's pane_current_command emits**, NOT a
+  guaranteed basename. In practice that means:
+
+  - For most processes: a basename like ` + "`" + `'zsh'` + "`" + ` or ` + "`" + `'vim'` + "`" + `.
+  - For Node-wrapped CLIs (claude, npx tools, etc.): often the wrapper's
+    version string (` + "`" + `'2.1.126'` + "`" + `) instead of the friendly name. tmux reads
+    this from /proc/$pid/comm or the macOS equivalent, which Node sets
+    to its own runtime version when the script doesn't override argv[0].
+
+  Operators filtering by command should not assume a stable name —
+  ` + "`" + `currentCommandIn: ["claude"]` + "`" + ` will silently miss panes running the
+  Claude CLI when its wrapper has set comm to a version string. To
+  identify panes by program intent, walk to the foreground process via
+  ` + "`" + `Pane.process` + "`" + ` (when wired — see #394/#395) and inspect that node's
+  command/args instead.
+  """
   currentCommand: String!
 
   "Pid of the foreground process. Null when tmux reports no current pid."
@@ -2848,7 +2865,16 @@ input TmuxPaneFilter {
   "Pane ids (e.g. ` + "`" + `%26` + "`" + `) to include."
   paneIdIn: [String!]
 
-  "Only include panes whose ` + "`" + `currentCommand` + "`" + ` is in this list."
+  """
+  Only include panes whose ` + "`" + `currentCommand` + "`" + ` is in this list.
+
+  Note: ` + "`" + `currentCommand` + "`" + ` is the raw tmux ` + "`" + `pane_current_command` + "`" + ` value,
+  not a normalised basename. Wrapper processes (notably Node-based CLIs
+  like the Claude CLI) often surface as their version string rather
+  than the program name, so a filter like ` + "`" + `["claude"]` + "`" + ` may match zero
+  panes that are clearly running Claude. See the doc on
+  ` + "`" + `TmuxPane.currentCommand` + "`" + ` for the full caveat.
+  """
   currentCommandIn: [String!]
 
   "Only include panes in these session names."

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -465,7 +465,22 @@ type TmuxPane struct {
 	PaneID string `json:"paneId"`
 	// Pane title (tmux `pane_title`).
 	Title string `json:"title"`
-	// Foreground command basename (tmux `pane_current_command`, e.g. 'claude', 'zsh').
+	// Foreground command name as reported by `tmux #{pane_current_command}`.
+	// This is **whatever string tmux's pane_current_command emits**, NOT a
+	// guaranteed basename. In practice that means:
+	//
+	// - For most processes: a basename like `'zsh'` or `'vim'`.
+	// - For Node-wrapped CLIs (claude, npx tools, etc.): often the wrapper's
+	//   version string (`'2.1.126'`) instead of the friendly name. tmux reads
+	//   this from /proc/$pid/comm or the macOS equivalent, which Node sets
+	//   to its own runtime version when the script doesn't override argv[0].
+	//
+	// Operators filtering by command should not assume a stable name —
+	// `currentCommandIn: ["claude"]` will silently miss panes running the
+	// Claude CLI when its wrapper has set comm to a version string. To
+	// identify panes by program intent, walk to the foreground process via
+	// `Pane.process` (when wired — see #394/#395) and inspect that node's
+	// command/args instead.
 	CurrentCommand string `json:"currentCommand"`
 	// Pid of the foreground process. Null when tmux reports no current pid.
 	CurrentPid *int64 `json:"currentPid,omitempty"`
@@ -499,6 +514,13 @@ type TmuxPaneFilter struct {
 	// Pane ids (e.g. `%26`) to include.
 	PaneIDIn []string `json:"paneIdIn,omitempty"`
 	// Only include panes whose `currentCommand` is in this list.
+	//
+	// Note: `currentCommand` is the raw tmux `pane_current_command` value,
+	// not a normalised basename. Wrapper processes (notably Node-based CLIs
+	// like the Claude CLI) often surface as their version string rather
+	// than the program name, so a filter like `["claude"]` may match zero
+	// panes that are clearly running Claude. See the doc on
+	// `TmuxPane.currentCommand` for the full caveat.
 	CurrentCommandIn []string `json:"currentCommandIn,omitempty"`
 	// Only include panes in these session names.
 	SessionIn []string `json:"sessionIn,omitempty"`

--- a/schema.graphql
+++ b/schema.graphql
@@ -512,7 +512,24 @@ type TmuxPane implements Node {
   "Pane title (tmux `pane_title`)."
   title: String!
 
-  "Foreground command basename (tmux `pane_current_command`, e.g. 'claude', 'zsh')."
+  """
+  Foreground command name as reported by `tmux #{pane_current_command}`.
+  This is **whatever string tmux's pane_current_command emits**, NOT a
+  guaranteed basename. In practice that means:
+
+  - For most processes: a basename like `'zsh'` or `'vim'`.
+  - For Node-wrapped CLIs (claude, npx tools, etc.): often the wrapper's
+    version string (`'2.1.126'`) instead of the friendly name. tmux reads
+    this from /proc/$pid/comm or the macOS equivalent, which Node sets
+    to its own runtime version when the script doesn't override argv[0].
+
+  Operators filtering by command should not assume a stable name —
+  `currentCommandIn: ["claude"]` will silently miss panes running the
+  Claude CLI when its wrapper has set comm to a version string. To
+  identify panes by program intent, walk to the foreground process via
+  `Pane.process` (when wired — see #394/#395) and inspect that node's
+  command/args instead.
+  """
   currentCommand: String!
 
   "Pid of the foreground process. Null when tmux reports no current pid."
@@ -623,7 +640,16 @@ input TmuxPaneFilter {
   "Pane ids (e.g. `%26`) to include."
   paneIdIn: [String!]
 
-  "Only include panes whose `currentCommand` is in this list."
+  """
+  Only include panes whose `currentCommand` is in this list.
+
+  Note: `currentCommand` is the raw tmux `pane_current_command` value,
+  not a normalised basename. Wrapper processes (notably Node-based CLIs
+  like the Claude CLI) often surface as their version string rather
+  than the program name, so a filter like `["claude"]` may match zero
+  panes that are clearly running Claude. See the doc on
+  `TmuxPane.currentCommand` for the full caveat.
+  """
   currentCommandIn: [String!]
 
   "Only include panes in these session names."


### PR DESCRIPTION
## Summary

The doc on \`TmuxPane.currentCommand\` claimed the field returned a foreground command basename like \`'claude'\` or \`'zsh'\`. In practice tmux's \`pane_current_command\` reads \`/proc/\$pid/comm\` (or the macOS equivalent), which **Node-wrapped CLIs override with their wrapper version string**. So a pane running the Claude CLI shows up as \`'2.1.126'\`, and a naive operator filter \`currentCommandIn: ["claude"]\` returns 0.

Resolves **#399**.

## Fix

Rewrite the field doc to describe what tmux actually emits and point operators at \`Pane.process\` (when wired — #394/#395) for program-intent identification. Also extend the \`TmuxPaneFilter.currentCommandIn\` doc with the same caveat so callers see the gotcha at the use site.

Schema-only change (codegen regenerated, generated.go reflects the new docstrings).

## Tests

\`go test ./...\` all green.

## Test plan

- [ ] CI green
- [ ] Merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved `currentCommand` field documentation to clarify it reflects raw tmux output (not normalized), and wrapper processes like Node CLIs may yield version strings.
  * Recommended using the `process` field for more reliable command filtering instead of filtering by `currentCommand`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #399