### PR TITLE
fix(tmux): self-protection invariant for kill_tmux_session callers (resolves #369)

### DIFF
--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -452,7 +452,10 @@ pub fn apply_fixes(findings: &[HealFinding]) -> Vec<FixResult> {
                     });
                     continue;
                 }
-                let result = tmux::kill_tmux_session(name);
+                // The `is_self` guard above makes the cross-cutting
+                // wrapper redundant here, but use it anyway so the code
+                // path matches every other in-process kill site.
+                let result = tmux::kill_tmux_session_safe(name, tmux::current_session_name().as_deref());
                 results.push(FixResult {
                     message: format!("Killed session \"{}\"", name),
                     success: result.is_ok(),

--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -455,7 +455,8 @@ pub fn apply_fixes(findings: &[HealFinding]) -> Vec<FixResult> {
                 // The `is_self` guard above makes the cross-cutting
                 // wrapper redundant here, but use it anyway so the code
                 // path matches every other in-process kill site.
-                let result = tmux::kill_tmux_session_safe(name, tmux::current_session_name().as_deref());
+                let result =
+                    tmux::kill_tmux_session_safe(name, tmux::current_session_name().as_deref());
                 results.push(FixResult {
                     message: format!("Killed session \"{}\"", name),
                     success: result.is_ok(),

--- a/crates/orchard/src/tmux.rs
+++ b/crates/orchard/src/tmux.rs
@@ -150,13 +150,51 @@ pub fn session_exists(name: &str) -> bool {
 }
 
 /// Kills the tmux session with the given name.
-pub fn kill_tmux_session(name: &str) -> Result<()> {
+///
+/// **Direct callers should use [`kill_tmux_session_safe`] instead** —
+/// the raw function does not protect the invoking process's host session
+/// from being killed (which would terminate orchard itself when run inside
+/// tmux). The raw function stays accessible for cases where the safety
+/// check has already been performed (e.g. inside `kill_tmux_session_safe`)
+/// or where the target session is provably not the host (e.g. a remote
+/// SSH-targeted kill, where "current session" is meaningless).
+///
+/// Resolves issue #369.
+pub(crate) fn kill_tmux_session(name: &str) -> Result<()> {
     Command::new("tmux")
         .args(["kill-session", "-t", name])
         .status()
         .context("tmux kill-session")?;
     LOG.info(&format!("killTmuxSession: {}", name));
     Ok(())
+}
+
+/// Kills `name`, refusing if `name == current_session`.
+///
+/// Pass `current_session = current_session_name().as_deref()` from the
+/// caller. When the target equals the invoking process's host session,
+/// returns `Err(SelfKillRefused)` and emits no tmux command — this is
+/// the cross-cutting invariant that prevents orchard from self-immolating
+/// when run inside tmux. Pass `None` for `current_session` only when the
+/// caller is provably not inside tmux (background services, remote
+/// shellouts).
+///
+/// All in-process callers of `kill_tmux_session` should funnel through
+/// this wrapper; raw `kill_tmux_session` is `pub(crate)` so the safety
+/// check cannot be bypassed from outside the module.
+///
+/// Resolves issue #369.
+pub fn kill_tmux_session_safe(name: &str, current_session: Option<&str>) -> Result<()> {
+    if let Some(current) = current_session
+        && current == name
+    {
+        anyhow::bail!(
+            "refusing to kill tmux session '{name}': it is the host session of \
+             the orchard process. This guard prevents self-immolation when \
+             orchard runs inside tmux. See issue #369."
+        );
+    }
+    kill_tmux_session(name)
 }
 
 /// Captures the pane content of a tmux session, returning the last `lines` lines.
@@ -583,5 +621,60 @@ mod tests {
             !name.contains('\n'),
             "session name must not contain newlines"
         );
+    }
+
+    // -------- kill_tmux_session_safe — issue #369 invariant --------
+
+    /// Regression test: `kill_tmux_session_safe` MUST refuse to kill the
+    /// host session of the invoking process. This is the cross-cutting
+    /// invariant from issue #369; if any caller forgets the safety
+    /// wrapper they get the public function which can't bypass this
+    /// check.
+    #[test]
+    fn kill_tmux_session_safe_refuses_to_kill_self() {
+        let result = kill_tmux_session_safe("my_session", Some("my_session"));
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("refusing to kill"),
+            "error message must say so: {msg}"
+        );
+        assert!(msg.contains("my_session"), "must name the session: {msg}");
+    }
+
+    /// When the target differs from the host session, the wrapper
+    /// passes through to the raw kill. We can't test the actual tmux
+    /// call without a real tmux server (and that would require mocking
+    /// process spawn) — but we can at least confirm the guard does NOT
+    /// short-circuit for differing names. The downstream Command::new
+    /// will fail in a unit test environment where tmux isn't running,
+    /// so we accept either an error from tmux or success — what we
+    /// must NOT see is the "refusing to kill" guard message.
+    #[test]
+    fn kill_tmux_session_safe_passes_through_for_other_targets() {
+        let result =
+            kill_tmux_session_safe("some_other_session", Some("my_current_session"));
+        if let Err(e) = result {
+            let msg = format!("{e}");
+            assert!(
+                !msg.contains("refusing to kill"),
+                "must not trigger the self-kill guard for a different target: {msg}"
+            );
+        }
+    }
+
+    /// When `current_session` is None (caller is not inside tmux), the
+    /// guard cannot apply and the wrapper simply passes through. This
+    /// is the contract for background services / non-TTY callers.
+    #[test]
+    fn kill_tmux_session_safe_no_current_session_skips_guard() {
+        let result = kill_tmux_session_safe("any_session", None);
+        if let Err(e) = result {
+            let msg = format!("{e}");
+            assert!(
+                !msg.contains("refusing to kill"),
+                "no-current-session callers must not trip the guard: {msg}"
+            );
+        }
     }
 }

--- a/crates/orchard/src/tmux.rs
+++ b/crates/orchard/src/tmux.rs
@@ -652,8 +652,7 @@ mod tests {
     /// must NOT see is the "refusing to kill" guard message.
     #[test]
     fn kill_tmux_session_safe_passes_through_for_other_targets() {
-        let result =
-            kill_tmux_session_safe("some_other_session", Some("my_current_session"));
+        let result = kill_tmux_session_safe("some_other_session", Some("my_current_session"));
         if let Err(e) = result {
             let msg = format!("{e}");
             assert!(

--- a/crates/orchard/src/tui/worktree_ops.rs
+++ b/crates/orchard/src/tui/worktree_ops.rs
@@ -65,9 +65,11 @@ pub(super) fn delete_task_row(
         return Ok(());
     }
 
-    // Local deletion
+    // Local deletion. Use the safety wrapper so a TUI delete action
+    // can never kill the orchard-tui process's own host session
+    // (which would terminate the dialog mid-action). Resolves #369.
     if let Some(sess) = session_name {
-        let _ = tmux::kill_tmux_session(sess);
+        let _ = tmux::kill_tmux_session_safe(sess, tmux::current_session_name().as_deref());
     }
     if worktree_core::remove_worktree(&row.worktree_path, false).is_err() {
         worktree_core::remove_worktree(&row.worktree_path, true)?;


### PR DESCRIPTION
## Summary

Adds \`kill_tmux_session_safe(name, current_session)\` that errors when \`name == current_session\` and otherwise delegates to the raw kill. Migrates in-process callers and downgrades raw \`kill_tmux_session\` to \`pub(crate)\` so the safety check cannot be bypassed from outside the module.

Resolves **#369**.

## Why

After PR #368/#361 hardened \`heal --fix\`, a sweep flagged other call sites that programmatically kill tmux sessions. None were same-bug today (each was gated by user intent, naming convention, or remote target), but the invariant "never kill the invoking process's host session" should be enforced cross-cuttingly so future changes can't reintroduce the regression.

## Migrations

| File | Before | After |
|---|---|---|
| \`heal.rs:455\` | \`tmux::kill_tmux_session(name)\` (gated by \`is_self\`) | wrapper, for consistency |
| \`tui/worktree_ops.rs:70\` | \`tmux::kill_tmux_session(sess)\` (unprotected) | wrapper |

\`pub fn kill_tmux_session\` → \`pub(crate) fn kill_tmux_session\`. The function stays accessible to siblings inside the module that have already performed the safety check (the wrapper itself).

## Out of scope per the issue

- \`restore.rs\` — test cleanup + naming-gated handshake; different model
- \`remote.rs\` — kill_remote_tmux_session is SSH-targeted; "current session" is meaningless across hosts
- \`shell.rs\` legacy_*_orchard cleanup — naming-gated, not session-name-equality

## Tests

3 new unit tests in \`crates/orchard/src/tmux.rs::tests\`:
- \`kill_tmux_session_safe_refuses_to_kill_self\` — guards the invariant
- \`kill_tmux_session_safe_passes_through_for_other_targets\` — non-self targets must NOT trip the guard
- \`kill_tmux_session_safe_no_current_session_skips_guard\` — outside-tmux callers (no current_session) pass through

## Test plan

- [ ] CI green
- [ ] Merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session-handling safety during cleanup to avoid terminating the app's own active host session, preventing unexpected interruptions.

* **Tests**
  * Added unit tests to verify the new self-protection behavior and related cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #369

# Related issue

- #369

# Related issue

- #369