### PR TITLE
feat(daemon): ClaudeInstance.lastActivityAt for TUI v2 LAST column (#443)

### DIFF
--- a/crates/orchard/hooks/orchard-state.sh
+++ b/crates/orchard/hooks/orchard-state.sh
@@ -169,6 +169,19 @@ write_state() {
         > "$tmp" && mv "$tmp" "$state_file"
 }
 
+# Emits last_activity (RFC3339Nano) as a JSON fragment for use as the $extra
+# argument to write_state. Called by events that mark real user-facing
+# activity: UserPromptSubmit (user sent a prompt) and PostToolUse / PostToolUseFailure
+# (tool call completed). PreToolUse is intentionally excluded — it fires before
+# the tool runs, not after, so it doesn't signal completed work.
+#
+# The value is the current UTC time in nanosecond-precision RFC3339 so the
+# orchard daemon's ClaudeInstance.lastActivityAt resolver can surface
+# "last touched N seconds ago" without consulting tmux pane state.
+last_activity_extra() {
+    jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)" '{last_activity: $ts}'
+}
+
 # ---------------------------------------------------------------------------
 # Event dispatch
 # ---------------------------------------------------------------------------
@@ -201,7 +214,8 @@ case "$event" in
         inflight=$(echo "$inflight" | jq --arg id "$tool_use_id" '[.[] | select(. != $id)]')
         write_inflight "$inflight"
     fi
-    write_state "working"
+    # Emit last_activity: tool completion is user-facing activity.
+    write_state "working" "$(last_activity_extra)"
     ;;
 
   Stop)
@@ -346,7 +360,9 @@ case "$event" in
     # Keep first line only and truncate to 80 characters.
     first_line=$(printf '%s' "$prompt" | head -n 1)
     task=$(printf '%.80s' "$first_line")
-    write_state "working" "$(jq -n --arg t "$task" '{current_task: $t}')"
+    # Emit last_activity: the user just sent a prompt — this is the most
+    # direct signal of recency for the LAST column in the TUI.
+    write_state "working" "$(jq -n --arg t "$task" --arg la "$(date -u +%Y-%m-%dT%H:%M:%S.%NZ)" '{current_task: $t, last_activity: $la}')"
     ;;
 
   SessionEnd)

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -69,15 +69,16 @@ type ComplexityRoot struct {
 	}
 
 	ClaudeInstance struct {
-		Account     func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Pane        func(childComplexity int) int
-		Process     func(childComplexity int) int
-		RcEnabled   func(childComplexity int) int
-		RcURL       func(childComplexity int) int
-		SessionUUID func(childComplexity int) int
-		StartedAt   func(childComplexity int) int
-		State       func(childComplexity int) int
+		Account        func(childComplexity int) int
+		ID             func(childComplexity int) int
+		LastActivityAt func(childComplexity int) int
+		Pane           func(childComplexity int) int
+		Process        func(childComplexity int) int
+		RcEnabled      func(childComplexity int) int
+		RcURL          func(childComplexity int) int
+		SessionUUID    func(childComplexity int) int
+		StartedAt      func(childComplexity int) int
+		State          func(childComplexity int) int
 	}
 
 	Contract struct {
@@ -596,6 +597,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ClaudeInstance.SessionUUID(childComplexity), true
+
+	case "ClaudeInstance.lastActivityAt":
+		if e.complexity.ClaudeInstance.LastActivityAt == nil {
+			break
+		}
+
+		return e.complexity.ClaudeInstance.LastActivityAt(childComplexity), true
 
 	case "ClaudeInstance.startedAt":
 		if e.complexity.ClaudeInstance.StartedAt == nil {
@@ -2418,6 +2426,13 @@ type ClaudeInstance implements Node {
 
   "RFC3339 timestamp the session was started."
   startedAt: String
+
+  """
+  ISO8601 timestamp of the most recent activity for this Claude instance —
+  derived from the heartbeat's last_activity field, falling back to
+  TmuxPane.lastActivityAt, falling back to null when neither is available.
+  """
+  lastActivityAt: String
 }
 
 "Lifecycle states for a Claude instance."
@@ -4153,6 +4168,8 @@ func (ec *executionContext) fieldContext_ClaudeAccount_instances(ctx context.Con
 				return ec.fieldContext_ClaudeInstance_sessionUuid(ctx, field)
 			case "startedAt":
 				return ec.fieldContext_ClaudeInstance_startedAt(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_ClaudeInstance_lastActivityAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
 		},
@@ -4604,6 +4621,47 @@ func (ec *executionContext) _ClaudeInstance_startedAt(ctx context.Context, field
 }
 
 func (ec *executionContext) fieldContext_ClaudeInstance_startedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ClaudeInstance",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ClaudeInstance_lastActivityAt(ctx context.Context, field graphql.CollectedField, obj *ClaudeInstance) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ClaudeInstance_lastActivityAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastActivityAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ClaudeInstance_lastActivityAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ClaudeInstance",
 		Field:      field,
@@ -8199,6 +8257,8 @@ func (ec *executionContext) fieldContext_Process_claudeInstance(ctx context.Cont
 				return ec.fieldContext_ClaudeInstance_sessionUuid(ctx, field)
 			case "startedAt":
 				return ec.fieldContext_ClaudeInstance_startedAt(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_ClaudeInstance_lastActivityAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
 		},
@@ -10440,6 +10500,8 @@ func (ec *executionContext) fieldContext_Query_claudeInstances(ctx context.Conte
 				return ec.fieldContext_ClaudeInstance_sessionUuid(ctx, field)
 			case "startedAt":
 				return ec.fieldContext_ClaudeInstance_startedAt(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_ClaudeInstance_lastActivityAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
 		},
@@ -12998,6 +13060,8 @@ func (ec *executionContext) fieldContext_TmuxPane_claudeInstance(ctx context.Con
 				return ec.fieldContext_ClaudeInstance_sessionUuid(ctx, field)
 			case "startedAt":
 				return ec.fieldContext_ClaudeInstance_startedAt(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_ClaudeInstance_lastActivityAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
 		},
@@ -17711,6 +17775,8 @@ func (ec *executionContext) _ClaudeInstance(ctx context.Context, sel ast.Selecti
 			out.Values[i] = ec._ClaudeInstance_sessionUuid(ctx, field, obj)
 		case "startedAt":
 			out.Values[i] = ec._ClaudeInstance_startedAt(ctx, field, obj)
+		case "lastActivityAt":
+			out.Values[i] = ec._ClaudeInstance_lastActivityAt(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -77,6 +77,10 @@ type ClaudeInstance struct {
 	SessionUUID *string `json:"sessionUuid,omitempty"`
 	// RFC3339 timestamp the session was started.
 	StartedAt *string `json:"startedAt,omitempty"`
+	// ISO8601 timestamp of the most recent activity for this Claude instance —
+	// derived from the heartbeat's last_activity field, falling back to
+	// TmuxPane.lastActivityAt, falling back to null when neither is available.
+	LastActivityAt *string `json:"lastActivityAt,omitempty"`
 }
 
 func (ClaudeInstance) IsNode() {}

--- a/internal/server/providers/claudeinstance/adapter.go
+++ b/internal/server/providers/claudeinstance/adapter.go
@@ -119,13 +119,19 @@ type rawHeartbeat struct {
 
 	// Optional ADR-011 fields. The hook script will be updated to emit
 	// these; when absent, the composer falls back to other matching.
-	ClaudePid       int    `json:"claudePid,omitempty"`
-	ClaudePidSnake  int    `json:"claude_pid,omitempty"`
-	RcURL           string `json:"rcUrl,omitempty"`
-	RcURLSnake      string `json:"rc_url,omitempty"`
-	RcEnabled       *bool  `json:"rcEnabled,omitempty"`
-	RcEnabledSnake  *bool  `json:"rc_enabled,omitempty"`
-	LastHeartbeatAt string `json:"lastHeartbeatAt,omitempty"`
+	ClaudePid          int    `json:"claudePid,omitempty"`
+	ClaudePidSnake     int    `json:"claude_pid,omitempty"`
+	RcURL              string `json:"rcUrl,omitempty"`
+	RcURLSnake         string `json:"rc_url,omitempty"`
+	RcEnabled          *bool  `json:"rcEnabled,omitempty"`
+	RcEnabledSnake     *bool  `json:"rc_enabled,omitempty"`
+	LastHeartbeatAt    string `json:"lastHeartbeatAt,omitempty"`
+	// last_activity / lastActivity — RFC3339 or RFC3339Nano timestamp of the
+	// most recent activity this session performed (tool call, user turn, etc.).
+	// Both naming conventions are accepted; snake_case matches today's hook
+	// script style while camelCase matches the ADR-011 forward-compatible shape.
+	LastActivity      string `json:"last_activity,omitempty"`
+	LastActivityCamel string `json:"lastActivity,omitempty"`
 }
 
 // parseFile reads and decodes one heartbeat file. Returns (Heartbeat,
@@ -165,6 +171,20 @@ func parseFile(path string) (Heartbeat, bool) {
 	}
 	if hb.LastHeartbeatAt.IsZero() {
 		hb.LastHeartbeatAt = hb.Timestamp
+	}
+
+	// Parse last_activity / lastActivity — prefer snake_case (today's hook
+	// script convention) then fall back to camelCase. Malformed values are
+	// silently ignored; the zero value signals "no last_activity available"
+	// so the composer can fall back to the pane's lastActivityAt.
+	rawLastActivity := firstNonEmpty(raw.LastActivity, raw.LastActivityCamel)
+	if rawLastActivity != "" {
+		if t, err := time.Parse(time.RFC3339Nano, rawLastActivity); err == nil {
+			hb.LastActivity = t
+		} else if t, err := time.Parse(time.RFC3339, rawLastActivity); err == nil {
+			hb.LastActivity = t
+		}
+		// Malformed value: hb.LastActivity stays zero (silently ignored).
 	}
 
 	// A heartbeat with no tmux session is unparseable from the

--- a/internal/server/providers/claudeinstance/composer.go
+++ b/internal/server/providers/claudeinstance/composer.go
@@ -178,6 +178,14 @@ func (c *Composer) composeOne(ctx context.Context, hb Heartbeat) *graphql.Claude
 		v := hb.Timestamp.UTC().Format(time.RFC3339Nano)
 		inst.StartedAt = &v
 	}
+	if !hb.LastActivity.IsZero() {
+		// Preserve sub-second precision from the original value by using
+		// RFC3339Nano. When the source had no nanoseconds, RFC3339Nano
+		// still produces a valid RFC3339 string (trailing zeros are
+		// stripped by Go's time formatter).
+		v := hb.LastActivity.UTC().Format(time.RFC3339Nano)
+		inst.LastActivityAt = &v
+	}
 	return inst
 }
 

--- a/internal/server/providers/claudeinstance/composer.go
+++ b/internal/server/providers/claudeinstance/composer.go
@@ -179,12 +179,26 @@ func (c *Composer) composeOne(ctx context.Context, hb Heartbeat) *graphql.Claude
 		inst.StartedAt = &v
 	}
 	if !hb.LastActivity.IsZero() {
+		// Primary source: heartbeat's last_activity field.
 		// Preserve sub-second precision from the original value by using
 		// RFC3339Nano. When the source had no nanoseconds, RFC3339Nano
 		// still produces a valid RFC3339 string (trailing zeros are
 		// stripped by Go's time formatter).
 		v := hb.LastActivity.UTC().Format(time.RFC3339Nano)
 		inst.LastActivityAt = &v
+	} else {
+		// Fallback (option a): read pane.Window.Session.LastActivityAt.
+		// TmuxPane has no lastActivityAt field of its own; the session-level
+		// timestamp is the same conceptual recency for the user's purposes
+		// ("when was this claude instance last touched"). Option (b) — adding
+		// TmuxPane.lastActivityAt as a new schema field — can be layered on
+		// top later when pane-level granularity is needed, without breaking
+		// this fallback.
+		if pane != nil && pane.Window != nil && pane.Window.Session != nil &&
+			pane.Window.Session.LastActivityAt != nil {
+			v := *pane.Window.Session.LastActivityAt
+			inst.LastActivityAt = &v
+		}
 	}
 	return inst
 }

--- a/internal/server/providers/claudeinstance/last_activity_at_ac2_test.go
+++ b/internal/server/providers/claudeinstance/last_activity_at_ac2_test.go
@@ -1,0 +1,378 @@
+package claudeinstance
+
+// Tests for ClaudeInstance.lastActivityAt — AC 2 of issue #443.
+//
+// Seven unit scenarios from specs/features/schema-claude-instance-last-activity-at.feature:
+//
+//  1. "Resolver prefers heartbeat last_activity over the pane fallback"
+//  2. "Resolver falls back to the TmuxPane's lastActivityAt when heartbeat last_activity is absent"
+//  3. "Resolver falls back to the TmuxPane's lastActivityAt when heartbeat last_activity is empty string"
+//  4. "Resolver returns null when heartbeat lacks last_activity AND no pane matches"
+//  5. "Resolver returns null when heartbeat lacks last_activity AND the matched pane has no lastActivityAt"
+//  6. "Heartbeat parser accepts both last_activity (snake_case) and lastActivity (camelCase)"
+//  7. "Malformed heartbeat last_activity is treated as absent (does not crash, falls back)"
+//
+// Design note (option a, per spec):
+//   TmuxPane today has no lastActivityAt field. The fallback reads
+//   pane.Window.Session.LastActivityAt — existing data, no new schema surface.
+//   This is deliberate: session-level recency is the same conceptual signal
+//   ("when was this claude instance last touched") without adding a new field.
+//   See commit message for rationale.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// buildPaneWithSessionLastActivityAt constructs a TmuxPane → TmuxWindow →
+// TmuxSession graph whose session carries the given lastActivityAt string.
+// When lastActivityAt is empty, the session's field is nil (absent).
+func buildPaneWithSessionLastActivityAt(lastActivityAt string) *graphql.TmuxPane {
+	var sessLastActivity *string
+	if lastActivityAt != "" {
+		v := lastActivityAt
+		sessLastActivity = &v
+	}
+	sess := &graphql.TmuxSession{
+		ID:             "TmuxSession:local:test",
+		Name:           "test",
+		CreatedAt:      "2026-05-07T18:00:00Z",
+		LastActivityAt: sessLastActivity,
+	}
+	win := &graphql.TmuxWindow{
+		ID:      "TmuxWindow:local:test:0",
+		Session: sess,
+		Name:    "test",
+	}
+	pane := &graphql.TmuxPane{
+		ID:     "TmuxPane:local:%26",
+		Window: win,
+		PaneID: "%26",
+	}
+	return pane
+}
+
+// heartbeatWithLastActivity returns a fresh Heartbeat with LastActivity set
+// to the parsed value of rawTS. If rawTS is empty, LastActivity is zero.
+func heartbeatWithLastActivity(rawTS string) Heartbeat {
+	now := time.Date(2026, 5, 7, 18, 42, 15, 0, time.UTC)
+	hb := Heartbeat{
+		TmuxSession:     "alpha",
+		SessionID:       "uuid-alpha",
+		State:           "working",
+		Timestamp:       now.Add(-5 * time.Second),
+		LastHeartbeatAt: now.Add(-5 * time.Second),
+	}
+	if rawTS != "" {
+		if t, err := time.Parse(time.RFC3339Nano, rawTS); err == nil {
+			hb.LastActivity = t
+		} else if t, err := time.Parse(time.RFC3339, rawTS); err == nil {
+			hb.LastActivity = t
+		}
+		// Malformed rawTS → LastActivity stays zero (intentional for scenario 7).
+	}
+	return hb
+}
+
+// newComposerForTest builds a Composer with a fixed clock suitable for
+// AC 2 tests. The pane finder returns a static pane keyed by session name.
+func newComposerForTest(pane *graphql.TmuxPane) *Composer {
+	now := time.Date(2026, 5, 7, 18, 42, 15, 0, time.UTC)
+	var pf PaneFinder
+	if pane != nil {
+		pf = &fakePaneFinder{
+			bySession: map[string]*graphql.TmuxPane{"alpha": pane},
+		}
+	} else {
+		pf = &fakePaneFinder{} // no matches
+	}
+	return NewComposerWith(
+		"local",
+		pf,
+		&fakeProcessFinder{},
+		&fakeAccountFinder{},
+		fakeLiveness{alive: map[int]bool{}},
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+}
+
+// TestLastActivityAt_PrefersHeartbeatOverPane covers scenario 1:
+// "Resolver prefers heartbeat last_activity over the pane fallback."
+//
+// When the heartbeat carries a last_activity, the composer uses it and
+// does not consult the pane's session lastActivityAt.
+func TestLastActivityAt_PrefersHeartbeatOverPane(t *testing.T) {
+	const heartbeatTS = "2026-05-07T18:42:11Z"
+	const paneSessionTS = "2026-05-07T18:30:00Z"
+
+	pane := buildPaneWithSessionLastActivityAt(paneSessionTS)
+	hb := heartbeatWithLastActivity(heartbeatTS)
+
+	c := newComposerForTest(pane)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if len(out) != 1 {
+		t.Fatalf("got %d instances, want 1", len(out))
+	}
+	inst := out[0]
+	if inst.LastActivityAt == nil {
+		t.Fatal("LastActivityAt is nil; expected heartbeat value")
+	}
+	got := *inst.LastActivityAt
+	// Parsed time must equal heartbeatTS, not paneSessionTS.
+	wantParsed, _ := time.Parse(time.RFC3339, heartbeatTS)
+	gotParsed, err := time.Parse(time.RFC3339Nano, got)
+	if err != nil {
+		gotParsed, err = time.Parse(time.RFC3339, got)
+		if err != nil {
+			t.Fatalf("LastActivityAt %q is not parseable as RFC3339/RFC3339Nano: %v", got, err)
+		}
+	}
+	if !gotParsed.Equal(wantParsed) {
+		t.Errorf("LastActivityAt = %v, want heartbeat value %v (not pane %s)", gotParsed, wantParsed, paneSessionTS)
+	}
+}
+
+// TestLastActivityAt_FallsBackToPaneWhenAbsent covers scenario 2:
+// "Resolver falls back to the TmuxPane's lastActivityAt when heartbeat
+// last_activity is absent."
+func TestLastActivityAt_FallsBackToPaneWhenAbsent(t *testing.T) {
+	const paneSessionTS = "2026-05-07T18:30:00Z"
+
+	pane := buildPaneWithSessionLastActivityAt(paneSessionTS)
+	hb := heartbeatWithLastActivity("") // no last_activity
+	hb.LastActivity = time.Time{}       // ensure zero
+
+	c := newComposerForTest(pane)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if len(out) != 1 {
+		t.Fatalf("got %d instances, want 1", len(out))
+	}
+	inst := out[0]
+	if inst.LastActivityAt == nil {
+		t.Fatal("LastActivityAt is nil; expected pane session fallback value")
+	}
+	got := *inst.LastActivityAt
+	wantParsed, _ := time.Parse(time.RFC3339, paneSessionTS)
+	gotParsed, err := time.Parse(time.RFC3339Nano, got)
+	if err != nil {
+		gotParsed, err = time.Parse(time.RFC3339, got)
+		if err != nil {
+			t.Fatalf("LastActivityAt %q is not parseable: %v", got, err)
+		}
+	}
+	if !gotParsed.Equal(wantParsed) {
+		t.Errorf("LastActivityAt = %v, want pane session value %v", gotParsed, wantParsed)
+	}
+}
+
+// TestLastActivityAt_FallsBackToPaneWhenEmptyString covers scenario 3:
+// "Resolver falls back to the TmuxPane's lastActivityAt when heartbeat
+// last_activity is empty string."
+//
+// An empty string in the JSON field produces a zero LastActivity in the
+// Heartbeat; the composer must treat that the same as absent and fall back.
+func TestLastActivityAt_FallsBackToPaneWhenEmptyString(t *testing.T) {
+	const paneSessionTS = "2026-05-07T18:30:00Z"
+
+	dir := t.TempDir()
+	// Write a heartbeat file with last_activity: "" (empty string).
+	writeJSON(t, filepath.Join(dir, "orchard-claude-alpha.json"), map[string]any{
+		"tmux_session":  "alpha",
+		"session_id":    "uuid-alpha",
+		"state":         "working",
+		"timestamp":     "2026-05-07T18:42:10Z",
+		"last_activity": "",
+	})
+
+	r := NewFileReader(dir)
+	hbs, err := r.ReadAll(context.Background())
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(hbs) != 1 {
+		t.Fatalf("got %d heartbeats, want 1", len(hbs))
+	}
+	hb := hbs[0]
+	if !hb.LastActivity.IsZero() {
+		t.Errorf("empty-string last_activity should parse to zero; got %v", hb.LastActivity)
+	}
+
+	pane := buildPaneWithSessionLastActivityAt(paneSessionTS)
+	c := newComposerForTest(pane)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if len(out) != 1 {
+		t.Fatalf("got %d instances, want 1", len(out))
+	}
+	inst := out[0]
+	if inst.LastActivityAt == nil {
+		t.Fatal("LastActivityAt is nil; expected pane session fallback for empty-string last_activity")
+	}
+	got := *inst.LastActivityAt
+	wantParsed, _ := time.Parse(time.RFC3339, paneSessionTS)
+	gotParsed, err := time.Parse(time.RFC3339Nano, got)
+	if err != nil {
+		gotParsed, err = time.Parse(time.RFC3339, got)
+		if err != nil {
+			t.Fatalf("LastActivityAt %q is not parseable: %v", got, err)
+		}
+	}
+	if !gotParsed.Equal(wantParsed) {
+		t.Errorf("LastActivityAt = %v, want pane session value %v", gotParsed, wantParsed)
+	}
+}
+
+// TestLastActivityAt_NullWhenNoPaneAndNoHeartbeat covers scenario 4:
+// "Resolver returns null when heartbeat lacks last_activity AND no pane matches."
+func TestLastActivityAt_NullWhenNoPaneAndNoHeartbeat(t *testing.T) {
+	hb := heartbeatWithLastActivity("")
+	hb.LastActivity = time.Time{}
+
+	c := newComposerForTest(nil) // no pane
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if len(out) != 1 {
+		t.Fatalf("got %d instances, want 1", len(out))
+	}
+	if out[0].LastActivityAt != nil {
+		t.Errorf("LastActivityAt = %v, want nil when no heartbeat last_activity and no pane", out[0].LastActivityAt)
+	}
+}
+
+// TestLastActivityAt_NullWhenPaneHasNoLastActivityAt covers scenario 5:
+// "Resolver returns null when heartbeat lacks last_activity AND the matched
+// pane has no lastActivityAt."
+func TestLastActivityAt_NullWhenPaneHasNoLastActivityAt(t *testing.T) {
+	// Pane exists but its session has no lastActivityAt (nil).
+	pane := buildPaneWithSessionLastActivityAt("") // empty → session.LastActivityAt = nil
+
+	hb := heartbeatWithLastActivity("")
+	hb.LastActivity = time.Time{}
+
+	c := newComposerForTest(pane)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if len(out) != 1 {
+		t.Fatalf("got %d instances, want 1", len(out))
+	}
+	if out[0].LastActivityAt != nil {
+		t.Errorf("LastActivityAt = %v, want nil when pane session has no lastActivityAt", out[0].LastActivityAt)
+	}
+}
+
+// TestLastActivityAt_DualTagParser covers scenario 6:
+// "Heartbeat parser accepts both last_activity (snake_case) and lastActivity (camelCase)."
+//
+// Both naming conventions must produce the same Heartbeat.LastActivity value.
+func TestLastActivityAt_DualTagParser(t *testing.T) {
+	const rawTS = "2026-05-07T18:42:11Z"
+	dir := t.TempDir()
+
+	// snake_case: last_activity
+	writeJSON(t, filepath.Join(dir, "orchard-claude-snake.json"), map[string]any{
+		"tmux_session":  "snake",
+		"session_id":    "uuid-snake",
+		"state":         "working",
+		"timestamp":     rawTS,
+		"last_activity": rawTS,
+	})
+
+	// camelCase: lastActivity
+	writeJSON(t, filepath.Join(dir, "orchard-claude-camel.json"), map[string]any{
+		"tmux_session":  "camel",
+		"session_id":    "uuid-camel",
+		"state":         "working",
+		"timestamp":     rawTS,
+		"lastActivity":  rawTS,
+	})
+
+	r := NewFileReader(dir)
+	hbs, err := r.ReadAll(context.Background())
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(hbs) != 2 {
+		t.Fatalf("got %d heartbeats, want 2 (snake + camel)", len(hbs))
+	}
+
+	// Sorted: camel before snake.
+	camel := hbs[0]
+	snake := hbs[1]
+	if camel.TmuxSession != "camel" {
+		t.Errorf("hbs[0].TmuxSession = %s, want camel (alphabetical sort)", camel.TmuxSession)
+	}
+	if snake.TmuxSession != "snake" {
+		t.Errorf("hbs[1].TmuxSession = %s, want snake", snake.TmuxSession)
+	}
+
+	if snake.LastActivity.IsZero() {
+		t.Error("snake heartbeat: LastActivity is zero; should parse from last_activity field")
+	}
+	if camel.LastActivity.IsZero() {
+		t.Error("camel heartbeat: LastActivity is zero; should parse from lastActivity field")
+	}
+	if !snake.LastActivity.Equal(camel.LastActivity) {
+		t.Errorf("snake.LastActivity %v != camel.LastActivity %v; both forms must produce the same timestamp",
+			snake.LastActivity, camel.LastActivity)
+	}
+}
+
+// TestLastActivityAt_MalformedFallsBackToPane covers scenario 7:
+// "Malformed heartbeat last_activity is treated as absent (does not crash,
+// falls back)."
+//
+// A non-timestamp string in last_activity must be silently ignored (LastActivity
+// stays zero), causing the composer to fall back to the pane's session.
+func TestLastActivityAt_MalformedFallsBackToPane(t *testing.T) {
+	const paneSessionTS = "2026-05-07T18:30:00Z"
+
+	dir := t.TempDir()
+	writeJSON(t, filepath.Join(dir, "orchard-claude-alpha.json"), map[string]any{
+		"tmux_session":  "alpha",
+		"session_id":    "uuid-alpha",
+		"state":         "working",
+		"timestamp":     "2026-05-07T18:42:10Z",
+		"last_activity": "not-a-timestamp",
+	})
+
+	r := NewFileReader(dir)
+	hbs, err := r.ReadAll(context.Background())
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(hbs) != 1 {
+		t.Fatalf("got %d heartbeats, want 1", len(hbs))
+	}
+	hb := hbs[0]
+
+	// Malformed value must produce zero LastActivity, not crash.
+	if !hb.LastActivity.IsZero() {
+		t.Errorf("malformed last_activity should be ignored; got LastActivity = %v", hb.LastActivity)
+	}
+
+	// Composer must fall back to the pane's session lastActivityAt.
+	pane := buildPaneWithSessionLastActivityAt(paneSessionTS)
+	c := newComposerForTest(pane)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if len(out) != 1 {
+		t.Fatalf("got %d instances, want 1", len(out))
+	}
+	inst := out[0]
+	if inst.LastActivityAt == nil {
+		t.Fatal("LastActivityAt is nil; expected pane session fallback after malformed last_activity")
+	}
+	got := *inst.LastActivityAt
+	wantParsed, _ := time.Parse(time.RFC3339, paneSessionTS)
+	gotParsed, err := time.Parse(time.RFC3339Nano, got)
+	if err != nil {
+		gotParsed, err = time.Parse(time.RFC3339, got)
+		if err != nil {
+			t.Fatalf("LastActivityAt %q is not parseable: %v", got, err)
+		}
+	}
+	if !gotParsed.Equal(wantParsed) {
+		t.Errorf("LastActivityAt = %v, want pane session value %v", gotParsed, wantParsed)
+	}
+}

--- a/internal/server/providers/claudeinstance/last_activity_at_ac3_e2e_test.go
+++ b/internal/server/providers/claudeinstance/last_activity_at_ac3_e2e_test.go
@@ -1,0 +1,399 @@
+package claudeinstance_test
+
+// E2E tests for ClaudeInstance.lastActivityAt — AC 3 of issue #443.
+//
+// Two @e2e scenarios from specs/features/schema-claude-instance-last-activity-at.feature:
+//
+//  1. "Live daemon query returns lastActivityAt for tracked Claude instances"
+//     — Query claudeInstances and assert that every instance with a heartbeat
+//     last_activity returns a non-null, RFC3339-parseable lastActivityAt.
+//
+//  2. "Updates to a heartbeat are observable in the next nodeChanged event"
+//     — Subscribe via WebSocket. Rewrite the heartbeat with a newer last_activity.
+//     Provider.Refresh is called directly to simulate the watcher sweep. Expect
+//     the subscriber to receive a nodeChanged event whose lastActivityAt matches
+//     the new value.
+//
+// E2E infrastructure note: the live daemon at 127.0.0.1:7777 is not
+// available in CI. These tests are implemented as httptest-backed integration
+// tests that use the full GraphQL stack (schema, resolver, subscription relay,
+// WebSocket transport) against a Provider driven by real heartbeat files in
+// t.TempDir(). This is the same pattern used by the nodechanged_e2e_test.go
+// file in internal/server/resolvers/ for WebSocket subscription tests.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/gorilla/websocket"
+
+	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeinstance"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+)
+
+// newTestDaemonWS is like newTestDaemon but also registers the WebSocket
+// transport so Subscription.nodeChanged is reachable over WS. Used for
+// the AC 3 subscription e2e test.
+func newTestDaemonWS(t *testing.T, provider *claudeinstance.Provider) *httptest.Server {
+	t.Helper()
+	cfg := gql.Config{Resolvers: resolvers.New(time.Now()).WithClaudeInstance(provider)}
+	gqlSrv := handler.New(gql.NewExecutableSchema(cfg))
+	gqlSrv.AddTransport(transport.POST{})
+	gqlSrv.AddTransport(transport.GET{})
+	gqlSrv.AddTransport(transport.Websocket{
+		KeepAlivePingInterval: 10 * time.Second,
+		Upgrader: websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+			CheckOrigin:     func(*http.Request) bool { return true },
+			Subprotocols:    []string{"graphql-transport-ws", "graphql-ws"},
+		},
+	})
+
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", gqlSrv)
+	return httptest.NewServer(mux)
+}
+
+// instanceNodeWithActivity extends instanceNode with the lastActivityAt
+// field so it can be decoded from the query response.
+type instanceNodeWithActivity struct {
+	ID             string  `json:"id"`
+	State          string  `json:"state"`
+	LastActivityAt *string `json:"lastActivityAt"`
+}
+
+// graphqlResponseWithActivity decodes a claudeInstances query that
+// selects lastActivityAt.
+type graphqlResponseWithActivity struct {
+	Data struct {
+		ClaudeInstances []instanceNodeWithActivity `json:"claudeInstances"`
+	} `json:"data"`
+	Errors []map[string]any `json:"errors,omitempty"`
+}
+
+// postQueryActivity issues a claudeInstances query that includes
+// lastActivityAt and decodes the result.
+func postQueryActivity(t *testing.T, serverURL string) graphqlResponseWithActivity {
+	t.Helper()
+	body, err := json.Marshal(map[string]string{"query": `query { claudeInstances { id state lastActivityAt } }`})
+	if err != nil {
+		t.Fatalf("marshal query: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, serverURL+"/graphql", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var out graphqlResponseWithActivity
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode response %q: %v", raw, err)
+	}
+	return out
+}
+
+// TestClaudeInstance_E2E_QueryLastActivityAt covers the @e2e scenario:
+//
+//	"Live daemon query returns lastActivityAt for tracked Claude instances"
+//
+// Writes two heartbeats: one with last_activity set, one without.
+// Queries `{ claudeInstances { id state lastActivityAt } }` and asserts:
+//   - The instance whose heartbeat has last_activity returns a non-null,
+//     RFC3339-parseable lastActivityAt.
+//   - The instance whose heartbeat lacks last_activity AND whose pane has
+//     no lastActivityAt returns null.
+func TestClaudeInstance_E2E_QueryLastActivityAt(t *testing.T) {
+	heartbeatDir := t.TempDir()
+	now := time.Date(2026, 5, 7, 18, 42, 15, 0, time.UTC)
+	freshTS := now.Add(-2 * time.Second).Format(time.RFC3339)
+	const activityTS = "2026-05-07T18:42:11Z"
+
+	// alpha: has last_activity.
+	writeHeartbeat(t, heartbeatDir, "alpha", map[string]any{
+		"tmux_session":    "alpha",
+		"session_id":      "uuid-alpha",
+		"state":           "working",
+		"timestamp":       freshTS,
+		"claudePid":       20042,
+		"lastHeartbeatAt": freshTS,
+		"last_activity":   activityTS,
+	})
+
+	// bravo: no last_activity, no pane → lastActivityAt must be null.
+	writeHeartbeat(t, heartbeatDir, "bravo", map[string]any{
+		"tmux_session":    "bravo",
+		"session_id":      "uuid-bravo",
+		"state":           "idle",
+		"timestamp":       freshTS,
+		"claudePid":       20099,
+		"lastHeartbeatAt": freshTS,
+	})
+
+	panes := &fakePaneFinder{
+		byPid: map[int]*gql.TmuxPane{
+			20042: {ID: "TmuxPane:local:%42"},
+			// bravo (20099) intentionally absent so lastActivityAt is null.
+		},
+	}
+	procs := &fakeProcessFinder{
+		byPid: map[int]*gql.Process{
+			20042: {ID: "Process:local:20042"},
+			20099: {ID: "Process:local:20099"},
+		},
+	}
+	liveness := fakeLiveness{alive: map[int]bool{20042: true, 20099: true}}
+
+	composer := claudeinstance.NewComposerWith(
+		"local", panes, procs, &fakeAccountFinder{}, liveness,
+		func() time.Time { return now }, claudeinstance.HeartbeatStaleAfter,
+	)
+	reader := claudeinstance.NewFileReader(heartbeatDir)
+	provider := claudeinstance.NewWith("local", reader, composer, func() time.Time { return now })
+	if err := provider.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	srv := newTestDaemon(t, provider)
+	defer srv.Close()
+
+	resp := postQueryActivity(t, srv.URL)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	if got := len(resp.Data.ClaudeInstances); got != 2 {
+		t.Fatalf("got %d instances, want 2", got)
+	}
+
+	byID := map[string]instanceNodeWithActivity{}
+	for _, inst := range resp.Data.ClaudeInstances {
+		byID[inst.ID] = inst
+	}
+
+	// alpha: must have a parseable lastActivityAt.
+	alpha, ok := byID["ClaudeInstance:local:20042"]
+	if !ok {
+		t.Fatalf("alpha instance missing from response; got: %v", byID)
+	}
+	if alpha.LastActivityAt == nil {
+		t.Error("alpha.lastActivityAt is nil; expected RFC3339 string from heartbeat last_activity")
+	} else {
+		got := *alpha.LastActivityAt
+		if _, err := time.Parse(time.RFC3339Nano, got); err != nil {
+			if _, err2 := time.Parse(time.RFC3339, got); err2 != nil {
+				t.Errorf("alpha.lastActivityAt %q is not parseable as RFC3339: %v", got, err)
+			}
+		}
+		wantParsed, _ := time.Parse(time.RFC3339, activityTS)
+		gotParsed, _ := time.Parse(time.RFC3339Nano, got)
+		if !gotParsed.Equal(wantParsed) {
+			t.Errorf("alpha.lastActivityAt = %v, want %v", gotParsed, wantParsed)
+		}
+	}
+
+	// bravo: no last_activity and no pane → lastActivityAt must be null.
+	bravo, ok := byID["ClaudeInstance:local:20099"]
+	if !ok {
+		t.Fatalf("bravo instance missing from response; got: %v", byID)
+	}
+	if bravo.LastActivityAt != nil {
+		t.Errorf("bravo.lastActivityAt = %v, want null (no heartbeat last_activity, no pane)", bravo.LastActivityAt)
+	}
+}
+
+// TestClaudeInstance_E2E_SubscriptionOnLastActivityChange covers the
+// @e2e scenario:
+//
+//	"Updates to a heartbeat are observable in the next nodeChanged event"
+//
+// Opens a WebSocket subscription on Subscription.nodeChanged for
+// "ClaudeInstance:local:30042". Rewrites the heartbeat file with a newer
+// last_activity. Calls provider.Refresh to simulate the watcher sweep.
+// Asserts the subscriber receives a nodeChanged event whose lastActivityAt
+// matches the new value.
+func TestClaudeInstance_E2E_SubscriptionOnLastActivityChange(t *testing.T) {
+	heartbeatDir := t.TempDir()
+	now := time.Date(2026, 5, 7, 18, 42, 15, 0, time.UTC)
+	freshTS := now.Add(-2 * time.Second).Format(time.RFC3339)
+	const initialActivity = "2026-05-07T18:30:00Z"
+	const updatedActivity = "2026-05-07T18:42:11Z"
+	const pid = 30042
+
+	writeHeartbeat(t, heartbeatDir, "gamma", map[string]any{
+		"tmux_session":    "gamma",
+		"session_id":      "uuid-gamma",
+		"state":           "working",
+		"timestamp":       freshTS,
+		"claudePid":       pid,
+		"lastHeartbeatAt": freshTS,
+		"last_activity":   initialActivity,
+	})
+
+	liveness := fakeLiveness{alive: map[int]bool{pid: true}}
+	composer := claudeinstance.NewComposerWith(
+		"local",
+		&fakePaneFinder{},
+		&fakeProcessFinder{},
+		&fakeAccountFinder{},
+		liveness,
+		func() time.Time { return now },
+		claudeinstance.HeartbeatStaleAfter,
+	)
+	reader := claudeinstance.NewFileReader(heartbeatDir)
+	provider := claudeinstance.NewWith("local", reader, composer, func() time.Time { return now })
+	if err := provider.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	srv := newTestDaemonWS(t, provider)
+	defer srv.Close()
+
+	// Dial WebSocket and complete graphql-transport-ws handshake.
+	wsURL := "ws://" + stripHost(t, srv.URL) + "/graphql"
+	dialer := *websocket.DefaultDialer
+	dialer.Subprotocols = []string{"graphql-transport-ws"}
+	dialer.HandshakeTimeout = 5 * time.Second
+
+	conn, _, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial ws: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// connection_init → connection_ack.
+	if err := conn.WriteJSON(map[string]any{"type": "connection_init"}); err != nil {
+		t.Fatalf("write init: %v", err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	var ack map[string]any
+	if err := conn.ReadJSON(&ack); err != nil {
+		t.Fatalf("read ack: %v", err)
+	}
+	if ack["type"] != "connection_ack" {
+		t.Fatalf("expected connection_ack, got %v", ack["type"])
+	}
+
+	// Subscribe to nodeChanged for our instance id.
+	const instanceID = "ClaudeInstance:local:30042"
+	const subID = "ac3-sub-1"
+	if err := conn.WriteJSON(map[string]any{
+		"id":   subID,
+		"type": "subscribe",
+		"payload": map[string]any{
+			"query": `subscription { nodeChanged(id: "ClaudeInstance:local:30042") { __typename ... on ClaudeInstance { id lastActivityAt } } }`,
+		},
+	}); err != nil {
+		t.Fatalf("write subscribe: %v", err)
+	}
+
+	// Give the server a beat to register the subscription before we refresh.
+	time.Sleep(100 * time.Millisecond)
+
+	// Rewrite the heartbeat with the updated last_activity.
+	writeHeartbeat(t, heartbeatDir, "gamma", map[string]any{
+		"tmux_session":    "gamma",
+		"session_id":      "uuid-gamma",
+		"state":           "working",
+		"timestamp":       freshTS,
+		"claudePid":       pid,
+		"lastHeartbeatAt": freshTS,
+		"last_activity":   updatedActivity,
+	})
+
+	// Drive the refresh that the watcher would do.
+	if err := provider.Refresh(context.Background(), "activity-update"); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	// Read frames until we get a "next" for our subscription.
+	type wsFrame struct {
+		ID      string          `json:"id"`
+		Type    string          `json:"type"`
+		Payload json.RawMessage `json:"payload,omitempty"`
+	}
+	type nodeChangedPayload struct {
+		Data struct {
+			NodeChanged struct {
+				Typename       string  `json:"__typename"`
+				ID             string  `json:"id"`
+				LastActivityAt *string `json:"lastActivityAt"`
+			} `json:"nodeChanged"`
+		} `json:"data"`
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if err := conn.SetReadDeadline(deadline); err != nil {
+			t.Fatalf("set read deadline: %v", err)
+		}
+		var f wsFrame
+		if err := conn.ReadJSON(&f); err != nil {
+			t.Fatalf("read frame (timeout?): %v", err)
+		}
+		if f.ID != subID {
+			continue
+		}
+		if f.Type == "error" {
+			t.Fatalf("subscription error: %s", string(f.Payload))
+		}
+		if f.Type != "next" {
+			continue
+		}
+		var p nodeChangedPayload
+		if err := json.Unmarshal(f.Payload, &p); err != nil {
+			t.Fatalf("decode payload: %v (%s)", err, string(f.Payload))
+		}
+		nc := p.Data.NodeChanged
+		if nc.ID != instanceID {
+			t.Fatalf("nodeChanged id = %q, want %q", nc.ID, instanceID)
+		}
+		if nc.Typename != "ClaudeInstance" {
+			t.Fatalf("nodeChanged __typename = %q, want ClaudeInstance", nc.Typename)
+		}
+		if nc.LastActivityAt == nil {
+			t.Fatal("nodeChanged.lastActivityAt is nil; expected the updated timestamp")
+		}
+		gotParsed, err := time.Parse(time.RFC3339Nano, *nc.LastActivityAt)
+		if err != nil {
+			gotParsed, err = time.Parse(time.RFC3339, *nc.LastActivityAt)
+			if err != nil {
+				t.Fatalf("nodeChanged.lastActivityAt %q not parseable: %v", *nc.LastActivityAt, err)
+			}
+		}
+		wantParsed, _ := time.Parse(time.RFC3339, updatedActivity)
+		if !gotParsed.Equal(wantParsed) {
+			t.Errorf("nodeChanged.lastActivityAt = %v, want %v", gotParsed, wantParsed)
+		}
+		return // success
+	}
+}
+
+// stripHost returns the host:port portion of a URL.
+func stripHost(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url %q: %v", raw, err)
+	}
+	return u.Host
+}

--- a/internal/server/providers/claudeinstance/last_activity_at_ac3_test.go
+++ b/internal/server/providers/claudeinstance/last_activity_at_ac3_test.go
@@ -1,0 +1,221 @@
+package claudeinstance
+
+// Tests for ClaudeInstance.lastActivityAt — AC 3 of issue #443.
+//
+// Three scenarios from specs/features/schema-claude-instance-last-activity-at.feature:
+//
+//  1. @unit "instancesEqual treats lastActivityAt as observable"
+//     — instancesEqual must return false when only LastActivityAt differs.
+//
+//  2. @integration "Heartbeat refresh that changes only last_activity emits a nodeChanged event"
+//     — a refresh whose only change is a new lastActivityAt must fire one
+//     subscriber event.
+//
+//  3. @integration "Heartbeat refresh where lastActivityAt did not change does NOT emit a noise event"
+//     — when lastActivityAt is identical between sweeps, no event must fire.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// ptrStr is a tiny helper that returns a pointer to s. Used throughout
+// these tests to build *string values without declaring a local variable
+// on every line.
+func ptrStr(s string) *string { return &s }
+
+// TestInstancesEqual_TreatsLastActivityAtAsObservable covers the @unit
+// scenario:
+//
+//	"instancesEqual treats lastActivityAt as observable"
+//
+// Two ClaudeInstance values that are identical except for LastActivityAt
+// must NOT be equal — the change-detection path would otherwise silently
+// suppress a subscription emit when only activity recency changes.
+func TestInstancesEqual_TreatsLastActivityAtAsObservable(t *testing.T) {
+	base := &graphql.ClaudeInstance{
+		ID:             "ClaudeInstance:local:42100",
+		State:          graphql.InstanceStateWorking,
+		RcEnabled:      false,
+		LastActivityAt: ptrStr("2026-05-07T18:30:00Z"),
+	}
+	changed := &graphql.ClaudeInstance{
+		ID:             "ClaudeInstance:local:42100",
+		State:          graphql.InstanceStateWorking,
+		RcEnabled:      false,
+		LastActivityAt: ptrStr("2026-05-07T18:42:11Z"),
+	}
+
+	if instancesEqual(base, changed) {
+		t.Error("instancesEqual returned true for instances that differ only in LastActivityAt; " +
+			"want false so the subscription path emits an event")
+	}
+
+	// Sanity: identical structs must still compare equal.
+	if !instancesEqual(base, base) {
+		t.Error("instancesEqual(base, base) returned false; want true")
+	}
+}
+
+// TestProvider_Subscribe_FiresOnLastActivityChange covers the @integration
+// scenario:
+//
+//	"Heartbeat refresh that changes only last_activity emits a nodeChanged event"
+//
+// The test boots a Provider with a staticReader, subscribes, triggers an
+// initial sweep to populate the cache, then triggers a second sweep that
+// produces the same instance with an updated LastActivityAt — only that
+// field changes. The subscriber must receive exactly one event.
+func TestProvider_Subscribe_FiresOnLastActivityChange(t *testing.T) {
+	now := time.Date(2026, 5, 7, 18, 30, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	const pid = 42100
+	baseTS := "2026-05-07T18:30:00Z"
+	laterTS := "2026-05-07T18:42:11Z"
+
+	// Heartbeat for the initial sweep: baseTS as LastActivity.
+	baseActivity, _ := time.Parse(time.RFC3339, baseTS)
+
+	r := &staticReader{
+		heartbeats: []Heartbeat{{
+			TmuxSession:     "alpha",
+			SessionID:       "uuid-alpha",
+			State:           "working",
+			ClaudePid:       pid,
+			Timestamp:       now.Add(-2 * time.Second),
+			LastHeartbeatAt: now.Add(-2 * time.Second),
+			LastActivity:    baseActivity,
+		}},
+	}
+	c := NewComposerWith("local", nil, nil, nil,
+		fakeLiveness{alive: map[int]bool{pid: true}},
+		clock,
+		HeartbeatStaleAfter,
+	)
+	p := NewWith("local", r, c, clock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events := p.Subscribe(ctx)
+
+	// Populate cache with the initial heartbeat.
+	if err := p.Refresh(ctx, "boot"); err != nil {
+		t.Fatalf("initial Refresh: %v", err)
+	}
+
+	// Drain any initial event (new key appearing always fires).
+	select {
+	case <-events:
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Re-sweep with a new LastActivity and nothing else changed.
+	laterActivity, _ := time.Parse(time.RFC3339, laterTS)
+	r.heartbeats = []Heartbeat{{
+		TmuxSession:     "alpha",
+		SessionID:       "uuid-alpha",
+		State:           "working",
+		ClaudePid:       pid,
+		Timestamp:       now.Add(-2 * time.Second),
+		LastHeartbeatAt: now.Add(-2 * time.Second),
+		LastActivity:    laterActivity,
+	}}
+
+	if err := p.Refresh(ctx, "activity-changed"); err != nil {
+		t.Fatalf("second Refresh: %v", err)
+	}
+
+	select {
+	case ev := <-events:
+		if ev.Key.ClaudePid != pid {
+			t.Errorf("event pid = %d, want %d", ev.Key.ClaudePid, pid)
+		}
+		if ev.Reason != "activity-changed" {
+			t.Errorf("event reason = %q, want activity-changed", ev.Reason)
+		}
+		// Verify the cache carries the new lastActivityAt.
+		inst, _, err := p.Get(ctx, ev.Key)
+		if err != nil {
+			t.Fatalf("Get after event: %v", err)
+		}
+		if inst.LastActivityAt == nil || *inst.LastActivityAt == "" {
+			t.Fatal("cached instance has nil/empty LastActivityAt after event")
+		}
+		gotParsed, err := time.Parse(time.RFC3339Nano, *inst.LastActivityAt)
+		if err != nil {
+			gotParsed, err = time.Parse(time.RFC3339, *inst.LastActivityAt)
+			if err != nil {
+				t.Fatalf("LastActivityAt %q not parseable: %v", *inst.LastActivityAt, err)
+			}
+		}
+		wantParsed, _ := time.Parse(time.RFC3339, laterTS)
+		if !gotParsed.Equal(wantParsed) {
+			t.Errorf("event payload LastActivityAt = %v, want %v", gotParsed, wantParsed)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("no event received after lastActivityAt change; want one event")
+	}
+}
+
+// TestProvider_Subscribe_SilentOnLastActivityUnchanged covers the
+// @integration scenario:
+//
+//	"Heartbeat refresh where lastActivityAt did not change does NOT emit a noise event"
+//
+// When the sweep produces an identical instance (same LastActivityAt and
+// all other fields), the subscriber must NOT receive an event.
+func TestProvider_Subscribe_SilentOnLastActivityUnchanged(t *testing.T) {
+	now := time.Date(2026, 5, 7, 18, 30, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
+
+	const pid = 42200
+	const sameTS = "2026-05-07T18:30:00Z"
+	sameActivity, _ := time.Parse(time.RFC3339, sameTS)
+
+	hb := Heartbeat{
+		TmuxSession:     "bravo",
+		SessionID:       "uuid-bravo",
+		State:           "idle",
+		ClaudePid:       pid,
+		Timestamp:       now.Add(-2 * time.Second),
+		LastHeartbeatAt: now.Add(-2 * time.Second),
+		LastActivity:    sameActivity,
+	}
+	r := &staticReader{heartbeats: []Heartbeat{hb}}
+	c := NewComposerWith("local", nil, nil, nil,
+		fakeLiveness{alive: map[int]bool{pid: true}},
+		clock,
+		HeartbeatStaleAfter,
+	)
+	p := NewWith("local", r, c, clock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events := p.Subscribe(ctx)
+
+	// First sweep — populates the cache (may fire one event for new key).
+	if err := p.Refresh(ctx, "boot"); err != nil {
+		t.Fatalf("first Refresh: %v", err)
+	}
+	// Drain the new-key event.
+	select {
+	case <-events:
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Second sweep with IDENTICAL data — no change in LastActivityAt.
+	if err := p.Refresh(ctx, "noop"); err != nil {
+		t.Fatalf("second Refresh: %v", err)
+	}
+
+	select {
+	case ev := <-events:
+		t.Errorf("unexpected event for unchanged lastActivityAt: %+v", ev)
+	case <-time.After(100 * time.Millisecond):
+		// No event — desired.
+	}
+}

--- a/internal/server/providers/claudeinstance/last_activity_at_test.go
+++ b/internal/server/providers/claudeinstance/last_activity_at_test.go
@@ -1,0 +1,181 @@
+package claudeinstance
+
+// Tests for ClaudeInstance.lastActivityAt — AC 1 of issue #443.
+//
+// Three unit scenarios from specs/features/schema-claude-instance-last-activity-at.feature:
+//
+//   1. "lastActivityAt field is declared on ClaudeInstance and is nullable String"
+//      — verified by compile-time field access on graphql.ClaudeInstance.
+//
+//   2. "lastActivityAt resolver returns RFC3339 string for an instance with a
+//      fresh heartbeat last_activity"
+//      — parseFile → Heartbeat.LastActivity populated; composeOne → inst.LastActivityAt set.
+//
+//   3. "lastActivityAt resolver returns RFC3339Nano when the heartbeat
+//      last_activity is sub-second"
+//      — sub-second precision is preserved through the full pipeline.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// TestLastActivityAt_FieldExistsAndIsNullable verifies that the
+// ClaudeInstance GraphQL model carries a nullable *string LastActivityAt
+// field — the schema contract for AC 1, scenario 1.
+//
+// This test will fail to compile if the field is absent or has the wrong
+// type, which is sufficient proof that the schema change landed.
+func TestLastActivityAt_FieldExistsAndIsNullable(t *testing.T) {
+	inst := graphql.ClaudeInstance{}
+	// Nullable means the zero value is nil (pointer).
+	if inst.LastActivityAt != nil {
+		t.Errorf("zero-value ClaudeInstance.LastActivityAt should be nil (nullable); got %v", inst.LastActivityAt)
+	}
+	// Assign to confirm the type is *string (compile-time check).
+	v := "2026-05-07T18:42:11Z"
+	inst.LastActivityAt = &v
+	if inst.LastActivityAt == nil || *inst.LastActivityAt != v {
+		t.Errorf("LastActivityAt = %v, want %q", inst.LastActivityAt, v)
+	}
+}
+
+// TestLastActivityAt_RFC3339FromHeartbeat verifies scenario 2:
+// a heartbeat with last_activity "2026-05-07T18:42:11Z" produces a
+// ClaudeInstance whose LastActivityAt is the same RFC3339 string.
+func TestLastActivityAt_RFC3339FromHeartbeat(t *testing.T) {
+	const rawTS = "2026-05-07T18:42:11Z"
+	dir := t.TempDir()
+
+	writeJSON(t, filepath.Join(dir, "orchard-claude-alpha.json"), map[string]any{
+		"tmux_session":  "alpha",
+		"session_id":    "uuid-alpha",
+		"state":         "working",
+		"timestamp":     rawTS,
+		"last_activity": rawTS,
+	})
+
+	r := NewFileReader(dir)
+	hbs, err := r.ReadAll(context.Background())
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(hbs) != 1 {
+		t.Fatalf("got %d heartbeats, want 1", len(hbs))
+	}
+	hb := hbs[0]
+	if hb.LastActivity.IsZero() {
+		t.Fatal("Heartbeat.LastActivity is zero; expected it to be parsed from last_activity field")
+	}
+
+	// Build a composer and compose the instance.
+	now := time.Date(2026, 5, 7, 18, 42, 15, 0, time.UTC) // 4s after activity
+	c := NewComposerWith(
+		"local",
+		&fakePaneFinder{},
+		&fakeProcessFinder{},
+		&fakeAccountFinder{},
+		fakeLiveness{alive: map[int]bool{}},
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+	out := c.Compose(context.Background(), hbs)
+	if len(out) != 1 {
+		t.Fatalf("got %d instances, want 1", len(out))
+	}
+	inst := out[0]
+	if inst.LastActivityAt == nil {
+		t.Fatal("ClaudeInstance.LastActivityAt is nil; expected RFC3339 string")
+	}
+
+	// Must parse cleanly as RFC3339 or RFC3339Nano.
+	got := *inst.LastActivityAt
+	if _, err := time.Parse(time.RFC3339Nano, got); err != nil {
+		if _, err2 := time.Parse(time.RFC3339, got); err2 != nil {
+			t.Errorf("LastActivityAt %q does not parse as RFC3339/RFC3339Nano: %v", got, err)
+		}
+	}
+
+	// Round-trip: parsed time must equal original.
+	parsed, _ := time.Parse(time.RFC3339, rawTS)
+	gotParsed, _ := time.Parse(time.RFC3339Nano, got)
+	if !gotParsed.Equal(parsed) {
+		t.Errorf("LastActivityAt round-trip mismatch: got %v, want %v", gotParsed, parsed)
+	}
+}
+
+// TestLastActivityAt_RFC3339NanoSubSecond verifies scenario 3:
+// a heartbeat with last_activity "2026-05-07T18:42:11.123456Z" (sub-second)
+// produces a LastActivityAt that preserves the sub-second precision.
+func TestLastActivityAt_RFC3339NanoSubSecond(t *testing.T) {
+	const rawTS = "2026-05-07T18:42:11.123456Z"
+	dir := t.TempDir()
+
+	writeJSON(t, filepath.Join(dir, "orchard-claude-subsec.json"), map[string]any{
+		"tmux_session":  "subsec",
+		"session_id":    "uuid-subsec",
+		"state":         "idle",
+		"timestamp":     rawTS,
+		"last_activity": rawTS,
+	})
+
+	r := NewFileReader(dir)
+	hbs, err := r.ReadAll(context.Background())
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(hbs) != 1 {
+		t.Fatalf("got %d heartbeats, want 1", len(hbs))
+	}
+	hb := hbs[0]
+	if hb.LastActivity.IsZero() {
+		t.Fatal("Heartbeat.LastActivity is zero; expected sub-second timestamp")
+	}
+	// Verify the nanosecond component was preserved in the in-memory struct.
+	if hb.LastActivity.Nanosecond() == 0 {
+		t.Errorf("Heartbeat.LastActivity has no sub-second component; got %v", hb.LastActivity)
+	}
+
+	now := time.Date(2026, 5, 7, 18, 42, 15, 0, time.UTC)
+	c := NewComposerWith(
+		"local",
+		&fakePaneFinder{},
+		&fakeProcessFinder{},
+		&fakeAccountFinder{},
+		fakeLiveness{alive: map[int]bool{}},
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+	out := c.Compose(context.Background(), hbs)
+	if len(out) != 1 {
+		t.Fatalf("got %d instances, want 1", len(out))
+	}
+	inst := out[0]
+	if inst.LastActivityAt == nil {
+		t.Fatal("ClaudeInstance.LastActivityAt is nil")
+	}
+
+	got := *inst.LastActivityAt
+
+	// Must parse as RFC3339Nano (since it has sub-second precision).
+	parsed, err := time.Parse(time.RFC3339Nano, got)
+	if err != nil {
+		t.Fatalf("LastActivityAt %q does not parse as RFC3339Nano: %v", got, err)
+	}
+
+	// The parsed time must equal the original (sub-second preserved).
+	original, _ := time.Parse(time.RFC3339Nano, rawTS)
+	if !parsed.Equal(original) {
+		t.Errorf("sub-second precision lost: got %v, want %v", parsed, original)
+	}
+	if parsed.Nanosecond() == 0 {
+		t.Errorf("sub-second component missing in output: got %q", got)
+	}
+}
+
+// writeJSON and writeRaw helpers are defined in adapter_test.go and are
+// shared across all _test.go files in this package.

--- a/internal/server/providers/claudeinstance/provider.go
+++ b/internal/server/providers/claudeinstance/provider.go
@@ -317,6 +317,9 @@ func instancesEqual(a, b *graphql.ClaudeInstance) bool {
 	if !ptrStringEqual(a.StartedAt, b.StartedAt) {
 		return false
 	}
+	if !ptrStringEqual(a.LastActivityAt, b.LastActivityAt) {
+		return false
+	}
 	return true
 }
 

--- a/internal/server/providers/claudeinstance/types.go
+++ b/internal/server/providers/claudeinstance/types.go
@@ -78,6 +78,12 @@ type Heartbeat struct {
 	// field is absent — the schema's `rcEnabled` is non-nullable so we
 	// default to false rather than nil.
 	RcEnabled bool
+	// LastActivity is the RFC3339/RFC3339Nano timestamp of the most recent
+	// Claude activity as recorded by the hook script in the last_activity /
+	// lastActivity field. Zero when the heartbeat file does not include the
+	// field (e.g. older hook versions). Used as the primary source for
+	// ClaudeInstance.lastActivityAt; zero means "fall back to pane".
+	LastActivity time.Time
 }
 
 // HostID returns the host id this provider was constructed with. Useful

--- a/schema.graphql
+++ b/schema.graphql
@@ -109,6 +109,13 @@ type ClaudeInstance implements Node {
 
   "RFC3339 timestamp the session was started."
   startedAt: String
+
+  """
+  ISO8601 timestamp of the most recent activity for this Claude instance —
+  derived from the heartbeat's last_activity field, falling back to
+  TmuxPane.lastActivityAt, falling back to null when neither is available.
+  """
+  lastActivityAt: String
 }
 
 "Lifecycle states for a Claude instance."

--- a/specs/features/schema-claude-instance-last-activity-at.feature
+++ b/specs/features/schema-claude-instance-last-activity-at.feature
@@ -1,0 +1,191 @@
+Feature: Schema ClaudeInstance.lastActivityAt — recency of activity for the LAST column
+  As a thin-shell TUI consuming the orchard daemon's GraphQL schema
+  I want ClaudeInstance to expose lastActivityAt as a derived ISO8601 timestamp
+  So that the TUI v2 dashboard's LAST column can render "12m", "3h", "8s" without
+  re-deriving recency from heartbeat files or tmux state client-side
+
+  # Issue #443. Sister of #421 (false `no_claude` for live sessions): once both land,
+  # "alive but inactive" rows can be visually distinguished from "broken claude" rows.
+  #
+  # Source-of-truth shape (per issue body):
+  #   extend type ClaudeInstance {
+  #     "ISO8601 timestamp of the most recent activity for this Claude instance —
+  #     derived from the heartbeat's last_activity field, falling back to
+  #     TmuxPane.lastActivityAt."
+  #     lastActivityAt: String
+  #   }
+  #
+  # Fallback chain (per AC 2):
+  #   1. heartbeat file's last_activity field
+  #   2. the TmuxPane's lastActivityAt (the pane hosting the claude pid)
+  #   3. null
+
+  Background:
+    Given the daemon serves a GraphQL schema at 127.0.0.1:7777
+    And the ClaudeInstance type exists with the existing fields (id, pane, process, account, state, rcUrl, rcEnabled, sessionUuid, startedAt)
+    And the heartbeat reader parses orchard-claude-<session>.json files written by the orchard hook script
+    And the heartbeat parser already accepts both snake_case and camelCase field names
+
+  # ===================================================================
+  # AC 1 — ClaudeInstance.lastActivityAt returns ISO8601 timestamp
+  # ===================================================================
+
+  @unit
+  Scenario: lastActivityAt field is declared on ClaudeInstance and is nullable String
+    Given the generated GraphQL schema
+    When the ClaudeInstance.lastActivityAt field is inspected
+    Then the field exists on type ClaudeInstance
+    And its type is String (nullable, matching startedAt's shape)
+    And it carries a doc comment describing the heartbeat→pane fallback chain
+
+  @unit
+  Scenario: lastActivityAt resolver returns RFC3339 string for an instance with a fresh heartbeat last_activity
+    Given a heartbeat file with last_activity "2026-05-07T18:42:11Z"
+    When a GraphQL query selects ClaudeInstance.lastActivityAt for that instance
+    Then the resolver returns "2026-05-07T18:42:11Z"
+    And the value parses cleanly as RFC3339
+
+  @unit
+  Scenario: lastActivityAt resolver returns RFC3339Nano when the heartbeat last_activity is sub-second
+    Given a heartbeat file with last_activity "2026-05-07T18:42:11.123456Z"
+    When a GraphQL query selects ClaudeInstance.lastActivityAt
+    Then the resolver returns a value parseable as RFC3339Nano
+    And the value preserves the sub-second precision
+
+  # ===================================================================
+  # AC 2 — Source: heartbeat.last_activity → TmuxPane.lastActivityAt → null
+  # ===================================================================
+
+  @unit
+  Scenario: Resolver prefers heartbeat last_activity over the pane fallback
+    Given a heartbeat with last_activity "2026-05-07T18:42:11Z"
+    And the matched TmuxPane reports lastActivityAt "2026-05-07T18:30:00Z"
+    When the lastActivityAt field is resolved
+    Then the resolver returns "2026-05-07T18:42:11Z"
+    And the pane's value is not consulted
+
+  @unit
+  Scenario: Resolver falls back to the TmuxPane's lastActivityAt when heartbeat last_activity is absent
+    Given a heartbeat with no last_activity field
+    And the matched TmuxPane reports lastActivityAt "2026-05-07T18:30:00Z"
+    When the lastActivityAt field is resolved
+    Then the resolver returns "2026-05-07T18:30:00Z"
+
+  @unit
+  Scenario: Resolver falls back to the TmuxPane's lastActivityAt when heartbeat last_activity is empty string
+    Given a heartbeat with last_activity equal to ""
+    And the matched TmuxPane reports lastActivityAt "2026-05-07T18:30:00Z"
+    When the lastActivityAt field is resolved
+    Then the resolver returns "2026-05-07T18:30:00Z"
+
+  @unit
+  Scenario: Resolver returns null when heartbeat lacks last_activity AND no pane matches
+    Given a heartbeat with no last_activity field
+    And no TmuxPane is matched for this instance (pane: null)
+    When the lastActivityAt field is resolved
+    Then the resolver returns null
+
+  @unit
+  Scenario: Resolver returns null when heartbeat lacks last_activity AND the matched pane has no lastActivityAt
+    Given a heartbeat with no last_activity field
+    And the matched TmuxPane reports lastActivityAt as null/zero
+    When the lastActivityAt field is resolved
+    Then the resolver returns null
+
+  @unit
+  Scenario: Heartbeat parser accepts both last_activity (snake_case) and lastActivity (camelCase)
+    Given a heartbeat file written with the field name "last_activity"
+    And another heartbeat file written with the field name "lastActivity"
+    When each file is parsed
+    Then both produce the same parsed last_activity timestamp
+    And the dual-tag pattern mirrors how claudePid/claude_pid are accepted today
+
+  @unit
+  Scenario: Malformed heartbeat last_activity is treated as absent (does not crash, falls back)
+    Given a heartbeat with last_activity "not-a-timestamp"
+    And the matched TmuxPane reports lastActivityAt "2026-05-07T18:30:00Z"
+    When the lastActivityAt field is resolved
+    Then the resolver returns "2026-05-07T18:30:00Z"
+    And the parser logs/skips silently rather than failing the whole sweep
+
+  # ===================================================================
+  # AC 3 — Subscription.nodeChanged emits when lastActivityAt changes
+  # ===================================================================
+
+  @integration
+  Scenario: Heartbeat refresh that changes only last_activity emits a nodeChanged event
+    Given a subscriber is connected to Subscription.nodeChanged for "ClaudeInstance:<host>:<pid>"
+    And the cached instance currently has lastActivityAt "2026-05-07T18:30:00Z"
+    When a new heartbeat sweep produces the same instance with lastActivityAt "2026-05-07T18:42:11Z" and no other field changes
+    Then the subscriber receives one nodeChanged event for that instance
+    And the event payload's lastActivityAt is "2026-05-07T18:42:11Z"
+
+  @integration
+  Scenario: Heartbeat refresh where lastActivityAt did not change does NOT emit a noise event
+    Given a subscriber is connected to Subscription.nodeChanged for "ClaudeInstance:<host>:<pid>"
+    And the cached instance currently has lastActivityAt "2026-05-07T18:30:00Z"
+    When a new heartbeat sweep produces an instance where lastActivityAt is still "2026-05-07T18:30:00Z" and no other observable field changed
+    Then the subscriber receives no nodeChanged event
+
+  @unit
+  Scenario: instancesEqual treats lastActivityAt as observable
+    Given two ClaudeInstance values that differ only in lastActivityAt
+    When instancesEqual compares them
+    Then the function returns false
+    # Today instancesEqual ignores lastActivityAt because the field doesn't exist;
+    # this scenario locks in that the change-detection path is updated alongside the field.
+
+  # ===================================================================
+  # End-to-end — full dashboard query against the live daemon
+  # ===================================================================
+
+  @e2e
+  Scenario: Live daemon query returns lastActivityAt for tracked Claude instances
+    Given the daemon is running on 127.0.0.1:7777
+    And at least one heartbeat file exists in $TMPDIR with last_activity set
+    When a GraphQL query selects { claudeInstances { id state lastActivityAt } }
+    Then every instance with a heartbeat last_activity returns a non-null lastActivityAt parseable as RFC3339
+    And every instance whose heartbeat lacks last_activity AND whose pane has no activity returns null
+
+  @e2e
+  Scenario: Updates to a heartbeat are observable in the next nodeChanged event
+    Given the daemon is running on 127.0.0.1:7777
+    And a subscriber is open on Subscription.nodeChanged for an existing ClaudeInstance id
+    When the heartbeat file for that instance is rewritten with a newer last_activity
+    Then the subscriber receives a nodeChanged event whose lastActivityAt reflects the new value
+
+  # --- AC Coverage Map ---
+  # AC 1: "ClaudeInstance.lastActivityAt returns ISO8601 timestamp"
+  #   -> @unit "lastActivityAt field is declared on ClaudeInstance and is nullable String"
+  #   -> @unit "lastActivityAt resolver returns RFC3339 string for an instance with a fresh heartbeat last_activity"
+  #   -> @unit "lastActivityAt resolver returns RFC3339Nano when the heartbeat last_activity is sub-second"
+  #   -> @e2e  "Live daemon query returns lastActivityAt for tracked Claude instances"
+  #
+  # AC 2: "Sourced from heartbeat file's `last_activity` field if present, falling back to `TmuxPane.lastActivityAt`, falling back to `null`"
+  #   -> @unit "Resolver prefers heartbeat last_activity over the pane fallback"
+  #   -> @unit "Resolver falls back to the TmuxPane's lastActivityAt when heartbeat last_activity is absent"
+  #   -> @unit "Resolver falls back to the TmuxPane's lastActivityAt when heartbeat last_activity is empty string"
+  #   -> @unit "Resolver returns null when heartbeat lacks last_activity AND no pane matches"
+  #   -> @unit "Resolver returns null when heartbeat lacks last_activity AND the matched pane has no lastActivityAt"
+  #   -> @unit "Heartbeat parser accepts both last_activity (snake_case) and lastActivity (camelCase)"
+  #   -> @unit "Malformed heartbeat last_activity is treated as absent (does not crash, falls back)"
+  #   -> @e2e  "Live daemon query returns lastActivityAt for tracked Claude instances"
+  #
+  # AC 3: "Updates are reflected in the next Subscription.nodeChanged event for the instance"
+  #   -> @integration "Heartbeat refresh that changes only last_activity emits a nodeChanged event"
+  #   -> @integration "Heartbeat refresh where lastActivityAt did not change does NOT emit a noise event"
+  #   -> @unit        "instancesEqual treats lastActivityAt as observable"
+  #   -> @e2e         "Updates to a heartbeat are observable in the next nodeChanged event"
+  #
+  # Open notes for /plan or /investigate (do not drop ACs without asking the user):
+  #   - The issue body says fallback is `TmuxPane.lastActivityAt`, but the schema today
+  #     defines lastActivityAt only on TmuxSession (line 470) and TmuxClient (line 605),
+  #     not on TmuxPane. Implementer must either (a) read pane.window.session.lastActivityAt,
+  #     (b) add a new TmuxPane.lastActivityAt field, or (c) confirm with the issue author
+  #     which is intended. Spec stays faithful to the issue's wording; resolver wiring is
+  #     implementer's call.
+  #   - Hook script (crates/orchard/hooks/orchard-state.sh) does not currently emit a
+  #     last_activity field. Updating it is part of the same change so the read path has
+  #     a value to surface. The hook update is implicit in AC 2's "heartbeat file's
+  #     last_activity field if present" — out of scope for this spec to dictate which
+  #     event(s) write it; coder + tests will lock the semantics.


### PR DESCRIPTION
## Why

Closes #443.

The TUI v2 dashboard's `LAST` column needs to render "12m", "3h", "8s" — the time since each worktree's claude session was last active. Today the daemon's `ClaudeInstance` doesn't expose `lastActivityAt`. `TmuxSession.lastActivityAt` exists, but the dashboard sorts/displays per-worktree and the recency that matters is per-claude-instance, not per-tmux-session. This PR adds the field so the TUI can read it directly without re-deriving recency from heartbeat files or tmux state client-side.

## What changed

Added `ClaudeInstance.lastActivityAt: String` (nullable, ISO8601) to the daemon's GraphQL schema. The resolver reads `last_activity` from the heartbeat file written by the orchard hook script, parses it as RFC3339 (with sub-second precision preserved), and exposes it as a string. The heartbeat parser accepts both `last_activity` (snake_case) and `lastActivity` (camelCase), mirroring how `claude_pid`/`claudePid` are handled.

This is **AC 1 of 3** for the issue. Follow-up commits on this branch will add:
- AC 2: pane fallback (when heartbeat lacks `last_activity`) + parser robustness for malformed values + hook script update to actually emit `last_activity`
- AC 3: `instancesEqual` change-detection updates so `Subscription.nodeChanged` emits when only `lastActivityAt` changes

The contract for all three ACs lives in `specs/features/schema-claude-instance-last-activity-at.feature` (added in this PR).

## Test plan

- [x] 3 unit scenarios from the feature file's AC 1 section, implemented as Go tests in `internal/server/providers/claudeinstance/last_activity_at_test.go`:
  - Field exists on `ClaudeInstance` and is nullable `*string`
  - Heartbeat with `last_activity: "2026-05-07T18:42:11Z"` round-trips through parser → composer → field as RFC3339
  - Sub-second `last_activity: "2026-05-07T18:42:11.123456Z"` preserves nanosecond precision via RFC3339Nano
- [x] Full Go test suite green (`go test ./...` — 22 packages pass)

## Anything surprising?

- **Branch is stacked on AC 1 only.** This PR is intentionally narrow. AC 2 and AC 3 land as additional commits on the same branch — reviewers can wait for the full stack before merging or land it incrementally.
- **`TmuxPane.lastActivityAt` doesn't exist yet.** AC 2 asks for the resolver to fall back to the pane's `lastActivityAt`, but the schema currently exposes `lastActivityAt` only on `TmuxSession` and `TmuxClient`. The follow-up commit will need to either (a) read `pane.window.session.lastActivityAt`, (b) add a new `TmuxPane.lastActivityAt` field, or (c) confirm the intent with @drewdrewthis. Out of scope for this commit.
- **Hook script doesn't emit `last_activity` today.** The follow-up commit (AC 2) updates `crates/orchard/hooks/orchard-state.sh` so the read path has a value to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #443

# Related issue

- #443

# Related issue

- #443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `lastActivityAt` field to Claude instance information in the GraphQL API, displaying the timestamp of the most recent activity for each Claude instance using RFC3339 format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #443