### PR TITLE
fix(global_config): preserve unknown top-level keys on save (#432)

### DIFF
--- a/crates/orchard/src/global_config.rs
+++ b/crates/orchard/src/global_config.rs
@@ -1748,28 +1748,44 @@ mod tests {
     #[test]
     fn save_to_path_preserves_multiple_unknown_top_level_keys() {
         let dir = tempdir().unwrap();
-        let path = write_config(dir.path(), r#"{
+        let path = write_config(
+            dir.path(),
+            r#"{
             "repos": [],
             "terminal_app": "com.apple.Terminal",
             "peers": [{"name": "boxd-vm"}],
             "watch_observability": {"enabled": true},
             "federation_tls_pin": "sha256:abc123"
-        }"#);
-        let cfg = GlobalConfig { terminal_app: "com.googlecode.iterm2".to_string(), ..GlobalConfig::default() };
+        }"#,
+        );
+        let cfg = GlobalConfig {
+            terminal_app: "com.googlecode.iterm2".to_string(),
+            ..GlobalConfig::default()
+        };
         save_to_path(&cfg, &path).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
         assert!(v["peers"].is_array(), "peers must be preserved");
-        assert!(v["watch_observability"].is_object(), "watch_observability must be preserved");
-        assert_eq!(v["federation_tls_pin"].as_str(), Some("sha256:abc123"), "federation_tls_pin must be preserved");
+        assert!(
+            v["watch_observability"].is_object(),
+            "watch_observability must be preserved"
+        );
+        assert_eq!(
+            v["federation_tls_pin"].as_str(),
+            Some("sha256:abc123"),
+            "federation_tls_pin must be preserved"
+        );
     }
 
     #[test]
     fn save_to_path_preserves_nested_values_inside_unknown_top_level_key() {
         let dir = tempdir().unwrap();
-        let path = write_config(dir.path(), r#"{
+        let path = write_config(
+            dir.path(),
+            r#"{
             "repos": [],
             "peers": [{"name": "boxd-vm", "address": "user@vm.example", "tls": true, "metadata": {"region": "us-east-1"}}]
-        }"#);
+        }"#,
+        );
         let cfg = GlobalConfig::default();
         save_to_path(&cfg, &path).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
@@ -1783,15 +1799,25 @@ mod tests {
     #[test]
     fn save_to_path_overwrites_known_keys_present_in_struct() {
         let dir = tempdir().unwrap();
-        let path = write_config(dir.path(), r#"{
+        let path = write_config(
+            dir.path(),
+            r#"{
             "repos": [],
             "terminal_app": "old.app",
             "peers": [{"name": "boxd-vm"}]
-        }"#);
-        let cfg = GlobalConfig { terminal_app: "new.app".to_string(), ..GlobalConfig::default() };
+        }"#,
+        );
+        let cfg = GlobalConfig {
+            terminal_app: "new.app".to_string(),
+            ..GlobalConfig::default()
+        };
         save_to_path(&cfg, &path).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(v["terminal_app"].as_str(), Some("new.app"), "struct must win for known keys");
+        assert_eq!(
+            v["terminal_app"].as_str(),
+            Some("new.app"),
+            "struct must win for known keys"
+        );
         assert!(v["peers"].is_array(), "unknown peers must still exist");
     }
 
@@ -1799,15 +1825,28 @@ mod tests {
     fn save_to_path_writes_struct_when_file_absent() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("config.json");
-        let cfg = GlobalConfig { terminal_app: "com.mitchellh.ghostty".to_string(), ..GlobalConfig::default() };
+        let cfg = GlobalConfig {
+            terminal_app: "com.mitchellh.ghostty".to_string(),
+            ..GlobalConfig::default()
+        };
         save_to_path(&cfg, &path).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
         assert_eq!(v["terminal_app"].as_str(), Some("com.mitchellh.ghostty"));
         // No spurious keys beyond what GlobalConfig serializes.
-        let known_keys = ["repos", "terminal_app", "tmux_sessions", "chat_target", "watch", "ci_gate_patterns"];
+        let known_keys = [
+            "repos",
+            "terminal_app",
+            "tmux_sessions",
+            "chat_target",
+            "watch",
+            "ci_gate_patterns",
+        ];
         let obj = v.as_object().unwrap();
         for key in obj.keys() {
-            assert!(known_keys.contains(&key.as_str()), "unexpected key on disk: {key}");
+            assert!(
+                known_keys.contains(&key.as_str()),
+                "unexpected key on disk: {key}"
+            );
         }
     }
 
@@ -1817,54 +1856,91 @@ mod tests {
         let path = write_config(dir.path(), "not valid {");
         let cfg = GlobalConfig::default();
         let result = save_to_path(&cfg, &path);
-        assert!(result.is_ok(), "save must succeed even when existing file is malformed");
+        assert!(
+            result.is_ok(),
+            "save must succeed even when existing file is malformed"
+        );
         let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert!(v.is_object(), "file must contain valid JSON after fallback write");
+        assert!(
+            v.is_object(),
+            "file must contain valid JSON after fallback write"
+        );
     }
 
     #[test]
     fn save_to_path_preserves_unknown_keys_with_edge_case_values() {
         let dir = tempdir().unwrap();
-        let path = write_config(dir.path(), r#"{
+        let path = write_config(
+            dir.path(),
+            r#"{
             "repos": [],
             "peers": [],
             "watch_observability": null,
             "feature_flag_x": false,
             "empty_object_field": {}
-        }"#);
+        }"#,
+        );
         let cfg = GlobalConfig::default();
         save_to_path(&cfg, &path).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert_eq!(v["peers"], serde_json::Value::Array(vec![]), "empty array must be preserved");
-        assert_eq!(v["watch_observability"], serde_json::Value::Null, "null must be preserved");
-        assert_eq!(v["feature_flag_x"], serde_json::Value::Bool(false), "false must be preserved");
-        assert_eq!(v["empty_object_field"], serde_json::json!({}), "empty object must be preserved");
+        assert_eq!(
+            v["peers"],
+            serde_json::Value::Array(vec![]),
+            "empty array must be preserved"
+        );
+        assert_eq!(
+            v["watch_observability"],
+            serde_json::Value::Null,
+            "null must be preserved"
+        );
+        assert_eq!(
+            v["feature_flag_x"],
+            serde_json::Value::Bool(false),
+            "false must be preserved"
+        );
+        assert_eq!(
+            v["empty_object_field"],
+            serde_json::json!({}),
+            "empty object must be preserved"
+        );
     }
 
     #[test]
     fn save_to_path_shallow_merge_drops_nested_unknown_under_known_key() {
         let dir = tempdir().unwrap();
-        let path = write_config(dir.path(), r#"{
+        let path = write_config(
+            dir.path(),
+            r#"{
             "repos": [],
             "watch": {"local_poll_secs": 10, "full_poll_secs": 60, "threshold_cooldown_secs": 300, "notifications": true, "experimental_flag": true}
-        }"#);
+        }"#,
+        );
         let cfg = GlobalConfig::default();
         save_to_path(&cfg, &path).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
         // Shallow merge: `watch` is overwritten by the struct's serialization.
         // The unknown nested key `experimental_flag` is dropped — by design.
-        assert!(v["watch"]["experimental_flag"].is_null(), "nested unknown under known key must be dropped (shallow merge)");
+        assert!(
+            v["watch"]["experimental_flag"].is_null(),
+            "nested unknown under known key must be dropped (shallow merge)"
+        );
     }
 
     #[test]
     fn save_to_path_remains_atomic() {
         let dir = tempdir().unwrap();
-        let path = write_config(dir.path(), r#"{"repos": [], "peers": [{"name": "boxd-vm"}]}"#);
+        let path = write_config(
+            dir.path(),
+            r#"{"repos": [], "peers": [{"name": "boxd-vm"}]}"#,
+        );
         let tmp = path.with_extension("json.tmp");
         let cfg = GlobalConfig::default();
         save_to_path(&cfg, &path).unwrap();
         // After a successful save the .tmp staging file must not remain.
-        assert!(!tmp.exists(), ".tmp file must not remain after successful atomic save");
+        assert!(
+            !tmp.exists(),
+            ".tmp file must not remain after successful atomic save"
+        );
         // And the final file must be valid JSON.
         let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
         assert!(v["peers"].is_array(), "peers must be present in final file");
@@ -1875,11 +1951,18 @@ mod tests {
         let dir = tempdir().unwrap();
         let path = dir.path().join("config.json");
         let cfg = GlobalConfig {
-            repos: vec![RepoConfig { slug: "owner/repo".to_string(), path: "/ws/repo".to_string(), remotes: vec![] }],
+            repos: vec![RepoConfig {
+                slug: "owner/repo".to_string(),
+                path: "/ws/repo".to_string(),
+                remotes: vec![],
+            }],
             terminal_app: "org.alacritty".to_string(),
             tmux_sessions: vec![],
             chat_target: Some("orchardist".to_string()),
-            watch: WatchConfig { local_poll_secs: 7, ..WatchConfig::default() },
+            watch: WatchConfig {
+                local_poll_secs: 7,
+                ..WatchConfig::default()
+            },
             ci_gate_patterns: vec!["custom-gate".to_string()],
         };
         save_to_path(&cfg, &path).unwrap();
@@ -1891,22 +1974,43 @@ mod tests {
         assert_eq!(v["ci_gate_patterns"][0].as_str(), Some("custom-gate"));
         assert_eq!(v["repos"][0]["slug"].as_str(), Some("owner/repo"));
         // No extra keys beyond the struct fields.
-        let known_keys = ["repos", "terminal_app", "tmux_sessions", "chat_target", "watch", "ci_gate_patterns"];
+        let known_keys = [
+            "repos",
+            "terminal_app",
+            "tmux_sessions",
+            "chat_target",
+            "watch",
+            "ci_gate_patterns",
+        ];
         for key in v.as_object().unwrap().keys() {
-            assert!(known_keys.contains(&key.as_str()), "unexpected key after round-trip: {key}");
+            assert!(
+                known_keys.contains(&key.as_str()),
+                "unexpected key after round-trip: {key}"
+            );
         }
     }
 
     #[test]
     fn save_to_path_preserves_peers_across_back_to_back_saves() {
         let dir = tempdir().unwrap();
-        let path = write_config(dir.path(), r#"{"repos": [], "peers": [{"name": "boxd-vm"}]}"#);
-        let cfg1 = GlobalConfig { terminal_app: "org.alacritty".to_string(), ..GlobalConfig::default() };
+        let path = write_config(
+            dir.path(),
+            r#"{"repos": [], "peers": [{"name": "boxd-vm"}]}"#,
+        );
+        let cfg1 = GlobalConfig {
+            terminal_app: "org.alacritty".to_string(),
+            ..GlobalConfig::default()
+        };
         save_to_path(&cfg1, &path).unwrap();
-        let cfg2 = GlobalConfig { chat_target: Some("orchardist".to_string()), ..GlobalConfig::default() };
+        let cfg2 = GlobalConfig {
+            chat_target: Some("orchardist".to_string()),
+            ..GlobalConfig::default()
+        };
         save_to_path(&cfg2, &path).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        let peers = v["peers"].as_array().expect("peers must survive back-to-back saves");
+        let peers = v["peers"]
+            .as_array()
+            .expect("peers must survive back-to-back saves");
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0]["name"].as_str(), Some("boxd-vm"));
     }
@@ -1914,13 +2018,21 @@ mod tests {
     #[test]
     fn save_to_path_preserves_peers_when_auto_registering_new_repo() {
         let dir = tempdir().unwrap();
-        let path = write_config(dir.path(), r#"{"repos": [], "peers": [{"name": "boxd-vm"}]}"#);
+        let path = write_config(
+            dir.path(),
+            r#"{"repos": [], "peers": [{"name": "boxd-vm"}]}"#,
+        );
         let mut cfg = GlobalConfig::default();
         append_repo_if_new(&mut cfg, "/workspace/my-project", "acme/my-project", vec![]);
         save_to_path(&cfg, &path).unwrap();
         let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        assert!(v["repos"].as_array().map(|a| a.len() == 1).unwrap_or(false), "new repo must be in repos[]");
-        let peers = v["peers"].as_array().expect("peers must survive append_repo_if_new + save");
+        assert!(
+            v["repos"].as_array().map(|a| a.len() == 1).unwrap_or(false),
+            "new repo must be in repos[]"
+        );
+        let peers = v["peers"]
+            .as_array()
+            .expect("peers must survive append_repo_if_new + save");
         assert_eq!(peers.len(), 1);
         assert_eq!(peers[0]["name"].as_str(), Some("boxd-vm"));
     }

--- a/crates/orchard/src/global_config.rs
+++ b/crates/orchard/src/global_config.rs
@@ -335,7 +335,9 @@ pub fn save_global_config(cfg: &GlobalConfig) -> Result<(), String> {
 
 /// Persists `cfg` to the given `path`.
 ///
-/// Creates the parent directory if needed. Writes atomically via a temporary
+/// Creates the parent directory if needed. Performs a shallow merge with the
+/// existing on-disk config so that unknown top-level fields (fields not modeled
+/// by [`GlobalConfig`]) are preserved as-is. Writes atomically via a temporary
 /// file to avoid partial writes. Used directly in tests to avoid touching
 /// the real `~/.orchard/config.json`.
 pub fn save_to_path(cfg: &GlobalConfig, path: &std::path::Path) -> Result<(), String> {
@@ -345,7 +347,15 @@ pub fn save_to_path(cfg: &GlobalConfig, path: &std::path::Path) -> Result<(), St
 
     std::fs::create_dir_all(dir).map_err(|e| format!("creating {}: {e}", dir.display()))?;
 
-    let json = serde_json::to_string_pretty(cfg).map_err(|e| format!("serializing config: {e}"))?;
+    let cfg_value = serde_json::to_value(cfg).map_err(|e| format!("serializing config: {e}"))?;
+    let serde_json::Value::Object(cfg_map) = cfg_value else {
+        return Err("serialized config is not a JSON object".to_string());
+    };
+
+    let merged = merge_with_existing(path, cfg_map);
+
+    let json =
+        serde_json::to_string_pretty(&merged).map_err(|e| format!("serializing config: {e}"))?;
 
     let tmp = path.with_extension("json.tmp");
     std::fs::write(&tmp, &json).map_err(|e| format!("writing {}: {e}", tmp.display()))?;
@@ -353,6 +363,47 @@ pub fn save_to_path(cfg: &GlobalConfig, path: &std::path::Path) -> Result<(), St
 
     LOG.info(&format!("global_config: saved to {}", path.display()));
     Ok(())
+}
+
+/// Reads the existing JSON object at `path` and shallow-merges `new_fields`
+/// into it.
+///
+/// Keys from `new_fields` overwrite matching keys in the existing object.
+/// Keys present in the existing object but absent from `new_fields` are
+/// preserved as-is. If the file does not exist, cannot be read, or does not
+/// parse as a top-level JSON object, `new_fields` is returned as-is.
+fn merge_with_existing(
+    path: &std::path::Path,
+    new_fields: serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Value {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        // File does not exist or is unreadable — no existing data to preserve.
+        Err(_) => return serde_json::Value::Object(new_fields),
+    };
+
+    let existing: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            LOG.warn(&format!(
+                "global_config: could not parse existing config for merge — skipping: {e}"
+            ));
+            return serde_json::Value::Object(new_fields);
+        }
+    };
+
+    match existing {
+        serde_json::Value::Object(mut existing_map) => {
+            for (key, value) in new_fields {
+                existing_map.insert(key, value);
+            }
+            serde_json::Value::Object(existing_map)
+        }
+        _ => {
+            LOG.warn("global_config: existing config is not a JSON object — skipping merge");
+            serde_json::Value::Object(new_fields)
+        }
+    }
 }
 
 /// Pure inner logic: appends `(cwd, slug, remotes)` to `cfg` if not already present.

--- a/crates/orchard/src/global_config.rs
+++ b/crates/orchard/src/global_config.rs
@@ -1623,6 +1623,67 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // save_to_path preserves unknown fields (issue #432)
+    // -----------------------------------------------------------------------
+
+    /// Regression test for issue #432: `save_to_path` must not clobber unknown
+    /// top-level fields that are present in the on-disk config but not modeled
+    /// by `GlobalConfig`.
+    ///
+    /// The current implementation serializes the struct directly, which drops
+    /// any fields not in the struct (e.g. a future `peers` array). This test
+    /// is intentionally written to FAIL against the pre-fix implementation so
+    /// that the fix can be verified.
+    #[test]
+    fn save_to_path_preserves_unknown_top_level_peers_field() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+
+        // Write a config that contains both modeled fields AND an unknown `peers`
+        // top-level array that the GlobalConfig struct does not model.
+        let initial_json = r#"{
+  "repos": [],
+  "terminal_app": "com.apple.Terminal",
+  "peers": [{"name": "boxd-vm", "address": "user@vm.example", "tls": true}]
+}"#;
+        std::fs::write(&path, initial_json).unwrap();
+
+        // Call save_to_path with a mutated terminal_app (everything else default).
+        let cfg = GlobalConfig {
+            repos: vec![],
+            terminal_app: "com.googlecode.iterm2".to_string(),
+            tmux_sessions: vec![],
+            chat_target: None,
+            watch: WatchConfig::default(),
+            ci_gate_patterns: default_ci_gate_patterns(),
+        };
+        save_to_path(&cfg, &path).expect("save_to_path must not fail");
+
+        // Read back the raw JSON as an untyped Value to inspect what was written.
+        let written = std::fs::read_to_string(&path).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&written).unwrap();
+
+        // The struct mutation must have taken effect.
+        assert_eq!(
+            value["terminal_app"].as_str(),
+            Some("com.googlecode.iterm2"),
+            "terminal_app must reflect the saved GlobalConfig value"
+        );
+
+        // The unknown `peers` array must still be present — save_to_path must
+        // not clobber fields it doesn't know about (issue #432).
+        let peers = value["peers"].as_array().expect(
+            "peers array must be preserved after save_to_path (issue #432: unknown fields are being dropped)"
+        );
+        assert_eq!(peers.len(), 1, "peers array must retain its single entry");
+        assert_eq!(
+            peers[0]["name"].as_str(),
+            Some("boxd-vm"),
+            "peers[0].name must be 'boxd-vm'"
+        );
+    }
+
     /// Legacy path is never loaded as a fallback (issue #424, scenario line 165-169).
     ///
     /// Simulates the situation where `~/.config/orchard/config.json` exists but

--- a/crates/orchard/src/global_config.rs
+++ b/crates/orchard/src/global_config.rs
@@ -340,6 +340,12 @@ pub fn save_global_config(cfg: &GlobalConfig) -> Result<(), String> {
 /// by [`GlobalConfig`]) are preserved as-is. Writes atomically via a temporary
 /// file to avoid partial writes. Used directly in tests to avoid touching
 /// the real `~/.orchard/config.json`.
+///
+/// Not safe against concurrent writers. The read-then-write window can lose
+/// updates if another process writes between the read and the rename. The
+/// merge narrows the clobber window from "any save wipes unknown keys" to
+/// "concurrent saves race" — file a follow-up issue if multi-writer safety
+/// is needed (e.g. advisory `flock`).
 pub fn save_to_path(cfg: &GlobalConfig, path: &std::path::Path) -> Result<(), String> {
     let dir = path
         .parent()

--- a/crates/orchard/src/global_config.rs
+++ b/crates/orchard/src/global_config.rs
@@ -1735,6 +1735,190 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // Additional save_to_path scenario tests (issue #432, BDD feature coverage)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn save_to_path_preserves_multiple_unknown_top_level_keys() {
+        let dir = tempdir().unwrap();
+        let path = write_config(dir.path(), r#"{
+            "repos": [],
+            "terminal_app": "com.apple.Terminal",
+            "peers": [{"name": "boxd-vm"}],
+            "watch_observability": {"enabled": true},
+            "federation_tls_pin": "sha256:abc123"
+        }"#);
+        let cfg = GlobalConfig { terminal_app: "com.googlecode.iterm2".to_string(), ..GlobalConfig::default() };
+        save_to_path(&cfg, &path).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert!(v["peers"].is_array(), "peers must be preserved");
+        assert!(v["watch_observability"].is_object(), "watch_observability must be preserved");
+        assert_eq!(v["federation_tls_pin"].as_str(), Some("sha256:abc123"), "federation_tls_pin must be preserved");
+    }
+
+    #[test]
+    fn save_to_path_preserves_nested_values_inside_unknown_top_level_key() {
+        let dir = tempdir().unwrap();
+        let path = write_config(dir.path(), r#"{
+            "repos": [],
+            "peers": [{"name": "boxd-vm", "address": "user@vm.example", "tls": true, "metadata": {"region": "us-east-1"}}]
+        }"#);
+        let cfg = GlobalConfig::default();
+        save_to_path(&cfg, &path).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        let peer = &v["peers"][0];
+        assert_eq!(peer["name"].as_str(), Some("boxd-vm"));
+        assert_eq!(peer["address"].as_str(), Some("user@vm.example"));
+        assert_eq!(peer["tls"].as_bool(), Some(true));
+        assert_eq!(peer["metadata"]["region"].as_str(), Some("us-east-1"));
+    }
+
+    #[test]
+    fn save_to_path_overwrites_known_keys_present_in_struct() {
+        let dir = tempdir().unwrap();
+        let path = write_config(dir.path(), r#"{
+            "repos": [],
+            "terminal_app": "old.app",
+            "peers": [{"name": "boxd-vm"}]
+        }"#);
+        let cfg = GlobalConfig { terminal_app: "new.app".to_string(), ..GlobalConfig::default() };
+        save_to_path(&cfg, &path).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(v["terminal_app"].as_str(), Some("new.app"), "struct must win for known keys");
+        assert!(v["peers"].is_array(), "unknown peers must still exist");
+    }
+
+    #[test]
+    fn save_to_path_writes_struct_when_file_absent() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let cfg = GlobalConfig { terminal_app: "com.mitchellh.ghostty".to_string(), ..GlobalConfig::default() };
+        save_to_path(&cfg, &path).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(v["terminal_app"].as_str(), Some("com.mitchellh.ghostty"));
+        // No spurious keys beyond what GlobalConfig serializes.
+        let known_keys = ["repos", "terminal_app", "tmux_sessions", "chat_target", "watch", "ci_gate_patterns"];
+        let obj = v.as_object().unwrap();
+        for key in obj.keys() {
+            assert!(known_keys.contains(&key.as_str()), "unexpected key on disk: {key}");
+        }
+    }
+
+    #[test]
+    fn save_to_path_falls_back_to_struct_write_on_malformed_existing_file() {
+        let dir = tempdir().unwrap();
+        let path = write_config(dir.path(), "not valid {");
+        let cfg = GlobalConfig::default();
+        let result = save_to_path(&cfg, &path);
+        assert!(result.is_ok(), "save must succeed even when existing file is malformed");
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert!(v.is_object(), "file must contain valid JSON after fallback write");
+    }
+
+    #[test]
+    fn save_to_path_preserves_unknown_keys_with_edge_case_values() {
+        let dir = tempdir().unwrap();
+        let path = write_config(dir.path(), r#"{
+            "repos": [],
+            "peers": [],
+            "watch_observability": null,
+            "feature_flag_x": false,
+            "empty_object_field": {}
+        }"#);
+        let cfg = GlobalConfig::default();
+        save_to_path(&cfg, &path).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(v["peers"], serde_json::Value::Array(vec![]), "empty array must be preserved");
+        assert_eq!(v["watch_observability"], serde_json::Value::Null, "null must be preserved");
+        assert_eq!(v["feature_flag_x"], serde_json::Value::Bool(false), "false must be preserved");
+        assert_eq!(v["empty_object_field"], serde_json::json!({}), "empty object must be preserved");
+    }
+
+    #[test]
+    fn save_to_path_shallow_merge_drops_nested_unknown_under_known_key() {
+        let dir = tempdir().unwrap();
+        let path = write_config(dir.path(), r#"{
+            "repos": [],
+            "watch": {"local_poll_secs": 10, "full_poll_secs": 60, "threshold_cooldown_secs": 300, "notifications": true, "experimental_flag": true}
+        }"#);
+        let cfg = GlobalConfig::default();
+        save_to_path(&cfg, &path).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        // Shallow merge: `watch` is overwritten by the struct's serialization.
+        // The unknown nested key `experimental_flag` is dropped — by design.
+        assert!(v["watch"]["experimental_flag"].is_null(), "nested unknown under known key must be dropped (shallow merge)");
+    }
+
+    #[test]
+    fn save_to_path_remains_atomic() {
+        let dir = tempdir().unwrap();
+        let path = write_config(dir.path(), r#"{"repos": [], "peers": [{"name": "boxd-vm"}]}"#);
+        let tmp = path.with_extension("json.tmp");
+        let cfg = GlobalConfig::default();
+        save_to_path(&cfg, &path).unwrap();
+        // After a successful save the .tmp staging file must not remain.
+        assert!(!tmp.exists(), ".tmp file must not remain after successful atomic save");
+        // And the final file must be valid JSON.
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert!(v["peers"].is_array(), "peers must be present in final file");
+    }
+
+    #[test]
+    fn save_to_path_struct_only_round_trip_unchanged_when_no_unknown_keys() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let cfg = GlobalConfig {
+            repos: vec![RepoConfig { slug: "owner/repo".to_string(), path: "/ws/repo".to_string(), remotes: vec![] }],
+            terminal_app: "org.alacritty".to_string(),
+            tmux_sessions: vec![],
+            chat_target: Some("orchardist".to_string()),
+            watch: WatchConfig { local_poll_secs: 7, ..WatchConfig::default() },
+            ci_gate_patterns: vec!["custom-gate".to_string()],
+        };
+        save_to_path(&cfg, &path).unwrap();
+        save_to_path(&cfg, &path).unwrap(); // Second save: no unknown keys to merge.
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(v["terminal_app"].as_str(), Some("org.alacritty"));
+        assert_eq!(v["chat_target"].as_str(), Some("orchardist"));
+        assert_eq!(v["watch"]["local_poll_secs"].as_u64(), Some(7));
+        assert_eq!(v["ci_gate_patterns"][0].as_str(), Some("custom-gate"));
+        assert_eq!(v["repos"][0]["slug"].as_str(), Some("owner/repo"));
+        // No extra keys beyond the struct fields.
+        let known_keys = ["repos", "terminal_app", "tmux_sessions", "chat_target", "watch", "ci_gate_patterns"];
+        for key in v.as_object().unwrap().keys() {
+            assert!(known_keys.contains(&key.as_str()), "unexpected key after round-trip: {key}");
+        }
+    }
+
+    #[test]
+    fn save_to_path_preserves_peers_across_back_to_back_saves() {
+        let dir = tempdir().unwrap();
+        let path = write_config(dir.path(), r#"{"repos": [], "peers": [{"name": "boxd-vm"}]}"#);
+        let cfg1 = GlobalConfig { terminal_app: "org.alacritty".to_string(), ..GlobalConfig::default() };
+        save_to_path(&cfg1, &path).unwrap();
+        let cfg2 = GlobalConfig { chat_target: Some("orchardist".to_string()), ..GlobalConfig::default() };
+        save_to_path(&cfg2, &path).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        let peers = v["peers"].as_array().expect("peers must survive back-to-back saves");
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0]["name"].as_str(), Some("boxd-vm"));
+    }
+
+    #[test]
+    fn save_to_path_preserves_peers_when_auto_registering_new_repo() {
+        let dir = tempdir().unwrap();
+        let path = write_config(dir.path(), r#"{"repos": [], "peers": [{"name": "boxd-vm"}]}"#);
+        let mut cfg = GlobalConfig::default();
+        append_repo_if_new(&mut cfg, "/workspace/my-project", "acme/my-project", vec![]);
+        save_to_path(&cfg, &path).unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert!(v["repos"].as_array().map(|a| a.len() == 1).unwrap_or(false), "new repo must be in repos[]");
+        let peers = v["peers"].as_array().expect("peers must survive append_repo_if_new + save");
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0]["name"].as_str(), Some("boxd-vm"));
+    }
+
     /// Legacy path is never loaded as a fallback (issue #424, scenario line 165-169).
     ///
     /// Simulates the situation where `~/.config/orchard/config.json` exists but

--- a/specs/features/save-global-config-preserves-unknown-keys.feature
+++ b/specs/features/save-global-config-preserves-unknown-keys.feature
@@ -1,0 +1,195 @@
+Feature: save_global_config preserves unknown top-level keys (round-trip merge)
+  As an orchard user with a multi-writer global config
+  I want the Rust TUI's save path to merge into existing JSON, not rewrite it
+  So that fields written by other tools (like the daemon's `peers[]`) are not silently dropped on save
+
+  Background:
+    Given the canonical global config path is "~/.orchard/config.json"
+    And the Rust TUI is one of several writers to this file (daemon `config add-peer`, future tools)
+    And `GlobalConfig` (in `crates/orchard/src/global_config.rs`) models a strict subset of the file's top-level keys
+
+  # ===================================================================
+  # AC 1 — `save_global_config` preserves all unknown top-level keys round-trip
+  # ===================================================================
+
+  @unit
+  Scenario: save_to_path preserves an unknown top-level key when the file already contains it
+    Given a config file at a temp path containing the JSON object:
+      """
+      {
+        "repos": [],
+        "terminal_app": "com.apple.Terminal",
+        "peers": [{"name": "boxd-vm", "address": "user@vm.example", "tls": true}]
+      }
+      """
+    When `save_to_path` is called with a `GlobalConfig` whose `terminal_app` is "com.googlecode.iterm2"
+    Then the file on disk contains `terminal_app` equal to "com.googlecode.iterm2"
+    And the file on disk still contains the `peers` array with the original entry intact
+
+  @unit
+  Scenario: save_to_path preserves multiple unrelated unknown top-level keys in one save
+    Given a config file containing unknown top-level keys "peers", "watch_observability", and "federation_tls_pin"
+    When `save_to_path` is called with any in-struct field changed
+    Then all three unknown top-level keys are present on disk after the save with their original values
+
+  @unit
+  Scenario: save_to_path preserves nested values inside an unknown top-level key verbatim
+    Given the file contains an unknown key "peers" whose value is an array of objects with nested fields ("name", "address", "tls", "metadata.region")
+    When `save_to_path` rewrites the file via the merge path
+    Then every nested field under "peers" is byte-for-byte preserved (no key reordering inside objects required, only that values are not lost)
+
+  @unit
+  Scenario: save_to_path overwrites known keys present in the struct
+    Given the existing file contains `terminal_app` = "old.app" AND an unknown key "peers"
+    When `save_to_path` is called with `GlobalConfig.terminal_app` = "new.app"
+    Then the file's `terminal_app` is "new.app" (struct wins for known keys)
+    And the unknown key "peers" still exists
+
+  @unit
+  Scenario: save_to_path writes the struct as-is when the existing file is absent
+    Given no config file exists at the target path
+    When `save_to_path` is called with a populated `GlobalConfig`
+    Then the file is created with exactly the struct's JSON representation
+    And no spurious unknown keys appear (nothing to merge from)
+
+  @unit
+  Scenario: save_to_path falls back to a plain struct write when the existing file is unreadable
+    Given a file exists at the target path but is malformed JSON ("not valid {")
+    When `save_to_path` is called with a populated `GlobalConfig`
+    Then the file is overwritten with the struct's JSON representation (clean recovery)
+    And the save returns success (callers do not see a malformed-input error)
+    And a warning is logged that the existing file could not be parsed for merge
+
+  @unit
+  Scenario: save_to_path preserves unknown keys whose values are null, false, or empty
+    Given the existing file contains unknown top-level keys with edge-case values:
+      | key                | value         |
+      | peers              | []            |
+      | watch_observability| null          |
+      | feature_flag_x     | false         |
+      | empty_object_field | {}            |
+    When `save_to_path` is called
+    Then every one of those keys is present after the save with the same JSON value
+    And no key is dropped because its value is "empty"
+
+  @unit
+  Scenario: Merge is shallow — top-level only, not deep recursive
+    Given the existing file contains a known key `watch` with an unknown nested key `watch.experimental_flag`
+    And the in-memory `GlobalConfig.watch` does not model `experimental_flag`
+    When `save_to_path` is called
+    Then the resulting file's `watch` block matches the struct's serialization (the nested unknown is dropped — by design, this scope is shallow merge only)
+    And a follow-up issue may track a deep-merge variant if needed (out of scope here)
+
+  @unit
+  Scenario: save_to_path remains atomic via the tmp-and-rename path
+    Given the existing file contains an unknown key "peers"
+    When `save_to_path` is invoked
+    Then the merged JSON is first written to a `<path>.tmp` file
+    And then renamed atomically to the final path (no partial writes observable to other readers)
+
+  # ===================================================================
+  # AC 2 — Test asserts `peers` field survives a TUI save
+  # (Reproduction of the original federation incident)
+  # ===================================================================
+
+  @integration
+  Scenario: `peers` field survives a TUI-driven save of `terminal_app`
+    Given the user has run `orchard config add-peer --name X --address Y --tls` (daemon-side)
+    And `~/.orchard/config.json` contains a populated `peers[]` array with that entry
+    When the TUI's save path runs (e.g. `init` wizard finalises, or `register_cwd_repo_if_new` persists, or `terminal_app` save fires)
+    And the only field the TUI mutates in-struct is `terminal_app`
+    Then re-reading `~/.orchard/config.json` shows `peers[]` still contains the original entry untouched
+    And `terminal_app` reflects the TUI's new value
+
+  @integration
+  Scenario: `peers` field survives back-to-back TUI saves
+    Given the file starts with one peer "boxd-vm" present
+    When the TUI executes two consecutive saves (e.g. terminal_app then chat_target)
+    Then after each save the `peers[]` array is intact and unchanged
+    And no save iteration drops or re-orders the peer entry
+
+  @integration
+  Scenario: `peers` field survives a save that also auto-registers a new CWD repo
+    Given the file contains peers "boxd-vm" AND no repo entry for the current working directory
+    When `register_cwd_repo_if_new` detects the CWD repo and triggers `save_global_config`
+    Then the saved file contains BOTH:
+      | content                                         |
+      | the new repo entry appended to `repos[]`        |
+      | the original `peers[]` array unmodified         |
+
+  # ===================================================================
+  # AC 3 — No regression in existing tests
+  # ===================================================================
+
+  @integration
+  Scenario: All existing global_config tests continue to pass
+    Given the test suite under `crates/orchard/src/global_config.rs::tests` (and `crates/orchard/tests/`)
+    When `cargo test -p orchard global_config` is run on the merge-aware implementation
+    Then every existing test passes without modification (or with modifications that are purely additive — e.g. asserting the new behavior, never weakening an old assertion)
+
+  @integration
+  Scenario: `save_to_path` round-trip of a struct-only payload remains identical to today
+    Given a `GlobalConfig` with no unknown keys on disk (clean install, struct-only)
+    When `save_to_path` writes and `load_from_path` re-reads
+    Then every modeled field round-trips identically (`repos`, `terminal_app`, `tmux_sessions`, `chat_target`, `watch`, `ci_gate_patterns`)
+    And no extra keys appear in the file that were not in the struct
+
+  @integration
+  Scenario: `save_global_config` (real path) and `save_to_path` (test path) share the same merge behavior
+    Given identical preconditions on a controlled temp path for both functions
+    When `save_global_config` is invoked indirectly (via a HOME redirection or equivalent test plumbing) and `save_to_path` is invoked directly
+    Then both produce byte-equivalent merged output (the `save_global_config` wrapper must not bypass the merge)
+
+  # ===================================================================
+  # Out-of-scope guards (issue "Out of scope")
+  # ===================================================================
+
+  @unit
+  Scenario: No deep recursive merge is introduced
+    Given the merge implementation
+    When code is inspected
+    Then it does not recursively walk nested objects to merge
+    And it operates on the top-level `Map<String, Value>` only
+
+  @unit
+  Scenario: No schema-versioned migration is introduced
+    Given the merge implementation
+    When code is inspected
+    Then no `schema_version` field is added to `GlobalConfig`
+    And no migration step is run as part of `save_to_path`
+
+  @unit
+  Scenario: Config location is not changed by this work
+    Given the canonical path is already `~/.orchard/config.json` (per ADR-014, issue #424)
+    When this issue's changes ship
+    Then the read/write path is unchanged
+    And no movement of the config file is performed
+
+  # --- AC Coverage Map ---
+  # AC 1: "save_global_config preserves all unknown top-level keys round-trip"
+  #   -> Scenario: save_to_path preserves an unknown top-level key when the file already contains it
+  #   -> Scenario: save_to_path preserves multiple unrelated unknown top-level keys in one save
+  #   -> Scenario: save_to_path preserves nested values inside an unknown top-level key verbatim
+  #   -> Scenario: save_to_path overwrites known keys present in the struct
+  #   -> Scenario: save_to_path writes the struct as-is when the existing file is absent
+  #   -> Scenario: save_to_path falls back to a plain struct write when the existing file is unreadable
+  #   -> Scenario: save_to_path preserves unknown keys whose values are null, false, or empty
+  #   -> Scenario: Merge is shallow — top-level only, not deep recursive
+  #   -> Scenario: save_to_path remains atomic via the tmp-and-rename path
+  #
+  # AC 2: "Test asserts `peers` field survives a TUI save"
+  #   -> Scenario: `peers` field survives a TUI-driven save of `terminal_app`
+  #   -> Scenario: `peers` field survives back-to-back TUI saves
+  #   -> Scenario: `peers` field survives a save that also auto-registers a new CWD repo
+  #
+  # AC 3: "No regression in existing tests"
+  #   -> Scenario: All existing global_config tests continue to pass
+  #   -> Scenario: save_to_path round-trip of a struct-only payload remains identical to today
+  #   -> Scenario: save_global_config (real path) and save_to_path (test path) share the same merge behavior
+  #
+  # Out-of-scope guards (issue "Out of scope" + scope guards):
+  #   -> Scenario: No deep recursive merge is introduced
+  #   -> Scenario: No schema-versioned migration is introduced
+  #   -> Scenario: Config location is not changed by this work
+  #
+  # AC count: 3. Mapped scenarios: 3/3. No drops, no gaps.


### PR DESCRIPTION
## Why

Closes #432.

The Rust TUI's `save_global_config` serializes a `GlobalConfig` struct over `~/.orchard/config.json`. Any top-level JSON keys not modeled in the struct are silently dropped on every save.

Today the daemon's `peers[]` field is the visible victim — added via `orchard config add-peer`, then wiped the next time the TUI runs (init wizard, repo auto-registration, terminal-app save, shepherd setup). Federation state vanishes silently. Future top-level fields written by other tools (e.g. `watch.observability`, `federation.tls_pin`) face the same fate.

## What changed

- Added a regression test that pins the bug: write `peers[]` into the file, run a TUI-style save mutating `terminal_app`, assert `peers[]` survives.
- Added the BDD feature file mapping all 3 ACs to 18 scenarios under `specs/features/save-global-config-preserves-unknown-keys.feature`.
- Fix to convert `save_to_path` into a round-trip-preserving merge — pending in next commit.

## Test plan

- [x] `save_to_path_preserves_unknown_top_level_peers_field` written and confirmed FAILING against current implementation (panics asserting `peers` array missing).
- [ ] After fix lands: regression test passes.
- [ ] After fix lands: scenario coverage tests for shallow merge, malformed-file fallback, atomicity, struct-only round-trip parity.
- [ ] All existing `cargo test -p orchard global_config` tests continue to pass.

## Anything surprising?

- Merge is **shallow** (top-level `Map<String, Value>` only) by design — the issue's proposal explicitly scopes this to top-level keys. Deep recursive merge is out of scope; the feature file pins this with an explicit guard scenario.
- The fix path also handles the malformed-file case: if the existing file is unparseable, fall back to a clean struct write and log a warning. Callers don't see a malformed-input error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #432

# Related issue

- #432

# Related issue

- #432

# Related issue

- #432

# Related issue

- #432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Global config saves now preserve unknown top-level configuration fields that were previously dropped, preventing data loss of custom configuration entries managed manually or by external tools.

* **Tests**
  * Added comprehensive regression and unit tests validating correct field preservation across multiple scenarios, including consecutive saves, automatic repository registration, and graceful handling of malformed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #432