### PR TITLE
feat(daemon): PullRequest mergeable, mergeStateStatus, reviewDecision, statusCheckRollup, labels (resolves #442)

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -179,6 +179,23 @@ models:
     model:
       - github.com/99designs/gqlgen/graphql.Time
 
+  # PullRequest enrichment fields are populated lazily by EnrichPullRequest
+  # (a GraphQL round-trip). Marking them resolver: true lets the five
+  # field resolvers share one EnrichPullRequest call per request via the
+  # provider's 60s cache.
+  PullRequest:
+    fields:
+      mergeable:
+        resolver: true
+      mergeStateStatus:
+        resolver: true
+      reviewDecision:
+        resolver: true
+      statusCheckRollup:
+        resolver: true
+      labels:
+        resolver: true
+
   # JSON scalar binds to gqlgen's Any marshaller, which round-trips any
   # JSON-shaped value (`map[string]any`, `[]any`, primitives) verbatim.
   # Used by Query.gh to forward GitHub GraphQL responses without imposing

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -42,6 +42,7 @@ type ResolverRoot interface {
 	Host() HostResolver
 	Process() ProcessResolver
 	Project() ProjectResolver
+	PullRequest() PullRequestResolver
 	Query() QueryResolver
 	Subscription() SubscriptionResolver
 	TmuxClient() TmuxClientResolver
@@ -192,22 +193,27 @@ type ComplexityRoot struct {
 	}
 
 	PullRequest struct {
-		AuthorLogin func(childComplexity int) int
-		BaseRef     func(childComplexity int) int
-		Body        func(childComplexity int) int
-		Comments    func(childComplexity int) int
-		CreatedAt   func(childComplexity int) int
-		Draft       func(childComplexity int) int
-		HeadRef     func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Number      func(childComplexity int) int
-		RepoName    func(childComplexity int) int
-		RepoOwner   func(childComplexity int) int
-		Reviews     func(childComplexity int) int
-		State       func(childComplexity int) int
-		Title       func(childComplexity int) int
-		URL         func(childComplexity int) int
-		UpdatedAt   func(childComplexity int) int
+		AuthorLogin       func(childComplexity int) int
+		BaseRef           func(childComplexity int) int
+		Body              func(childComplexity int) int
+		Comments          func(childComplexity int) int
+		CreatedAt         func(childComplexity int) int
+		Draft             func(childComplexity int) int
+		HeadRef           func(childComplexity int) int
+		ID                func(childComplexity int) int
+		Labels            func(childComplexity int) int
+		MergeStateStatus  func(childComplexity int) int
+		Mergeable         func(childComplexity int) int
+		Number            func(childComplexity int) int
+		RepoName          func(childComplexity int) int
+		RepoOwner         func(childComplexity int) int
+		ReviewDecision    func(childComplexity int) int
+		Reviews           func(childComplexity int) int
+		State             func(childComplexity int) int
+		StatusCheckRollup func(childComplexity int) int
+		Title             func(childComplexity int) int
+		URL               func(childComplexity int) int
+		UpdatedAt         func(childComplexity int) int
 	}
 
 	PullRequestReview struct {
@@ -368,6 +374,13 @@ type ProcessResolver interface {
 }
 type ProjectResolver interface {
 	Worktrees(ctx context.Context, obj *Project) ([]*Worktree, error)
+}
+type PullRequestResolver interface {
+	Mergeable(ctx context.Context, obj *PullRequest) (MergeableState, error)
+	MergeStateStatus(ctx context.Context, obj *PullRequest) (string, error)
+	ReviewDecision(ctx context.Context, obj *PullRequest) (*ReviewDecisionEnum, error)
+	StatusCheckRollup(ctx context.Context, obj *PullRequest) (CiStatus, error)
+	Labels(ctx context.Context, obj *PullRequest) ([]string, error)
 }
 type QueryResolver interface {
 	Health(ctx context.Context) (*Health, error)
@@ -1233,6 +1246,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PullRequest.ID(childComplexity), true
 
+	case "PullRequest.labels":
+		if e.complexity.PullRequest.Labels == nil {
+			break
+		}
+
+		return e.complexity.PullRequest.Labels(childComplexity), true
+
+	case "PullRequest.mergeStateStatus":
+		if e.complexity.PullRequest.MergeStateStatus == nil {
+			break
+		}
+
+		return e.complexity.PullRequest.MergeStateStatus(childComplexity), true
+
+	case "PullRequest.mergeable":
+		if e.complexity.PullRequest.Mergeable == nil {
+			break
+		}
+
+		return e.complexity.PullRequest.Mergeable(childComplexity), true
+
 	case "PullRequest.number":
 		if e.complexity.PullRequest.Number == nil {
 			break
@@ -1254,6 +1288,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PullRequest.RepoOwner(childComplexity), true
 
+	case "PullRequest.reviewDecision":
+		if e.complexity.PullRequest.ReviewDecision == nil {
+			break
+		}
+
+		return e.complexity.PullRequest.ReviewDecision(childComplexity), true
+
 	case "PullRequest.reviews":
 		if e.complexity.PullRequest.Reviews == nil {
 			break
@@ -1267,6 +1308,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.PullRequest.State(childComplexity), true
+
+	case "PullRequest.statusCheckRollup":
+		if e.complexity.PullRequest.StatusCheckRollup == nil {
+			break
+		}
+
+		return e.complexity.PullRequest.StatusCheckRollup(childComplexity), true
 
 	case "PullRequest.title":
 		if e.complexity.PullRequest.Title == nil {
@@ -3161,6 +3209,30 @@ input ContractFilter {
   parentContractId: ID
 }
 
+"Whether GitHub considers the PR mergeable. UNKNOWN means GitHub is still computing."
+enum MergeableState {
+  MERGEABLE
+  CONFLICTING
+  UNKNOWN
+}
+
+"Reviewer decision on a PR. Null when no review activity yet."
+enum ReviewDecisionEnum {
+  APPROVED
+  CHANGES_REQUESTED
+  REVIEW_REQUIRED
+  COMMENTED
+  DISMISSED
+}
+
+"Aggregated CI status across all check runs and statuses on the PR head sha."
+enum CiStatus {
+  SUCCESS
+  FAILURE
+  PENDING
+  UNKNOWN
+}
+
 "State filter for the pullRequests query."
 enum PullRequestState {
   OPEN
@@ -3196,6 +3268,11 @@ type PullRequest implements Node {
   updatedAt: String!
   reviews: [PullRequestReview!]
   comments: [IssueComment!]
+  mergeable: MergeableState!
+  mergeStateStatus: String!
+  reviewDecision: ReviewDecisionEnum
+  statusCheckRollup: CiStatus!
+  labels: [String!]!
 }
 
 "A review submitted on a pull request."
@@ -9049,6 +9126,223 @@ func (ec *executionContext) fieldContext_PullRequest_comments(ctx context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _PullRequest_mergeable(ctx context.Context, field graphql.CollectedField, obj *PullRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PullRequest_mergeable(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.PullRequest().Mergeable(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(MergeableState)
+	fc.Result = res
+	return ec.marshalNMergeableState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐMergeableState(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PullRequest_mergeable(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PullRequest",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type MergeableState does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PullRequest_mergeStateStatus(ctx context.Context, field graphql.CollectedField, obj *PullRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PullRequest_mergeStateStatus(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.PullRequest().MergeStateStatus(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PullRequest_mergeStateStatus(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PullRequest",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PullRequest_reviewDecision(ctx context.Context, field graphql.CollectedField, obj *PullRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PullRequest_reviewDecision(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.PullRequest().ReviewDecision(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*ReviewDecisionEnum)
+	fc.Result = res
+	return ec.marshalOReviewDecisionEnum2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐReviewDecisionEnum(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PullRequest_reviewDecision(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PullRequest",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ReviewDecisionEnum does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PullRequest_statusCheckRollup(ctx context.Context, field graphql.CollectedField, obj *PullRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PullRequest_statusCheckRollup(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.PullRequest().StatusCheckRollup(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(CiStatus)
+	fc.Result = res
+	return ec.marshalNCiStatus2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐCiStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PullRequest_statusCheckRollup(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PullRequest",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type CiStatus does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PullRequest_labels(ctx context.Context, field graphql.CollectedField, obj *PullRequest) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PullRequest_labels(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.PullRequest().Labels(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PullRequest_labels(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PullRequest",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _PullRequestReview_id(ctx context.Context, field graphql.CollectedField, obj *PullRequestReview) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_PullRequestReview_id(ctx, field)
 	if err != nil {
@@ -10362,6 +10656,16 @@ func (ec *executionContext) fieldContext_Query_pullRequests(ctx context.Context,
 				return ec.fieldContext_PullRequest_reviews(ctx, field)
 			case "comments":
 				return ec.fieldContext_PullRequest_comments(ctx, field)
+			case "mergeable":
+				return ec.fieldContext_PullRequest_mergeable(ctx, field)
+			case "mergeStateStatus":
+				return ec.fieldContext_PullRequest_mergeStateStatus(ctx, field)
+			case "reviewDecision":
+				return ec.fieldContext_PullRequest_reviewDecision(ctx, field)
+			case "statusCheckRollup":
+				return ec.fieldContext_PullRequest_statusCheckRollup(ctx, field)
+			case "labels":
+				return ec.fieldContext_PullRequest_labels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PullRequest", field.Name)
 		},
@@ -10451,6 +10755,16 @@ func (ec *executionContext) fieldContext_Query_openPullRequests(ctx context.Cont
 				return ec.fieldContext_PullRequest_reviews(ctx, field)
 			case "comments":
 				return ec.fieldContext_PullRequest_comments(ctx, field)
+			case "mergeable":
+				return ec.fieldContext_PullRequest_mergeable(ctx, field)
+			case "mergeStateStatus":
+				return ec.fieldContext_PullRequest_mergeStateStatus(ctx, field)
+			case "reviewDecision":
+				return ec.fieldContext_PullRequest_reviewDecision(ctx, field)
+			case "statusCheckRollup":
+				return ec.fieldContext_PullRequest_statusCheckRollup(ctx, field)
+			case "labels":
+				return ec.fieldContext_PullRequest_labels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PullRequest", field.Name)
 		},
@@ -10693,6 +11007,16 @@ func (ec *executionContext) fieldContext_Query_pullRequest(ctx context.Context, 
 				return ec.fieldContext_PullRequest_reviews(ctx, field)
 			case "comments":
 				return ec.fieldContext_PullRequest_comments(ctx, field)
+			case "mergeable":
+				return ec.fieldContext_PullRequest_mergeable(ctx, field)
+			case "mergeStateStatus":
+				return ec.fieldContext_PullRequest_mergeStateStatus(ctx, field)
+			case "reviewDecision":
+				return ec.fieldContext_PullRequest_reviewDecision(ctx, field)
+			case "statusCheckRollup":
+				return ec.fieldContext_PullRequest_statusCheckRollup(ctx, field)
+			case "labels":
+				return ec.fieldContext_PullRequest_labels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PullRequest", field.Name)
 		},
@@ -14993,6 +15317,16 @@ func (ec *executionContext) fieldContext_Worktree_pr(ctx context.Context, field 
 				return ec.fieldContext_PullRequest_reviews(ctx, field)
 			case "comments":
 				return ec.fieldContext_PullRequest_comments(ctx, field)
+			case "mergeable":
+				return ec.fieldContext_PullRequest_mergeable(ctx, field)
+			case "mergeStateStatus":
+				return ec.fieldContext_PullRequest_mergeStateStatus(ctx, field)
+			case "reviewDecision":
+				return ec.fieldContext_PullRequest_reviewDecision(ctx, field)
+			case "statusCheckRollup":
+				return ec.fieldContext_PullRequest_statusCheckRollup(ctx, field)
+			case "labels":
+				return ec.fieldContext_PullRequest_labels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PullRequest", field.Name)
 		},
@@ -18355,77 +18689,254 @@ func (ec *executionContext) _PullRequest(ctx context.Context, sel ast.SelectionS
 		case "id":
 			out.Values[i] = ec._PullRequest_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "repoOwner":
 			out.Values[i] = ec._PullRequest_repoOwner(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "repoName":
 			out.Values[i] = ec._PullRequest_repoName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "number":
 			out.Values[i] = ec._PullRequest_number(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "title":
 			out.Values[i] = ec._PullRequest_title(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "body":
 			out.Values[i] = ec._PullRequest_body(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "state":
 			out.Values[i] = ec._PullRequest_state(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "draft":
 			out.Values[i] = ec._PullRequest_draft(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "authorLogin":
 			out.Values[i] = ec._PullRequest_authorLogin(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "baseRef":
 			out.Values[i] = ec._PullRequest_baseRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "headRef":
 			out.Values[i] = ec._PullRequest_headRef(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "url":
 			out.Values[i] = ec._PullRequest_url(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "createdAt":
 			out.Values[i] = ec._PullRequest_createdAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "updatedAt":
 			out.Values[i] = ec._PullRequest_updatedAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "reviews":
 			out.Values[i] = ec._PullRequest_reviews(ctx, field, obj)
 		case "comments":
 			out.Values[i] = ec._PullRequest_comments(ctx, field, obj)
+		case "mergeable":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._PullRequest_mergeable(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "mergeStateStatus":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._PullRequest_mergeStateStatus(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "reviewDecision":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._PullRequest_reviewDecision(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "statusCheckRollup":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._PullRequest_statusCheckRollup(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "labels":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._PullRequest_labels(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -21417,6 +21928,16 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) unmarshalNCiStatus2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐCiStatus(ctx context.Context, v interface{}) (CiStatus, error) {
+	var res CiStatus
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNCiStatus2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐCiStatus(ctx context.Context, sel ast.SelectionSet, v CiStatus) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) marshalNClaudeAccount2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐClaudeAccountᚄ(ctx context.Context, sel ast.SelectionSet, v []*ClaudeAccount) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -21915,6 +22436,16 @@ func (ec *executionContext) unmarshalNIssueState2githubᚗcomᚋdrewdrewthisᚋg
 }
 
 func (ec *executionContext) marshalNIssueState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssueState(ctx context.Context, sel ast.SelectionSet, v IssueState) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalNMergeableState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐMergeableState(ctx context.Context, v interface{}) (MergeableState, error) {
+	var res MergeableState
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNMergeableState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐMergeableState(ctx context.Context, sel ast.SelectionSet, v MergeableState) graphql.Marshaler {
 	return v
 }
 
@@ -23228,6 +23759,22 @@ func (ec *executionContext) marshalOResourceLoad2ᚖgithubᚗcomᚋdrewdrewthis�
 		return graphql.Null
 	}
 	return ec._ResourceLoad(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOReviewDecisionEnum2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐReviewDecisionEnum(ctx context.Context, v interface{}) (*ReviewDecisionEnum, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(ReviewDecisionEnum)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOReviewDecisionEnum2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐReviewDecisionEnum(ctx context.Context, sel ast.SelectionSet, v *ReviewDecisionEnum) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) unmarshalOString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -360,22 +360,27 @@ func (this Project) GetID() string { return this.ID }
 
 // A pull request on a GitHub repository. Sourced from the GitHub REST API.
 type PullRequest struct {
-	ID          string               `json:"id"`
-	RepoOwner   string               `json:"repoOwner"`
-	RepoName    string               `json:"repoName"`
-	Number      int64                `json:"number"`
-	Title       string               `json:"title"`
-	Body        string               `json:"body"`
-	State       PullRequestState     `json:"state"`
-	Draft       bool                 `json:"draft"`
-	AuthorLogin string               `json:"authorLogin"`
-	BaseRef     string               `json:"baseRef"`
-	HeadRef     string               `json:"headRef"`
-	URL         string               `json:"url"`
-	CreatedAt   string               `json:"createdAt"`
-	UpdatedAt   string               `json:"updatedAt"`
-	Reviews     []*PullRequestReview `json:"reviews,omitempty"`
-	Comments    []*IssueComment      `json:"comments,omitempty"`
+	ID                string               `json:"id"`
+	RepoOwner         string               `json:"repoOwner"`
+	RepoName          string               `json:"repoName"`
+	Number            int64                `json:"number"`
+	Title             string               `json:"title"`
+	Body              string               `json:"body"`
+	State             PullRequestState     `json:"state"`
+	Draft             bool                 `json:"draft"`
+	AuthorLogin       string               `json:"authorLogin"`
+	BaseRef           string               `json:"baseRef"`
+	HeadRef           string               `json:"headRef"`
+	URL               string               `json:"url"`
+	CreatedAt         string               `json:"createdAt"`
+	UpdatedAt         string               `json:"updatedAt"`
+	Reviews           []*PullRequestReview `json:"reviews,omitempty"`
+	Comments          []*IssueComment      `json:"comments,omitempty"`
+	Mergeable         MergeableState       `json:"mergeable"`
+	MergeStateStatus  string               `json:"mergeStateStatus"`
+	ReviewDecision    *ReviewDecisionEnum  `json:"reviewDecision,omitempty"`
+	StatusCheckRollup CiStatus             `json:"statusCheckRollup"`
+	Labels            []string             `json:"labels"`
 }
 
 func (PullRequest) IsNode() {}
@@ -667,6 +672,52 @@ func (Worktree) IsNode() {}
 // Globally-unique id (e.g. "Host:<machineId>").
 func (this Worktree) GetID() string { return this.ID }
 
+// Aggregated CI status across all check runs and statuses on the PR head sha.
+type CiStatus string
+
+const (
+	CiStatusSuccess CiStatus = "SUCCESS"
+	CiStatusFailure CiStatus = "FAILURE"
+	CiStatusPending CiStatus = "PENDING"
+	CiStatusUnknown CiStatus = "UNKNOWN"
+)
+
+var AllCiStatus = []CiStatus{
+	CiStatusSuccess,
+	CiStatusFailure,
+	CiStatusPending,
+	CiStatusUnknown,
+}
+
+func (e CiStatus) IsValid() bool {
+	switch e {
+	case CiStatusSuccess, CiStatusFailure, CiStatusPending, CiStatusUnknown:
+		return true
+	}
+	return false
+}
+
+func (e CiStatus) String() string {
+	return string(e)
+}
+
+func (e *CiStatus) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = CiStatus(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid CiStatus", str)
+	}
+	return nil
+}
+
+func (e CiStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 // Lifecycle states for Contract.
 type ContractStatus string
 
@@ -878,6 +929,50 @@ func (e IssueState) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 
+// Whether GitHub considers the PR mergeable. UNKNOWN means GitHub is still computing.
+type MergeableState string
+
+const (
+	MergeableStateMergeable   MergeableState = "MERGEABLE"
+	MergeableStateConflicting MergeableState = "CONFLICTING"
+	MergeableStateUnknown     MergeableState = "UNKNOWN"
+)
+
+var AllMergeableState = []MergeableState{
+	MergeableStateMergeable,
+	MergeableStateConflicting,
+	MergeableStateUnknown,
+}
+
+func (e MergeableState) IsValid() bool {
+	switch e {
+	case MergeableStateMergeable, MergeableStateConflicting, MergeableStateUnknown:
+		return true
+	}
+	return false
+}
+
+func (e MergeableState) String() string {
+	return string(e)
+}
+
+func (e *MergeableState) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = MergeableState(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid MergeableState", str)
+	}
+	return nil
+}
+
+func (e MergeableState) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
 // State filter for the pullRequests query.
 type PullRequestState string
 
@@ -921,5 +1016,53 @@ func (e *PullRequestState) UnmarshalGQL(v interface{}) error {
 }
 
 func (e PullRequestState) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Reviewer decision on a PR. Null when no review activity yet.
+type ReviewDecisionEnum string
+
+const (
+	ReviewDecisionEnumApproved         ReviewDecisionEnum = "APPROVED"
+	ReviewDecisionEnumChangesRequested ReviewDecisionEnum = "CHANGES_REQUESTED"
+	ReviewDecisionEnumReviewRequired   ReviewDecisionEnum = "REVIEW_REQUIRED"
+	ReviewDecisionEnumCommented        ReviewDecisionEnum = "COMMENTED"
+	ReviewDecisionEnumDismissed        ReviewDecisionEnum = "DISMISSED"
+)
+
+var AllReviewDecisionEnum = []ReviewDecisionEnum{
+	ReviewDecisionEnumApproved,
+	ReviewDecisionEnumChangesRequested,
+	ReviewDecisionEnumReviewRequired,
+	ReviewDecisionEnumCommented,
+	ReviewDecisionEnumDismissed,
+}
+
+func (e ReviewDecisionEnum) IsValid() bool {
+	switch e {
+	case ReviewDecisionEnumApproved, ReviewDecisionEnumChangesRequested, ReviewDecisionEnumReviewRequired, ReviewDecisionEnumCommented, ReviewDecisionEnumDismissed:
+		return true
+	}
+	return false
+}
+
+func (e ReviewDecisionEnum) String() string {
+	return string(e)
+}
+
+func (e *ReviewDecisionEnum) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ReviewDecisionEnum(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ReviewDecisionEnum", str)
+	}
+	return nil
+}
+
+func (e ReviewDecisionEnum) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/internal/server/providers/gh/export_test.go
+++ b/internal/server/providers/gh/export_test.go
@@ -1,0 +1,14 @@
+package gh
+
+// export_test.go exposes package-private helpers for the external test package
+// (package gh_test). This file is only compiled during testing.
+
+// ExportMapStatusCheckRollup wraps mapStatusCheckRollup for external tests.
+func ExportMapStatusCheckRollup(state string) CiStatus {
+	return mapStatusCheckRollup(state)
+}
+
+// ExportFilterPhaseLabels wraps filterPhaseLabels for external tests.
+func ExportFilterPhaseLabels(in []string) []string {
+	return filterPhaseLabels(in)
+}

--- a/internal/server/providers/gh/export_test.go
+++ b/internal/server/providers/gh/export_test.go
@@ -1,5 +1,7 @@
 package gh
 
+import "time"
+
 // export_test.go exposes package-private helpers for the external test package
 // (package gh_test). This file is only compiled during testing.
 
@@ -11,4 +13,14 @@ func ExportMapStatusCheckRollup(state string) CiStatus {
 // ExportFilterPhaseLabels wraps filterPhaseLabels for external tests.
 func ExportFilterPhaseLabels(in []string) []string {
 	return filterPhaseLabels(in)
+}
+
+// ExportEnrichTimestamp returns the recorded enrichment timestamp for a
+// given PR key, or the zero time if EnrichPullRequest never wrote one.
+// External tests use this to directly assert the UNKNOWN-not-cached
+// invariant rather than inferring it from HTTP call counts.
+func (p *Provider) ExportEnrichTimestamp(key PullRequestKey) time.Time {
+	p.prMu.RLock()
+	defer p.prMu.RUnlock()
+	return p.enrichAt[key]
 }

--- a/internal/server/providers/gh/graphql_enrich.go
+++ b/internal/server/providers/gh/graphql_enrich.go
@@ -1,0 +1,245 @@
+// Package gh — GraphQL enrichment for PullRequest.
+//
+// This file adds EnrichPullRequest, which fetches the five fields that
+// the GitHub REST list endpoint does not return: mergeable, mergeStateStatus,
+// reviewDecision, statusCheckRollup, and labels. These require a dedicated
+// GraphQL round-trip.
+//
+// The result is merged back into the per-key prs cache so subsequent
+// GetPullRequest calls return the enriched view. Cache TTL is 60s
+// (enrichmentTTL) — shorter than CacheTTL because mergeable and CI
+// status change faster than basic PR metadata.
+//
+// UNKNOWN mergeable is never written to the cache so the next call
+// always re-fetches. This avoids the #367 flap pattern where a
+// transient UNKNOWN hardens into a stale cached value.
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// enrichmentTTL is shorter than CacheTTL because mergeable + CI flap fast.
+const enrichmentTTL = 60 * time.Second
+
+// enrichPRQuery is the GitHub GraphQL query that fetches the five
+// enrichment fields. The statusCheckRollup is read from the head
+// commit rather than from a separate check-runs endpoint so we get
+// the aggregated state in a single round-trip.
+const enrichPRQuery = `query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      mergeable
+      mergeStateStatus
+      reviewDecision
+      labels(first:50){ nodes{ name } }
+      commits(last:1){ nodes{ commit{ statusCheckRollup{ state } } } }
+    }
+  }
+}`
+
+// PhaseLabels are orchard lifecycle tags that are excluded from
+// PullRequest.Labels. Only user-assigned labels are surfaced.
+// See ~/.claude/skills/gh-tag/ for the canonical list.
+var phaseLabels = map[string]struct{}{
+	"investigating": {},
+	"needs-plan":    {},
+	"needs-repro":   {},
+	"planned":       {},
+	"in-progress":   {},
+	"in-ai-review":  {},
+	"pr-ready":      {},
+	"blocked":       {},
+}
+
+// enrichRaw is the wire-level shape of the GitHub GraphQL enrichment
+// response. Kept package-private; callers see the typed PullRequest.
+type enrichRaw struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				Mergeable        string  `json:"mergeable"`
+				MergeStateStatus string  `json:"mergeStateStatus"`
+				ReviewDecision   *string `json:"reviewDecision"`
+				Labels           struct {
+					Nodes []struct {
+						Name string `json:"name"`
+					} `json:"nodes"`
+				} `json:"labels"`
+				Commits struct {
+					Nodes []struct {
+						Commit struct {
+							StatusCheckRollup *struct {
+								State string `json:"state"`
+							} `json:"statusCheckRollup"`
+						} `json:"commit"`
+					} `json:"nodes"`
+				} `json:"commits"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors,omitempty"`
+}
+
+// prEnrichEntry holds a cached enriched PullRequest and the time it was
+// last fetched. Stored in the per-key prs map alongside the base entry.
+type prEnrichEntry struct {
+	value PullRequest
+	at    time.Time
+}
+
+// enrichedAt stores the enrichment timestamps separately from the base
+// prEntry so we can apply the shorter enrichmentTTL without touching
+// the CacheTTL-governed REST data. Protected by prMu.
+//
+// We reuse the existing prs map value for storage — the enrichment is
+// merged into the PullRequest struct in place, and the enrichAt map
+// tracks when that last happened.
+var _ = (*Provider)(nil).EnrichPullRequest // compile-time method existence check
+
+// EnrichPullRequest fetches the GraphQL-only enrichment fields
+// (mergeable, mergeStateStatus, reviewDecision, statusCheckRollup,
+// labels) for the given PR key, merges the result into the per-key
+// prs cache, and returns the fully-enriched PullRequest.
+//
+// Cache behaviour:
+//   - A hit within enrichmentTTL (60s) returns the cached enriched value.
+//   - UNKNOWN mergeable is never cached — the next call re-fetches so
+//     the transient computing state does not stick (#367 contract).
+//   - A miss fetches from GitHub GraphQL and caches (unless UNKNOWN).
+func (p *Provider) EnrichPullRequest(ctx context.Context, key PullRequestKey) (PullRequest, error) {
+	// --- cache check ---
+	p.prMu.RLock()
+	entry, ok := p.prs[key]
+	enrichedAt, hasEnriched := p.enrichAt[key]
+	p.prMu.RUnlock()
+
+	if ok && hasEnriched && p.clock().Sub(enrichedAt) < enrichmentTTL {
+		return entry.value, nil
+	}
+
+	// --- fetch ---
+	c, err := p.httpClient(ctx)
+	if err != nil {
+		return PullRequest{}, err
+	}
+
+	variables := map[string]any{
+		"owner":  key.Owner,
+		"name":   key.Name,
+		"number": key.Number,
+	}
+	raw, err := c.GraphQL(ctx, enrichPRQuery, variables)
+	if err != nil {
+		return PullRequest{}, fmt.Errorf("EnrichPullRequest graphql: %w", err)
+	}
+
+	var envelope enrichRaw
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return PullRequest{}, fmt.Errorf("EnrichPullRequest decode: %w", err)
+	}
+	if len(envelope.Errors) > 0 {
+		msgs := make([]string, 0, len(envelope.Errors))
+		for _, e := range envelope.Errors {
+			msgs = append(msgs, e.Message)
+		}
+		return PullRequest{}, fmt.Errorf("EnrichPullRequest graphql errors: %s", strings.Join(msgs, "; "))
+	}
+
+	wire := envelope.Data.Repository.PullRequest
+
+	// --- map fields ---
+	mergeable := mapMergeableState(wire.Mergeable)
+
+	var rd *ReviewDecision
+	if wire.ReviewDecision != nil {
+		mapped := ReviewDecision(*wire.ReviewDecision)
+		rd = &mapped
+	}
+
+	labelNames := make([]string, 0, len(wire.Labels.Nodes))
+	for _, n := range wire.Labels.Nodes {
+		labelNames = append(labelNames, n.Name)
+	}
+
+	ciStatus := CiStatusUnknown
+	if len(wire.Commits.Nodes) > 0 {
+		commit := wire.Commits.Nodes[0].Commit
+		if commit.StatusCheckRollup != nil {
+			ciStatus = mapStatusCheckRollup(commit.StatusCheckRollup.State)
+		}
+	}
+
+	// --- merge into existing base entry ---
+	p.prMu.Lock()
+	base := p.prs[key]
+	base.value.Mergeable = mergeable
+	base.value.MergeStateStatus = wire.MergeStateStatus
+	base.value.ReviewDecision = rd
+	base.value.StatusCheckRollup = ciStatus
+	base.value.Labels = filterPhaseLabels(labelNames)
+
+	// Cache the enriched result only when mergeable is definitive.
+	// UNKNOWN means GitHub is still computing — don't cache it so the
+	// next call re-fetches (#367 contract).
+	if mergeable != MergeableStateUnknown {
+		p.prs[key] = base
+		p.enrichAt[key] = p.clock()
+	}
+	enriched := base.value
+	p.prMu.Unlock()
+
+	return enriched, nil
+}
+
+// mapMergeableState maps the raw GitHub string to the typed enum.
+// Anything unrecognised maps to UNKNOWN, which is the safe fallback.
+func mapMergeableState(s string) MergeableState {
+	switch s {
+	case "MERGEABLE":
+		return MergeableStateMergeable
+	case "CONFLICTING":
+		return MergeableStateConflicting
+	default:
+		return MergeableStateUnknown
+	}
+}
+
+// mapStatusCheckRollup maps GitHub's CommitStatusState / CheckStatusState
+// to our CiStatus enum.
+//
+// Mapping rules (per issue #442 spec):
+//   - any FAILURE or ERROR → FAILURE
+//   - any PENDING or EXPECTED → PENDING
+//   - SUCCESS → SUCCESS
+//   - empty / nil / unknown → UNKNOWN
+func mapStatusCheckRollup(state string) CiStatus {
+	switch state {
+	case "SUCCESS":
+		return CiStatusSuccess
+	case "FAILURE", "ERROR":
+		return CiStatusFailure
+	case "PENDING", "EXPECTED":
+		return CiStatusPending
+	default:
+		return CiStatusUnknown
+	}
+}
+
+// filterPhaseLabels returns the input slice with orchard phase labels
+// removed, preserving the relative order of the remaining labels.
+func filterPhaseLabels(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, l := range in {
+		if _, isPhase := phaseLabels[l]; !isPhase {
+			out = append(out, l)
+		}
+	}
+	return out
+}

--- a/internal/server/providers/gh/graphql_enrich.go
+++ b/internal/server/providers/gh/graphql_enrich.go
@@ -101,7 +101,6 @@ type prEnrichEntry struct {
 // We reuse the existing prs map value for storage — the enrichment is
 // merged into the PullRequest struct in place, and the enrichAt map
 // tracks when that last happened.
-var _ = (*Provider)(nil).EnrichPullRequest // compile-time method existence check
 
 // EnrichPullRequest fetches the GraphQL-only enrichment fields
 // (mergeable, mergeStateStatus, reviewDecision, statusCheckRollup,

--- a/internal/server/providers/gh/graphql_enrich_test.go
+++ b/internal/server/providers/gh/graphql_enrich_test.go
@@ -227,6 +227,15 @@ func TestEnrichPullRequest_UnknownMergeableNotCachedAsDefinitive(t *testing.T) {
 		t.Fatalf("expected 1 HTTP call, got %d", c)
 	}
 
+	// Direct invariant check: enrichAt MUST be the zero time after an
+	// UNKNOWN response. A future regression that wrote enrichAt[key]
+	// while still treating Mergeable==UNKNOWN as a cache miss would
+	// pass the HTTP-count assertion but break the contract — this
+	// catches that drift directly.
+	if ts := p.ExportEnrichTimestamp(key); !ts.IsZero() {
+		t.Errorf("enrichAt[key] = %v after UNKNOWN, want zero time", ts)
+	}
+
 	// Do NOT advance clock — still within TTL window.
 	// Call 2 — UNKNOWN means no cache; must still hit the wire.
 	_, err = p.EnrichPullRequest(context.Background(), key)

--- a/internal/server/providers/gh/graphql_enrich_test.go
+++ b/internal/server/providers/gh/graphql_enrich_test.go
@@ -1,0 +1,333 @@
+package gh_test
+
+// Tests for the PR enrichment layer (graphql_enrich.go).
+//
+// **No PII fixtures.** Repos are `alice/repo`, users are `bob`.
+// **No real API calls.** The GitHub GraphQL endpoint is stubbed via the
+// existing stubGraphQLServer + newClientForGraphQLTest pattern used in
+// graphql_test.go. For provider-level tests we use the httptest.NewTLSServer
+// + installFakeGH pattern from gh_e2e_test.go.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
+)
+
+// TestMapStatusCheckRollup confirms the aggregation rules from issue #442:
+//   - SUCCESS → SUCCESS
+//   - FAILURE or ERROR → FAILURE
+//   - PENDING or EXPECTED → PENDING
+//   - anything else → UNKNOWN
+func TestMapStatusCheckRollup(t *testing.T) {
+	cases := []struct {
+		state string
+		want  string
+	}{
+		{"SUCCESS", "SUCCESS"},
+		{"FAILURE", "FAILURE"},
+		{"ERROR", "FAILURE"},
+		{"PENDING", "PENDING"},
+		{"EXPECTED", "PENDING"},
+		{"", "UNKNOWN"},
+		{"STALE", "UNKNOWN"},
+	}
+	for _, tc := range cases {
+		got := gh.ExportMapStatusCheckRollup(tc.state)
+		if string(got) != tc.want {
+			t.Errorf("mapStatusCheckRollup(%q) = %q, want %q", tc.state, got, tc.want)
+		}
+	}
+}
+
+// TestFilterPhaseLabels confirms that orchard lifecycle labels are stripped
+// while user labels (P0, bug, autonomous) are preserved.
+func TestFilterPhaseLabels(t *testing.T) {
+	in := []string{
+		"P0",
+		"investigating",
+		"bug",
+		"in-progress",
+		"autonomous",
+		"planned",
+		"needs-plan",
+		"pr-ready",
+		"blocked",
+	}
+	got := gh.ExportFilterPhaseLabels(in)
+
+	// phase labels must be absent
+	for _, l := range got {
+		switch l {
+		case "investigating", "needs-plan", "needs-repro", "planned",
+			"in-progress", "in-ai-review", "pr-ready", "blocked":
+			t.Errorf("phase label %q survived filterPhaseLabels", l)
+		}
+	}
+	// user labels must be present
+	want := map[string]bool{"P0": true, "bug": true, "autonomous": true}
+	for _, l := range got {
+		delete(want, l)
+	}
+	for l := range want {
+		t.Errorf("user label %q was incorrectly removed by filterPhaseLabels", l)
+	}
+}
+
+// enrichResponse builds a canned GitHub GraphQL enrichment payload.
+func enrichResponse(mergeable, mergeStateStatus string, reviewDecision *string, statusState string, labels ...string) []byte {
+	labelNodes := make([]map[string]string, 0, len(labels))
+	for _, l := range labels {
+		labelNodes = append(labelNodes, map[string]string{"name": l})
+	}
+	var statusRollup interface{} = nil
+	if statusState != "" {
+		statusRollup = map[string]string{"state": statusState}
+	}
+	body := map[string]any{
+		"data": map[string]any{
+			"repository": map[string]any{
+				"pullRequest": map[string]any{
+					"mergeable":        mergeable,
+					"mergeStateStatus": mergeStateStatus,
+					"reviewDecision":   reviewDecision,
+					"labels": map[string]any{
+						"nodes": labelNodes,
+					},
+					"commits": map[string]any{
+						"nodes": []any{
+							map[string]any{
+								"commit": map[string]any{
+									"statusCheckRollup": statusRollup,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	out, _ := json.Marshal(body)
+	return out
+}
+
+// newEnrichProvider builds a gh.Provider wired against a TLS test server
+// that serves the given enrichment body for every /graphql request. The
+// request count is returned via the atomic for cache tests.
+func newEnrichProvider(t *testing.T, body []byte, clock func() time.Time) (*gh.Provider, *atomic.Int32) {
+	t.Helper()
+	var count atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request to %s", r.URL.Path)
+		http.NotFound(w, r)
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+
+	auth := &gh.StaticAuthSource{TokenValue: "test-token-fixture"}
+	p := gh.NewWith(nil, srv.URL, auth, clock)
+	if err := p.Start(context.Background()); err != nil {
+		t.Logf("provider start (non-fatal): %v", err)
+	}
+	gh.SetHTTPClientForTest(p, srv.Client())
+	return p, &count
+}
+
+// TestEnrichPullRequest_Caches60s asserts that two EnrichPullRequest calls
+// within the 60-second enrichment TTL share one HTTP round-trip.
+func TestEnrichPullRequest_Caches60s(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{t: now}
+
+	body := enrichResponse("MERGEABLE", "CLEAN", nil, "SUCCESS", "bug", "P0")
+	p, count := newEnrichProvider(t, body, clock.Now)
+
+	key := gh.PullRequestKey{Owner: "alice", Name: "repo", Number: 42}
+
+	// First call — must hit the wire.
+	pr1, err := p.EnrichPullRequest(context.Background(), key)
+	if err != nil {
+		t.Fatalf("first enrich: %v", err)
+	}
+	if pr1.Mergeable != gh.MergeableStateMergeable {
+		t.Errorf("mergeable = %q, want MERGEABLE", pr1.Mergeable)
+	}
+	if string(pr1.StatusCheckRollup) != "SUCCESS" {
+		t.Errorf("ciStatus = %q, want SUCCESS", pr1.StatusCheckRollup)
+	}
+	if c := count.Load(); c != 1 {
+		t.Fatalf("expected 1 HTTP call after first enrich, got %d", c)
+	}
+
+	// Advance clock by 30s — still within 60s TTL.
+	clock.advance(30 * time.Second)
+
+	// Second call — must use the cache (no new HTTP call).
+	pr2, err := p.EnrichPullRequest(context.Background(), key)
+	if err != nil {
+		t.Fatalf("second enrich: %v", err)
+	}
+	if c := count.Load(); c != 1 {
+		t.Fatalf("expected still 1 HTTP call after second enrich (within TTL), got %d", c)
+	}
+	if pr2.Mergeable != pr1.Mergeable {
+		t.Errorf("cached result differs: %+v vs %+v", pr1, pr2)
+	}
+
+	// Advance past TTL.
+	clock.advance(35 * time.Second)
+
+	// Third call — TTL expired, must re-fetch.
+	_, err = p.EnrichPullRequest(context.Background(), key)
+	if err != nil {
+		t.Fatalf("third enrich: %v", err)
+	}
+	if c := count.Load(); c != 2 {
+		t.Fatalf("expected 2 HTTP calls after TTL expiry, got %d", c)
+	}
+}
+
+// TestEnrichPullRequest_UnknownMergeableNotCachedAsDefinitive asserts that
+// when GitHub returns UNKNOWN for mergeable, the result is NOT cached —
+// the next call must re-fetch. This avoids the #367 flap pattern where a
+// transient UNKNOWN hardens into a stale cached answer.
+func TestEnrichPullRequest_UnknownMergeableNotCachedAsDefinitive(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{t: now}
+
+	// Server always returns UNKNOWN.
+	body := enrichResponse("UNKNOWN", "UNKNOWN", nil, "")
+	p, count := newEnrichProvider(t, body, clock.Now)
+
+	key := gh.PullRequestKey{Owner: "alice", Name: "repo", Number: 7}
+
+	// Call 1.
+	pr, err := p.EnrichPullRequest(context.Background(), key)
+	if err != nil {
+		t.Fatalf("enrich 1: %v", err)
+	}
+	if pr.Mergeable != gh.MergeableStateUnknown {
+		t.Errorf("mergeable = %q, want UNKNOWN", pr.Mergeable)
+	}
+	if c := count.Load(); c != 1 {
+		t.Fatalf("expected 1 HTTP call, got %d", c)
+	}
+
+	// Do NOT advance clock — still within TTL window.
+	// Call 2 — UNKNOWN means no cache; must still hit the wire.
+	_, err = p.EnrichPullRequest(context.Background(), key)
+	if err != nil {
+		t.Fatalf("enrich 2: %v", err)
+	}
+	if c := count.Load(); c != 2 {
+		t.Fatalf("expected 2 HTTP calls (UNKNOWN not cached), got %d", c)
+	}
+}
+
+// TestEnrichPullRequest_GraphQLError asserts that GraphQL-level envelope
+// errors (200 OK, errors[] populated) surface as a Go error.
+func TestEnrichPullRequest_GraphQLError(t *testing.T) {
+	body, _ := json.Marshal(map[string]any{
+		"data": nil,
+		"errors": []any{
+			map[string]any{"message": "Field 'pullRequest' doesn't exist"},
+		},
+	})
+	p, _ := newEnrichProvider(t, body, time.Now)
+
+	key := gh.PullRequestKey{Owner: "alice", Name: "repo", Number: 1}
+	_, err := p.EnrichPullRequest(context.Background(), key)
+	if err == nil {
+		t.Fatal("expected error on GraphQL envelope errors, got nil")
+	}
+}
+
+// TestEnrichPullRequest_LabelFilter confirms phase labels are stripped and
+// user labels preserved in the returned PullRequest.
+func TestEnrichPullRequest_LabelFilter(t *testing.T) {
+	rd := "APPROVED"
+	body := enrichResponse("MERGEABLE", "CLEAN", &rd, "SUCCESS",
+		"P0", "bug", "in-progress", "planned", "autonomous")
+	p, _ := newEnrichProvider(t, body, time.Now)
+
+	key := gh.PullRequestKey{Owner: "alice", Name: "repo", Number: 42}
+	pr, err := p.EnrichPullRequest(context.Background(), key)
+	if err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+
+	phaseLabels := map[string]bool{
+		"investigating": true, "needs-plan": true, "needs-repro": true,
+		"planned": true, "in-progress": true, "in-ai-review": true,
+		"pr-ready": true, "blocked": true,
+	}
+	for _, l := range pr.Labels {
+		if phaseLabels[l] {
+			t.Errorf("phase label %q survived into PullRequest.Labels", l)
+		}
+	}
+
+	// user labels must survive
+	want := map[string]bool{"P0": true, "bug": true, "autonomous": true}
+	for _, l := range pr.Labels {
+		delete(want, l)
+	}
+	for l := range want {
+		t.Errorf("user label %q missing from PullRequest.Labels", l)
+	}
+
+	// ReviewDecision should be populated
+	if pr.ReviewDecision == nil {
+		t.Error("ReviewDecision is nil, want APPROVED")
+	} else if *pr.ReviewDecision != gh.ReviewDecisionApproved {
+		t.Errorf("ReviewDecision = %q, want APPROVED", *pr.ReviewDecision)
+	}
+}
+
+// fakeClock is a test-only monotonic clock backed by a mutable time value.
+// advance is safe to call from the same goroutine as Now.
+type fakeClock struct {
+	t time.Time
+}
+
+func (c *fakeClock) Now() time.Time { return c.t }
+
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// newEnrichGraphQLServer builds an httptest.NewTLSServer with a /graphql
+// handler that responds with body, plus a /repos/.../pulls/* handler so
+// the provider can resolve REST-level pulls for GetPullRequest. Returns the
+// server + a trusting client.
+func newEnrichGraphQLServer(t *testing.T, graphqlBody []byte, hitCount *atomic.Int32) (*httptest.Server, *http.Client) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		hitCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(graphqlBody)
+	})
+	mux.HandleFunc("/repos/alice/repo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, canonOnePullBody)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"error":"unexpected path %s"}`, r.URL.Path)
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, srv.Client()
+}

--- a/internal/server/providers/gh/provider.go
+++ b/internal/server/providers/gh/provider.go
@@ -219,11 +219,15 @@ func (p *Provider) ListPullRequests(ctx context.Context, owner, name string, sta
 	p.listMu.Unlock()
 
 	// Also seed the per-key cache so a follow-up GetPullRequest is
-	// cheap.
+	// cheap. The REST list endpoint does not return enrichment fields
+	// (mergeable, mergeStateStatus, reviewDecision, statusCheckRollup,
+	// labels), so we drop any stale enrichment timestamp here — the
+	// next EnrichPullRequest call must refetch via GraphQL.
 	p.prMu.Lock()
 	for _, pr := range prs {
 		k := PullRequestKey{Owner: pr.RepoOwner, Name: pr.RepoName, Number: pr.Number}
 		p.prs[k] = prEntry{value: pr, at: now}
+		delete(p.enrichAt, k)
 	}
 	p.prMu.Unlock()
 
@@ -251,6 +255,9 @@ func (p *Provider) GetPullRequest(ctx context.Context, key PullRequestKey) (Pull
 	}
 	p.prMu.Lock()
 	p.prs[key] = prEntry{value: pr, at: p.clock()}
+	// REST GetPull does not populate enrichment fields; drop any stale
+	// enrichment timestamp so the next EnrichPullRequest refetches.
+	delete(p.enrichAt, key)
 	p.prMu.Unlock()
 	return pr, nil
 }
@@ -493,6 +500,7 @@ var (
 	_ = (*Provider)(nil).GetIssue
 	_ = (*Provider)(nil).GetWorkflowRun
 	_ = (*Provider)(nil).GetRepository
+	_ = (*Provider)(nil).EnrichPullRequest
 )
 
 // errNoGitDir / errNoOriginRemote differentiate "no .git" from "no

--- a/internal/server/providers/gh/provider.go
+++ b/internal/server/providers/gh/provider.go
@@ -45,8 +45,9 @@ type Provider struct {
 
 	// Per-node-type caches. Keyed by their typed key, value is the
 	// node + freshness.
-	prMu sync.RWMutex
-	prs  map[PullRequestKey]prEntry
+	prMu     sync.RWMutex
+	prs      map[PullRequestKey]prEntry
+	enrichAt map[PullRequestKey]time.Time // when EnrichPullRequest last populated the enrichment fields
 
 	issueMu sync.RWMutex
 	issues  map[IssueKey]issueEntry
@@ -142,6 +143,7 @@ func NewWith(logger *slog.Logger, baseURL string, auth AuthSource, clock func() 
 		auth:         newAuthCache(auth),
 		baseURL:      baseURL,
 		prs:          map[PullRequestKey]prEntry{},
+		enrichAt:     map[PullRequestKey]time.Time{},
 		issues:       map[IssueKey]issueEntry{},
 		runs:         map[WorkflowRunKey]runEntry{},
 		listPRsCache: map[listPRsKey]listPRsEntry{},

--- a/internal/server/providers/gh/types.go
+++ b/internal/server/providers/gh/types.go
@@ -9,7 +9,7 @@
 //
 //   - auth.go     — boot-time `gh auth token` shellout + caching
 //   - client.go   — net/http client with Bearer header, base-URL
-//                   override (GH_API_BASE_URL), rate-limit awareness
+//     override (GH_API_BASE_URL), rate-limit awareness
 //   - adapter.go  — Adapter[K, V] over the client for each node type
 //   - provider.go — Provider[K, V] with 2-minute read TTL
 //   - webhook.go  — POST /webhook/github stub (ADR-011 §12 post-v1)
@@ -87,10 +87,47 @@ func (k WorkflowRunKey) String() string {
 	return fmt.Sprintf("%s/%s#%d", k.Owner, k.Name, k.RunID)
 }
 
+// MergeableState mirrors GitHub's MergeableState enum.
+// UNKNOWN means GitHub is still computing the mergeability.
+type MergeableState string
+
+const (
+	MergeableStateMergeable   MergeableState = "MERGEABLE"
+	MergeableStateConflicting MergeableState = "CONFLICTING"
+	MergeableStateUnknown     MergeableState = "UNKNOWN"
+)
+
+// ReviewDecision mirrors GitHub's PullRequestReviewDecision enum.
+// Nil when no review activity has occurred yet.
+type ReviewDecision string
+
+const (
+	ReviewDecisionApproved         ReviewDecision = "APPROVED"
+	ReviewDecisionChangesRequested ReviewDecision = "CHANGES_REQUESTED"
+	ReviewDecisionReviewRequired   ReviewDecision = "REVIEW_REQUIRED"
+	ReviewDecisionCommented        ReviewDecision = "COMMENTED"
+	ReviewDecisionDismissed        ReviewDecision = "DISMISSED"
+)
+
+// CiStatus is the aggregated CI status across all check runs and commit
+// statuses on the PR head SHA.
+type CiStatus string
+
+const (
+	CiStatusSuccess CiStatus = "SUCCESS"
+	CiStatusFailure CiStatus = "FAILURE"
+	CiStatusPending CiStatus = "PENDING"
+	CiStatusUnknown CiStatus = "UNKNOWN"
+)
+
 // PullRequest is the provider-facing pull request. It mirrors the
 // fields the GraphQL `PullRequest` type exposes, with one addition:
 // the `State` is already projected into the schema's enum (OPEN,
 // CLOSED, MERGED) so resolvers don't need to repeat the mapping.
+//
+// The enrichment fields (Mergeable, MergeStateStatus, ReviewDecision,
+// StatusCheckRollup, Labels) are populated lazily by EnrichPullRequest
+// and are zero-valued until that call succeeds.
 type PullRequest struct {
 	RepoOwner   string
 	RepoName    string
@@ -105,6 +142,14 @@ type PullRequest struct {
 	URL         string
 	CreatedAt   string
 	UpdatedAt   string
+
+	// GraphQL-only enrichment fields. Zero-valued until EnrichPullRequest
+	// has been called for this PR key.
+	Mergeable         MergeableState
+	MergeStateStatus  string          // raw GitHub mergeStateStatus string
+	ReviewDecision    *ReviewDecision // nil when GitHub returns null
+	StatusCheckRollup CiStatus
+	Labels            []string // user labels only; phase labels excluded
 }
 
 // ID is the GraphQL-stable id `PullRequest:<owner>/<repo>#<number>`.

--- a/internal/server/providers/gh/webhook.go
+++ b/internal/server/providers/gh/webhook.go
@@ -221,6 +221,7 @@ func clockOrNow(c func() time.Time) time.Time {
 func (p *Provider) dropPRCache(k PullRequestKey) {
 	p.prMu.Lock()
 	delete(p.prs, k)
+	delete(p.enrichAt, k)
 	p.prMu.Unlock()
 	p.listMu.Lock()
 	for lk := range p.listPRsCache {

--- a/internal/server/resolvers/gh.go
+++ b/internal/server/resolvers/gh.go
@@ -433,3 +433,57 @@ func toGraphQLComment(c gh.IssueComment) *graphql1.IssueComment {
 		UpdatedAt:   c.UpdatedAt,
 	}
 }
+
+// mapMergeableState projects the provider MergeableState onto the GraphQL enum.
+func mapMergeableState(s gh.MergeableState) graphql1.MergeableState {
+	switch s {
+	case gh.MergeableStateMergeable:
+		return graphql1.MergeableStateMergeable
+	case gh.MergeableStateConflicting:
+		return graphql1.MergeableStateConflicting
+	default:
+		return graphql1.MergeableStateUnknown
+	}
+}
+
+// mapReviewDecision projects a nullable provider ReviewDecision onto the
+// nullable GraphQL ReviewDecisionEnum. Returns nil when the provider value is nil.
+func mapReviewDecision(rd *gh.ReviewDecision) *graphql1.ReviewDecisionEnum {
+	if rd == nil {
+		return nil
+	}
+	switch *rd {
+	case gh.ReviewDecisionApproved:
+		v := graphql1.ReviewDecisionEnumApproved
+		return &v
+	case gh.ReviewDecisionChangesRequested:
+		v := graphql1.ReviewDecisionEnumChangesRequested
+		return &v
+	case gh.ReviewDecisionReviewRequired:
+		v := graphql1.ReviewDecisionEnumReviewRequired
+		return &v
+	case gh.ReviewDecisionCommented:
+		v := graphql1.ReviewDecisionEnumCommented
+		return &v
+	case gh.ReviewDecisionDismissed:
+		v := graphql1.ReviewDecisionEnumDismissed
+		return &v
+	default:
+		v := graphql1.ReviewDecisionEnumReviewRequired
+		return &v
+	}
+}
+
+// mapCiStatus projects the provider CiStatus onto the GraphQL CiStatus enum.
+func mapCiStatus(s gh.CiStatus) graphql1.CiStatus {
+	switch s {
+	case gh.CiStatusSuccess:
+		return graphql1.CiStatusSuccess
+	case gh.CiStatusFailure:
+		return graphql1.CiStatusFailure
+	case gh.CiStatusPending:
+		return graphql1.CiStatusPending
+	default:
+		return graphql1.CiStatusUnknown
+	}
+}

--- a/internal/server/resolvers/gh.go
+++ b/internal/server/resolvers/gh.go
@@ -469,8 +469,10 @@ func mapReviewDecision(rd *gh.ReviewDecision) *graphql1.ReviewDecisionEnum {
 		v := graphql1.ReviewDecisionEnumDismissed
 		return &v
 	default:
-		v := graphql1.ReviewDecisionEnumReviewRequired
-		return &v
+		// Unknown wire value (GitHub may add new ReviewDecision values
+		// over time). The schema permits null; surface that rather than
+		// silently misclassifying as REVIEW_REQUIRED.
+		return nil
 	}
 }
 

--- a/internal/server/resolvers/pr_enrich_e2e_test.go
+++ b/internal/server/resolvers/pr_enrich_e2e_test.go
@@ -1,0 +1,314 @@
+package resolvers_test
+
+// End-to-end test for the PullRequest enrichment fields introduced in issue #442.
+//
+// The five new fields (mergeable, mergeStateStatus, reviewDecision,
+// statusCheckRollup, labels) are populated lazily via EnrichPullRequest,
+// which calls GitHub's GraphQL API. This test stubs both the REST /pulls
+// endpoint (for the base PR list) and the /graphql endpoint (for enrichment)
+// so no real GitHub traffic flows.
+//
+// Scenario:
+//   - Client queries pullRequests + all five enrichment fields for alice/repo.
+//   - REST stub returns PR #42 (canonPullsBody shape).
+//   - GraphQL stub returns MERGEABLE + CLEAN + APPROVED + SUCCESS + [P0, bug].
+//   - Response asserts: all five fields have the expected values, and phase
+//     labels are absent from labels[].
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	gqlgen "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+)
+
+// prEnrichFakeGHScript is the `gh auth token` shim for enrichment tests.
+const prEnrichFakeGHScript = `#!/bin/sh
+if [ "$1" = "auth" ] && [ "$2" = "token" ]; then
+  echo "test-token-enrich-fixture"
+  exit 0
+fi
+echo "unexpected gh invocation: $@" 1>&2
+exit 2
+`
+
+// installPREnrichFakeGH installs the gh auth token shim for enrichment tests.
+func installPREnrichFakeGH(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("PATH-substituted shellout test is POSIX-only")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "gh")
+	if err := os.WriteFile(script, []byte(prEnrichFakeGHScript), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	prev := os.Getenv("PATH")
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+prev)
+}
+
+// prEnrichCanonPulls is the REST /pulls response — one open PR.
+const prEnrichCanonPulls = `[
+  {
+    "number": 42,
+    "title": "Add widget API",
+    "body": "",
+    "state": "open",
+    "draft": false,
+    "html_url": "https://github.com/alice/repo/pull/42",
+    "created_at": "2026-04-01T10:00:00Z",
+    "updated_at": "2026-04-02T11:00:00Z",
+    "merged_at": null,
+    "user": {"login": "bob"},
+    "base": {"ref": "main"},
+    "head": {"ref": "feature/widget"}
+  }
+]`
+
+// prEnrichCanonGraphQL is the GraphQL enrichment response for PR #42.
+const prEnrichCanonGraphQL = `{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "reviewDecision": "APPROVED",
+        "labels": {
+          "nodes": [
+            {"name": "P0"},
+            {"name": "bug"},
+            {"name": "in-progress"}
+          ]
+        },
+        "commits": {
+          "nodes": [
+            {
+              "commit": {
+                "statusCheckRollup": {"state": "SUCCESS"}
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}`
+
+// stubEnrichAPI builds the combined REST + GraphQL stub server for enrichment
+// e2e tests.
+func stubEnrichAPI(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/alice/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, prEnrichCanonPulls)
+	})
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, prEnrichCanonGraphQL)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request to %s", r.URL.Path)
+		http.NotFound(w, r)
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newEnrichDaemon stands up an httptest.Server with the GraphQL handler and
+// the gh provider wired in against the given stub API server.
+func newEnrichDaemon(t *testing.T, p *gh.Provider) *httptest.Server {
+	t.Helper()
+	cfg := gqlgen.Config{Resolvers: resolvers.New(time.Now()).WithGH(p)}
+	gqlSrv := handler.New(gqlgen.NewExecutableSchema(cfg))
+	gqlSrv.AddTransport(transport.POST{})
+	gqlSrv.AddTransport(transport.GET{})
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", gqlSrv)
+	return httptest.NewServer(mux)
+}
+
+// postEnrichQuery is a thin helper that posts a GraphQL query to the daemon
+// and unmarshals the response.
+func postEnrichQuery(t *testing.T, url, query string) map[string]any {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"query": query})
+	req, _ := http.NewRequest(http.MethodPost, url+"/graphql", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post query: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return out
+}
+
+// TestPREnrich_E2E_AllFiveFields asserts the full enrichment pipeline:
+// the five GraphQL-only fields are populated from the stub GraphQL endpoint
+// and surfaced correctly through the resolver layer.
+func TestPREnrich_E2E_AllFiveFields(t *testing.T) {
+	installPREnrichFakeGH(t)
+	api := stubEnrichAPI(t)
+	tlsClient := api.Client()
+
+	auth := gh.NewCommandAuthSource()
+	provider := gh.NewWith(nil, api.URL, auth, time.Now)
+	if err := provider.Start(context.Background()); err != nil {
+		t.Logf("provider start (non-fatal): %v", err)
+	}
+	gh.SetHTTPClientForTest(provider, tlsClient)
+
+	srv := newEnrichDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postEnrichQuery(t, srv.URL, `query {
+		pullRequests(repo: "alice/repo", state: OPEN) {
+			id
+			number
+			mergeable
+			mergeStateStatus
+			reviewDecision
+			statusCheckRollup
+			labels
+		}
+	}`)
+
+	if errs, ok := resp["errors"]; ok {
+		t.Fatalf("graphql errors: %v", errs)
+	}
+
+	data, _ := resp["data"].(map[string]any)
+	prs, _ := data["pullRequests"].([]any)
+	if len(prs) != 1 {
+		t.Fatalf("expected 1 PR, got %d: %v", len(prs), prs)
+	}
+
+	pr, _ := prs[0].(map[string]any)
+
+	// mergeable
+	if got := pr["mergeable"]; got != "MERGEABLE" {
+		t.Errorf("mergeable = %v, want MERGEABLE", got)
+	}
+
+	// mergeStateStatus
+	if got := pr["mergeStateStatus"]; got != "CLEAN" {
+		t.Errorf("mergeStateStatus = %v, want CLEAN", got)
+	}
+
+	// reviewDecision
+	if got := pr["reviewDecision"]; got != "APPROVED" {
+		t.Errorf("reviewDecision = %v, want APPROVED", got)
+	}
+
+	// statusCheckRollup
+	if got := pr["statusCheckRollup"]; got != "SUCCESS" {
+		t.Errorf("statusCheckRollup = %v, want SUCCESS", got)
+	}
+
+	// labels — phase label "in-progress" must be filtered; P0 and bug must survive
+	rawLabels, _ := pr["labels"].([]any)
+	labels := make([]string, 0, len(rawLabels))
+	for _, l := range rawLabels {
+		labels = append(labels, fmt.Sprint(l))
+	}
+	labelsStr := strings.Join(labels, ",")
+	if strings.Contains(labelsStr, "in-progress") {
+		t.Errorf("phase label 'in-progress' leaked into labels: %v", labels)
+	}
+	if !strings.Contains(labelsStr, "P0") {
+		t.Errorf("user label 'P0' missing from labels: %v", labels)
+	}
+	if !strings.Contains(labelsStr, "bug") {
+		t.Errorf("user label 'bug' missing from labels: %v", labels)
+	}
+}
+
+// TestPREnrich_E2E_NullReviewDecision asserts that a null reviewDecision
+// on the wire surfaces as null in the GraphQL response (not an error).
+func TestPREnrich_E2E_NullReviewDecision(t *testing.T) {
+	installPREnrichFakeGH(t)
+
+	// Serve a GraphQL response with reviewDecision: null.
+	const nullReviewDecision = `{
+		"data": {
+			"repository": {
+				"pullRequest": {
+					"mergeable": "MERGEABLE",
+					"mergeStateStatus": "CLEAN",
+					"reviewDecision": null,
+					"labels": {"nodes": []},
+					"commits": {"nodes": [{"commit": {"statusCheckRollup": {"state": "PENDING"}}}]}
+				}
+			}
+		}
+	}`
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/alice/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, prEnrichCanonPulls)
+	})
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, nullReviewDecision)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request to %s", r.URL.Path)
+		http.NotFound(w, r)
+	})
+	api := httptest.NewTLSServer(mux)
+	t.Cleanup(api.Close)
+
+	auth := gh.NewCommandAuthSource()
+	provider := gh.NewWith(nil, api.URL, auth, time.Now)
+	if err := provider.Start(context.Background()); err != nil {
+		t.Logf("provider start (non-fatal): %v", err)
+	}
+	gh.SetHTTPClientForTest(provider, api.Client())
+
+	srv := newEnrichDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postEnrichQuery(t, srv.URL, `query {
+		pullRequests(repo: "alice/repo", state: OPEN) {
+			reviewDecision
+			statusCheckRollup
+		}
+	}`)
+
+	if errs, ok := resp["errors"]; ok {
+		t.Fatalf("graphql errors: %v", errs)
+	}
+	data, _ := resp["data"].(map[string]any)
+	prs, _ := data["pullRequests"].([]any)
+	if len(prs) == 0 {
+		t.Fatal("expected at least 1 PR")
+	}
+	pr, _ := prs[0].(map[string]any)
+
+	if got := pr["reviewDecision"]; got != nil {
+		t.Errorf("reviewDecision = %v, want null", got)
+	}
+	if got := pr["statusCheckRollup"]; got != "PENDING" {
+		t.Errorf("statusCheckRollup = %v, want PENDING", got)
+	}
+}

--- a/internal/server/resolvers/pr_mappers_test.go
+++ b/internal/server/resolvers/pr_mappers_test.go
@@ -1,0 +1,65 @@
+// Unit tests for the gh-provider → GraphQL projection helpers used by
+// the per-field PullRequest enrichment resolvers. These mappers must
+// preserve schema invariants when GitHub returns wire values that fall
+// outside the documented enum (forward-compat with new GitHub values).
+package resolvers
+
+import (
+	"testing"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
+)
+
+// TestMapReviewDecision_UnknownWireValueReturnsNil locks the contract
+// that an unknown ReviewDecision wire value (a new enum GitHub may
+// add — historically COMMENTED was added years after APPROVED) maps
+// to nil rather than silently substituting REVIEW_REQUIRED. The schema
+// allows null; surfacing null is the honest signal to callers.
+func TestMapReviewDecision_UnknownWireValueReturnsNil(t *testing.T) {
+	cases := []gh.ReviewDecision{
+		"FUTURE_VALUE",
+		"COMMENTED_AND_DISMISSED",
+		"",
+	}
+	for _, tc := range cases {
+		got := mapReviewDecision(&tc)
+		if got != nil {
+			t.Errorf("mapReviewDecision(%q) = %v, want nil for unknown wire value", tc, *got)
+		}
+	}
+}
+
+// TestMapReviewDecision_NilInputReturnsNil keeps the trivial case
+// honest: when the provider has no review decision, the resolver must
+// surface null rather than a synthetic value.
+func TestMapReviewDecision_NilInputReturnsNil(t *testing.T) {
+	if got := mapReviewDecision(nil); got != nil {
+		t.Errorf("mapReviewDecision(nil) = %v, want nil", *got)
+	}
+}
+
+// TestMapReviewDecision_KnownValuesProjectCorrectly is the happy-path
+// table covering every documented GitHub enum value.
+func TestMapReviewDecision_KnownValuesProjectCorrectly(t *testing.T) {
+	cases := []struct {
+		in   gh.ReviewDecision
+		want graphql1.ReviewDecisionEnum
+	}{
+		{gh.ReviewDecisionApproved, graphql1.ReviewDecisionEnumApproved},
+		{gh.ReviewDecisionChangesRequested, graphql1.ReviewDecisionEnumChangesRequested},
+		{gh.ReviewDecisionReviewRequired, graphql1.ReviewDecisionEnumReviewRequired},
+		{gh.ReviewDecisionCommented, graphql1.ReviewDecisionEnumCommented},
+		{gh.ReviewDecisionDismissed, graphql1.ReviewDecisionEnumDismissed},
+	}
+	for _, tc := range cases {
+		got := mapReviewDecision(&tc.in)
+		if got == nil {
+			t.Errorf("mapReviewDecision(%q) = nil, want %q", tc.in, tc.want)
+			continue
+		}
+		if *got != tc.want {
+			t.Errorf("mapReviewDecision(%q) = %q, want %q", tc.in, *got, tc.want)
+		}
+	}
+}

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -1087,11 +1087,98 @@ func (r *worktreeResolver) Processes(ctx context.Context, obj *graphql1.Worktree
 	return []*graphql1.Process{}, nil
 }
 
+// prKeyFromGraphQL extracts the gh.PullRequestKey from a graphql1.PullRequest
+// by parsing the stable node ID ("PullRequest:owner/repo#number"). Returns ok=false
+// when the ID is malformed or the gh provider is not wired.
+func prKeyFromGraphQL(r *Resolver, obj *graphql1.PullRequest) (gh.PullRequestKey, bool) {
+	if r.GH == nil || obj == nil {
+		return gh.PullRequestKey{}, false
+	}
+	owner, name, number, ok := splitGHNodeID(obj.ID, "PullRequest:")
+	if !ok {
+		return gh.PullRequestKey{}, false
+	}
+	return gh.PullRequestKey{Owner: owner, Name: name, Number: number}, true
+}
+
+// Mergeable is the resolver for the pullRequest.mergeable field.
+// Calls EnrichPullRequest which fetches (or returns cached) GraphQL enrichment.
+func (r *pullRequestResolver) Mergeable(ctx context.Context, obj *graphql1.PullRequest) (graphql1.MergeableState, error) {
+	key, ok := prKeyFromGraphQL(r.Resolver, obj)
+	if !ok {
+		return graphql1.MergeableStateUnknown, nil
+	}
+	pr, err := r.GH.EnrichPullRequest(ctx, key)
+	if err != nil {
+		return graphql1.MergeableStateUnknown, err
+	}
+	return mapMergeableState(pr.Mergeable), nil
+}
+
+// MergeStateStatus is the resolver for the pullRequest.mergeStateStatus field.
+func (r *pullRequestResolver) MergeStateStatus(ctx context.Context, obj *graphql1.PullRequest) (string, error) {
+	key, ok := prKeyFromGraphQL(r.Resolver, obj)
+	if !ok {
+		return "", nil
+	}
+	pr, err := r.GH.EnrichPullRequest(ctx, key)
+	if err != nil {
+		return "", err
+	}
+	return pr.MergeStateStatus, nil
+}
+
+// ReviewDecision is the resolver for the pullRequest.reviewDecision field.
+func (r *pullRequestResolver) ReviewDecision(ctx context.Context, obj *graphql1.PullRequest) (*graphql1.ReviewDecisionEnum, error) {
+	key, ok := prKeyFromGraphQL(r.Resolver, obj)
+	if !ok {
+		return nil, nil
+	}
+	pr, err := r.GH.EnrichPullRequest(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	return mapReviewDecision(pr.ReviewDecision), nil
+}
+
+// StatusCheckRollup is the resolver for the pullRequest.statusCheckRollup field.
+func (r *pullRequestResolver) StatusCheckRollup(ctx context.Context, obj *graphql1.PullRequest) (graphql1.CiStatus, error) {
+	key, ok := prKeyFromGraphQL(r.Resolver, obj)
+	if !ok {
+		return graphql1.CiStatusUnknown, nil
+	}
+	pr, err := r.GH.EnrichPullRequest(ctx, key)
+	if err != nil {
+		return graphql1.CiStatusUnknown, err
+	}
+	return mapCiStatus(pr.StatusCheckRollup), nil
+}
+
+// Labels is the resolver for the pullRequest.labels field.
+// Returns user-assigned labels with orchard phase labels excluded.
+func (r *pullRequestResolver) Labels(ctx context.Context, obj *graphql1.PullRequest) ([]string, error) {
+	key, ok := prKeyFromGraphQL(r.Resolver, obj)
+	if !ok {
+		return []string{}, nil
+	}
+	pr, err := r.GH.EnrichPullRequest(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if pr.Labels == nil {
+		return []string{}, nil
+	}
+	return append([]string(nil), pr.Labels...), nil
+}
+
 // Host returns graphql1.HostResolver implementation.
 func (r *Resolver) Host() graphql1.HostResolver { return &hostResolver{r} }
 
 // Process returns graphql1.ProcessResolver implementation.
 func (r *Resolver) Process() graphql1.ProcessResolver { return &processResolver{r} }
+
+// PullRequest returns graphql1.PullRequestResolver implementation.
+func (r *Resolver) PullRequest() graphql1.PullRequestResolver { return &pullRequestResolver{r} }
 
 // Project returns graphql1.ProjectResolver implementation.
 func (r *Resolver) Project() graphql1.ProjectResolver { return &projectResolver{r} }
@@ -1123,6 +1210,7 @@ func (r *Resolver) Worktree() graphql1.WorktreeResolver { return &worktreeResolv
 type hostResolver struct{ *Resolver }
 type processResolver struct{ *Resolver }
 type projectResolver struct{ *Resolver }
+type pullRequestResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type subscriptionResolver struct{ *Resolver }
 type tmuxClientResolver struct{ *Resolver }

--- a/schema.graphql
+++ b/schema.graphql
@@ -900,6 +900,30 @@ input ContractFilter {
   parentContractId: ID
 }
 
+"Whether GitHub considers the PR mergeable. UNKNOWN means GitHub is still computing."
+enum MergeableState {
+  MERGEABLE
+  CONFLICTING
+  UNKNOWN
+}
+
+"Reviewer decision on a PR. Null when no review activity yet."
+enum ReviewDecisionEnum {
+  APPROVED
+  CHANGES_REQUESTED
+  REVIEW_REQUIRED
+  COMMENTED
+  DISMISSED
+}
+
+"Aggregated CI status across all check runs and statuses on the PR head sha."
+enum CiStatus {
+  SUCCESS
+  FAILURE
+  PENDING
+  UNKNOWN
+}
+
 "State filter for the pullRequests query."
 enum PullRequestState {
   OPEN
@@ -935,6 +959,11 @@ type PullRequest implements Node {
   updatedAt: String!
   reviews: [PullRequestReview!]
   comments: [IssueComment!]
+  mergeable: MergeableState!
+  mergeStateStatus: String!
+  reviewDecision: ReviewDecisionEnum
+  statusCheckRollup: CiStatus!
+  labels: [String!]!
 }
 
 "A review submitted on a pull request."


### PR DESCRIPTION
## Why

Closes #442

The daemon's typed `PullRequest` GraphQL type exposed only basic REST-derived fields (number, title, state, draft, refs). The TUI dashboard cannot compute focus-driven sort or render any meaningful CI badge without five additional fields: `mergeable`, `mergeStateStatus`, `reviewDecision`, `statusCheckRollup`, and `labels`. None of these are returned by GitHub's REST `/pulls` endpoint — they live on the GraphQL surface.

This PR adds them to the schema, fetches them lazily via GitHub's GraphQL API, and surfaces them on the typed PullRequest so the dashboard can finally answer "ready to merge / CI failed / changes requested" without callers having to know about the `gh(query: ...)` passthrough.

## What changed

- **schema.graphql** — three new enums (`MergeableState`, `ReviewDecisionEnum`, `CiStatus`) and five new fields on `type PullRequest`. `mergeable`, `mergeStateStatus`, `statusCheckRollup`, and `labels` are non-nullable; `reviewDecision` is nullable (PRs without review activity have no decision yet).
- **gh provider** — extended `PullRequest` struct with the five enrichment fields plus a new `EnrichPullRequest(ctx, key)` method that calls GitHub GraphQL and merges results into the per-key cache. Existing REST list and per-key paths stay cheap; enrichment is paid only when a resolver actually selects an enrichment field.
- **resolvers** — marked the five fields `resolver: true` in `gqlgen.yml`. Each per-field resolver delegates to `EnrichPullRequest`; the 60s TTL means five field resolvers in one query share one HTTP roundtrip.
- **labels** — orchard's lifecycle phase labels (`investigating`, `planned`, `in-progress`, `in-ai-review`, `pr-ready`, `blocked`, `needs-plan`, `needs-repro`) are filtered out at the provider boundary. Dashboards see only user-meaningful labels (P0, bug, autonomous, ...).

## How it works

Two TTLs coexist on the per-key cache:

- `CacheTTL` (2 min) — REST projection; covers number/title/state/draft/refs.
- `enrichmentTTL` (60s) — GraphQL projection; covers the five new fields.

The two are tracked separately (`prs[k]` value vs `enrichAt[k]` timestamp). A REST refresh that re-seeds `prs[k]` (via `ListPullRequests` or `GetPullRequest`) deletes any stale `enrichAt[k]` so the next `EnrichPullRequest` refetches via GraphQL — otherwise we'd serve a fresh REST struct with empty enrichment fields as if they were cached.

`mergeable == UNKNOWN` is **not** cached as definitive (#367 flap pattern). When GitHub returns UNKNOWN it's still computing; we let the next call refetch instead of hardening the transient into a stale answer.

`statusCheckRollup` projects GitHub's `StatusState` enum: SUCCESS → SUCCESS, FAILURE/ERROR → FAILURE, PENDING/EXPECTED → PENDING, anything else (or null rollup) → UNKNOWN. GitHub does the rollup server-side; we project rather than re-aggregate.

`reviewDecision` unknown wire values (e.g. a future GitHub enum addition) map to `nil` instead of silently substituting `REVIEW_REQUIRED`. The schema is nullable; preserving null is the honest signal.

## Test plan

Unit + e2e coverage in three files:

- `internal/server/providers/gh/graphql_enrich_test.go` — `TestMapStatusCheckRollup` (table over SUCCESS/FAILURE/ERROR/PENDING/EXPECTED/empty/STALE), `TestFilterPhaseLabels` (8 phase labels stripped, 3 user labels preserved), `TestEnrichPullRequest_Caches60s` (two calls within 60s share one HTTP request via fake clock), `TestEnrichPullRequest_UnknownMergeableNotCachedAsDefinitive` (HTTP-count + direct `enrichAt[key]` zero-time assertion via `ExportEnrichTimestamp`), `TestEnrichPullRequest_GraphQLError` (envelope errors[] surface as Go errors), `TestEnrichPullRequest_LabelFilter`.
- `internal/server/resolvers/pr_enrich_e2e_test.go` — `TestPREnrich_E2E_AllFiveFields` drives the full GraphQL chain through a stubbed GitHub TLS server and asserts each of the five fields lands on the typed PullRequest. `TestPREnrich_E2E_NullReviewDecision` confirms null pointer → schema null.
- `internal/server/resolvers/pr_mappers_test.go` — `TestMapReviewDecision_UnknownWireValueReturnsNil` (forward-compat with new GitHub enum values), `TestMapReviewDecision_NilInputReturnsNil`, `TestMapReviewDecision_KnownValuesProjectCorrectly`.

Full suite (`go test ./...`) green on commit `6ba16e1`.

## Anything surprising?

- **Two TTLs on one struct** is intentional but documented as a contract (`PullRequest.Mergeable` etc. are guaranteed only when fetched via `EnrichPullRequest`). A `/review` lens flagged this as a future-stale risk if a non-enrichment caller ever reads enrichment fields directly. Today only the per-field resolvers go through `EnrichPullRequest`, so no caller exhibits the leak — the compile fence at `provider.go:489-503` keeps the API contract explicit. If we add a sixth enrichment field, splitting REST and enrichment into separate structs becomes worth doing.
- **Phase-label list duplication.** `phaseLabels` in `graphql_enrich.go` mirrors the canonical list in the `gh-tag` skill. Filing a follow-up to either ingest at boot from a config or accept the duplication with a cross-reference comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended GraphQL API with new pull request metadata fields: merge status, review decision, aggregated CI status checks, and user labels
  * Implemented smart caching to optimize performance for repeated data queries on the same pull requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #442