### PR TITLE
feat(daemon): gate introspection behind ORCHARD_INTROSPECTION env var (resolves #401)

### DIFF
--- a/internal/server/introspection_test.go
+++ b/internal/server/introspection_test.go
@@ -1,0 +1,124 @@
+// Tests for introspection gating — issue #401.
+//
+// We test the env-var helper directly (cheap, no daemon boot needed) and
+// confirm via httptest that a daemon with introspection disabled returns
+// the canonical "introspection disabled" error from gqlgen, while one
+// with it enabled returns the schema.
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+)
+
+// --- env-var gate ---
+
+func TestIntrospectionEnabled_DefaultsOff(t *testing.T) {
+	t.Setenv("ORCHARD_INTROSPECTION", "")
+	if introspectionEnabled() {
+		t.Errorf("default (unset) must be off; got on")
+	}
+}
+
+func TestIntrospectionEnabled_OffWhenZero(t *testing.T) {
+	t.Setenv("ORCHARD_INTROSPECTION", "0")
+	if introspectionEnabled() {
+		t.Errorf("ORCHARD_INTROSPECTION=0 must be off; got on")
+	}
+}
+
+func TestIntrospectionEnabled_OnWhenOne(t *testing.T) {
+	t.Setenv("ORCHARD_INTROSPECTION", "1")
+	if !introspectionEnabled() {
+		t.Errorf("ORCHARD_INTROSPECTION=1 must be on; got off")
+	}
+}
+
+func TestIntrospectionEnabled_OnWhenTrue(t *testing.T) {
+	t.Setenv("ORCHARD_INTROSPECTION", "true")
+	if !introspectionEnabled() {
+		t.Errorf("ORCHARD_INTROSPECTION=true must be on; got off")
+	}
+}
+
+func TestIntrospectionEnabled_OnWhenYes(t *testing.T) {
+	t.Setenv("ORCHARD_INTROSPECTION", "yes")
+	if !introspectionEnabled() {
+		t.Errorf("ORCHARD_INTROSPECTION=yes must be on; got off")
+	}
+}
+
+func TestIntrospectionEnabled_OnWhenOn(t *testing.T) {
+	t.Setenv("ORCHARD_INTROSPECTION", "on")
+	if !introspectionEnabled() {
+		t.Errorf("ORCHARD_INTROSPECTION=on must be on; got off")
+	}
+}
+
+func TestIntrospectionEnabled_OffOnGarbage(t *testing.T) {
+	t.Setenv("ORCHARD_INTROSPECTION", "maybe")
+	if introspectionEnabled() {
+		t.Errorf("ORCHARD_INTROSPECTION=maybe must be off (strict allow-list); got on")
+	}
+}
+
+// --- end-to-end: daemon refuses __schema with introspection off ---
+
+func TestIntrospection_HTTPDisabledByDefault(t *testing.T) {
+	// Default empty env — server should refuse __schema.
+	t.Setenv("ORCHARD_INTROSPECTION", "")
+
+	res := &resolvers.Resolver{}
+	srv := httptest.NewServer(graphqlHandlerFor(res))
+	t.Cleanup(srv.Close)
+
+	body := postQuery(t, srv.URL, `{ __schema { types { name } } }`)
+	if !strings.Contains(body, "introspection disabled") {
+		t.Errorf("expected 'introspection disabled' in response; got: %s", body)
+	}
+}
+
+func TestIntrospection_HTTPEnabledWhenEnvSet(t *testing.T) {
+	t.Setenv("ORCHARD_INTROSPECTION", "1")
+
+	res := &resolvers.Resolver{}
+	srv := httptest.NewServer(graphqlHandlerFor(res))
+	t.Cleanup(srv.Close)
+
+	body := postQuery(t, srv.URL, `{ __schema { queryType { name } } }`)
+	if strings.Contains(body, "introspection disabled") {
+		t.Errorf("expected schema response; got error: %s", body)
+	}
+	if !strings.Contains(body, "Query") {
+		t.Errorf("expected 'Query' in schema response; got: %s", body)
+	}
+}
+
+// postQuery posts a single GraphQL document and returns the raw response body.
+func postQuery(t *testing.T, url, query string) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"query": query})
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build req: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return string(raw)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
 	gqlws "github.com/gorilla/websocket"
 
@@ -394,6 +395,28 @@ func graphqlHandlerFor(res *resolvers.Resolver) http.Handler {
 			Subprotocols:    []string{"graphql-transport-ws", "graphql-ws"},
 		},
 	})
+	// Introspection is gated by env var. Off by default in prod (gqlgen
+	// sets DisableIntrospection: true unless extension.Introspection is
+	// registered) so adversarial probes can't enumerate the surface; on
+	// for dev/CLI when ORCHARD_INTROSPECTION=1 so operators can run
+	// `__schema { types { name } }` without round-tripping through
+	// schema.graphql. Resolves issue #401.
+	if introspectionEnabled() {
+		srv.Use(extension.Introspection{})
+	}
 	return srv
+}
+
+// introspectionEnabled returns true when the daemon should respond to
+// `__schema` / `__type` queries. The toggle is intentionally an env var
+// rather than a CLI flag so daemons started by launchd / systemd can
+// opt in without a wrapper script that re-execs with `--introspection`.
+func introspectionEnabled() bool {
+	switch os.Getenv("ORCHARD_INTROSPECTION") {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 


### PR DESCRIPTION
## Summary

Adds a runtime toggle: when \`ORCHARD_INTROSPECTION\` is set to a truthy value (\`1\`/\`true\`/\`yes\`/\`on\`), the daemon registers \`extension.Introspection\` on its handler and responds to \`__schema\` / \`__type\` queries. Otherwise introspection stays off and queries return gqlgen's canonical \`introspection disabled\` error — the prod default.

Resolves **#401**.

## Why env var, not CLI flag

Daemons started by launchd / systemd shouldn't need a wrapper script that re-execs with \`--introspection\`. Operators flip the toggle by editing the unit file or exporting in their shell. The env var also composes nicely with the existing \`ORCHARD_DAEMON_URL\` and \`ORCHARD_EVENTS_PATH\` overrides.

## Truthy values

\`1\`, \`true\`, \`yes\`, \`on\`. Anything else (including the empty string and \`0\`) is off — a strict allow-list so a typo like \`tru\` doesn't silently leave the daemon open in prod.

## Tests

9 unit tests in \`internal/server/introspection_test.go\`:
- 7 cover the env-var helper across truthy / falsy / garbage values.
- 2 boot a real \`httptest.Server\` via \`graphqlHandlerFor\` and confirm \`__schema\` responds with "introspection disabled" by default and with the schema when the env var is on.

## Test plan

- [ ] CI green
- [ ] Merge once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #401

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GraphQL schema introspection can now be controlled via the `ORCHARD_INTROSPECTION` environment variable. Introspection is disabled by default and can be enabled with values: `1`, `true`, `yes`, or `on`.

* **Tests**
  * Added comprehensive test coverage for introspection gating, including validation of environment variable parsing and schema query request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #401