### PR TITLE
fix(restore): stop resurrecting killed tmux sessions on every read (#460)

### DIFF
--- a/crates/orchard-dispatcher/src/main.rs
+++ b/crates/orchard-dispatcher/src/main.rs
@@ -62,6 +62,7 @@ const TUI_VERBS: &[&str] = &[
     "list-remotes",
     "hook-enrich",
     "webhook-serve",
+    "restore",
 ];
 
 const HELP: &str = "\
@@ -89,6 +90,7 @@ Commands:
   list-remotes [--json]         List configured remotes.
   hook-enrich --transcript ...  Claude Code hook entry point.
   webhook-serve                 Run the GitHub webhook receiver.
+  restore                       Reconstruct dead tmux sessions from cache.
 
 Worktree shortcuts (the worktree is Orchard's primary unit):
   orchard new <issue>           ≡ orchard worktree new <issue>
@@ -319,6 +321,7 @@ mod tests {
                 "list-remotes",
                 "hook-enrich",
                 "webhook-serve",
+                "restore",
             ]
         );
     }

--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -339,10 +339,6 @@ pub fn refresh_and_build_with_walker_config(
     use crate::transitive_walker::{WalkerConfig, walk};
     use std::sync::Arc;
 
-    // Best-effort restore of dead tmux sessions from cache before the first
-    // refresh, so the subsequent tmux listing already reflects them.
-    let _ = crate::restore::restore_all_local();
-
     // Refresh local sources. Per-repo refreshes fan out concurrently so
     // GitHub API latency for one repo can't block another.
     crate::refresh_parallel::for_each_repo_parallel(config, |repo| {

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -469,10 +469,7 @@ fn handle_restore() {
             }
             restore::SessionRestoreOutcome::Failed { step, error } => {
                 failed += 1;
-                println!(
-                    "  failed:   {name} ({}: {error})",
-                    restore_step_str(step)
-                );
+                println!("  failed:   {name} ({}: {error})", restore_step_str(step));
             }
         }
     }

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -22,6 +22,7 @@ use orchard::heal;
 use orchard::hook_enrich;
 use orchard::json_output::JsonOutput;
 use orchard::logger;
+use orchard::restore;
 use orchard::setup_remote;
 use orchard::shell;
 use orchard::tui;
@@ -109,6 +110,7 @@ fn main() {
         "webhook-serve" => handle_webhook_serve(&args),
         "list-remotes" => handle_list_remotes(json_flag),
         "sessions" => handle_sessions(json_flag),
+        "restore" => handle_restore(),
         _ => {
             if json_flag {
                 handle_json();
@@ -430,6 +432,48 @@ fn handle_sessions(json: bool) {
     if code != 0 {
         std::process::exit(code);
     }
+}
+
+/// Handles `orchard-tui restore` — explicitly reconstruct dead tmux sessions
+/// from the local manifest cache.
+///
+/// This is the **only** caller of [`restore::restore_all_local`] in production.
+/// Read paths (`refresh_and_build`, `App::new`, `--json`) deliberately do NOT
+/// invoke restore — killed sessions stay killed until the user runs this
+/// subcommand. See issue #460.
+///
+/// Prints one line per cached entry classifying it as Restored / Skipped(reason)
+/// / Failed(step). Exits 0 even on partial Failures (matching the historical
+/// best-effort semantics of `restore_all_local`); a non-zero exit is reserved
+/// for cases where the orchestration itself can't run.
+fn handle_restore() {
+    let report = restore::restore_all_local();
+
+    if report.sessions.is_empty() {
+        println!("restore: no cached sessions to restore");
+        return;
+    }
+
+    let mut restored = 0usize;
+    let mut skipped = 0usize;
+    let mut failed = 0usize;
+    for (name, outcome) in &report.sessions {
+        match outcome {
+            restore::SessionRestoreOutcome::Restored { windows, panes } => {
+                restored += 1;
+                println!("  restored: {name} ({windows} windows, {panes} panes)");
+            }
+            restore::SessionRestoreOutcome::Skipped(reason) => {
+                skipped += 1;
+                println!("  skipped:  {name} ({reason:?})");
+            }
+            restore::SessionRestoreOutcome::Failed { step, error } => {
+                failed += 1;
+                println!("  failed:   {name} (step={step:?}, error={error})");
+            }
+        }
+    }
+    println!("restore: {restored} restored, {skipped} skipped, {failed} failed");
 }
 
 /// Handles `orchard-tui refresh` — probes hosts, fetches remote data, writes

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -465,15 +465,35 @@ fn handle_restore() {
             }
             restore::SessionRestoreOutcome::Skipped(reason) => {
                 skipped += 1;
-                println!("  skipped:  {name} ({reason:?})");
+                println!("  skipped:  {name} ({})", skip_reason_str(reason));
             }
             restore::SessionRestoreOutcome::Failed { step, error } => {
                 failed += 1;
-                println!("  failed:   {name} (step={step:?}, error={error})");
+                println!(
+                    "  failed:   {name} ({}: {error})",
+                    restore_step_str(step)
+                );
             }
         }
     }
     println!("restore: {restored} restored, {skipped} skipped, {failed} failed");
+}
+
+/// Maps a [`restore::SkipReason`] to a short user-facing phrase.
+fn skip_reason_str(reason: &restore::SkipReason) -> &'static str {
+    match reason {
+        restore::SkipReason::AlreadyRunning => "already running",
+        restore::SkipReason::WorktreeGone => "worktree gone",
+        restore::SkipReason::RemoteNotSupported => "remote (not supported in v1)",
+    }
+}
+
+/// Maps a [`restore::RestoreStep`] to a short user-facing phrase.
+fn restore_step_str(step: &restore::RestoreStep) -> &'static str {
+    match step {
+        restore::RestoreStep::NewSession => "tmux new-session failed",
+        restore::RestoreStep::InputValidation => "cache input rejected",
+    }
 }
 
 /// Handles `orchard-tui refresh` — probes hosts, fetches remote data, writes
@@ -682,6 +702,9 @@ fn print_usage() {
   orchard-tui webhook-serve [--port <n>]
                                        Receive GitHub webhooks and append to events.jsonl
                                        Requires ORCHARD_WEBHOOK_SECRET env var
+  orchard-tui restore                Reconstruct dead tmux sessions from the local
+                                       cache. Read paths never resurrect killed
+                                       sessions — this is the only deliberate path.
 
 Options:
   --version, -V  Print version and exit

--- a/crates/orchard/src/restore.rs
+++ b/crates/orchard/src/restore.rs
@@ -7,7 +7,6 @@
 
 use std::path::Path;
 use std::process::Command;
-use std::time::Duration;
 
 use crate::cache::CachedTmuxSession;
 use crate::logger::LOG;
@@ -175,53 +174,20 @@ pub fn live_local_session_names() -> Option<Vec<String>> {
     )
 }
 
-/// Minimum interval between two consecutive restore attempts across orchard
-/// processes. A cron-polling `orchard-tui --json` every minute would otherwise
-/// keep re-probing tmux and risk `kill-session` + recreate against sessions
-/// tmux just failed to list.
-const RESTORE_COOLDOWN: Duration = Duration::from_secs(5 * 60);
-
-/// Filename for the sentinel that records the last restore attempt. Lives in
-/// the cache dir so it shares the tmux cache's lifecycle (rotated, cleaned
-/// alongside it).
-const RESTORE_SENTINEL: &str = "restore_last_run";
-
-/// Guard that ensures [`restore_all_local`] runs at most once per process,
-/// backstopping the file-based cooldown for the double-call-within-one-binary
-/// case (TUI boot + manual `refresh_and_build`).
-///
-/// **Testing note:** this is a process-global `OnceLock`. Tests that want to
-/// exercise the restore orchestration must call [`run_restore`] directly —
-/// calling [`restore_all_local`] from a test leaks state across test cases in
-/// the same process (and racy-shares it across threads).
-static RESTORE_RAN: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-
 /// Reads the local tmux cache, partitions cached sessions by [`restore`], runs
 /// [`restore_session`] for each plan, and returns a combined [`RestoreReport`].
 ///
-/// Safe to call from every `orchard` entry point. Two guards prevent storms:
+/// Invoked exactly once per explicit `orchard restore` user action — never
+/// from a read path. The cooldown / OnceLock guards that used to defend against
+/// the read-path call storm were removed in #460 once the storm itself was
+/// fixed.
 ///
-/// 1. **In-process**: a [`OnceLock`] short-circuits repeated calls within the
-///    same binary (e.g. `App::new` + `refresh_and_build` both invoking restore).
-/// 2. **Cross-process**: a sentinel file in the cache dir records the last
-///    restore timestamp. If the previous run was within [`RESTORE_COOLDOWN`],
-///    this call is a no-op. That keeps `orchard-tui --json` in a cron loop from
-///    re-probing every minute.
-///
-/// Silently returns an empty report on any IO failure so startup is never
-/// blocked.
+/// Silently returns an empty report on any IO failure so the subcommand exits
+/// cleanly when the cache is missing.
 pub fn restore_all_local() -> RestoreReport {
-    if RESTORE_RAN.set(()).is_err() {
-        return RestoreReport::default();
-    }
-    if recently_attempted_restore_at(&sentinel_path(), RESTORE_COOLDOWN) {
-        return RestoreReport::default();
-    }
-
     let cached: Vec<CachedTmuxSession> =
         crate::cache::read_cache::<CachedTmuxSession>(&crate::cache::tmux_cache_path(None)).entries;
     if cached.is_empty() {
-        record_restore_attempt();
         return RestoreReport::default();
     }
 
@@ -231,42 +197,7 @@ pub fn restore_all_local() -> RestoreReport {
         );
         return RestoreReport::default();
     };
-    record_restore_attempt();
     run_restore(&live, &cached)
-}
-
-/// Returns true when the sentinel file at `path` exists and was modified less
-/// than `cooldown` ago. Missing or stale sentinels return false.
-///
-/// Path is injected so unit tests can point at a tempfile instead of the
-/// real per-user cache dir.
-fn recently_attempted_restore_at(path: &Path, cooldown: Duration) -> bool {
-    let Ok(metadata) = std::fs::metadata(path) else {
-        return false;
-    };
-    let Ok(modified) = metadata.modified() else {
-        return false;
-    };
-    modified
-        .elapsed()
-        .map(|elapsed| elapsed < cooldown)
-        .unwrap_or(false)
-}
-
-/// Touches the restore sentinel file so the next process's
-/// [`recently_attempted_restore_at`] check can see the timestamp. Failure is
-/// non-fatal (restore proceeds regardless).
-fn record_restore_attempt() {
-    let path = sentinel_path();
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    // Writing zero bytes is enough — only the mtime matters.
-    let _ = std::fs::write(&path, b"");
-}
-
-fn sentinel_path() -> std::path::PathBuf {
-    crate::cache::cache_dir().join(RESTORE_SENTINEL)
 }
 
 /// Folds the pure classifier and the imperative shell into a single
@@ -631,6 +562,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+    use std::time::Duration;
 
     fn make_cached(name: &str, path: &str, host: Option<&str>) -> CachedTmuxSession {
         CachedTmuxSession {
@@ -835,55 +767,6 @@ mod tests {
         assert!(!is_valid_pane_target("0."));
         assert!(!is_valid_pane_target("0.a"));
         assert!(!is_valid_pane_target("a.0"));
-    }
-
-    // -----------------------------------------------------------------------
-    // Cooldown guard tests (no tmux required — sentinel path is injected)
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn recently_attempted_restore_at_is_false_when_sentinel_missing() {
-        let missing = std::env::temp_dir().join(format!(
-            "orchard-test-missing-sentinel-{}-{}",
-            std::process::id(),
-            line!()
-        ));
-        assert!(!missing.exists(), "precondition: sentinel must not exist");
-        assert!(!recently_attempted_restore_at(
-            &missing,
-            Duration::from_secs(300)
-        ));
-    }
-
-    #[test]
-    fn recently_attempted_restore_at_is_true_when_sentinel_is_recent() {
-        let path = std::env::temp_dir().join(format!(
-            "orchard-test-recent-sentinel-{}-{}",
-            std::process::id(),
-            line!()
-        ));
-        std::fs::write(&path, b"").unwrap();
-        let result = recently_attempted_restore_at(&path, Duration::from_secs(300));
-        let _ = std::fs::remove_file(&path);
-        assert!(
-            result,
-            "a just-written sentinel must register as recent under a 5-min cooldown"
-        );
-    }
-
-    #[test]
-    fn recently_attempted_restore_at_is_false_when_cooldown_is_zero() {
-        // Zero cooldown ⇒ nothing is "recent" by definition — the elapsed
-        // time is always >= 0, so the `elapsed < cooldown` check fails.
-        let path = std::env::temp_dir().join(format!(
-            "orchard-test-zero-cooldown-{}-{}",
-            std::process::id(),
-            line!()
-        ));
-        std::fs::write(&path, b"").unwrap();
-        let result = recently_attempted_restore_at(&path, Duration::from_secs(0));
-        let _ = std::fs::remove_file(&path);
-        assert!(!result, "zero cooldown must treat every sentinel as stale");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -214,11 +214,6 @@ impl App {
         let mut global_cfg = global_config::load_global_config();
         global_config::register_cwd_repo_if_new(&mut global_cfg);
 
-        // Best-effort restore of dead tmux sessions from the cache before the
-        // first build_state, so the TUI's first paint already reflects any
-        // just-reconstructed sessions. Failures are logged, never block startup.
-        let _ = crate::restore::restore_all_local();
-
         let task_rows = crate::build_state::build_task_rows(&global_cfg);
         let hosts = crate::cache::read_host_reachability();
         let state = crate::merge_remote::build_state_with_cached_snapshots(&global_cfg, &hosts);

--- a/crates/orchard/tests/ac4_no_restore_from_read_path.rs
+++ b/crates/orchard/tests/ac4_no_restore_from_read_path.rs
@@ -152,6 +152,13 @@ fn refresh_and_build_does_not_invoke_restore_session_for_dead_cached_session() {
 
     // 2. tmux session cache: one dead-but-restorable local session "ghost".
     write_ghost_session_cache(&cache_dir, &worktree_path);
+    let cache_file = cache_dir.join("tmux_sessions.json");
+    let cache_meta = std::fs::metadata(&cache_file)
+        .expect("precondition: cache file must exist after write_ghost_session_cache");
+    assert!(
+        cache_meta.len() > 0,
+        "precondition: cache file must be non-empty (else marker absence proves nothing)"
+    );
 
     // 3. A minimal git repo so orchard-tui doesn't complain about cwd.
     let repo = common::TestRepo::new();

--- a/crates/orchard/tests/ac4_no_restore_from_read_path.rs
+++ b/crates/orchard/tests/ac4_no_restore_from_read_path.rs
@@ -1,0 +1,207 @@
+//! AC 4 — Regression test: `refresh_and_build` (and `--json` mode) must NOT
+//! invoke `restore_session` for cached dead-but-restorable sessions.
+//!
+//! Feature file: specs/features/restore-explicit-subcommand.feature
+//!   Scenario: "refresh_and_build does not invoke restore_session for cached dead entries"
+//!
+//! # Why subprocess, not in-process
+//!
+//! `restore_all_local` is guarded by a process-global `OnceLock<()>` called
+//! `RESTORE_RAN`. Once set, it short-circuits all subsequent calls in the same
+//! process. Running the assertion in a subprocess gives us:
+//!   - A fresh `RESTORE_RAN` state every time.
+//!   - No cross-test contamination from the OnceLock.
+//!   - A clean filesystem (HOME redirected to a tempdir).
+//!
+//! After AC 6 removes `RESTORE_RAN`, the subprocess approach is still correct
+//! because it exercises the binary exactly as a real user would.
+//!
+//! # Mechanism
+//!
+//! 1. Write a `tmux_sessions.json` cache entry for session "ghost" whose
+//!    worktree path exists on disk but which is NOT in the live tmux server.
+//! 2. Place a fake `tmux` binary first on PATH that:
+//!    - Returns an empty session list for `list-sessions` (tmux is up, no sessions).
+//!    - Returns empty output for `list-panes` (used by `refresh_local`).
+//!    - Writes a marker file and exits 0 for `new-session` (so we can detect
+//!      whether `restore_session` was ever called).
+//! 3. Run `orchard-tui --json` with the fake tmux on PATH.
+//! 4. Assert the marker file was NOT written.
+//!    - On current code: `refresh_and_build` calls `restore_all_local()`, which
+//!      finds "ghost" dead+restorable and calls `tmux new-session` → marker written
+//!      → assertion fails → test fails (the desired FAIL-on-main behaviour).
+//!    - After the fix (remove read-path calls): no restore → no marker → test passes.
+
+mod common;
+
+use assert_cmd::Command;
+use orchard::cache::{CachedTmuxSession, tmux_cache_path, write_cache};
+use std::os::unix::fs::PermissionsExt;
+use tempfile::TempDir;
+
+/// Creates a fake `tmux` shell script inside `bin_dir` that:
+/// - `list-sessions` (any flags) → exits 0, prints nothing.
+/// - `list-panes` (any flags)   → exits 0, prints nothing.
+/// - `new-session` (any flags)  → writes `<marker_path>` and exits 0.
+/// - anything else              → exits 0, prints nothing.
+///
+/// The caller must prepend `bin_dir` to PATH before running the binary under test.
+fn write_fake_tmux(bin_dir: &std::path::Path, marker_path: &std::path::Path) {
+    let script = format!(
+        r#"#!/bin/sh
+# Fake tmux for AC-4 regression test.
+# Detects the first positional subcommand and acts accordingly.
+subcommand="$1"
+case "$subcommand" in
+  new-session)
+    # Record that restore_session called us.
+    touch '{marker}'
+    exit 0
+    ;;
+  list-sessions|list-panes|list-windows|kill-session|has-session|select-window|select-pane|rename-window|split-window|new-window|send-keys|select-layout|capture-pane)
+    # All other session-management commands: succeed silently.
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+"#,
+        marker = marker_path.display()
+    );
+
+    let tmux_path = bin_dir.join("tmux");
+    std::fs::write(&tmux_path, script).expect("write fake tmux script");
+    std::fs::set_permissions(&tmux_path, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod +x fake tmux");
+}
+
+/// Writes a `CachedTmuxSession` for a local (no host) session named "ghost"
+/// whose working directory is `worktree_path`.
+///
+/// This session is "dead but restorable": it is not in `list-sessions` output
+/// (because our fake tmux returns nothing) but its path exists on disk.
+fn write_ghost_session_cache(cache_dir: &std::path::Path, worktree_path: &std::path::Path) {
+    // The cache file lives at the standard path relative to `cache_dir`.
+    // `tmux_cache_path(None)` gives us the global filename we need.
+    let global = tmux_cache_path(None);
+    let filename = global.file_name().expect("tmux cache path has filename");
+    let cache_file = cache_dir.join(filename);
+
+    let ghost = CachedTmuxSession {
+        name: "ghost".to_string(),
+        path: worktree_path.to_string_lossy().into_owned(),
+        host: None, // local session — eligible for restore_all_local
+        pane_targets: vec!["0.0".to_string()],
+        pane_titles: vec![],
+        pane_commands: vec!["bash".to_string()],
+        window_names: vec!["main".to_string()],
+        window_active: vec!["1".to_string()],
+        window_layouts: vec![],
+        pane_paths: vec![],
+        pane_active: vec!["1".to_string()],
+        created_at: None,
+        last_activity_at: None,
+        last_output_lines: vec![],
+        claude_state_raw: None,
+    };
+
+    write_cache(&cache_file, &[ghost]).expect("write ghost session cache");
+}
+
+// ---------------------------------------------------------------------------
+// The regression test
+// ---------------------------------------------------------------------------
+
+/// AC 4: `orchard-tui --json` (which calls `refresh_and_build`) must NOT
+/// invoke `restore_session` for a cached dead-but-restorable local session.
+///
+/// This test FAILS on main (where `build_state.rs` calls `restore_all_local`)
+/// and PASSES once that call is removed (AC 1 fix).
+///
+/// Design invariants:
+/// - Deterministic: no real tmux server needed; fake tmux is deterministic.
+/// - No flakes: the marker file is either written (restore happened) or absent.
+/// - Subprocess: avoids the process-global `RESTORE_RAN` OnceLock contaminating
+///   other tests in this suite.
+#[test]
+fn refresh_and_build_does_not_invoke_restore_session_for_dead_cached_session() {
+    // -----------------------------------------------------------------------
+    // Set up temp dirs
+    // -----------------------------------------------------------------------
+    let tmp = TempDir::new().expect("create root temp dir");
+
+    // HOME for the subprocess — cache lives at <home>/.cache/orchard/.
+    let home_dir = tmp.path().join("home");
+    std::fs::create_dir_all(&home_dir).expect("create home dir");
+
+    let cache_dir = home_dir.join(".cache").join("orchard");
+    std::fs::create_dir_all(&cache_dir).expect("create cache dir");
+
+    // A fake worktree path that EXISTS on disk (so worktree_exists_default returns true).
+    let worktree_path = tmp.path().join("ghost-worktree");
+    std::fs::create_dir_all(&worktree_path).expect("create ghost worktree dir");
+
+    // Where the fake tmux will drop its marker if new-session is called.
+    let marker_path = tmp.path().join("new-session-called.marker");
+
+    // Directory holding the fake tmux binary.
+    let fake_bin_dir = tmp.path().join("fake-bin");
+    std::fs::create_dir_all(&fake_bin_dir).expect("create fake bin dir");
+
+    // -----------------------------------------------------------------------
+    // Write fixtures
+    // -----------------------------------------------------------------------
+
+    // 1. Fake tmux binary: records new-session calls via the marker file.
+    write_fake_tmux(&fake_bin_dir, &marker_path);
+
+    // 2. tmux session cache: one dead-but-restorable local session "ghost".
+    write_ghost_session_cache(&cache_dir, &worktree_path);
+
+    // 3. A minimal git repo so orchard-tui doesn't complain about cwd.
+    let repo = common::TestRepo::new();
+
+    // -----------------------------------------------------------------------
+    // Build a PATH that puts our fake tmux before the real one
+    // -----------------------------------------------------------------------
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{}:{original_path}", fake_bin_dir.display());
+
+    // -----------------------------------------------------------------------
+    // Run the binary under test
+    // -----------------------------------------------------------------------
+    // `orchard-tui --json` exercises exactly the `refresh_and_build` path.
+    // We redirect HOME so the binary reads from our controlled cache directory.
+    // We unset TMUX so the binary does not enter popup/session-attach paths.
+    let _output = Command::cargo_bin("orchard-tui")
+        .expect("orchard-tui binary must be available")
+        .arg("--json")
+        .current_dir(repo.path())
+        .env("HOME", &home_dir)
+        .env("PATH", &patched_path)
+        .env_remove("TMUX")
+        // Ensure GH CLI calls fail gracefully rather than hanging on auth.
+        .env("GH_TOKEN", "test-token-invalid")
+        .timeout(std::time::Duration::from_secs(30))
+        .output()
+        .expect("orchard-tui --json must not hang");
+
+    // -----------------------------------------------------------------------
+    // Assert: the fake tmux's `new-session` must NOT have been called
+    // -----------------------------------------------------------------------
+    // On current main: restore_all_local() is called from refresh_and_build_with_walker_config
+    // (build_state.rs:344). It finds "ghost" dead+restorable → calls tmux new-session
+    // → the fake tmux writes the marker → this assertion fails (test fails on main ✓).
+    //
+    // After the AC-1 fix (remove restore_all_local from build_state.rs):
+    // No restore is invoked → marker file absent → assertion passes (test passes ✓).
+    assert!(
+        !marker_path.exists(),
+        "restore_session must not be called from the read path (--json / refresh_and_build).\n\
+         The fake tmux's `new-session` was invoked, which means restore_all_local() ran \
+         from inside refresh_and_build. Remove the restore_all_local() call at \
+         crates/orchard/src/build_state.rs and crates/orchard/src/tui/mod.rs \
+         (issue #460 AC 1) to fix this."
+    );
+}

--- a/crates/orchard/tests/ac4_no_restore_from_read_path.rs
+++ b/crates/orchard/tests/ac4_no_restore_from_read_path.rs
@@ -6,15 +6,9 @@
 //!
 //! # Why subprocess, not in-process
 //!
-//! `restore_all_local` is guarded by a process-global `OnceLock<()>` called
-//! `RESTORE_RAN`. Once set, it short-circuits all subsequent calls in the same
-//! process. Running the assertion in a subprocess gives us:
-//!   - A fresh `RESTORE_RAN` state every time.
-//!   - No cross-test contamination from the OnceLock.
-//!   - A clean filesystem (HOME redirected to a tempdir).
-//!
-//! After AC 6 removes `RESTORE_RAN`, the subprocess approach is still correct
-//! because it exercises the binary exactly as a real user would.
+//! Running the assertion in a subprocess exercises the binary exactly as a
+//! real user would: HOME redirected to a tempdir, fake tmux on PATH, and a
+//! pristine cache file. No risk of in-process state leaking between tests.
 //!
 //! # Mechanism
 //!
@@ -122,8 +116,8 @@ fn write_ghost_session_cache(cache_dir: &std::path::Path, worktree_path: &std::p
 /// Design invariants:
 /// - Deterministic: no real tmux server needed; fake tmux is deterministic.
 /// - No flakes: the marker file is either written (restore happened) or absent.
-/// - Subprocess: avoids the process-global `RESTORE_RAN` OnceLock contaminating
-///   other tests in this suite.
+/// - Subprocess: exercises the binary like a real user, with HOME and PATH
+///   redirected to test fixtures.
 #[test]
 fn refresh_and_build_does_not_invoke_restore_session_for_dead_cached_session() {
     // -----------------------------------------------------------------------

--- a/specs/features/restore-explicit-subcommand.feature
+++ b/specs/features/restore-explicit-subcommand.feature
@@ -1,0 +1,138 @@
+Feature: Restore is an explicit subcommand, not a read-path side effect (#460)
+
+  As a developer who deliberately kills tmux sessions
+  I want orchard reads (--json, TUI, daemon poll) to never resurrect them
+  So that killed means killed, and restore happens only when I ask for it.
+
+  Background:
+    Given the session manifest at ~/.cache/orchard/session_manifest.json contains
+      a dead-but-restorable cached session named "ghost"
+    And tmux list-sessions does not include "ghost"
+    And the worktree path for "ghost" still exists on disk
+
+  # AC 1 — No restore from read paths
+  @unit
+  Scenario: Static check — restore_all_local is not called from read paths
+    Given the orchard source tree
+    When I grep for "restore_all_local(" under crates/orchard/src
+    Then the only matches are inside crates/orchard/src/restore.rs
+      and the new restore subcommand handler
+    And neither crates/orchard/src/build_state.rs
+      nor crates/orchard/src/tui/mod.rs contains a call to restore_all_local
+
+  # AC 2 — Explicit subcommand exists and reports
+  @e2e
+  Scenario: orchard-tui restore invokes restore_all_local once and prints a report
+    Given the manifest contains "ghost" and "phantom"
+    And tmux list-sessions does not include either
+    When I run "orchard-tui restore"
+    Then restore_all_local is invoked exactly once
+    And stdout contains a human-readable per-session line for "ghost"
+      classified as Restored, Skipped(<reason>), or Failed(<step>)
+    And stdout contains the same shape of line for "phantom"
+    And the exit code is 0 on partial success
+    And the exit code is non-zero only when classification or IO setup fails
+
+  @integration
+  Scenario: orchard restore (dispatcher shortcut) routes to orchard-tui restore
+    Given the orchard-dispatcher binary is built
+    When I run "orchard restore"
+    Then orchard-tui restore is exec'd by the dispatcher
+    And the same RestoreReport summary is printed
+
+  # AC 3 — Killed sessions stay killed across every read path
+  @e2e
+  Scenario Outline: Read paths never resurrect killed sessions
+    Given tmux kill-session -t "ghost" was just run
+    When I run "<read_command>"
+    Then "ghost" is not present in tmux list-sessions afterwards
+    And restore_session was not invoked
+
+    Examples:
+      | read_command          |
+      | orchard-tui --json    |
+      | orchard-tui refresh   |
+      | orchard-tui           |
+
+  @integration
+  Scenario: The watch daemon poll loop does not resurrect killed sessions
+    Given tmux kill-session -t "ghost" was just run
+    And the watch daemon is running
+    When the daemon's next poll cycle completes
+    Then "ghost" is not present in tmux list-sessions
+    And restore_session was not invoked by the daemon
+
+  @e2e
+  Scenario: Explicit restore brings the session back
+    Given tmux kill-session -t "ghost" was just run
+    And several read commands have run since (none resurrected it)
+    When I run "orchard restore"
+    Then "ghost" is present in tmux list-sessions
+    And the report classifies "ghost" as Restored
+
+  # AC 4 — Regression test
+  @integration
+  Scenario: refresh_and_build does not invoke restore_session for cached dead entries
+    Given the manifest contains a dead-but-restorable session
+    And a tmux spy (or behavioural counter) records calls to restore_session
+    When refresh_and_build is invoked
+    Then the spy reports zero calls to restore_session
+    And the test fails on main (where the read-path call still exists)
+      and passes on this branch
+
+  # AC 5 — Capture semantics unchanged
+  @integration
+  Scenario: tmux::refresh_local still writes session_manifest.json on session create
+    Given session_manifest.json is empty
+    When a new tmux session "fresh" is created
+    And tmux::refresh_local runs
+    Then session_manifest.json contains an entry for "fresh"
+    And no other manifest-writer behaviour has changed
+
+  @unit
+  Scenario: Manifest writers continue to record session metadata
+    Given a freshly captured TmuxSessionInfo
+    When the manifest is written
+    Then window layouts, pane working dirs, and pane active flags are persisted
+      as before this change
+
+  # AC 6 — Cooldown sentinel removed or repurposed
+  @unit
+  Scenario: Cooldown defenses are removed once read-path call storm is gone
+    Given the restore module no longer needs to defend against per-read calls
+    When I grep crates/orchard/src/restore.rs
+    Then RESTORE_COOLDOWN, RESTORE_RAN, recently_attempted_restore_at,
+      record_restore_attempt, and sentinel_path are absent
+    And no code references the ~/.cache/orchard/restore_last_run sentinel file
+
+  @unit
+  Scenario: Two back-to-back explicit restores both run (no in-process guard)
+    Given restore_all_local() has already been invoked once in this process
+    When restore_all_local() is invoked again from the subcommand handler
+    Then it executes the classifier and (where applicable) restore_session again
+    And it does not short-circuit to an empty RestoreReport on the basis
+      of having "already run"
+
+  Out of scope:
+    - Manifest expiry / hygiene (option 2 from issue body)
+    - A restore_on_read config flag (option 3 from issue body)
+    - Remote session restore (SkipReason::RemoteNotSupported is unchanged)
+    - Changing capture semantics (when/how session_manifest.json is written)
+    - TUI key binding for restore (subcommand-only for v1)
+
+# --- AC Coverage Map ---
+# AC 1 "No restore from read paths" → Scenario: Static check — restore_all_local is not called from read paths
+# AC 2 "orchard-tui restore subcommand prints RestoreReport summary" → Scenarios:
+#   - orchard-tui restore invokes restore_all_local once and prints a report
+#   - orchard restore (dispatcher shortcut) routes to orchard-tui restore
+# AC 3 "Killed sessions stay killed across --json, refresh, daemon, fresh TUI; reappear only after explicit restore" → Scenarios:
+#   - Read paths never resurrect killed sessions (Outline: --json, refresh, TUI cold start)
+#   - The watch daemon poll loop does not resurrect killed sessions
+#   - Explicit restore brings the session back
+# AC 4 "Regression test: read path does not invoke restore_session" → Scenario: refresh_and_build does not invoke restore_session for cached dead entries
+# AC 5 "Capture path unchanged — tmux::refresh_local still writes session_manifest.json" → Scenarios:
+#   - tmux::refresh_local still writes session_manifest.json on session create
+#   - Manifest writers continue to record session metadata
+# AC 6 "Cooldown sentinel removed or repurposed" → Scenarios:
+#   - Cooldown defenses are removed once read-path call storm is gone
+#   - Two back-to-back explicit restores both run (no in-process guard)

--- a/specs/features/session-restore-reconstruct-tmux.feature
+++ b/specs/features/session-restore-reconstruct-tmux.feature
@@ -46,18 +46,11 @@ Feature: Session restore — reconstruct tmux geometry + cwds (#190)
     And tmux list-panes reports 2 panes
     And each pane's current path matches its saved cwd
 
-  @unit
-  Scenario: Startup restore runs at most once per process
-    Given restore_all_local() has already run in this process
-    When restore_all_local() is called again
-    Then an empty RestoreReport is returned
-
-  @unit
-  Scenario: Startup restore respects a cross-process cooldown
-    Given the restore-sentinel file was touched under the cooldown
-    When restore_all_local() is called in a fresh process
-    Then an empty RestoreReport is returned
-    And no tmux subprocess is spawned
+  # NOTE: Issue #460 removed the OnceLock + cross-process cooldown that
+  # used to short-circuit repeated calls to restore_all_local. The user is
+  # now the only trigger (`orchard restore` subcommand), so per-process and
+  # per-cooldown short-circuits are no longer needed. See
+  # specs/features/restore-explicit-subcommand.feature for current contract.
 
   @unit
   Scenario: live_local_session_names returns None on tmux error
@@ -94,5 +87,6 @@ Feature: Session restore — reconstruct tmux geometry + cwds (#190)
     - Persisting Claude session IDs in the cache (the hook files in $TMPDIR
       remain the live source of truth for telemetry)
     - Shell history replay
-    - An explicit `orchard restore` CLI subcommand (restore is automatic)
     - TUI "restored" indicator (dropped — user verifies via the session list itself)
+    # Restore is now invoked explicitly via `orchard restore` (see #460);
+    # the v1 "automatic on startup" model was reversed.


### PR DESCRIPTION
## Summary

Closes #460. Restore is no longer a side effect of every orchard read.

- Drops `restore::restore_all_local()` calls from `build_state.rs` and `tui/mod.rs`
- Adds explicit `orchard-tui restore` subcommand (and `orchard restore` dispatcher shortcut)
- Removes the cooldown ceremony that defended against the now-removed call storm

## Test plan

- [x] Regression test: `crates/orchard/tests/ac4_no_restore_from_read_path.rs` (fails on main, passes here)
- [ ] AC 1: grep confirms no `restore_all_local(` calls in build_state.rs or tui/mod.rs
- [ ] AC 2: `orchard-tui restore` prints RestoreReport summary; `orchard restore` routes via dispatcher
- [ ] AC 3: kill session → `orchard-tui --json` → session stays gone
- [ ] AC 5: `tmux::refresh_local` still writes session_manifest.json
- [ ] AC 6: cooldown infrastructure removed (RESTORE_COOLDOWN, RESTORE_RAN, sentinel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #460

# Related issue

- #460

# Related issue

- #460

# Related issue

- #460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit `orchard restore` subcommand with per-session status reporting for restore operations.

* **Bug Fixes**
  * Read-path operations (`--json`, `refresh`) no longer automatically restore dead sessions.
  * Removed automatic session restoration on startup; restoration now requires explicit user invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #460