### PR TITLE
feat(daemon): Worktree host/repo/pr/issue fields (Phase 1 of #441)

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -39,6 +39,14 @@ models:
         resolver: true
   Worktree:
     fields:
+      host:
+        resolver: true
+      repo:
+        resolver: true
+      pr:
+        resolver: true
+      issue:
+        resolver: true
       processes:
         resolver: true
 

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -343,9 +343,13 @@ type ComplexityRoot struct {
 		Bare      func(childComplexity int) int
 		Branch    func(childComplexity int) int
 		Head      func(childComplexity int) int
+		Host      func(childComplexity int) int
 		ID        func(childComplexity int) int
+		Issue     func(childComplexity int) int
 		Path      func(childComplexity int) int
+		Pr        func(childComplexity int) int
 		Processes func(childComplexity int) int
+		Repo      func(childComplexity int) int
 	}
 }
 
@@ -449,6 +453,10 @@ type TmuxWindowResolver interface {
 	CurrentPane(ctx context.Context, obj *TmuxWindow) (*TmuxPane, error)
 }
 type WorktreeResolver interface {
+	Host(ctx context.Context, obj *Worktree) (string, error)
+	Repo(ctx context.Context, obj *Worktree) (*string, error)
+	Pr(ctx context.Context, obj *Worktree) (*PullRequest, error)
+	Issue(ctx context.Context, obj *Worktree) (*Issue, error)
 	Processes(ctx context.Context, obj *Worktree) ([]*Process, error)
 }
 
@@ -2090,12 +2098,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Worktree.Head(childComplexity), true
 
+	case "Worktree.host":
+		if e.complexity.Worktree.Host == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Host(childComplexity), true
+
 	case "Worktree.id":
 		if e.complexity.Worktree.ID == nil {
 			break
 		}
 
 		return e.complexity.Worktree.ID(childComplexity), true
+
+	case "Worktree.issue":
+		if e.complexity.Worktree.Issue == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Issue(childComplexity), true
 
 	case "Worktree.path":
 		if e.complexity.Worktree.Path == nil {
@@ -2104,12 +2126,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Worktree.Path(childComplexity), true
 
+	case "Worktree.pr":
+		if e.complexity.Worktree.Pr == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Pr(childComplexity), true
+
 	case "Worktree.processes":
 		if e.complexity.Worktree.Processes == nil {
 			break
 		}
 
 		return e.complexity.Worktree.Processes(childComplexity), true
+
+	case "Worktree.repo":
+		if e.complexity.Worktree.Repo == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Repo(childComplexity), true
 
 	}
 	return 0, false
@@ -2613,6 +2649,18 @@ type Worktree implements Node {
 
   "True when HEAD references a deleted branch or otherwise fails to resolve to a commit. Bare worktrees still appear in the list — they just have no live branch."
   bare: Boolean!
+
+  "Hostname this worktree was discovered on. v1: always 'local'. Workstream F populates per-peer."
+  host: String!
+
+  "owner/repo slug derived from origin remote. Null when origin is not a GitHub URL."
+  repo: String
+
+  "Open PR whose headRef matches this worktree's branch. Null when no match, branch is detached, or branch is the project's default branch."
+  pr: PullRequest
+
+  "Issue linked from the worktree's branch (issue<N>/... convention). Null when the branch doesn't carry an issue number."
+  issue: Issue
 
   "Processes whose cwd lies under ` + "`" + `path` + "`" + `. Resolved by the ps provider (ws-b-ps); returns ` + "`" + `[]` + "`" + ` until that provider lands."
   processes: [Process!]!
@@ -8003,6 +8051,14 @@ func (ec *executionContext) fieldContext_Process_worktree(ctx context.Context, f
 				return ec.fieldContext_Worktree_head(ctx, field)
 			case "bare":
 				return ec.fieldContext_Worktree_bare(ctx, field)
+			case "host":
+				return ec.fieldContext_Worktree_host(ctx, field)
+			case "repo":
+				return ec.fieldContext_Worktree_repo(ctx, field)
+			case "pr":
+				return ec.fieldContext_Worktree_pr(ctx, field)
+			case "issue":
+				return ec.fieldContext_Worktree_issue(ctx, field)
 			case "processes":
 				return ec.fieldContext_Worktree_processes(ctx, field)
 			}
@@ -8254,6 +8310,14 @@ func (ec *executionContext) fieldContext_Project_worktrees(ctx context.Context, 
 				return ec.fieldContext_Worktree_head(ctx, field)
 			case "bare":
 				return ec.fieldContext_Worktree_bare(ctx, field)
+			case "host":
+				return ec.fieldContext_Worktree_host(ctx, field)
+			case "repo":
+				return ec.fieldContext_Worktree_repo(ctx, field)
+			case "pr":
+				return ec.fieldContext_Worktree_pr(ctx, field)
+			case "issue":
+				return ec.fieldContext_Worktree_issue(ctx, field)
 			case "processes":
 				return ec.fieldContext_Worktree_processes(ctx, field)
 			}
@@ -14776,6 +14840,233 @@ func (ec *executionContext) fieldContext_Worktree_bare(ctx context.Context, fiel
 	return fc, nil
 }
 
+func (ec *executionContext) _Worktree_host(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_host(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Worktree().Host(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_host(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_repo(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_repo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Worktree().Repo(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_repo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_pr(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_pr(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Worktree().Pr(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*PullRequest)
+	fc.Result = res
+	return ec.marshalOPullRequest2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐPullRequest(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_pr(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_PullRequest_id(ctx, field)
+			case "repoOwner":
+				return ec.fieldContext_PullRequest_repoOwner(ctx, field)
+			case "repoName":
+				return ec.fieldContext_PullRequest_repoName(ctx, field)
+			case "number":
+				return ec.fieldContext_PullRequest_number(ctx, field)
+			case "title":
+				return ec.fieldContext_PullRequest_title(ctx, field)
+			case "body":
+				return ec.fieldContext_PullRequest_body(ctx, field)
+			case "state":
+				return ec.fieldContext_PullRequest_state(ctx, field)
+			case "draft":
+				return ec.fieldContext_PullRequest_draft(ctx, field)
+			case "authorLogin":
+				return ec.fieldContext_PullRequest_authorLogin(ctx, field)
+			case "baseRef":
+				return ec.fieldContext_PullRequest_baseRef(ctx, field)
+			case "headRef":
+				return ec.fieldContext_PullRequest_headRef(ctx, field)
+			case "url":
+				return ec.fieldContext_PullRequest_url(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_PullRequest_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_PullRequest_updatedAt(ctx, field)
+			case "reviews":
+				return ec.fieldContext_PullRequest_reviews(ctx, field)
+			case "comments":
+				return ec.fieldContext_PullRequest_comments(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type PullRequest", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_issue(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_issue(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Worktree().Issue(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*Issue)
+	fc.Result = res
+	return ec.marshalOIssue2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssue(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_issue(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Issue_id(ctx, field)
+			case "repoOwner":
+				return ec.fieldContext_Issue_repoOwner(ctx, field)
+			case "repoName":
+				return ec.fieldContext_Issue_repoName(ctx, field)
+			case "number":
+				return ec.fieldContext_Issue_number(ctx, field)
+			case "title":
+				return ec.fieldContext_Issue_title(ctx, field)
+			case "body":
+				return ec.fieldContext_Issue_body(ctx, field)
+			case "state":
+				return ec.fieldContext_Issue_state(ctx, field)
+			case "authorLogin":
+				return ec.fieldContext_Issue_authorLogin(ctx, field)
+			case "url":
+				return ec.fieldContext_Issue_url(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_Issue_createdAt(ctx, field)
+			case "updatedAt":
+				return ec.fieldContext_Issue_updatedAt(ctx, field)
+			case "comments":
+				return ec.fieldContext_Issue_comments(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Issue", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Worktree_processes(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Worktree_processes(ctx, field)
 	if err != nil {
@@ -20591,6 +20882,141 @@ func (ec *executionContext) _Worktree(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "host":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Worktree_host(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "repo":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Worktree_repo(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "pr":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Worktree_pr(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "issue":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Worktree_issue(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "processes":
 			field := field
 

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -650,6 +650,14 @@ type Worktree struct {
 	Head string `json:"head"`
 	// True when HEAD references a deleted branch or otherwise fails to resolve to a commit. Bare worktrees still appear in the list — they just have no live branch.
 	Bare bool `json:"bare"`
+	// Hostname this worktree was discovered on. v1: always 'local'. Workstream F populates per-peer.
+	Host string `json:"host"`
+	// owner/repo slug derived from origin remote. Null when origin is not a GitHub URL.
+	Repo *string `json:"repo,omitempty"`
+	// Open PR whose headRef matches this worktree's branch. Null when no match, branch is detached, or branch is the project's default branch.
+	Pr *PullRequest `json:"pr,omitempty"`
+	// Issue linked from the worktree's branch (issue<N>/... convention). Null when the branch doesn't carry an issue number.
+	Issue *Issue `json:"issue,omitempty"`
 	// Processes whose cwd lies under `path`. Resolved by the ps provider (ws-b-ps); returns `[]` until that provider lands.
 	Processes []*Process `json:"processes"`
 }

--- a/internal/server/loaders/loaders.go
+++ b/internal/server/loaders/loaders.go
@@ -16,6 +16,7 @@ package loaders
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -24,10 +25,18 @@ import (
 
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	ghprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	hostprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 	psprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 )
+
+// GHPullRequestLister is the narrow gh surface the PullRequestsForRepo
+// loader needs. *gh.Provider satisfies this automatically. Defined as
+// an interface so tests can inject a stub without standing up HTTP.
+type GHPullRequestLister interface {
+	ListPullRequests(ctx context.Context, owner, name string, state ghprovider.PullRequestState) ([]ghprovider.PullRequest, error)
+}
 
 // ProvidersBundle is the read-side surface the loaders need from the
 // resolver root. A struct (not an interface) because the loaders only
@@ -38,6 +47,10 @@ type ProvidersBundle struct {
 	Git      *gitprovider.Provider
 	Ps       *psprovider.Provider
 	Projects configprovider.Lister
+	// GH is the narrow gh surface the PullRequestsForRepo loader needs.
+	// *gh.Provider satisfies GHPullRequestLister automatically; tests
+	// can inject a stub without standing up HTTP.
+	GH GHPullRequestLister
 }
 
 // loaderKey is the private context key for the per-request loaders.
@@ -48,14 +61,29 @@ type loaderKey struct{}
 // emission). Every dataloader instance holds its own batched promise
 // state.
 type Loaders struct {
-	Host           *dataloader.Loader[string, *graphql1.Host]
-	WorktreeForCwd *dataloader.Loader[string, *graphql1.Worktree]
-	Process        *dataloader.Loader[ProcessKey, *graphql1.Process]
+	Host               *dataloader.Loader[string, *graphql1.Host]
+	WorktreeForCwd     *dataloader.Loader[string, *graphql1.Worktree]
+	Process            *dataloader.Loader[ProcessKey, *graphql1.Process]
+	PullRequestsForRepo *dataloader.Loader[RepoKey, []*graphql1.PullRequest]
 
 	// metrics — provider call counts, used by the n+1 detector test.
 	hostBatches     *batchCounter
 	worktreeBatches *batchCounter
 	processBatches  *batchCounter
+	prBatches       *batchCounter
+}
+
+// RepoKey is the composite key for the PullRequestsForRepo loader.
+// It identifies a GitHub repository by owner and name.
+type RepoKey struct {
+	Owner string
+	Name  string
+}
+
+// String renders a RepoKey as "owner/name" — the canonical repo slug
+// used in GraphQL IDs and human-readable log output.
+func (k RepoKey) String() string {
+	return fmt.Sprintf("%s/%s", k.Owner, k.Name)
 }
 
 // ProcessKey is the composite key for the [TmuxPane].process edge.
@@ -80,6 +108,7 @@ func NewLoaders(providers *ProvidersBundle) *Loaders {
 	hostBatches := &batchCounter{}
 	worktreeBatches := &batchCounter{}
 	processBatches := &batchCounter{}
+	prBatches := &batchCounter{}
 
 	hostBatch := func(_ context.Context, ids []string) []*dataloader.Result[*graphql1.Host] {
 		hostBatches.inc()
@@ -92,6 +121,10 @@ func NewLoaders(providers *ProvidersBundle) *Loaders {
 	processBatch := func(_ context.Context, keys []ProcessKey) []*dataloader.Result[*graphql1.Process] {
 		processBatches.inc()
 		return loadProcesses(providers, keys)
+	}
+	prBatch := func(ctx context.Context, keys []RepoKey) []*dataloader.Result[[]*graphql1.PullRequest] {
+		prBatches.inc()
+		return loadPullRequestsForRepo(ctx, providers, keys)
 	}
 
 	hostOpts := []dataloader.Option[string, *graphql1.Host]{
@@ -106,14 +139,20 @@ func NewLoaders(providers *ProvidersBundle) *Loaders {
 		dataloader.WithWait[ProcessKey, *graphql1.Process](1 * time.Millisecond),
 		dataloader.WithCache[ProcessKey, *graphql1.Process](&dataloader.NoCache[ProcessKey, *graphql1.Process]{}),
 	}
+	prOpts := []dataloader.Option[RepoKey, []*graphql1.PullRequest]{
+		dataloader.WithWait[RepoKey, []*graphql1.PullRequest](1 * time.Millisecond),
+		dataloader.WithCache[RepoKey, []*graphql1.PullRequest](&dataloader.NoCache[RepoKey, []*graphql1.PullRequest]{}),
+	}
 
 	return &Loaders{
-		Host:            dataloader.NewBatchedLoader(hostBatch, hostOpts...),
-		WorktreeForCwd:  dataloader.NewBatchedLoader(worktreeBatch, worktreeOpts...),
-		Process:         dataloader.NewBatchedLoader(processBatch, processOpts...),
-		hostBatches:     hostBatches,
-		worktreeBatches: worktreeBatches,
-		processBatches:  processBatches,
+		Host:                dataloader.NewBatchedLoader(hostBatch, hostOpts...),
+		WorktreeForCwd:      dataloader.NewBatchedLoader(worktreeBatch, worktreeOpts...),
+		Process:             dataloader.NewBatchedLoader(processBatch, processOpts...),
+		PullRequestsForRepo: dataloader.NewBatchedLoader(prBatch, prOpts...),
+		hostBatches:         hostBatches,
+		worktreeBatches:     worktreeBatches,
+		processBatches:      processBatches,
+		prBatches:           prBatches,
 	}
 }
 
@@ -128,6 +167,10 @@ func (l *Loaders) WorktreeBatchCount() int { return l.worktreeBatches.value() }
 // ProcessBatchCount returns the number of process-loader batch
 // invocations.
 func (l *Loaders) ProcessBatchCount() int { return l.processBatches.value() }
+
+// PullRequestsForRepoBatchCount returns the number of PR-loader batch
+// invocations since this Loaders was constructed. Used by n+1 tests.
+func (l *Loaders) PullRequestsForRepoBatchCount() int { return l.prBatches.value() }
 
 // Middleware wraps an http.Handler to attach a fresh *Loaders to the
 // request context. Mount it once around the GraphQL handler.
@@ -299,6 +342,105 @@ func loadProcesses(providers *ProvidersBundle, keys []ProcessKey) []*dataloader.
 		out[i] = &dataloader.Result[*graphql1.Process]{Data: projectProcess(&v, k.HostID)}
 	}
 	return out
+}
+
+// loadPullRequestsForRepo is the DataLoader batch function for the
+// PullRequestsForRepo loader. Each key is a RepoKey (owner/name pair);
+// the batch collapses all concurrent resolver calls for the same repo
+// into one underlying gh.Provider.ListPullRequests call.
+//
+// When NoCache is configured (as in production), the DataLoader may
+// present duplicate keys in the same batch. This function deduplicates
+// internally so the gh provider is called at most once per unique repo,
+// regardless of how many Load calls arrived with the same key.
+//
+// Returns the full open-PR slice for each position in keys (including
+// duplicate positions). The resolver layer does the headRef→branch match
+// locally against this slice.
+func loadPullRequestsForRepo(ctx context.Context, providers *ProvidersBundle, keys []RepoKey) []*dataloader.Result[[]*graphql1.PullRequest] {
+	out := make([]*dataloader.Result[[]*graphql1.PullRequest], len(keys))
+	ghp := providers.GH
+	if ghp == nil {
+		for i := range out {
+			out[i] = &dataloader.Result[[]*graphql1.PullRequest]{Data: nil}
+		}
+		return out
+	}
+
+	// Deduplicate: fetch each unique repo exactly once, even when the
+	// NoCache loader sends the same key multiple times in one batch.
+	type repoResult struct {
+		prs []*graphql1.PullRequest
+		err error
+	}
+	cache := make(map[RepoKey]*repoResult, len(keys))
+	for _, key := range keys {
+		if _, seen := cache[key]; seen {
+			continue
+		}
+		prs, err := ghp.ListPullRequests(ctx, key.Owner, key.Name, ghprovider.PullRequestStateOpen)
+		if err != nil {
+			cache[key] = &repoResult{err: err}
+			continue
+		}
+		gqlPRs := make([]*graphql1.PullRequest, 0, len(prs))
+		for _, p := range prs {
+			pr := p // avoid loop-var capture
+			gqlPRs = append(gqlPRs, projectPullRequest(pr))
+		}
+		cache[key] = &repoResult{prs: gqlPRs}
+	}
+
+	for i, key := range keys {
+		r := cache[key]
+		if r.err != nil {
+			out[i] = &dataloader.Result[[]*graphql1.PullRequest]{Error: r.err}
+		} else {
+			out[i] = &dataloader.Result[[]*graphql1.PullRequest]{Data: r.prs}
+		}
+	}
+	return out
+}
+
+// projectPullRequest projects a provider PullRequest into the GraphQL
+// model. Duplicated from resolvers/gh.go (toGraphQLPullRequest) to
+// keep the loaders package free of a circular import — the resolvers
+// package imports loaders, so loaders cannot import resolvers.
+func projectPullRequest(p ghprovider.PullRequest) *graphql1.PullRequest {
+	return &graphql1.PullRequest{
+		ID:          p.ID(),
+		RepoOwner:   p.RepoOwner,
+		RepoName:    p.RepoName,
+		Number:      int64(p.Number),
+		Title:       p.Title,
+		Body:        p.Body,
+		State:       mapPullRequestState(p.State),
+		Draft:       p.Draft,
+		AuthorLogin: p.AuthorLogin,
+		BaseRef:     p.BaseRef,
+		HeadRef:     p.HeadRef,
+		URL:         p.URL,
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+	}
+}
+
+// mapPullRequestState maps the provider's PullRequestState enum to the
+// generated GraphQL enum. Mirrors resolvers/gh.go mapPRStateBack without
+// importing that package.
+func mapPullRequestState(s ghprovider.PullRequestState) graphql1.PullRequestState {
+	switch s {
+	case ghprovider.PullRequestStateOpen:
+		return graphql1.PullRequestStateOpen
+	case ghprovider.PullRequestStateClosed:
+		return graphql1.PullRequestStateClosed
+	case ghprovider.PullRequestStateMerged:
+		return graphql1.PullRequestStateMerged
+	case ghprovider.PullRequestStateAll:
+		return graphql1.PullRequestStateAll
+	default:
+		return graphql1.PullRequestStateOpen
+	}
 }
 
 // projectProcess mirrors the resolver-layer projection so the loader

--- a/internal/server/loaders/loaders.go
+++ b/internal/server/loaders/loaders.go
@@ -357,6 +357,13 @@ func loadProcesses(providers *ProvidersBundle, keys []ProcessKey) []*dataloader.
 // Returns the full open-PR slice for each position in keys (including
 // duplicate positions). The resolver layer does the headRef→branch match
 // locally against this slice.
+//
+// Slice-sharing contract: when multiple positions in keys map to the same
+// RepoKey, every position receives the SAME *graphql1.PullRequest slice
+// pointer. Callers MUST treat the slice as read-only — appending,
+// sorting, or otherwise mutating the slice would corrupt sibling
+// consumers in the same batch. The Worktree.pr resolver only iterates
+// for headRef equality, which is safe.
 func loadPullRequestsForRepo(ctx context.Context, providers *ProvidersBundle, keys []RepoKey) []*dataloader.Result[[]*graphql1.PullRequest] {
 	out := make([]*dataloader.Result[[]*graphql1.PullRequest], len(keys))
 	ghp := providers.GH
@@ -406,6 +413,11 @@ func loadPullRequestsForRepo(ctx context.Context, providers *ProvidersBundle, ke
 // model. Duplicated from resolvers/gh.go (toGraphQLPullRequest) to
 // keep the loaders package free of a circular import — the resolvers
 // package imports loaders, so loaders cannot import resolvers.
+//
+// MUST mirror resolvers/gh.go::toGraphQLPullRequest field-for-field.
+// When you add a field to one, add it to the other in the same commit
+// (and consider extracting to a shared internal/server/graphql/projection
+// package if the duplication grows beyond two sites).
 func projectPullRequest(p ghprovider.PullRequest) *graphql1.PullRequest {
 	return &graphql1.PullRequest{
 		ID:          p.ID(),

--- a/internal/server/loaders/loaders_test.go
+++ b/internal/server/loaders/loaders_test.go
@@ -11,6 +11,7 @@ import (
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/loaders"
 	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	ghprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	hostprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 	psprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
@@ -186,4 +187,152 @@ func (f *fixedLister) List(_ context.Context) ([]configprovider.Project, error) 
 	out := make([]configprovider.Project, len(f.rows))
 	copy(out, f.rows)
 	return out, nil
+}
+
+// --- PullRequestsForRepo loader tests ---
+
+// TestPullRequestsForRepo_BatchesIntraRepo asserts that many concurrent
+// loads for the same repo collapse into a single batch and one provider
+// call.
+func TestPullRequestsForRepo_BatchesIntraRepo(t *testing.T) {
+	stub := &prStub{prs: map[string]int{}}
+	stub.prs["owner/repo"] = 2 // 2 PRs for this repo
+
+	bundle := &loaders.ProvidersBundle{GH: stub}
+	l := loaders.NewLoaders(bundle)
+
+	ctx := context.Background()
+	const N = 8
+	thunks := make([]func() ([]*graphql1.PullRequest, error), 0, N)
+	for i := 0; i < N; i++ {
+		thunks = append(thunks, l.PullRequestsForRepo.Load(ctx, loaders.RepoKey{Owner: "owner", Name: "repo"}))
+	}
+	for i, thunk := range thunks {
+		got, err := thunk()
+		if err != nil {
+			t.Fatalf("thunk %d error: %v", i, err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("thunk %d returned %d PRs, want 2", i, len(got))
+		}
+	}
+
+	if got := l.PullRequestsForRepoBatchCount(); got != 1 {
+		t.Errorf("batch count = %d, want 1 (n+1 detection)", got)
+	}
+	if got := stub.CallCount(); got != 1 {
+		t.Errorf("provider calls = %d, want 1", got)
+	}
+}
+
+// TestPullRequestsForRepo_BatchesAcrossRepos asserts that concurrent
+// loads for 5 distinct repos collapse into 1 batch and 5 provider calls
+// (one per unique repo).
+func TestPullRequestsForRepo_BatchesAcrossRepos(t *testing.T) {
+	repos := []string{
+		"org/alpha",
+		"org/beta",
+		"org/gamma",
+		"org/delta",
+		"org/epsilon",
+	}
+	stub := &prStub{prs: map[string]int{}}
+	for _, r := range repos {
+		stub.prs[r] = 1
+	}
+
+	bundle := &loaders.ProvidersBundle{GH: stub}
+	l := loaders.NewLoaders(bundle)
+
+	ctx := context.Background()
+	const perRepo = 8
+	thunks := make([]func() ([]*graphql1.PullRequest, error), 0, len(repos)*perRepo)
+	for _, slug := range repos {
+		parts := strings.SplitN(slug, "/", 2)
+		owner, name := parts[0], parts[1]
+		for i := 0; i < perRepo; i++ {
+			thunks = append(thunks, l.PullRequestsForRepo.Load(ctx, loaders.RepoKey{Owner: owner, Name: name}))
+		}
+	}
+	for i, thunk := range thunks {
+		if _, err := thunk(); err != nil {
+			t.Fatalf("thunk %d error: %v", i, err)
+		}
+	}
+
+	if got := l.PullRequestsForRepoBatchCount(); got != 1 {
+		t.Errorf("batch count = %d, want 1 (all repos coalesced into one batch)", got)
+	}
+	if got := stub.CallCount(); got != len(repos) {
+		t.Errorf("provider calls = %d, want %d (one per repo)", got, len(repos))
+	}
+}
+
+// TestPullRequestsForRepo_PerRequestScoped asserts that two separate
+// Loaders instances do not share state: each fires its own batch, so
+// the provider receives two calls for the same repo.
+func TestPullRequestsForRepo_PerRequestScoped(t *testing.T) {
+	stub := &prStub{prs: map[string]int{"owner/repo": 1}}
+
+	ctx := context.Background()
+
+	// First "request"
+	bundle1 := &loaders.ProvidersBundle{GH: stub}
+	l1 := loaders.NewLoaders(bundle1)
+	if _, err := l1.PullRequestsForRepo.Load(ctx, loaders.RepoKey{Owner: "owner", Name: "repo"})(); err != nil {
+		t.Fatalf("l1 load error: %v", err)
+	}
+
+	// Second "request" — separate Loaders instance.
+	bundle2 := &loaders.ProvidersBundle{GH: stub}
+	l2 := loaders.NewLoaders(bundle2)
+	if _, err := l2.PullRequestsForRepo.Load(ctx, loaders.RepoKey{Owner: "owner", Name: "repo"})(); err != nil {
+		t.Fatalf("l2 load error: %v", err)
+	}
+
+	// Each loader should have batched exactly once.
+	if got := l1.PullRequestsForRepoBatchCount(); got != 1 {
+		t.Errorf("l1 batch count = %d, want 1", got)
+	}
+	if got := l2.PullRequestsForRepoBatchCount(); got != 1 {
+		t.Errorf("l2 batch count = %d, want 1", got)
+	}
+	// Provider should have been called twice — once per loader.
+	if got := stub.CallCount(); got != 2 {
+		t.Errorf("provider calls = %d, want 2 (per-request scoping)", got)
+	}
+}
+
+// prStub implements loaders.GHPullRequestLister with a call counter.
+// prs maps "owner/name" to the number of dummy PRs to return.
+type prStub struct {
+	mu    sync.Mutex
+	calls int
+	prs   map[string]int // slug → PR count
+}
+
+func (s *prStub) ListPullRequests(_ context.Context, owner, name string, _ ghprovider.PullRequestState) ([]ghprovider.PullRequest, error) {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+
+	slug := owner + "/" + name
+	n := s.prs[slug]
+	out := make([]ghprovider.PullRequest, n)
+	for i := range out {
+		out[i] = ghprovider.PullRequest{
+			RepoOwner: owner,
+			RepoName:  name,
+			Number:    100 + i,
+			HeadRef:   fmt.Sprintf("feature/%s-%d", name, i),
+			State:     ghprovider.PullRequestStateOpen,
+		}
+	}
+	return out, nil
+}
+
+func (s *prStub) CallCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
 }

--- a/internal/server/providers/gh/branch_issue.go
+++ b/internal/server/providers/gh/branch_issue.go
@@ -1,0 +1,88 @@
+package gh
+
+import (
+	"regexp"
+	"strconv"
+)
+
+// Package-level compiled regexes — compiling once at init time is cheaper
+// than sync.Once for patterns that are always needed.
+var (
+	// issueKeywordRe matches "issue" (case-insensitive) optionally followed by
+	// "/" or "-" and then the issue number. Applied to BOTH the original branch
+	// name and the prefix-stripped version.
+	issueKeywordRe = regexp.MustCompile(`(?i)issue[/\-]?(\d+)`)
+
+	// leadingNumberRe matches a numeric sequence at the start of the stripped
+	// branch followed by a hyphen. Only N >= 100 is accepted by the caller.
+	leadingNumberRe = regexp.MustCompile(`^(\d+)-`)
+
+	// embeddedNumberRe matches a numeric sequence surrounded by a leading
+	// hyphen and either a trailing hyphen or end-of-string. Only N >= 100 is
+	// accepted by the caller.
+	embeddedNumberRe = regexp.MustCompile(`-(\d+)(?:-|$)`)
+
+	// stripPrefixRe matches a common branch-name prefix such as "feat/",
+	// "fix-", "wip_". The prefix is one or more alphanumeric chars (starting
+	// with a letter) followed by "/" or "_".
+	stripPrefixRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9]*[/_]`)
+)
+
+// ExtractIssueNumber attempts to derive a GitHub issue number from a branch
+// name, mirroring the logic in crates/orchard/src/github.rs.
+//
+// Rules applied IN ORDER — the first match wins:
+//
+//  1. Keyword pattern (case-insensitive, no minimum N):
+//     (?i)issue[/\-]?(\d+)
+//     Applied to BOTH the original branch name AND the prefix-stripped version.
+//     Accepts N >= 1.
+//
+//  2. Leading number on the stripped branch:
+//     ^(\d+)-
+//     Accepts N >= 100 only.
+//
+//  3. Embedded number on the stripped branch:
+//     -(\d+)(?:-|$)
+//     Accepts N >= 100 only.
+//
+// The "stripped" version removes any leading prefix matching
+// ^[a-zA-Z][a-zA-Z0-9]*[/_] (e.g. "feat/", "fix-", "wip_").
+//
+// Returns (n, true) on a successful match, (0, false) otherwise.
+func ExtractIssueNumber(branch string) (int, bool) {
+	if branch == "" {
+		return 0, false
+	}
+
+	// Compute the prefix-stripped variant once.
+	stripped := stripPrefixRe.ReplaceAllLiteralString(branch, "")
+
+	// 1. Keyword pattern on original and stripped.
+	for _, candidate := range []string{branch, stripped} {
+		if m := issueKeywordRe.FindStringSubmatch(candidate); m != nil {
+			n, err := strconv.Atoi(m[1])
+			if err == nil && n >= 1 {
+				return n, true
+			}
+		}
+	}
+
+	// 2. Leading number (>= 100) on stripped.
+	if m := leadingNumberRe.FindStringSubmatch(stripped); m != nil {
+		n, err := strconv.Atoi(m[1])
+		if err == nil && n >= 100 {
+			return n, true
+		}
+	}
+
+	// 3. Embedded number (>= 100) on stripped.
+	if m := embeddedNumberRe.FindStringSubmatch(stripped); m != nil {
+		n, err := strconv.Atoi(m[1])
+		if err == nil && n >= 100 {
+			return n, true
+		}
+	}
+
+	return 0, false
+}

--- a/internal/server/providers/gh/branch_issue_test.go
+++ b/internal/server/providers/gh/branch_issue_test.go
@@ -1,0 +1,153 @@
+package gh
+
+import "testing"
+
+// TestExtractIssueNumber covers the branch-parse rules ported from
+// crates/orchard/src/github.rs. The table includes all examples from the
+// feature file plus representative edge cases.
+func TestExtractIssueNumber(t *testing.T) {
+	tests := []struct {
+		branch  string
+		wantN   int
+		wantOK  bool
+		comment string
+	}{
+		// Keyword pattern — original branch.
+		{
+			branch:  "issue441/schema-enrichment",
+			wantN:   441,
+			wantOK:  true,
+			comment: "keyword pattern wins on original branch",
+		},
+		{
+			branch:  "Issue-123-something",
+			wantN:   123,
+			wantOK:  true,
+			comment: "keyword pattern case-insensitive, hyphen variant",
+		},
+		// Keyword pattern — small N (no minimum floor on keyword path).
+		{
+			branch:  "issue/1",
+			wantN:   1,
+			wantOK:  true,
+			comment: "lowercase issue/ with small N is valid for keyword path",
+		},
+		{
+			branch:  "issue/42",
+			wantN:   42,
+			wantOK:  true,
+			comment: "lowercase issue/ with N<100 still matches keyword pattern",
+		},
+		{
+			branch:  "Issue/777",
+			wantN:   777,
+			wantOK:  true,
+			comment: "mixed-case Issue/ parses keyword pattern",
+		},
+		// Keyword pattern on stripped branch.
+		{
+			branch:  "feat/issue441-description",
+			wantN:   441,
+			wantOK:  true,
+			comment: "keyword pattern on stripped branch (prefix feat/ stripped)",
+		},
+		// Leading number >= 100 on stripped.
+		{
+			branch:  "441-some-slug",
+			wantN:   441,
+			wantOK:  true,
+			comment: "leading number >= 100 on original (no prefix to strip)",
+		},
+		// Embedded number >= 100 on stripped.
+		{
+			branch:  "feature-441-slug",
+			wantN:   441,
+			wantOK:  true,
+			comment: "embedded number >= 100 on stripped (prefix feature- not stripped but 441 found embedded)",
+		},
+		// Leading number below 100 floor — must return false.
+		{
+			branch:  "12-something",
+			wantN:   0,
+			wantOK:  false,
+			comment: "leading number 12 fails >= 100 floor",
+		},
+		// No number at all.
+		{
+			branch:  "feature/no-number",
+			wantN:   0,
+			wantOK:  false,
+			comment: "no number anywhere",
+		},
+		// Keyword precedence: "issue441/441-other" → 441 via keyword, not 441 again.
+		{
+			branch:  "issue441/441-other",
+			wantN:   441,
+			wantOK:  true,
+			comment: "keyword pattern on original wins first",
+		},
+		// Empty branch.
+		{
+			branch:  "",
+			wantN:   0,
+			wantOK:  false,
+			comment: "empty branch returns no match",
+		},
+		// Embedded number exactly at the 100 boundary.
+		{
+			branch:  "fix-100-something",
+			wantN:   100,
+			wantOK:  true,
+			comment: "embedded number exactly at 100 boundary is accepted",
+		},
+		// Embedded number just below 100 floor.
+		{
+			branch:  "fix-99-something",
+			wantN:   0,
+			wantOK:  false,
+			comment: "embedded number 99 fails >= 100 floor",
+		},
+		// Leading number at the 100 boundary on a prefixed branch.
+		{
+			branch:  "feat/100-description",
+			wantN:   100,
+			wantOK:  true,
+			comment: "leading number 100 on stripped branch accepted",
+		},
+		// Branch with only alpha chars.
+		{
+			branch:  "main",
+			wantN:   0,
+			wantOK:  false,
+			comment: "default-like branch with no numbers",
+		},
+		// issue0 — keyword matches but n < 1, should be rejected.
+		// Note: the regex requires \d+, so "issue0" captures "0" → n=0 < 1.
+		{
+			branch:  "issue0",
+			wantN:   0,
+			wantOK:  false,
+			comment: "issue0 is below the n>=1 floor on the keyword path",
+		},
+		// ISSUENNN (no separator) — the regex allows the separator to be absent.
+		{
+			branch:  "ISSUE999fix",
+			wantN:   999,
+			wantOK:  true,
+			comment: "uppercase ISSUE with no separator still matches keyword pattern",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.branch+"_"+tt.comment, func(t *testing.T) {
+			gotN, gotOK := ExtractIssueNumber(tt.branch)
+			if gotOK != tt.wantOK {
+				t.Errorf("ExtractIssueNumber(%q) ok=%v, want %v (%s)", tt.branch, gotOK, tt.wantOK, tt.comment)
+				return
+			}
+			if gotOK && gotN != tt.wantN {
+				t.Errorf("ExtractIssueNumber(%q) n=%d, want %d (%s)", tt.branch, gotN, tt.wantN, tt.comment)
+			}
+		})
+	}
+}

--- a/internal/server/providers/gh/repo_url.go
+++ b/internal/server/providers/gh/repo_url.go
@@ -17,7 +17,7 @@ import (
 // "origin"]` block has a `url =` entry; errNoGitDir when there is no
 // `.git` at the path; other I/O errors propagate.
 func ReadOriginURL(workdir string) (string, error) {
-	gitDir, err := resolveGitDirForWorktree(workdir)
+	gitDir, err := ResolveGitDirForWorktree(workdir)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return "", errNoGitDir
@@ -117,7 +117,7 @@ func splitOwnerName(s string) (string, string, bool) {
 	return parts[0], parts[1], true
 }
 
-// resolveGitDirForWorktree mirrors the git provider's logic so this
+// ResolveGitDirForWorktree mirrors the git provider's logic so this
 // package doesn't need to depend on it. Handles both `.git` as a
 // directory and as a file pointing at the actual git directory
 // (linked-worktree case).
@@ -129,7 +129,7 @@ func splitOwnerName(s string) (string, string, bool) {
 // `config` lives. This function follows `commondir` so that callers
 // (notably ReadOriginURL) always read `config` from the project root
 // rather than from the per-worktree directory.
-func resolveGitDirForWorktree(workdir string) (string, error) {
+func ResolveGitDirForWorktree(workdir string) (string, error) {
 	candidate := filepath.Join(workdir, ".git")
 	info, err := os.Stat(candidate)
 	if err != nil {

--- a/internal/server/providers/gh/repo_url.go
+++ b/internal/server/providers/gh/repo_url.go
@@ -121,6 +121,14 @@ func splitOwnerName(s string) (string, string, bool) {
 // package doesn't need to depend on it. Handles both `.git` as a
 // directory and as a file pointing at the actual git directory
 // (linked-worktree case).
+//
+// For linked worktrees, git writes a `gitdir` file in the checkout
+// pointing at `<project>/.git/worktrees/<name>/`. That directory in
+// turn contains a `commondir` file whose content is a relative or
+// absolute path back to the project's bare `.git` directory where
+// `config` lives. This function follows `commondir` so that callers
+// (notably ReadOriginURL) always read `config` from the project root
+// rather than from the per-worktree directory.
 func resolveGitDirForWorktree(workdir string) (string, error) {
 	candidate := filepath.Join(workdir, ".git")
 	info, err := os.Stat(candidate)
@@ -141,5 +149,22 @@ func resolveGitDirForWorktree(workdir string) (string, error) {
 	if !filepath.IsAbs(gd) {
 		gd = filepath.Join(workdir, gd)
 	}
-	return filepath.Clean(gd), nil
+	gd = filepath.Clean(gd)
+
+	// Linked-worktree case: `gd` points at `<project>/.git/worktrees/<name>/`.
+	// Follow `commondir` (if present) to reach the project's bare git dir,
+	// where `config` is stored. The commondir file contains a relative or
+	// absolute path from `gd` to the project root git dir.
+	commondirPath := filepath.Join(gd, "commondir")
+	if raw, cdErr := os.ReadFile(commondirPath); cdErr == nil { //nolint:gosec
+		cd := strings.TrimSpace(string(raw))
+		if cd != "" {
+			if !filepath.IsAbs(cd) {
+				cd = filepath.Join(gd, cd)
+			}
+			gd = filepath.Clean(cd)
+		}
+	}
+
+	return gd, nil
 }

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -140,5 +140,6 @@ func (r *Resolver) LoaderBundle() *loaders.ProvidersBundle {
 		Git:      r.Git,
 		Ps:       r.PS,
 		Projects: r.ProjectsProvider,
+		GH:       r.GH,
 	}
 }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/loaders"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/contracts"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
@@ -984,8 +985,56 @@ func (r *worktreeResolver) Repo(ctx context.Context, obj *graphql1.Worktree) (*s
 }
 
 // Pr is the resolver for the pr field.
+//
+// Looks up the open PR whose headRef matches the worktree's branch.
+// Uses the PullRequestsForRepo DataLoader so concurrent resolver calls
+// for multiple worktrees in the same repo collapse into one underlying
+// gh.Provider.ListPullRequests call.
+//
+// Returns nil (null in GraphQL) when:
+//   - obj is nil.
+//   - Branch is empty (detached HEAD).
+//   - Branch is the project's default branch (skip the lookup — the
+//     default branch never has an open PR targeting itself).
+//   - Origin is absent or not a GitHub URL.
+//   - No open PR has a headRef matching the branch.
+//
+// Returns an error only when the DataLoader is missing from context
+// (daemon misconfiguration) or when the gh provider returns a hard
+// error.
 func (r *worktreeResolver) Pr(ctx context.Context, obj *graphql1.Worktree) (*graphql1.PullRequest, error) {
-	panic(fmt.Errorf("not implemented: Pr - pr"))
+	if obj == nil || obj.Branch == "" {
+		return nil, nil
+	}
+	// Default-branch exclusion: the default branch never has an open PR
+	// targeting itself, so skip the DataLoader call entirely.
+	if defaultBranch, ok := readDefaultBranch(obj.Path); ok && defaultBranch == obj.Branch {
+		return nil, nil
+	}
+	// Derive the repo slug from the worktree's origin remote.
+	url, err := gh.ReadOriginURL(obj.Path)
+	if err != nil {
+		return nil, nil // missing origin → null (graceful)
+	}
+	owner, name, ok := gh.ParseGitHubURL(url)
+	if !ok {
+		return nil, nil // non-GitHub origin → null
+	}
+	// Load all open PRs for the repo via the DataLoader.
+	ldrs := loaders.FromContext(ctx)
+	if ldrs == nil {
+		return nil, fmt.Errorf("loaders not in context")
+	}
+	prs, err := ldrs.PullRequestsForRepo.Load(ctx, loaders.RepoKey{Owner: owner, Name: name})()
+	if err != nil {
+		return nil, err
+	}
+	for _, pr := range prs {
+		if pr != nil && pr.HeadRef == obj.Branch {
+			return pr, nil
+		}
+	}
+	return nil, nil
 }
 
 // Issue is the resolver for the issue field.

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -956,6 +956,26 @@ func (r *tmuxWindowResolver) CurrentPane(ctx context.Context, obj *graphql1.Tmux
 	return projectPane(p), nil
 }
 
+// Host is the resolver for the host field.
+func (r *worktreeResolver) Host(ctx context.Context, obj *graphql1.Worktree) (string, error) {
+	panic(fmt.Errorf("not implemented: Host - host"))
+}
+
+// Repo is the resolver for the repo field.
+func (r *worktreeResolver) Repo(ctx context.Context, obj *graphql1.Worktree) (*string, error) {
+	panic(fmt.Errorf("not implemented: Repo - repo"))
+}
+
+// Pr is the resolver for the pr field.
+func (r *worktreeResolver) Pr(ctx context.Context, obj *graphql1.Worktree) (*graphql1.PullRequest, error) {
+	panic(fmt.Errorf("not implemented: Pr - pr"))
+}
+
+// Issue is the resolver for the issue field.
+func (r *worktreeResolver) Issue(ctx context.Context, obj *graphql1.Worktree) (*graphql1.Issue, error) {
+	panic(fmt.Errorf("not implemented: Issue - issue"))
+}
+
 // Processes is the resolver for the worktree.processes field.
 func (r *worktreeResolver) Processes(ctx context.Context, obj *graphql1.Worktree) ([]*graphql1.Process, error) {
 	return []*graphql1.Process{}, nil

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -16,6 +16,7 @@ import (
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/contracts"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
@@ -957,13 +958,29 @@ func (r *tmuxWindowResolver) CurrentPane(ctx context.Context, obj *graphql1.Tmux
 }
 
 // Host is the resolver for the host field.
+// v1 sentinel: all locally-discovered worktrees report "local".
+// Workstream F populates per-peer hostnames in a later iteration.
 func (r *worktreeResolver) Host(ctx context.Context, obj *graphql1.Worktree) (string, error) {
-	panic(fmt.Errorf("not implemented: Host - host"))
+	return "local", nil
 }
 
 // Repo is the resolver for the repo field.
+// Derives owner/repo from the worktree's origin remote URL.
+// Returns nil (null in GraphQL) when origin is absent, or not a GitHub URL.
 func (r *worktreeResolver) Repo(ctx context.Context, obj *graphql1.Worktree) (*string, error) {
-	panic(fmt.Errorf("not implemented: Repo - repo"))
+	if obj == nil || obj.Path == "" {
+		return nil, nil
+	}
+	url, err := gh.ReadOriginURL(obj.Path)
+	if err != nil {
+		return nil, nil
+	}
+	owner, name, ok := gh.ParseGitHubURL(url)
+	if !ok {
+		return nil, nil
+	}
+	slug := owner + "/" + name
+	return &slug, nil
 }
 
 // Pr is the resolver for the pr field.

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -989,8 +989,48 @@ func (r *worktreeResolver) Pr(ctx context.Context, obj *graphql1.Worktree) (*gra
 }
 
 // Issue is the resolver for the issue field.
+//
+// Derives the GitHub issue number from the worktree's branch name using the
+// branch-parse rules ported from crates/orchard/src/github.rs, then fetches
+// the issue via the gh provider.
+//
+// Returns nil (null in GraphQL) when:
+//   - The branch is empty (detached HEAD).
+//   - No issue number can be parsed from the branch.
+//   - The origin remote is absent or not a GitHub URL.
+//   - The gh provider is not wired (returns errGHNotConfigured).
+//   - The issue is not found on GitHub (404).
 func (r *worktreeResolver) Issue(ctx context.Context, obj *graphql1.Worktree) (*graphql1.Issue, error) {
-	panic(fmt.Errorf("not implemented: Issue - issue"))
+	if obj == nil || obj.Branch == "" {
+		return nil, nil
+	}
+
+	n, ok := gh.ExtractIssueNumber(obj.Branch)
+	if !ok {
+		return nil, nil
+	}
+
+	url, err := gh.ReadOriginURL(obj.Path)
+	if err != nil {
+		return nil, nil
+	}
+	owner, name, ok := gh.ParseGitHubURL(url)
+	if !ok {
+		return nil, nil
+	}
+
+	if r.GH == nil {
+		return nil, errGHNotConfigured
+	}
+
+	issue, err := r.GH.GetIssue(ctx, gh.IssueKey{Owner: owner, Name: name, Number: n})
+	if err != nil {
+		if gh.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return toGraphQLIssue(issue), nil
 }
 
 // Processes is the resolver for the worktree.processes field.

--- a/internal/server/resolvers/worktree_dashboard_e2e_test.go
+++ b/internal/server/resolvers/worktree_dashboard_e2e_test.go
@@ -1,0 +1,404 @@
+package resolvers_test
+
+// End-to-end test for the full Worktree dashboard query — issue #441 Phase 1.
+//
+// What's "E2E" here:
+//   - A real git-worktree on-disk layout is synthesised in a temp directory
+//     (no `git` binary required — we write the raw files git worktree add
+//     produces).
+//   - A real gh.Provider is wired with an httptest stub that serves the
+//     canned PR + issue payloads without touching api.github.com.
+//   - A real git.Provider reads the tempdir layout.
+//   - The resolvers, DataLoader middleware, and gqlgen schema are all live.
+//   - We POST a query over HTTP and assert the JSON response shape.
+//
+// Scenario (feature file line ~181):
+//
+//	Given  the daemon has one project, one main worktree + one linked worktree
+//	       on branch "issue441/foo"
+//	And    the GitHub API stub returns PR #8765 with headRef "issue441/foo"
+//	And    the GitHub API stub returns issue #441
+//	When   we query { projects { worktrees { host repo branch pr { number } issue { number } } } }
+//	Then   the linked worktree row has
+//	         host  == "local"
+//	         repo  == "drewdrewthis/orchard-test"
+//	         pr.number  == 8765
+//	         issue.number == 441
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/loaders"
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
+	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+
+	gqlgen "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// dashboardE2EGHScript is the fake `gh auth token` shim.
+// Anything other than `gh auth token` exits 2 so unexpected invocations
+// are loud.
+const dashboardE2EGHScript = `#!/bin/sh
+if [ "$1" = "auth" ] && [ "$2" = "token" ]; then
+  echo "test-token-dashboard-e2e"
+  exit 0
+fi
+echo "unexpected gh invocation: $@" 1>&2
+exit 2
+`
+
+// installDashboardFakeGH writes a `gh` shim into a fresh temp dir and
+// prepends it to PATH. Returns cleanup function; also registers t.Cleanup.
+func installDashboardFakeGH(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-substituted shellout test is POSIX-only")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "gh")
+	if err := os.WriteFile(script, []byte(dashboardE2EGHScript), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	prev := os.Getenv("PATH")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+prev)
+}
+
+// stubGHAPI mounts a tiny mux that serves the canned PR list + single issue.
+// Any other path responds 404 and fails the test loudly.
+func stubGHAPI(t *testing.T) *httptest.Server {
+	t.Helper()
+	const (
+		prListBody = `[{
+			"number": 8765,
+			"title": "issue441/foo PR",
+			"body": "test PR",
+			"state": "open",
+			"draft": false,
+			"html_url": "https://github.com/drewdrewthis/orchard-test/pull/8765",
+			"created_at": "2026-01-01T00:00:00Z",
+			"updated_at": "2026-01-02T00:00:00Z",
+			"merged_at": null,
+			"user": {"login": "testuser"},
+			"base": {"ref": "main"},
+			"head": {"ref": "issue441/foo"}
+		}]`
+		issueBody = `{
+			"number": 441,
+			"title": "issue 441",
+			"body": "the test issue",
+			"state": "open",
+			"html_url": "https://github.com/drewdrewthis/orchard-test/issues/441",
+			"created_at": "2026-01-01T00:00:00Z",
+			"updated_at": "2026-01-02T00:00:00Z",
+			"user": {"login": "testuser"}
+		}`
+	)
+
+	mux := http.NewServeMux()
+
+	// PR list — called by the PullRequestsForRepo DataLoader.
+	mux.HandleFunc("/repos/drewdrewthis/orchard-test/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(prListBody))
+	})
+
+	// Single issue — called by Worktree.issue resolver.
+	mux.HandleFunc("/repos/drewdrewthis/orchard-test/issues/441", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(issueBody))
+	})
+
+	// Catch-all: fail the test for unexpected requests.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected GitHub API request: %s %s", r.Method, r.URL.Path)
+		http.NotFound(w, r)
+	})
+
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// buildWorktreeLayout creates a minimal on-disk git worktree layout
+// that the git provider can read without shelling out to git.
+//
+// Layout produced (under tmpdir):
+//
+//	<tmpdir>/
+//	  .git/                         ← main worktree git dir
+//	    config                      ← [remote "origin"] URL
+//	    HEAD                        ← ref: refs/heads/main
+//	    refs/heads/main             ← fake SHA (40 hex chars)
+//	    worktrees/
+//	      issue441-foo/
+//	        HEAD                    ← ref: refs/heads/issue441/foo
+//	        gitdir                  ← points at <checkout>/.git
+//	        commondir               ← "../.."
+//	  issue441-foo-checkout/        ← linked worktree checkout dir
+//	    .git                        ← file: "gitdir: <abs>/.git/worktrees/issue441-foo"
+//
+// Returns (projectDir, checkoutDir).
+func buildWorktreeLayout(t *testing.T) (projectDir, checkoutDir string) {
+	t.Helper()
+	tmpdir := t.TempDir()
+
+	// ── main git directory ──────────────────────────────────────────────
+	gitDir := filepath.Join(tmpdir, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+
+	// .git/config — origin pointing at the test repo.
+	cfg := "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n" +
+		"\n[remote \"origin\"]\n\turl = git@github.com:drewdrewthis/orchard-test.git\n" +
+		"\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write .git/config: %v", err)
+	}
+
+	// .git/HEAD — symbolic ref to main (default branch).
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("write .git/HEAD: %v", err)
+	}
+
+	// .git/refs/heads/main — fake but valid 40-char SHA.
+	refsHeads := filepath.Join(gitDir, "refs", "heads")
+	if err := os.MkdirAll(refsHeads, 0o755); err != nil {
+		t.Fatalf("mkdir refs/heads: %v", err)
+	}
+	fakeSHA := "0000000000000000000000000000000000000001"
+	if err := os.WriteFile(filepath.Join(refsHeads, "main"), []byte(fakeSHA+"\n"), 0o644); err != nil {
+		t.Fatalf("write refs/heads/main: %v", err)
+	}
+
+	// ── linked worktree gitdir entry ────────────────────────────────────
+	wtGitDir := filepath.Join(gitDir, "worktrees", "issue441-foo")
+	if err := os.MkdirAll(wtGitDir, 0o755); err != nil {
+		t.Fatalf("mkdir worktrees/issue441-foo: %v", err)
+	}
+
+	// The checkout directory that will become the linked worktree path.
+	checkoutDir = filepath.Join(tmpdir, "issue441-foo-checkout")
+	if err := os.MkdirAll(checkoutDir, 0o755); err != nil {
+		t.Fatalf("mkdir checkout: %v", err)
+	}
+
+	// .git/worktrees/issue441-foo/HEAD — branch of the linked worktree.
+	wtHead := "ref: refs/heads/issue441/foo\n"
+	if err := os.WriteFile(filepath.Join(wtGitDir, "HEAD"), []byte(wtHead), 0o644); err != nil {
+		t.Fatalf("write worktree HEAD: %v", err)
+	}
+
+	// .git/worktrees/issue441-foo/gitdir — points to <checkout>/.git
+	// (the file that lives in the checkout directory).
+	checkoutGitFile := filepath.Join(checkoutDir, ".git")
+	if err := os.WriteFile(filepath.Join(wtGitDir, "gitdir"), []byte(checkoutGitFile+"\n"), 0o644); err != nil {
+		t.Fatalf("write worktree gitdir: %v", err)
+	}
+
+	// .git/worktrees/issue441-foo/commondir — back-reference to main .git.
+	if err := os.WriteFile(filepath.Join(wtGitDir, "commondir"), []byte("../.."), 0o644); err != nil {
+		t.Fatalf("write commondir: %v", err)
+	}
+
+	// ── linked worktree checkout ────────────────────────────────────────
+	// <checkout>/.git — a FILE pointing back to the worktree gitdir.
+	gitFileContent := fmt.Sprintf("gitdir: %s\n", wtGitDir)
+	if err := os.WriteFile(checkoutGitFile, []byte(gitFileContent), 0o644); err != nil {
+		t.Fatalf("write checkout .git file: %v", err)
+	}
+
+	projectDir = tmpdir
+	return projectDir, checkoutDir
+}
+
+// staticProjectsListerE2E is a fixture-grade resolvers.ProjectsLister
+// that returns a fixed slice. Mirrors the identical type in git_e2e_test.go
+// (different package so we redefine it here).
+type staticProjectsListerE2E struct {
+	records []configprovider.Project
+}
+
+func (s *staticProjectsListerE2E) List(_ context.Context) ([]configprovider.Project, error) {
+	out := make([]configprovider.Project, len(s.records))
+	copy(out, s.records)
+	return out, nil
+}
+
+// TestWorktreeDashboard_E2E asserts the full Worktree dashboard query
+// returns host, repo, pr, issue for the linked worktree on branch
+// "issue441/foo". Resolves issue #441.
+func TestWorktreeDashboard_E2E(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-substituted shellout test is POSIX-only")
+	}
+
+	// ── 1. Install fake `gh auth token` shellout ────────────────────────
+	installDashboardFakeGH(t)
+
+	// ── 2. Stub the GitHub REST API ─────────────────────────────────────
+	api := stubGHAPI(t)
+	tlsClient := api.Client()
+	tlsClient.Timeout = 10 * time.Second
+
+	// ── 3. Build the tempdir git worktree layout ─────────────────────────
+	projectDir, _ := buildWorktreeLayout(t)
+
+	// ── 4. Start the git provider ─────────────────────────────────────────
+	gitProv := gitprovider.NewProvider(nil)
+	t.Cleanup(gitProv.Stop)
+	const projectID = "proj-1"
+	if err := gitProv.AddProject(gitprovider.Project{ID: projectID, Dir: projectDir}); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+
+	// ── 5. Wire the gh provider with stubbed HTTP ─────────────────────────
+	auth := gh.NewCommandAuthSource()
+	ghProv := gh.NewWith(nil, api.URL, auth, time.Now)
+	if err := ghProv.Start(context.Background()); err != nil {
+		t.Logf("gh provider start (non-fatal): %v", err)
+	}
+	// AuthError forces lazy client build, then we swap to the TLS-trusting client.
+	_ = ghProv.AuthError(context.Background())
+	gh.SetHTTPClientForTest(ghProv, tlsClient)
+
+	// ── 6. Build the projects lister ──────────────────────────────────────
+	projects := &staticProjectsListerE2E{
+		records: []configprovider.Project{
+			{ID: configprovider.ProjectID(projectID), Directory: projectDir, Name: "orchard-test"},
+		},
+	}
+
+	// ── 7. Wire the resolver + DataLoader middleware + httptest server ─────
+	r := resolvers.New(time.Now()).
+		WithGit(gitProv).
+		WithGH(ghProv).
+		WithProjects(projects)
+
+	gqlSrv := handler.New(gqlgen.NewExecutableSchema(gqlgen.Config{Resolvers: r}))
+	gqlSrv.AddTransport(transport.POST{})
+
+	ts := httptest.NewServer(loaders.Middleware(r.LoaderBundle(), gqlSrv))
+	t.Cleanup(ts.Close)
+
+	// ── 8. Fire the dashboard query ───────────────────────────────────────
+	const q = `{
+		projects {
+			worktrees {
+				branch
+				host
+				repo
+				pr { number }
+				issue { number }
+			}
+		}
+	}`
+
+	body, _ := json.Marshal(map[string]string{"query": q})
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("graphql request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("http status = %d, want 200", resp.StatusCode)
+	}
+
+	// ── 9. Decode response ─────────────────────────────────────────────────
+	var out struct {
+		Data struct {
+			Projects []struct {
+				Worktrees []struct {
+					Branch string  `json:"branch"`
+					Host   string  `json:"host"`
+					Repo   *string `json:"repo"`
+					Pr     *struct {
+						Number int64 `json:"number"`
+					} `json:"pr"`
+					Issue *struct {
+						Number int64 `json:"number"`
+					} `json:"issue"`
+				} `json:"worktrees"`
+			} `json:"projects"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(out.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", out.Errors)
+	}
+
+	// ── 10. Find the linked worktree row (branch == "issue441/foo") ────────
+	if len(out.Data.Projects) == 0 {
+		t.Fatalf("expected at least one project, got none")
+	}
+
+	var target *struct {
+		Branch string  `json:"branch"`
+		Host   string  `json:"host"`
+		Repo   *string `json:"repo"`
+		Pr     *struct {
+			Number int64 `json:"number"`
+		} `json:"pr"`
+		Issue *struct {
+			Number int64 `json:"number"`
+		} `json:"issue"`
+	}
+	for i := range out.Data.Projects[0].Worktrees {
+		wt := &out.Data.Projects[0].Worktrees[i]
+		if wt.Branch == "issue441/foo" {
+			target = wt
+			break
+		}
+	}
+	if target == nil {
+		branches := make([]string, 0, len(out.Data.Projects[0].Worktrees))
+		for _, wt := range out.Data.Projects[0].Worktrees {
+			branches = append(branches, fmt.Sprintf("%q", wt.Branch))
+		}
+		t.Fatalf("no worktree with branch 'issue441/foo'; got branches: %v", branches)
+	}
+
+	// ── 11. Assert the four values ─────────────────────────────────────────
+	if got := target.Host; got != "local" {
+		t.Errorf("host = %q, want %q", got, "local")
+	}
+	if target.Repo == nil {
+		t.Error("repo is nil, want \"drewdrewthis/orchard-test\"")
+	} else if got := *target.Repo; got != "drewdrewthis/orchard-test" {
+		t.Errorf("repo = %q, want %q", got, "drewdrewthis/orchard-test")
+	}
+	if target.Pr == nil {
+		t.Error("pr is nil, want {number: 8765}")
+	} else if got := target.Pr.Number; got != 8765 {
+		t.Errorf("pr.number = %d, want 8765", got)
+	}
+	if target.Issue == nil {
+		t.Error("issue is nil, want {number: 441}")
+	} else if got := target.Issue.Number; got != 441 {
+		t.Errorf("issue.number = %d, want 441", got)
+	}
+}

--- a/internal/server/resolvers/worktree_default_branch.go
+++ b/internal/server/resolvers/worktree_default_branch.go
@@ -1,0 +1,86 @@
+package resolvers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// readDefaultBranch returns the default branch of the git project that
+// owns the worktree at worktreePath. It reads the HEAD file of the
+// project's bare git dir — not the worktree's own HEAD — so it reflects
+// the branch the project was cloned on (typically "main" or "master").
+//
+// Returns ("", false) on any failure: missing .git, unreadable files,
+// unexpected format. Callers treat false as "don't skip" — the exclusion
+// is a best-effort optimisation, never an error path.
+func readDefaultBranch(worktreePath string) (string, bool) {
+	gitDir, ok := resolveProjectGitDir(worktreePath)
+	if !ok {
+		return "", false
+	}
+	headPath := filepath.Join(gitDir, "HEAD")
+	data, err := os.ReadFile(headPath) //nolint:gosec // trusted internal path
+	if err != nil {
+		return "", false
+	}
+	line := strings.TrimSpace(string(data))
+	// HEAD format for a symbolic ref: "ref: refs/heads/<branch>"
+	const prefix = "ref: refs/heads/"
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	branch := strings.TrimPrefix(line, prefix)
+	if branch == "" {
+		return "", false
+	}
+	return branch, true
+}
+
+// resolveProjectGitDir finds the bare git directory for the project that
+// owns worktreePath. It handles three layouts:
+//
+//  1. Ordinary working tree: <workdir>/.git is a directory.
+//     → the project git dir IS <workdir>/.git.
+//
+//  2. Linked worktree: <workdir>/.git is a file containing
+//     "gitdir: <abs-path-to-worktree-gitdir>" which points into
+//     <project-bare>/.git/worktrees/<name>/. The project's bare git
+//     dir is two levels up from the worktrees/<name> entry.
+//
+//  3. No .git at all: return false.
+func resolveProjectGitDir(worktreePath string) (string, bool) {
+	candidate := filepath.Join(worktreePath, ".git")
+	info, err := os.Stat(candidate)
+	if err != nil {
+		return "", false
+	}
+	if info.IsDir() {
+		// Ordinary working tree — the project git dir is right here.
+		return candidate, true
+	}
+	// Linked worktree: .git is a file.
+	data, err := os.ReadFile(candidate) //nolint:gosec
+	if err != nil {
+		return "", false
+	}
+	line := strings.TrimSpace(string(data))
+	// Format: "gitdir: /abs/path/to/.git/worktrees/<name>"
+	const prefix = "gitdir:"
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	worktreeGitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if !filepath.IsAbs(worktreeGitDir) {
+		worktreeGitDir = filepath.Join(worktreePath, worktreeGitDir)
+	}
+	worktreeGitDir = filepath.Clean(worktreeGitDir)
+
+	// Walk up past "worktrees/<name>" to reach the project's bare git dir.
+	// <project-bare>/.git/worktrees/<name> → <project-bare>/.git
+	parent := filepath.Dir(filepath.Dir(worktreeGitDir))
+	if parent == "" || parent == worktreeGitDir {
+		return "", false
+	}
+	return parent, true
+}

--- a/internal/server/resolvers/worktree_default_branch.go
+++ b/internal/server/resolvers/worktree_default_branch.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	gh "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
 )
 
 // readDefaultBranch returns the default branch of the git project that
@@ -14,9 +16,13 @@ import (
 // Returns ("", false) on any failure: missing .git, unreadable files,
 // unexpected format. Callers treat false as "don't skip" — the exclusion
 // is a best-effort optimisation, never an error path.
+//
+// Project gitdir resolution is delegated to gh.ResolveGitDirForWorktree
+// so this package does not duplicate the linked-worktree commondir-follow
+// logic. Two reasons to change → one place to change.
 func readDefaultBranch(worktreePath string) (string, bool) {
-	gitDir, ok := resolveProjectGitDir(worktreePath)
-	if !ok {
+	gitDir, err := gh.ResolveGitDirForWorktree(worktreePath)
+	if err != nil {
 		return "", false
 	}
 	headPath := filepath.Join(gitDir, "HEAD")
@@ -35,52 +41,4 @@ func readDefaultBranch(worktreePath string) (string, bool) {
 		return "", false
 	}
 	return branch, true
-}
-
-// resolveProjectGitDir finds the bare git directory for the project that
-// owns worktreePath. It handles three layouts:
-//
-//  1. Ordinary working tree: <workdir>/.git is a directory.
-//     → the project git dir IS <workdir>/.git.
-//
-//  2. Linked worktree: <workdir>/.git is a file containing
-//     "gitdir: <abs-path-to-worktree-gitdir>" which points into
-//     <project-bare>/.git/worktrees/<name>/. The project's bare git
-//     dir is two levels up from the worktrees/<name> entry.
-//
-//  3. No .git at all: return false.
-func resolveProjectGitDir(worktreePath string) (string, bool) {
-	candidate := filepath.Join(worktreePath, ".git")
-	info, err := os.Stat(candidate)
-	if err != nil {
-		return "", false
-	}
-	if info.IsDir() {
-		// Ordinary working tree — the project git dir is right here.
-		return candidate, true
-	}
-	// Linked worktree: .git is a file.
-	data, err := os.ReadFile(candidate) //nolint:gosec
-	if err != nil {
-		return "", false
-	}
-	line := strings.TrimSpace(string(data))
-	// Format: "gitdir: /abs/path/to/.git/worktrees/<name>"
-	const prefix = "gitdir:"
-	if !strings.HasPrefix(line, prefix) {
-		return "", false
-	}
-	worktreeGitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
-	if !filepath.IsAbs(worktreeGitDir) {
-		worktreeGitDir = filepath.Join(worktreePath, worktreeGitDir)
-	}
-	worktreeGitDir = filepath.Clean(worktreeGitDir)
-
-	// Walk up past "worktrees/<name>" to reach the project's bare git dir.
-	// <project-bare>/.git/worktrees/<name> → <project-bare>/.git
-	parent := filepath.Dir(filepath.Dir(worktreeGitDir))
-	if parent == "" || parent == worktreeGitDir {
-		return "", false
-	}
-	return parent, true
 }

--- a/internal/server/resolvers/worktree_resolver_test.go
+++ b/internal/server/resolvers/worktree_resolver_test.go
@@ -231,3 +231,72 @@ func TestWorktreeIssue_GHNotConfigured(t *testing.T) {
 		t.Errorf("Issue() = %v, want nil when gh provider is not configured", got)
 	}
 }
+
+// --- Pr resolver tests ---
+
+// TestWorktreePr_NilObj verifies that a nil worktree object returns nil, nil.
+func TestWorktreePr_NilObj(t *testing.T) {
+	r := newWorktreeResolver()
+
+	got, err := r.Pr(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Pr() returned unexpected error for nil obj: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Pr() = %v, want nil for nil worktree object", got)
+	}
+}
+
+// TestWorktreePr_DetachedHead verifies that an empty branch (detached HEAD)
+// causes the resolver to return nil without touching the DataLoader.
+func TestWorktreePr_DetachedHead(t *testing.T) {
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:", Path: "/any/path", Branch: ""}
+
+	got, err := r.Pr(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Pr() returned unexpected error for empty branch: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Pr() = %v, want nil for detached HEAD (empty branch)", got)
+	}
+}
+
+// TestWorktreePr_NonGitHubOrigin verifies that a non-GitHub origin (e.g.
+// GitLab) causes the resolver to return nil without error.
+func TestWorktreePr_NonGitHubOrigin(t *testing.T) {
+	dir := t.TempDir()
+	writeGitConfig(t, dir, "git@gitlab.com:other/repo.git")
+
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:feat", Path: dir, Branch: "feature/something"}
+
+	got, err := r.Pr(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Pr() returned unexpected error for non-GitHub origin: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Pr() = %v, want nil for non-GitHub origin", got)
+	}
+}
+
+// TestWorktreePr_NoLoadersInContext verifies that when no DataLoader is
+// attached to the context and the origin is a valid GitHub URL, the
+// resolver returns a non-nil error (not nil, nil — that would silently
+// swallow the misconfiguration).
+func TestWorktreePr_NoLoadersInContext(t *testing.T) {
+	dir := t.TempDir()
+	writeGitConfig(t, dir, "git@github.com:drewdrewthis/git-orchard-rs.git")
+
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:feat", Path: dir, Branch: "feature/something"}
+
+	// context.Background() has no loaders attached.
+	got, err := r.Pr(context.Background(), obj)
+	if err == nil {
+		t.Fatal("Pr() expected an error when loaders not in context, but got nil")
+	}
+	if got != nil {
+		t.Errorf("Pr() = %v, want nil on error path", got)
+	}
+}

--- a/internal/server/resolvers/worktree_resolver_test.go
+++ b/internal/server/resolvers/worktree_resolver_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/loaders"
+	ghprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
 )
 
 // writeGitConfig writes a minimal .git/config under dir with the given
@@ -298,5 +301,55 @@ func TestWorktreePr_NoLoadersInContext(t *testing.T) {
 	}
 	if got != nil {
 		t.Errorf("Pr() = %v, want nil on error path", got)
+	}
+}
+
+// neverCallStub satisfies loaders.GHPullRequestLister but fails the
+// surrounding test if its ListPullRequests is invoked. Used to prove
+// that a code path short-circuits before the DataLoader fires.
+type neverCallStub struct {
+	t      *testing.T
+	called atomic.Int32
+}
+
+func (s *neverCallStub) ListPullRequests(_ context.Context, _, _ string, _ ghprovider.PullRequestState) ([]ghprovider.PullRequest, error) {
+	s.called.Add(1)
+	s.t.Errorf("gh.ListPullRequests was called but the resolver should have skipped the loader")
+	return nil, nil
+}
+
+// TestWorktreePr_DefaultBranchSkipsLoader verifies that a worktree on the
+// project's default branch returns nil AND does not invoke the
+// PullRequestsForRepo DataLoader. This is the second half of the AC 3
+// scenario "pr resolver returns null when worktree branch is the project's
+// default branch ... And no PR list is fetched for this worktree".
+func TestWorktreePr_DefaultBranchSkipsLoader(t *testing.T) {
+	dir := t.TempDir()
+	writeGitConfig(t, dir, "git@github.com:drewdrewthis/git-orchard-rs.git")
+
+	// Write .git/HEAD pointing at refs/heads/main so readDefaultBranch
+	// returns ("main", true).
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("write .git/HEAD: %v", err)
+	}
+
+	stub := &neverCallStub{t: t}
+	bundle := &loaders.ProvidersBundle{GH: stub}
+	ldrs := loaders.NewLoaders(bundle)
+	ctx := loaders.WithLoaders(context.Background(), ldrs)
+
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:main", Path: dir, Branch: "main"}
+
+	got, err := r.Pr(ctx, obj)
+	if err != nil {
+		t.Fatalf("Pr() returned unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Pr() = %v, want nil for default-branch worktree", got)
+	}
+	if n := stub.called.Load(); n != 0 {
+		t.Errorf("gh.ListPullRequests was called %d times, want 0 (loader must be skipped)", n)
 	}
 }

--- a/internal/server/resolvers/worktree_resolver_test.go
+++ b/internal/server/resolvers/worktree_resolver_test.go
@@ -1,0 +1,112 @@
+package resolvers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// writeGitConfig writes a minimal .git/config under dir with the given
+// origin URL. Passing an empty originURL omits the [remote "origin"] block
+// entirely — simulating a repo that has no configured origin.
+func writeGitConfig(t *testing.T, dir string, originURL string) {
+	t.Helper()
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	cfg := "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n"
+	if originURL != "" {
+		cfg += "\n[remote \"origin\"]\n\turl = " + originURL + "\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+	}
+	cfgPath := filepath.Join(gitDir, "config")
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write .git/config: %v", err)
+	}
+}
+
+// newWorktreeResolver returns a worktreeResolver backed by a minimal
+// Resolver with no providers wired — enough for Host and Repo tests.
+func newWorktreeResolver() *worktreeResolver {
+	return &worktreeResolver{&Resolver{}}
+}
+
+// --- Host resolver tests ---
+
+// TestWorktreeHost_ReturnsLocal verifies the v1 sentinel: any worktree
+// resolves to the literal string "local", regardless of path or branch.
+func TestWorktreeHost_ReturnsLocal(t *testing.T) {
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "myproject:main", Path: "/some/path", Branch: "main"}
+
+	got, err := r.Host(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Host() returned error: %v", err)
+	}
+	if got != "local" {
+		t.Errorf("Host() = %q, want %q", got, "local")
+	}
+}
+
+// --- Repo resolver tests ---
+
+// TestWorktreeRepo_GitHubSSHURL verifies that a git@ GitHub SSH remote
+// produces the owner/repo slug.
+func TestWorktreeRepo_GitHubSSHURL(t *testing.T) {
+	dir := t.TempDir()
+	writeGitConfig(t, dir, "git@github.com:drewdrewthis/git-orchard-rs.git")
+
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:main", Path: dir}
+
+	got, err := r.Repo(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Repo() returned unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Repo() returned nil, want non-nil")
+	}
+	want := "drewdrewthis/git-orchard-rs"
+	if *got != want {
+		t.Errorf("Repo() = %q, want %q", *got, want)
+	}
+}
+
+// TestWorktreeRepo_NonGitHubURL verifies that a non-GitHub origin
+// (e.g. GitLab) causes the resolver to return nil.
+func TestWorktreeRepo_NonGitHubURL(t *testing.T) {
+	dir := t.TempDir()
+	writeGitConfig(t, dir, "git@gitlab.com:other/repo.git")
+
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:feat", Path: dir}
+
+	got, err := r.Repo(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Repo() returned unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Repo() = %q, want nil for non-GitHub origin", *got)
+	}
+}
+
+// TestWorktreeRepo_NoOriginRemote verifies that a repo with no origin
+// configured causes the resolver to return nil.
+func TestWorktreeRepo_NoOriginRemote(t *testing.T) {
+	dir := t.TempDir()
+	writeGitConfig(t, dir, "") // no origin
+
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:feat", Path: dir}
+
+	got, err := r.Repo(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Repo() returned unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Repo() = %q, want nil when no origin remote", *got)
+	}
+}

--- a/internal/server/resolvers/worktree_resolver_test.go
+++ b/internal/server/resolvers/worktree_resolver_test.go
@@ -110,3 +110,124 @@ func TestWorktreeRepo_NoOriginRemote(t *testing.T) {
 		t.Errorf("Repo() = %q, want nil when no origin remote", *got)
 	}
 }
+
+// --- Issue resolver tests ---
+
+// TestWorktreeIssue_EmptyBranch verifies that a detached-HEAD worktree
+// (empty branch) causes the resolver to return nil, nil without calling
+// the gh provider.
+func TestWorktreeIssue_EmptyBranch(t *testing.T) {
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:", Path: "/any/path", Branch: ""}
+
+	got, err := r.Issue(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Issue() returned unexpected error for empty branch: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Issue() = %v, want nil for empty branch (detached HEAD)", got)
+	}
+}
+
+// TestWorktreeIssue_UnparseableBranch verifies that a branch with no
+// parseable issue number causes the resolver to return nil without error.
+func TestWorktreeIssue_UnparseableBranch(t *testing.T) {
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:main", Path: "/any/path", Branch: "main"}
+
+	got, err := r.Issue(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Issue() returned unexpected error for unparseable branch: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Issue() = %v, want nil for branch with no parseable issue number", got)
+	}
+}
+
+// TestWorktreeIssue_BelowFloor verifies that a bare leading-numeric branch
+// whose number is below the 100 floor causes the resolver to return nil.
+func TestWorktreeIssue_BelowFloor(t *testing.T) {
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:feat", Path: "/any/path", Branch: "12-some-thing"}
+
+	got, err := r.Issue(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Issue() returned unexpected error for below-100 branch: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Issue() = %v, want nil for branch below 100 floor", got)
+	}
+}
+
+// TestWorktreeIssue_NilObject verifies that a nil worktree object returns
+// nil, nil gracefully.
+func TestWorktreeIssue_NilObject(t *testing.T) {
+	r := newWorktreeResolver()
+
+	got, err := r.Issue(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Issue() returned unexpected error for nil object: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Issue() = %v, want nil for nil worktree object", got)
+	}
+}
+
+// TestWorktreeIssue_NoGitDir verifies that a parseable branch but missing
+// .git directory causes the resolver to return nil without error (origin
+// unreadable → graceful nil).
+func TestWorktreeIssue_NoGitDir(t *testing.T) {
+	dir := t.TempDir() // no .git config written
+
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:issue441", Path: dir, Branch: "issue441/something"}
+
+	got, err := r.Issue(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Issue() returned unexpected error when .git is absent: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Issue() = %v, want nil when .git directory is absent", got)
+	}
+}
+
+// TestWorktreeIssue_NonGitHubOrigin verifies that a parseable branch but
+// a non-GitHub origin causes the resolver to return nil without error.
+func TestWorktreeIssue_NonGitHubOrigin(t *testing.T) {
+	dir := t.TempDir()
+	writeGitConfig(t, dir, "git@gitlab.com:other/repo.git")
+
+	r := newWorktreeResolver()
+	obj := &graphql1.Worktree{ID: "proj:issue441", Path: dir, Branch: "issue441/something"}
+
+	got, err := r.Issue(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Issue() returned unexpected error for non-GitHub origin: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Issue() = %v, want nil for non-GitHub origin", got)
+	}
+}
+
+// TestWorktreeIssue_GHNotConfigured verifies that when the gh provider is
+// nil and a valid issue branch + GitHub origin exist, the resolver returns
+// errGHNotConfigured.
+func TestWorktreeIssue_GHNotConfigured(t *testing.T) {
+	dir := t.TempDir()
+	writeGitConfig(t, dir, "git@github.com:drewdrewthis/git-orchard-rs.git")
+
+	r := newWorktreeResolver() // GH is nil by default
+
+	obj := &graphql1.Worktree{ID: "proj:issue441", Path: dir, Branch: "issue441/something"}
+
+	got, err := r.Issue(context.Background(), obj)
+	if err == nil {
+		t.Fatal("Issue() expected errGHNotConfigured but got nil error")
+	}
+	if err != errGHNotConfigured {
+		t.Errorf("Issue() error = %v, want errGHNotConfigured", err)
+	}
+	if got != nil {
+		t.Errorf("Issue() = %v, want nil when gh provider is not configured", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -36,6 +36,7 @@ import (
 	gqlws "github.com/gorilla/websocket"
 
 	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/loaders"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeinstance"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
@@ -215,7 +216,10 @@ func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 
 	mux := http.NewServeMux()
 	mux.Handle("/health", healthHandler(startedAt))
-	mux.Handle("/graphql", graphqlHandlerFor(res))
+	// Wrap the GraphQL handler with the request-scoped DataLoader middleware.
+	// The bundle is built from the resolver's provider set so the Pr resolver
+	// can batch ListPullRequests calls across all worktrees in one request.
+	mux.Handle("/graphql", loaders.Middleware(res.LoaderBundle(), graphqlHandlerFor(res)))
 
 	srv.httpSrv = &http.Server{
 		Addr:              addr,

--- a/schema.graphql
+++ b/schema.graphql
@@ -389,6 +389,18 @@ type Worktree implements Node {
   "True when HEAD references a deleted branch or otherwise fails to resolve to a commit. Bare worktrees still appear in the list — they just have no live branch."
   bare: Boolean!
 
+  "Hostname this worktree was discovered on. v1: always 'local'. Workstream F populates per-peer."
+  host: String!
+
+  "owner/repo slug derived from origin remote. Null when origin is not a GitHub URL."
+  repo: String
+
+  "Open PR whose headRef matches this worktree's branch. Null when no match, branch is detached, or branch is the project's default branch."
+  pr: PullRequest
+
+  "Issue linked from the worktree's branch (issue<N>/... convention). Null when the branch doesn't carry an issue number."
+  issue: Issue
+
   "Processes whose cwd lies under `path`. Resolved by the ps provider (ws-b-ps); returns `[]` until that provider lands."
   processes: [Process!]!
 }

--- a/specs/features/schema-worktree-host-pr-issue-joined-enrichment.feature
+++ b/specs/features/schema-worktree-host-pr-issue-joined-enrichment.feature
@@ -1,0 +1,342 @@
+Feature: Schema Worktree.host, repo, pr, issue, priorityFlag — joined enrichment for TUI dashboard
+  As a thin-shell TUI consuming the orchard daemon's GraphQL schema
+  I want the Worktree type to expose host, repo, joined PR/issue, and priorityFlag
+  So that the TUI renders the federated dashboard without re-doing joins client-side
+
+  Background:
+    Given the daemon serves a GraphQL schema at 127.0.0.1:7777
+    And the existing Worktree type already exposes id, path, branch, head, bare, processes
+    And the gh provider exposes ReadOriginURL and ParseGitHubURL helpers
+    And the loaders package already implements the WorktreeForCwd DataLoader pattern
+    And per-field GraphQL errors are the established contract for gh-derived fields
+
+  # ===================================================================
+  # AC 1 — Worktree.host: String! returns "local" sentinel for v1
+  # ===================================================================
+
+  @unit
+  Scenario: host resolver returns the literal "local" sentinel for a locally-discovered worktree
+    Given a worktree discovered by the local git provider
+    When a GraphQL query selects Worktree.host
+    Then the resolver returns the string "local"
+    And the value is independent of os.Hostname()
+
+  @unit
+  Scenario: host is non-nullable in the schema
+    Given the generated GraphQL schema
+    When the Worktree.host field is inspected
+    Then its type is String! (non-null)
+
+  # ===================================================================
+  # AC 2 — Worktree.repo: String — owner/repo slug from origin
+  # ===================================================================
+
+  @unit
+  Scenario: repo resolver returns owner/repo slug when origin is a GitHub URL
+    Given a worktree whose project's origin remote is "git@github.com:drewdrewthis/git-orchard-rs.git"
+    When a GraphQL query selects Worktree.repo
+    Then the resolver returns "drewdrewthis/git-orchard-rs"
+
+  @unit
+  Scenario: repo resolver returns null when origin is not a GitHub URL
+    Given a worktree whose project's origin remote is "git@gitlab.com:other/repo.git"
+    When a GraphQL query selects Worktree.repo
+    Then the resolver returns null
+
+  @unit
+  Scenario: repo resolver returns null when project has no origin remote
+    Given a worktree whose project has no origin remote configured
+    When a GraphQL query selects Worktree.repo
+    Then the resolver returns null
+
+  @unit
+  Scenario: repo field is nullable in the schema
+    Given the generated GraphQL schema
+    When the Worktree.repo field is inspected
+    Then its type is String (nullable)
+
+  # ===================================================================
+  # AC 3 — Worktree.pr: PullRequest — joined via headRef=branch, default branch excluded
+  # ===================================================================
+
+  @unit
+  Scenario: pr resolver matches PR by exact headRef equality with worktree branch
+    Given a worktree on branch "issue441/schema-enrich"
+    And the repo has an open PR with headRef "issue441/schema-enrich"
+    When the pr field is resolved
+    Then the resolver returns the matched PullRequest
+
+  @unit
+  Scenario: pr resolver returns null when no PR matches the branch
+    Given a worktree on branch "feature/no-pr-yet"
+    And the repo has no PR with that headRef
+    When the pr field is resolved
+    Then the resolver returns null
+
+  @unit
+  Scenario: pr resolver returns null when worktree branch is the project's default branch
+    Given a worktree on branch "main"
+    And "main" is the project's default branch (read from the bare's .git/HEAD)
+    When the pr field is resolved
+    Then the resolver returns null
+    And no PR list is fetched for this worktree
+
+  @unit
+  Scenario: pr resolver returns null when worktree is in detached-head state
+    Given a worktree with a detached HEAD (no branch)
+    When the pr field is resolved
+    Then the resolver returns null
+
+  @unit
+  Scenario: pr resolver scopes the PR search to the worktree's own repo
+    Given two worktrees in two different repos sharing the same branch name "wip/feature"
+    And each repo has its own PR with headRef "wip/feature"
+    When the pr field is resolved on each worktree
+    Then each worktree returns its own repo's PR, not the other repo's
+
+  # ===================================================================
+  # AC 4 — Worktree.issue: Issue — branch-parse for v1
+  # ===================================================================
+
+  @unit
+  Scenario: issue resolver parses "issue<N>/..." branch convention
+    Given a worktree on branch "issue441/schema-enrichment"
+    And issue 441 exists in the worktree's repo
+    When the issue field is resolved
+    Then the resolver returns the Issue with number 441
+
+  @unit
+  Scenario: issue resolver parses "issue-<N>-..." (case-insensitive, hyphen variant)
+    Given a worktree on branch "Issue-123-something"
+    And issue 123 exists in the worktree's repo
+    When the issue field is resolved
+    Then the resolver returns the Issue with number 123
+
+  @unit
+  Scenario: issue resolver parses leading number with N>=100
+    Given a worktree on branch "441-some-slug"
+    And issue 441 exists in the worktree's repo
+    When the issue field is resolved
+    Then the resolver returns the Issue with number 441
+
+  @unit
+  Scenario: issue resolver parses embedded number with N>=100
+    Given a worktree on branch "feature-441-slug"
+    And issue 441 exists in the worktree's repo
+    When the issue field is resolved
+    Then the resolver returns the Issue with number 441
+
+  @unit
+  Scenario: issue resolver enforces N>=100 floor on bare-leading numeric branches
+    Given a worktree on branch "12-something"
+    When the issue field is resolved
+    Then the resolver returns null
+    And no gh API call is made for issue 12
+
+  @unit
+  Scenario: issue resolver returns null when branch has no parseable issue number
+    Given a worktree on branch "feature/no-number"
+    When the issue field is resolved
+    Then the resolver returns null
+
+  @unit
+  Scenario: issue resolver matches Rust's regex precedence exactly
+    Given a worktree on branch "issue441/441-other"
+    When the issue field is resolved
+    Then the resolver returns the issue identified by the first matching regex (issue441)
+    And the precedence mirrors crates/orchard/src/github.rs:82-114
+
+  # ===================================================================
+  # AC 5 — Worktree.priorityFlag: Boolean! + Mutation.setWorktreePriority
+  # ===================================================================
+
+  @unit
+  Scenario: priorityFlag returns false when no priority is recorded for the worktree path
+    Given the daemon's priorities store contains no entry for the worktree's path
+    When the priorityFlag field is resolved
+    Then the resolver returns false
+
+  @unit
+  Scenario: priorityFlag returns true when the worktree's path is in the priorities store
+    Given the daemon's priorities store contains the worktree's absolute path
+    When the priorityFlag field is resolved
+    Then the resolver returns true
+
+  @unit
+  Scenario: priorityFlag is non-nullable in the schema
+    Given the generated GraphQL schema
+    When the Worktree.priorityFlag field is inspected
+    Then its type is Boolean! (non-null)
+
+  @integration
+  Scenario: setWorktreePriority(path, true) persists and reflects in the next read
+    Given a worktree at path "/Users/dev/repo/.worktrees/wt-1" with priorityFlag false
+    When Mutation.setWorktreePriority(path, true) is invoked
+    Then the mutation returns true
+    And a subsequent query for that worktree's priorityFlag returns true
+    And the priorities.json file on disk contains "/Users/dev/repo/.worktrees/wt-1"
+
+  @integration
+  Scenario: setWorktreePriority(path, false) removes the entry and persists
+    Given a worktree at path "/Users/dev/repo/.worktrees/wt-1" with priorityFlag true
+    When Mutation.setWorktreePriority(path, false) is invoked
+    Then the mutation returns false
+    And a subsequent query for that worktree's priorityFlag returns false
+    And the priorities.json file on disk does not contain that path
+
+  @integration
+  Scenario: priorities store reuses Rust's existing JSON file shape (zero-migration)
+    Given an existing ~/.cache/orchard/priorities.json with shape {"priorities":["/abs/path"]}
+    When the daemon starts and reads the file
+    Then the loaded set contains "/abs/path"
+    And subsequent writes preserve the same shape
+
+  @integration
+  Scenario: priorities store uses flock and atomic temp+rename on writes
+    Given two concurrent setWorktreePriority calls on different paths
+    When both mutations execute
+    Then both updates persist atomically with no lost write
+    And the on-disk file is never observed mid-write (atomic rename)
+
+  @integration
+  Scenario: Rust TUI's toggle_priority callsites cut over to the daemon mutation
+    Given the Rust TUI has been recompiled in this PR
+    When the user toggles priority on a worktree row
+    Then the TUI invokes Mutation.setWorktreePriority via GraphQL
+    And the Rust crate no longer writes priorities.json directly
+
+  # ===================================================================
+  # AC 6 — PullRequestsForRepo DataLoader batches multi-repo queries
+  # ===================================================================
+
+  @integration
+  Scenario: Multi-repo dashboard query collapses to one PR fetch per repo
+    Given 5 repos each with 8 worktrees
+    And every worktree resolves Worktree.pr in a single GraphQL query
+    When the query executes against a cold daemon (no gh cache)
+    Then the gh provider's ListPullRequests is called exactly 5 times (once per repo)
+    And not 40 times (worktree count)
+
+  @integration
+  Scenario: PullRequestsForRepo loader batches concurrent worktree pr resolutions
+    Given a single GraphQL query selecting pr on 8 worktrees in the same repo
+    When the field resolvers race in parallel
+    Then the loader batches them into one underlying gh ListPullRequests call
+
+  @integration
+  Scenario: PullRequestsForRepo loader is per-request scoped (mirrors WorktreeForCwd)
+    Given two separate GraphQL queries against the same repo
+    When each query independently resolves Worktree.pr
+    Then each query gets its own loader instance
+    And the loaders do not leak state across requests
+
+  # ===================================================================
+  # AC 7 — Typed error codes on gh-derived field failures
+  # ===================================================================
+
+  @integration
+  Scenario: pr field surfaces GH_NOT_AUTHED when gh CLI is not authenticated
+    Given the gh provider returns an authentication failure
+    When Worktree.pr is resolved
+    Then the field value is null
+    And the per-field GraphQL error has extensions.code == "GH_NOT_AUTHED"
+    And sibling fields on the same Worktree continue to resolve
+
+  @integration
+  Scenario: pr field surfaces NOT_GITHUB_REPO when repo cannot be derived
+    Given a worktree whose project's origin is not a GitHub URL
+    When Worktree.pr is resolved
+    Then the field value is null
+    And the per-field GraphQL error has extensions.code == "NOT_GITHUB_REPO"
+
+  @integration
+  Scenario: issue field surfaces typed error codes the same way as pr field
+    Given the gh provider returns an authentication failure
+    When Worktree.issue is resolved
+    Then the field value is null
+    And the per-field GraphQL error has extensions.code == "GH_NOT_AUTHED"
+
+  @integration
+  Scenario: typed errors let TUI collapse N identical errors into one indicator
+    Given 50 worktrees and a broken gh auth
+    When the TUI fetches the federated dashboard
+    Then 50 per-field errors arrive each carrying extensions.code == "GH_NOT_AUTHED"
+    And the TUI can deduplicate by code into a single status indicator
+
+  # ===================================================================
+  # End-to-end — full federated dashboard query against the live daemon
+  # ===================================================================
+
+  @e2e
+  Scenario: Full dashboard query returns host, repo, pr, issue, priorityFlag for every worktree
+    Given the daemon is running with at least one project and one worktree on a branch like "issue441/foo"
+    And the worktree's repo has an open PR with headRef "issue441/foo"
+    When a GraphQL query selects { worktree { host repo branch pr { number } issue { number } priorityFlag } }
+    Then host == "local"
+    And repo matches "owner/name"
+    And pr.number is the open PR's number
+    And issue.number == 441
+    And priorityFlag is a boolean
+
+  @e2e
+  Scenario: Toggling priority via mutation updates a subsequent dashboard query
+    Given the daemon is running with at least one worktree
+    And the worktree's priorityFlag is initially false
+    When Mutation.setWorktreePriority(path, true) is invoked
+    And a subsequent { worktree { priorityFlag } } query runs
+    Then priorityFlag is true
+
+  # --- AC Coverage Map ---
+  # AC 1: "Worktree.host: String! returns 'local' sentinel for v1"
+  #   -> @unit "host resolver returns the literal 'local' sentinel for a locally-discovered worktree"
+  #   -> @unit "host is non-nullable in the schema"
+  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue, priorityFlag for every worktree"
+  #
+  # AC 2: "Worktree.repo: String — owner/repo slug derived from project origin; null when origin is not a GitHub URL"
+  #   -> @unit "repo resolver returns owner/repo slug when origin is a GitHub URL"
+  #   -> @unit "repo resolver returns null when origin is not a GitHub URL"
+  #   -> @unit "repo resolver returns null when project has no origin remote"
+  #   -> @unit "repo field is nullable in the schema"
+  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue, priorityFlag for every worktree"
+  #
+  # AC 3: "Worktree.pr: PullRequest — joined via headRef = branch, scoped to the worktree's repo, default branch excluded"
+  #   -> @unit "pr resolver matches PR by exact headRef equality with worktree branch"
+  #   -> @unit "pr resolver returns null when no PR matches the branch"
+  #   -> @unit "pr resolver returns null when worktree branch is the project's default branch"
+  #   -> @unit "pr resolver returns null when worktree is in detached-head state"
+  #   -> @unit "pr resolver scopes the PR search to the worktree's own repo"
+  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue, priorityFlag for every worktree"
+  #
+  # AC 4: "Worktree.issue: Issue — joined by issue<N>/... branch parse for v1"
+  #   -> @unit "issue resolver parses 'issue<N>/...' branch convention"
+  #   -> @unit "issue resolver parses 'issue-<N>-...' (case-insensitive, hyphen variant)"
+  #   -> @unit "issue resolver parses leading number with N>=100"
+  #   -> @unit "issue resolver parses embedded number with N>=100"
+  #   -> @unit "issue resolver enforces N>=100 floor on bare-leading numeric branches"
+  #   -> @unit "issue resolver returns null when branch has no parseable issue number"
+  #   -> @unit "issue resolver matches Rust's regex precedence exactly"
+  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue, priorityFlag for every worktree"
+  #
+  # AC 5: "Worktree.priorityFlag: Boolean! — daemon-owned read+write store; pair with Mutation.setWorktreePriority(path, value)"
+  #   -> @unit "priorityFlag returns false when no priority is recorded for the worktree path"
+  #   -> @unit "priorityFlag returns true when the worktree's path is in the priorities store"
+  #   -> @unit "priorityFlag is non-nullable in the schema"
+  #   -> @integration "setWorktreePriority(path, true) persists and reflects in the next read"
+  #   -> @integration "setWorktreePriority(path, false) removes the entry and persists"
+  #   -> @integration "priorities store reuses Rust's existing JSON file shape (zero-migration)"
+  #   -> @integration "priorities store uses flock and atomic temp+rename on writes"
+  #   -> @integration "Rust TUI's toggle_priority callsites cut over to the daemon mutation"
+  #   -> @e2e  "Toggling priority via mutation updates a subsequent dashboard query"
+  #
+  # AC 6: "PR fetches go through a PullRequestsForRepo DataLoader so a multi-repo dashboard query collapses to one round-trip per repo"
+  #   -> @integration "Multi-repo dashboard query collapses to one PR fetch per repo"
+  #   -> @integration "PullRequestsForRepo loader batches concurrent worktree pr resolutions"
+  #   -> @integration "PullRequestsForRepo loader is per-request scoped (mirrors WorktreeForCwd)"
+  #
+  # AC 7: "gh-derived field failures (pr, issue) carry typed error codes (e.g. GH_NOT_AUTHED, NOT_GITHUB_REPO)"
+  #   -> @integration "pr field surfaces GH_NOT_AUTHED when gh CLI is not authenticated"
+  #   -> @integration "pr field surfaces NOT_GITHUB_REPO when repo cannot be derived"
+  #   -> @integration "issue field surfaces typed error codes the same way as pr field"
+  #   -> @integration "typed errors let TUI collapse N identical errors into one indicator"
+  #
+  # Math: 7 issue ACs -> all mapped, every AC has >=1 scenario. No drops.

--- a/specs/features/schema-worktree-host-pr-issue-joined-enrichment.feature
+++ b/specs/features/schema-worktree-host-pr-issue-joined-enrichment.feature
@@ -1,7 +1,9 @@
-Feature: Schema Worktree.host, repo, pr, issue, priorityFlag — joined enrichment for TUI dashboard
+Feature: Schema Worktree.host, repo, pr, issue — read-side joined enrichment for TUI dashboard
   As a thin-shell TUI consuming the orchard daemon's GraphQL schema
-  I want the Worktree type to expose host, repo, joined PR/issue, and priorityFlag
+  I want the Worktree type to expose host, repo, joined PR, and joined issue
   So that the TUI renders the federated dashboard without re-doing joins client-side
+
+  # Phase 1 of #441 (split). priorityFlag is owned by #466; typed gh-error codes are owned by #467.
 
   Background:
     Given the daemon serves a GraphQL schema at 127.0.0.1:7777
@@ -147,66 +149,7 @@ Feature: Schema Worktree.host, repo, pr, issue, priorityFlag — joined enrichme
     And the precedence mirrors crates/orchard/src/github.rs:82-114
 
   # ===================================================================
-  # AC 5 — Worktree.priorityFlag: Boolean! + Mutation.setWorktreePriority
-  # ===================================================================
-
-  @unit
-  Scenario: priorityFlag returns false when no priority is recorded for the worktree path
-    Given the daemon's priorities store contains no entry for the worktree's path
-    When the priorityFlag field is resolved
-    Then the resolver returns false
-
-  @unit
-  Scenario: priorityFlag returns true when the worktree's path is in the priorities store
-    Given the daemon's priorities store contains the worktree's absolute path
-    When the priorityFlag field is resolved
-    Then the resolver returns true
-
-  @unit
-  Scenario: priorityFlag is non-nullable in the schema
-    Given the generated GraphQL schema
-    When the Worktree.priorityFlag field is inspected
-    Then its type is Boolean! (non-null)
-
-  @integration
-  Scenario: setWorktreePriority(path, true) persists and reflects in the next read
-    Given a worktree at path "/Users/dev/repo/.worktrees/wt-1" with priorityFlag false
-    When Mutation.setWorktreePriority(path, true) is invoked
-    Then the mutation returns true
-    And a subsequent query for that worktree's priorityFlag returns true
-    And the priorities.json file on disk contains "/Users/dev/repo/.worktrees/wt-1"
-
-  @integration
-  Scenario: setWorktreePriority(path, false) removes the entry and persists
-    Given a worktree at path "/Users/dev/repo/.worktrees/wt-1" with priorityFlag true
-    When Mutation.setWorktreePriority(path, false) is invoked
-    Then the mutation returns false
-    And a subsequent query for that worktree's priorityFlag returns false
-    And the priorities.json file on disk does not contain that path
-
-  @integration
-  Scenario: priorities store reuses Rust's existing JSON file shape (zero-migration)
-    Given an existing ~/.cache/orchard/priorities.json with shape {"priorities":["/abs/path"]}
-    When the daemon starts and reads the file
-    Then the loaded set contains "/abs/path"
-    And subsequent writes preserve the same shape
-
-  @integration
-  Scenario: priorities store uses flock and atomic temp+rename on writes
-    Given two concurrent setWorktreePriority calls on different paths
-    When both mutations execute
-    Then both updates persist atomically with no lost write
-    And the on-disk file is never observed mid-write (atomic rename)
-
-  @integration
-  Scenario: Rust TUI's toggle_priority callsites cut over to the daemon mutation
-    Given the Rust TUI has been recompiled in this PR
-    When the user toggles priority on a worktree row
-    Then the TUI invokes Mutation.setWorktreePriority via GraphQL
-    And the Rust crate no longer writes priorities.json directly
-
-  # ===================================================================
-  # AC 6 — PullRequestsForRepo DataLoader batches multi-repo queries
+  # AC 5 — PullRequestsForRepo DataLoader batches multi-repo queries
   # ===================================================================
 
   @integration
@@ -231,73 +174,31 @@ Feature: Schema Worktree.host, repo, pr, issue, priorityFlag — joined enrichme
     And the loaders do not leak state across requests
 
   # ===================================================================
-  # AC 7 — Typed error codes on gh-derived field failures
-  # ===================================================================
-
-  @integration
-  Scenario: pr field surfaces GH_NOT_AUTHED when gh CLI is not authenticated
-    Given the gh provider returns an authentication failure
-    When Worktree.pr is resolved
-    Then the field value is null
-    And the per-field GraphQL error has extensions.code == "GH_NOT_AUTHED"
-    And sibling fields on the same Worktree continue to resolve
-
-  @integration
-  Scenario: pr field surfaces NOT_GITHUB_REPO when repo cannot be derived
-    Given a worktree whose project's origin is not a GitHub URL
-    When Worktree.pr is resolved
-    Then the field value is null
-    And the per-field GraphQL error has extensions.code == "NOT_GITHUB_REPO"
-
-  @integration
-  Scenario: issue field surfaces typed error codes the same way as pr field
-    Given the gh provider returns an authentication failure
-    When Worktree.issue is resolved
-    Then the field value is null
-    And the per-field GraphQL error has extensions.code == "GH_NOT_AUTHED"
-
-  @integration
-  Scenario: typed errors let TUI collapse N identical errors into one indicator
-    Given 50 worktrees and a broken gh auth
-    When the TUI fetches the federated dashboard
-    Then 50 per-field errors arrive each carrying extensions.code == "GH_NOT_AUTHED"
-    And the TUI can deduplicate by code into a single status indicator
-
-  # ===================================================================
-  # End-to-end — full federated dashboard query against the live daemon
+  # End-to-end — full dashboard query against the live daemon
   # ===================================================================
 
   @e2e
-  Scenario: Full dashboard query returns host, repo, pr, issue, priorityFlag for every worktree
+  Scenario: Full dashboard query returns host, repo, pr, issue for every worktree
     Given the daemon is running with at least one project and one worktree on a branch like "issue441/foo"
     And the worktree's repo has an open PR with headRef "issue441/foo"
-    When a GraphQL query selects { worktree { host repo branch pr { number } issue { number } priorityFlag } }
+    When a GraphQL query selects { worktree { host repo branch pr { number } issue { number } } }
     Then host == "local"
     And repo matches "owner/name"
     And pr.number is the open PR's number
     And issue.number == 441
-    And priorityFlag is a boolean
-
-  @e2e
-  Scenario: Toggling priority via mutation updates a subsequent dashboard query
-    Given the daemon is running with at least one worktree
-    And the worktree's priorityFlag is initially false
-    When Mutation.setWorktreePriority(path, true) is invoked
-    And a subsequent { worktree { priorityFlag } } query runs
-    Then priorityFlag is true
 
   # --- AC Coverage Map ---
   # AC 1: "Worktree.host: String! returns 'local' sentinel for v1"
   #   -> @unit "host resolver returns the literal 'local' sentinel for a locally-discovered worktree"
   #   -> @unit "host is non-nullable in the schema"
-  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue, priorityFlag for every worktree"
+  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue for every worktree"
   #
   # AC 2: "Worktree.repo: String — owner/repo slug derived from project origin; null when origin is not a GitHub URL"
   #   -> @unit "repo resolver returns owner/repo slug when origin is a GitHub URL"
   #   -> @unit "repo resolver returns null when origin is not a GitHub URL"
   #   -> @unit "repo resolver returns null when project has no origin remote"
   #   -> @unit "repo field is nullable in the schema"
-  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue, priorityFlag for every worktree"
+  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue for every worktree"
   #
   # AC 3: "Worktree.pr: PullRequest — joined via headRef = branch, scoped to the worktree's repo, default branch excluded"
   #   -> @unit "pr resolver matches PR by exact headRef equality with worktree branch"
@@ -305,7 +206,7 @@ Feature: Schema Worktree.host, repo, pr, issue, priorityFlag — joined enrichme
   #   -> @unit "pr resolver returns null when worktree branch is the project's default branch"
   #   -> @unit "pr resolver returns null when worktree is in detached-head state"
   #   -> @unit "pr resolver scopes the PR search to the worktree's own repo"
-  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue, priorityFlag for every worktree"
+  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue for every worktree"
   #
   # AC 4: "Worktree.issue: Issue — joined by issue<N>/... branch parse for v1"
   #   -> @unit "issue resolver parses 'issue<N>/...' branch convention"
@@ -315,28 +216,11 @@ Feature: Schema Worktree.host, repo, pr, issue, priorityFlag — joined enrichme
   #   -> @unit "issue resolver enforces N>=100 floor on bare-leading numeric branches"
   #   -> @unit "issue resolver returns null when branch has no parseable issue number"
   #   -> @unit "issue resolver matches Rust's regex precedence exactly"
-  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue, priorityFlag for every worktree"
+  #   -> @e2e  "Full dashboard query returns host, repo, pr, issue for every worktree"
   #
-  # AC 5: "Worktree.priorityFlag: Boolean! — daemon-owned read+write store; pair with Mutation.setWorktreePriority(path, value)"
-  #   -> @unit "priorityFlag returns false when no priority is recorded for the worktree path"
-  #   -> @unit "priorityFlag returns true when the worktree's path is in the priorities store"
-  #   -> @unit "priorityFlag is non-nullable in the schema"
-  #   -> @integration "setWorktreePriority(path, true) persists and reflects in the next read"
-  #   -> @integration "setWorktreePriority(path, false) removes the entry and persists"
-  #   -> @integration "priorities store reuses Rust's existing JSON file shape (zero-migration)"
-  #   -> @integration "priorities store uses flock and atomic temp+rename on writes"
-  #   -> @integration "Rust TUI's toggle_priority callsites cut over to the daemon mutation"
-  #   -> @e2e  "Toggling priority via mutation updates a subsequent dashboard query"
-  #
-  # AC 6: "PR fetches go through a PullRequestsForRepo DataLoader so a multi-repo dashboard query collapses to one round-trip per repo"
+  # AC 5: "PR fetches go through a PullRequestsForRepo DataLoader so a multi-repo dashboard query collapses to one round-trip per repo"
   #   -> @integration "Multi-repo dashboard query collapses to one PR fetch per repo"
   #   -> @integration "PullRequestsForRepo loader batches concurrent worktree pr resolutions"
   #   -> @integration "PullRequestsForRepo loader is per-request scoped (mirrors WorktreeForCwd)"
   #
-  # AC 7: "gh-derived field failures (pr, issue) carry typed error codes (e.g. GH_NOT_AUTHED, NOT_GITHUB_REPO)"
-  #   -> @integration "pr field surfaces GH_NOT_AUTHED when gh CLI is not authenticated"
-  #   -> @integration "pr field surfaces NOT_GITHUB_REPO when repo cannot be derived"
-  #   -> @integration "issue field surfaces typed error codes the same way as pr field"
-  #   -> @integration "typed errors let TUI collapse N identical errors into one indicator"
-  #
-  # Math: 7 issue ACs -> all mapped, every AC has >=1 scenario. No drops.
+  # Phase-1 scope only. AC 5 (priorityFlag) split to #466. AC 7 (typed gh errors) split to #467.


### PR DESCRIPTION
## Summary

Phase 1 of #441: read-side joined enrichment for the daemon's `Worktree` GraphQL type. Adds `host`, `repo`, `pr`, `issue` so the TUI v2 single-table dashboard can render `HOST | REPO | BRANCH | PR | …` without re-doing joins client-side.

`priorityFlag` and typed gh-error codes were originally in scope but split into follow-ups (#466, #467) per the challenge run on the proposal — each carries its own risk surface (Rust TUI cutover for priority, error-mapping covenant for typed codes).

Closes #441.

## What's in this PR

- **Schema**: 4 new fields on `Worktree` — `host: String!`, `repo: String`, `pr: PullRequest`, `issue: Issue`. gqlgen codegen regenerated.
- **Resolvers**: `host` returns `"local"` sentinel (federation-safe — Workstream F extends per-peer). `repo` derives `owner/repo` via existing `gh.ReadOriginURL` + `gh.ParseGitHubURL`. `pr` and `issue` resolvers land in the next commits.
- **DataLoader**: `PullRequestsForRepo` (mirroring `WorktreeForCwd`) — pending.
- **Branch parse**: regex port from Rust `crates/orchard/src/github.rs:82-114` (`issue<N>/...`, with N≥100 floor) — pending.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/server/resolvers/...` clean (4 new unit tests for host + repo)
- [ ] Unit tests for `pr` resolver (headRef match, default-branch exclusion, detached HEAD, per-repo scope)
- [ ] Unit tests for `issue` resolver (regex variants, ≥100 floor, precedence)
- [ ] Integration tests for `PullRequestsForRepo` DataLoader (cross-repo + concurrent batching + per-request scope)
- [ ] e2e test for the full dashboard query against a live daemon

## Status

Work in progress. Schema foundation + host/repo resolvers landed. PR resolver, issue resolver, DataLoader, and integration/e2e tests follow in subsequent commits before this PR is marked ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #441

# Related issue

- #441

# Related issue

- #441

# Related issue

- #441

# Related issue

- #441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Worktree dashboard with host, repository, pull request, and issue fields
  * Automatic GitHub pull request linking by matching branch names
  * GitHub issue discovery from branch naming patterns

* **Tests**
  * Added end-to-end dashboard query test
  * Added unit tests for resolver behaviors and DataLoader batching

* **Documentation**
  * Added BDD feature specification for Worktree enrichment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #441