### PR TITLE
fix(federation): federate Host.processes per peer (#465)

### DIFF
--- a/internal/server/providers/peerproxy/peerproxy_e2e_test.go
+++ b/internal/server/providers/peerproxy/peerproxy_e2e_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/drewdrewthis/git-orchard-rs/internal/server"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 )
 
 const remoteName = "remote-host"
@@ -44,9 +45,22 @@ type orchardFixture struct {
 
 // fixtureOpts tunes startOrchard for TLS variants and TLS-config
 // injection. Plain federation tests use the zero value.
+//
+// psHostID, when non-empty, wires a real ps provider to the daemon
+// using the given host id. Federation tests for `Host.processes` use
+// this to give each daemon a distinct host namespace so id prefixes
+// can be asserted on across the federation boundary (#465).
+//
+// psRunner, when non-nil, replaces the real shellout with a stub. The
+// federation test uses this to give each daemon a deterministic and
+// distinct process table — without it both daemons would shell out to
+// the same OS `ps`, making "did the data come from the local or peer
+// daemon?" unverifiable.
 type fixtureOpts struct {
 	tlsServer bool
 	tlsConfig *tls.Config
+	psHostID  string
+	psRunner  ps.CommandRunner
 }
 
 // startOrchard boots an orchard daemon attached to httptest. fedCfg is
@@ -66,10 +80,20 @@ func startOrchardOpts(t *testing.T, fedCfg peerproxy.FederationConfig, opts fixt
 	peerProvider := peerproxy.NewProvider(fedCfg, logger, provOpts...)
 	localEvents := peerproxy.NewLocalInvalidator()
 
-	srv := server.New("", logger,
+	serverOpts := []server.Option{
 		server.WithPeerProxy(peerProvider),
 		server.WithLocalEvents(localEvents),
-	)
+	}
+	var psProv *ps.Provider
+	if opts.psHostID != "" {
+		adapter := ps.NewAdapter(opts.psHostID).WithPollInterval(time.Hour)
+		if opts.psRunner != nil {
+			adapter = adapter.WithRunner(opts.psRunner)
+		}
+		psProv = ps.New(adapter, logger)
+		serverOpts = append(serverOpts, server.WithPS(psProv))
+	}
+	srv := server.New("", logger, serverOpts...)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -78,6 +102,12 @@ func startOrchardOpts(t *testing.T, fedCfg peerproxy.FederationConfig, opts fixt
 		t.Fatalf("start peerproxy: %v", err)
 	}
 	t.Cleanup(func() { _ = peerProvider.Stop() })
+
+	if psProv != nil {
+		if err := psProv.Start(ctx); err != nil {
+			t.Fatalf("start ps provider: %v", err)
+		}
+	}
 
 	if err := srv.StartHostProvider(ctx); err != nil {
 		t.Fatalf("start host provider: %v", err)
@@ -515,6 +545,197 @@ func TestPeers_TLS_WSSHandshake(t *testing.T) {
 	}) {
 		t.Fatalf("expected ≥1 upstream WSS subscription on remote, saw %d",
 			remote.events.SubscriberCount())
+	}
+}
+
+// fixedPsRunner returns a CommandRunner whose `ps -ax -o pid,...`
+// output is deterministic and tagged with `tag` in the COMMAND column.
+// Lets the federation test prove that data on the wire actually came
+// from the remote daemon's table, not the local one.
+type fixedPsRunner struct {
+	tag string
+	pid int
+}
+
+func (r fixedPsRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	if name != "ps" {
+		return nil, fmt.Errorf("unexpected exec %q", name)
+	}
+	header := "  PID  PPID USER             TT  %CPU    RSS                 STARTED COMMAND\n"
+	row := fmt.Sprintf(" %4d     1 testuser         ??   0.0    100 Mon Jan  1 00:00:00 2024 %s\n", r.pid, r.tag)
+	return []byte(header + row), nil
+}
+
+// TestPeers_Processes_FederatedPerPeer is the load-bearing regression
+// test for #465: querying `host { peers { processes } }` on the local
+// daemon must return the *peer's* process table, not the local one.
+//
+// Setup: two daemons in the same process. Each runs a stub `ps` that
+// emits exactly one process whose COMMAND column is the daemon's tag —
+// "local-cmd" on the local, "remote-cmd" on the remote. Local is
+// configured with the remote as a peer.
+//
+// Assertion: `peers[0].processes[0].command == "remote-cmd"` AND
+// `peers[0].processes[0].id` carries the remote-host prefix. If the
+// federation glue regresses, the test sees "local-cmd" and fails — the
+// exact symptom the bug report describes.
+func TestPeers_Processes_FederatedPerPeer(t *testing.T) {
+	const localHostID = "local-mac"
+	remote := startOrchardOpts(t,
+		peerproxy.FederationConfig{},
+		fixtureOpts{
+			psHostID: remoteName,
+			psRunner: fixedPsRunner{tag: "remote-cmd", pid: 7777},
+		},
+	)
+	local := startOrchardOpts(t,
+		peerproxy.FederationConfig{
+			Peers: []peerproxy.PeerConfig{
+				{Name: remoteName, Address: remote.addr},
+			},
+		},
+		fixtureOpts{
+			psHostID: localHostID,
+			psRunner: fixedPsRunner{tag: "local-cmd", pid: 1111},
+		},
+	)
+
+	// Wait for the local supervisor to mark the remote reachable, then
+	// query peers[].processes. Without reachability the federate path
+	// short-circuits with an error.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		envelope := graphQLPost(t, local,
+			`{ host { peers { id reachable } } }`)
+		data, _ := envelope["data"].(map[string]any)
+		host, _ := data["host"].(map[string]any)
+		peers, _ := host["peers"].([]any)
+		if len(peers) == 1 {
+			peer := peers[0].(map[string]any)
+			if peer["reachable"] == true {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("peer never reachable; envelope=%v", envelope)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	envelope := graphQLPost(t, local,
+		`{ host { peers { id processes { id pid command } } } }`)
+	if errs, ok := envelope["errors"].([]any); ok && len(errs) > 0 {
+		t.Fatalf("graphql errors: %v", errs)
+	}
+	data, _ := envelope["data"].(map[string]any)
+	host, _ := data["host"].(map[string]any)
+	peers, _ := host["peers"].([]any)
+	if len(peers) != 1 {
+		t.Fatalf("expected exactly 1 peer, got %d (%v)", len(peers), peers)
+	}
+	peer := peers[0].(map[string]any)
+	if peer["id"] != "Host:"+remoteName {
+		t.Fatalf("unexpected peer id %v", peer["id"])
+	}
+	procs, _ := peer["processes"].([]any)
+	if len(procs) == 0 {
+		t.Fatalf("peer.processes empty; expected federated remote process table")
+	}
+	// Find the seeded remote-cmd row. Stub `ps` only emits one process,
+	// so any COMMAND other than "remote-cmd" means we got the local
+	// daemon's table — i.e. the bug regressed.
+	var seenRemote bool
+	for _, p := range procs {
+		row := p.(map[string]any)
+		cmd, _ := row["command"].(string)
+		id, _ := row["id"].(string)
+		if cmd == "local-cmd" {
+			t.Fatalf("FEDERATION REGRESSION: peer.processes contains local daemon's row %+v (#465)", row)
+		}
+		if cmd == "remote-cmd" {
+			seenRemote = true
+			// id is built remote-side as `<remoteHostID>:<pid>`. The
+			// federation glue MUST NOT rewrite it to the local prefix.
+			if id != remoteName+":7777" {
+				t.Fatalf("expected remote-prefixed id %q, got %q (federation rewrote the prefix)",
+					remoteName+":7777", id)
+			}
+		}
+	}
+	if !seenRemote {
+		t.Fatalf("peer.processes did not include the seeded remote-cmd row; got %v", procs)
+	}
+}
+
+// TestPeers_Processes_UnreachablePeer asserts the second half of #465:
+// when a peer is configured but not reachable, `peers[].processes` must
+// surface a typed error rather than silently returning the local
+// daemon's process table. The bug report explicitly calls out this
+// confidently-wrong shape for unreachable peers.
+func TestPeers_Processes_UnreachablePeer(t *testing.T) {
+	const localHostID = "local-mac"
+	const deadPeer = "fork-orchardist-punch"
+	local := startOrchardOpts(t,
+		peerproxy.FederationConfig{
+			Peers: []peerproxy.PeerConfig{
+				// Address points to a closed port so reachability stays false.
+				{Name: deadPeer, Address: "127.0.0.1:1"},
+			},
+		},
+		fixtureOpts{
+			psHostID: localHostID,
+			psRunner: fixedPsRunner{tag: "local-cmd", pid: 1111},
+		},
+	)
+
+	// Wait until the supervisor's first probe fails — reachable=false.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		envelope := graphQLPost(t, local,
+			`{ host { peers { reachable } } }`)
+		data, _ := envelope["data"].(map[string]any)
+		host, _ := data["host"].(map[string]any)
+		peers, _ := host["peers"].([]any)
+		if len(peers) == 1 {
+			peer := peers[0].(map[string]any)
+			// reachable can be reported as false (probe completed) or
+			// nil (probe pending). Either is fine — we just need it
+			// not-true.
+			if r, ok := peer["reachable"].(bool); ok && !r {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("peer reachability never resolved; envelope=%v", envelope)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	envelope := graphQLPost(t, local,
+		`{ host { peers { id processes { id command } } } }`)
+	// Either the field surfaces an error AND processes is null, OR the
+	// processes list is empty. Returning the local daemon's table is
+	// the regression — assert it never appears.
+	data, _ := envelope["data"].(map[string]any)
+	host, _ := data["host"].(map[string]any)
+	peers, _ := host["peers"].([]any)
+	if len(peers) == 1 {
+		peer := peers[0].(map[string]any)
+		if procs, ok := peer["processes"].([]any); ok {
+			for _, p := range procs {
+				row := p.(map[string]any)
+				if cmd, _ := row["command"].(string); cmd == "local-cmd" {
+					t.Fatalf("FEDERATION REGRESSION: unreachable peer returned local daemon's row %+v (#465)", row)
+				}
+			}
+		}
+	}
+	// Errors slice should mention the unreachable peer when present —
+	// this is the typed-error half of the AC. Silent success with []
+	// processes would mask the real failure mode.
+	errs, _ := envelope["errors"].([]any)
+	if len(errs) == 0 {
+		t.Fatalf("expected GraphQL errors for unreachable peer.processes; envelope=%v", envelope)
 	}
 }
 

--- a/internal/server/providers/peerproxy/provider.go
+++ b/internal/server/providers/peerproxy/provider.go
@@ -230,6 +230,25 @@ func (p *Provider) Get(ctx context.Context, id NodeID) (*PeerNode, error) {
 	return a.FetchNode(ctx, id)
 }
 
+// Query forwards an arbitrary GraphQL query to a configured peer and
+// returns the decoded result. Used by federation-aware resolvers (e.g.
+// `Host.processes`) that need richer shapes than the node-id forwarder
+// provides.
+//
+// Returns an error when the peer is not configured. The result's Errors
+// slice (if any) is left for the caller to inspect — peerproxy does not
+// translate GraphQL errors into Go errors here, since some callers want
+// to surface partial data.
+func (p *Provider) Query(ctx context.Context, peer string, query string, vars map[string]any) (QueryResult, error) {
+	p.mu.RLock()
+	c, ok := p.clients[peer]
+	p.mu.RUnlock()
+	if !ok {
+		return QueryResult{}, fmt.Errorf("unknown peer %q", peer)
+	}
+	return c.Query(ctx, query, vars)
+}
+
 // Subscribe returns a channel that emits InvalidationEvent for every
 // node any peer pushes. Closing ctx (or calling Stop) tears the
 // subscription down.

--- a/internal/server/resolvers/federate_peer_processes.go
+++ b/internal/server/resolvers/federate_peer_processes.go
@@ -1,0 +1,161 @@
+// Federation glue for `Host.processes` on a peer Host. Kept separate
+// from schema.resolvers.go so gqlgen does not rewrite it when the
+// schema regenerates.
+//
+// Without this layer, the `Host.processes` resolver in the gqlgen-
+// generated path always returns the local daemon's `ps` snapshot
+// regardless of which Host the field is being resolved on (#465).
+// That is the textbook "confidently wrong" failure mode: the call
+// succeeds, the data comes back, but it labels local PIDs as belonging
+// to a different host. Federating to the peer daemon over the existing
+// peerproxy transport is the smallest change that makes the answer
+// match reality.
+package resolvers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
+)
+
+// federatePeerProcesses forwards a `host.processes` selection to the
+// peer daemon identified by `obj`, then re-tags the returned process
+// ids with the peer's host so traversal (`process.host`,
+// `splitProcessNodeID`) keeps the peer namespace.
+//
+// Errors when the peer is unreachable or the proxy isn't wired —
+// callers see a typed error rather than a silently-empty list, which
+// would be indistinguishable from "this peer genuinely has no matching
+// processes."
+func federatePeerProcesses(ctx context.Context, r *hostResolver, obj *graphql1.Host, filter *graphql1.ProcessFilter) ([]*graphql1.Process, error) {
+	if r.PeerProxy == nil {
+		return nil, fmt.Errorf("peer proxy not wired; cannot resolve processes for peer %q", obj.Hostname)
+	}
+	peerName := peerNameFromHost(obj)
+	if peerName == "" {
+		return nil, fmt.Errorf("peer host has no name; cannot federate")
+	}
+	if !r.PeerProxy.HasPeer(peerName) {
+		return nil, fmt.Errorf("peer %q is not configured", peerName)
+	}
+	if reachable, _, ok := r.PeerProxy.Reachability(peerName); ok && !reachable {
+		return nil, fmt.Errorf("peer %q is unreachable", peerName)
+	}
+
+	const peerProcessesQuery = `query($filter: ProcessFilter) {
+  host {
+    processes(filter: $filter) {
+      id
+      pid
+      ppid
+      command
+      startedAt
+      cpuPercent
+      memBytes
+      tty
+    }
+  }
+}`
+	vars := map[string]any{}
+	if f := buildProcessFilterVars(filter); f != nil {
+		vars["filter"] = f
+	}
+	res, err := r.PeerProxy.Query(ctx, peerName, peerProcessesQuery, vars)
+	if err != nil {
+		return nil, fmt.Errorf("federate peer %q: %w", peerName, err)
+	}
+	if err := res.AsError(); err != nil {
+		return nil, fmt.Errorf("federate peer %q: %w", peerName, err)
+	}
+	return decodePeerProcesses(res, peerName)
+}
+
+// peerNameFromHost extracts the configured peer name from the Host obj.
+// `Host.peers` populates Hostname == MachineID == the peer config name
+// (see schema.resolvers.go::Peers); both are kept in sync. Falls back
+// to the id suffix when neither field is set, so synthetic Host nodes
+// constructed from a node-id (e.g. via `node(id:)`) still resolve.
+func peerNameFromHost(obj *graphql1.Host) string {
+	if obj == nil {
+		return ""
+	}
+	if obj.MachineID != "" {
+		return obj.MachineID
+	}
+	if obj.Hostname != "" {
+		return obj.Hostname
+	}
+	const prefix = "Host:"
+	if len(obj.ID) > len(prefix) && obj.ID[:len(prefix)] == prefix {
+		return obj.ID[len(prefix):]
+	}
+	return ""
+}
+
+// buildProcessFilterVars projects the resolver-side ProcessFilter into
+// the variable map the peer's GraphQL surface expects. Returns nil when
+// the filter is empty so we don't send an empty object the peer might
+// treat as "match nothing."
+func buildProcessFilterVars(f *graphql1.ProcessFilter) map[string]any {
+	if f == nil {
+		return nil
+	}
+	out := map[string]any{}
+	if len(f.PidIn) > 0 {
+		out["pidIn"] = f.PidIn
+	}
+	if len(f.CommandIn) > 0 {
+		out["commandIn"] = f.CommandIn
+	}
+	if f.CwdPrefix != nil {
+		out["cwdPrefix"] = *f.CwdPrefix
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// decodePeerProcesses converts the QueryResult body into a slice of
+// resolver-shaped Process pointers. The peer's process ids carry the
+// peer's host segment already (the peer formatted them with its own
+// PS.HostID()), so we don't rewrite them — but we DO normalise the
+// nested Host pointer so `process.host` resolves to the same peer.
+func decodePeerProcesses(res peerproxy.QueryResult, peerName string) ([]*graphql1.Process, error) {
+	var body struct {
+		Host struct {
+			Processes []struct {
+				ID         string  `json:"id"`
+				Pid        int64   `json:"pid"`
+				Ppid       int64   `json:"ppid"`
+				Command    string  `json:"command"`
+				StartedAt  string  `json:"startedAt"`
+				CPUPercent float64 `json:"cpuPercent"`
+				MemBytes   int64   `json:"memBytes"`
+				Tty        *string `json:"tty"`
+			} `json:"processes"`
+		} `json:"host"`
+	}
+	if err := json.Unmarshal(res.Data, &body); err != nil {
+		return nil, fmt.Errorf("decode peer %q processes: %w", peerName, err)
+	}
+	hostID := "Host:" + peerName
+	out := make([]*graphql1.Process, 0, len(body.Host.Processes))
+	for _, p := range body.Host.Processes {
+		out = append(out, &graphql1.Process{
+			ID:         p.ID,
+			Host:       &graphql1.Host{ID: hostID, MachineID: peerName, Hostname: peerName},
+			Pid:        p.Pid,
+			Ppid:       p.Ppid,
+			Command:    p.Command,
+			StartedAt:  p.StartedAt,
+			CPUPercent: p.CPUPercent,
+			MemBytes:   p.MemBytes,
+			Tty:        p.Tty,
+		})
+	}
+	return out, nil
+}

--- a/internal/server/resolvers/federate_peer_processes_test.go
+++ b/internal/server/resolvers/federate_peer_processes_test.go
@@ -1,0 +1,140 @@
+package resolvers
+
+import (
+	"encoding/json"
+	"testing"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
+)
+
+func TestPeerNameFromHost_PrefersMachineID(t *testing.T) {
+	got := peerNameFromHost(&graphql1.Host{ID: "Host:other", MachineID: "boxd-1", Hostname: "fallback"})
+	if got != "boxd-1" {
+		t.Fatalf("want boxd-1, got %q", got)
+	}
+}
+
+func TestPeerNameFromHost_FallsBackToHostname(t *testing.T) {
+	got := peerNameFromHost(&graphql1.Host{ID: "Host:other", Hostname: "via-hostname"})
+	if got != "via-hostname" {
+		t.Fatalf("want via-hostname, got %q", got)
+	}
+}
+
+func TestPeerNameFromHost_FallsBackToIDSuffix(t *testing.T) {
+	got := peerNameFromHost(&graphql1.Host{ID: "Host:via-id"})
+	if got != "via-id" {
+		t.Fatalf("want via-id, got %q", got)
+	}
+}
+
+func TestPeerNameFromHost_NilOrEmpty(t *testing.T) {
+	if got := peerNameFromHost(nil); got != "" {
+		t.Fatalf("nil host should return empty, got %q", got)
+	}
+	if got := peerNameFromHost(&graphql1.Host{}); got != "" {
+		t.Fatalf("empty host should return empty, got %q", got)
+	}
+}
+
+func TestBuildProcessFilterVars_Nil(t *testing.T) {
+	if got := buildProcessFilterVars(nil); got != nil {
+		t.Fatalf("nil filter should yield nil vars, got %v", got)
+	}
+}
+
+func TestBuildProcessFilterVars_Empty(t *testing.T) {
+	if got := buildProcessFilterVars(&graphql1.ProcessFilter{}); got != nil {
+		t.Fatalf("empty filter should yield nil vars (avoid sending {} to peer), got %v", got)
+	}
+}
+
+func TestBuildProcessFilterVars_All(t *testing.T) {
+	prefix := "/home/boxd/"
+	vars := buildProcessFilterVars(&graphql1.ProcessFilter{
+		PidIn:     []int64{1, 2, 3},
+		CommandIn: []string{"claude"},
+		CwdPrefix: &prefix,
+	})
+	if vars == nil {
+		t.Fatalf("non-empty filter should produce vars")
+	}
+	if pids, ok := vars["pidIn"].([]int64); !ok || len(pids) != 3 {
+		t.Fatalf("pidIn missing or wrong: %v", vars["pidIn"])
+	}
+	if cmds, ok := vars["commandIn"].([]string); !ok || len(cmds) != 1 {
+		t.Fatalf("commandIn missing or wrong: %v", vars["commandIn"])
+	}
+	if cwd, ok := vars["cwdPrefix"].(string); !ok || cwd != prefix {
+		t.Fatalf("cwdPrefix missing or wrong: %v", vars["cwdPrefix"])
+	}
+}
+
+func TestDecodePeerProcesses_Shape(t *testing.T) {
+	raw := json.RawMessage(`{
+        "host": {
+            "processes": [
+                {
+                    "id": "boxd-vm:1234",
+                    "pid": 1234,
+                    "ppid": 1,
+                    "command": "claude",
+                    "startedAt": "2026-05-07T15:00:00Z",
+                    "cpuPercent": 1.5,
+                    "memBytes": 10485760,
+                    "tty": "ttys000"
+                },
+                {
+                    "id": "boxd-vm:5678",
+                    "pid": 5678,
+                    "ppid": 1234,
+                    "command": "node",
+                    "startedAt": "2026-05-07T15:01:00Z",
+                    "cpuPercent": 0.2,
+                    "memBytes": 5242880,
+                    "tty": null
+                }
+            ]
+        }
+    }`)
+	got, err := decodePeerProcesses(peerproxy.QueryResult{Data: raw}, "boxd-vm")
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 processes, got %d", len(got))
+	}
+	for _, p := range got {
+		if p.Host == nil {
+			t.Fatalf("process %d missing host pointer", p.Pid)
+		}
+		if p.Host.ID != "Host:boxd-vm" || p.Host.MachineID != "boxd-vm" {
+			t.Fatalf("process %d host wrong: %+v", p.Pid, p.Host)
+		}
+	}
+	if got[0].Tty == nil || *got[0].Tty != "ttys000" {
+		t.Fatalf("first process tty should be ttys000, got %v", got[0].Tty)
+	}
+	if got[1].Tty != nil {
+		t.Fatalf("second process tty should be nil (json null), got %v", *got[1].Tty)
+	}
+}
+
+func TestDecodePeerProcesses_EmptyList(t *testing.T) {
+	raw := json.RawMessage(`{"host":{"processes":[]}}`)
+	got, err := decodePeerProcesses(peerproxy.QueryResult{Data: raw}, "boxd-vm")
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want empty slice, got %d", len(got))
+	}
+}
+
+func TestDecodePeerProcesses_BadJSON(t *testing.T) {
+	raw := json.RawMessage(`{"this":"is not the right shape"`)
+	if _, err := decodePeerProcesses(peerproxy.QueryResult{Data: raw}, "x"); err == nil {
+		t.Fatal("malformed json should surface a decode error")
+	}
+}

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -54,18 +54,27 @@ func (r *hostResolver) Peers(ctx context.Context, obj *graphql1.Host) ([]*graphq
 }
 
 // Processes is the resolver for the host.processes field.
+//
+// For the local host the resolver consults the in-process `ps` provider.
+// For a peer Host (returned via `host.peers`) the resolver federates the
+// query to the peer's daemon over the peerproxy transport — without
+// federation, the local `ps` snapshot would be returned for every peer
+// (#465: confidently-wrong is the worst error mode).
 func (r *hostResolver) Processes(ctx context.Context, obj *graphql1.Host, filter *graphql1.ProcessFilter) ([]*graphql1.Process, error) {
-	if r.PS == nil {
-		return nil, fmt.Errorf("ps provider not wired")
+	if isLocalHostNode(r, obj) {
+		if r.PS == nil {
+			return nil, fmt.Errorf("ps provider not wired")
+		}
+		all := r.PS.List()
+		filtered := applyProcessFilter(ctx, r.PS, all, filter)
+		hostID := r.PS.HostID()
+		out := make([]*graphql1.Process, 0, len(filtered))
+		for i := range filtered {
+			out = append(out, projectProcess(&filtered[i], hostID))
+		}
+		return out, nil
 	}
-	all := r.PS.List()
-	filtered := applyProcessFilter(ctx, r.PS, all, filter)
-	hostID := r.PS.HostID()
-	out := make([]*graphql1.Process, 0, len(filtered))
-	for i := range filtered {
-		out = append(out, projectProcess(&filtered[i], hostID))
-	}
-	return out, nil
+	return federatePeerProcesses(ctx, r, obj, filter)
 }
 
 // Host is the resolver for the process.host field.

--- a/specs/features/federation-peer-processes.feature
+++ b/specs/features/federation-peer-processes.feature
@@ -1,0 +1,133 @@
+Feature: Federation — `Host.processes` returns the peer's process table, not the local one (#465)
+  As an orchardist querying `peers { processes }` to see "which Claude session is on which host"
+  I want each peer's processes field to return that peer's actual process list
+  And I want unreachable peers to surface a typed error rather than silent local data
+  So that federation answers match reality and confidently-wrong responses cannot mislead a decision
+
+  # Scope: federates `Host.processes` only. Other Host.* subfields
+  # (tmuxSessions, claudeInstances, hostServices, ...) are tracked
+  # separately and will reuse the new `peerproxy.Provider.Query` transport.
+
+  Background:
+    Given `internal/server/providers/peerproxy/provider.go` exposes a generic
+      `Provider.Query(ctx, peer, query, vars) (QueryResult, error)` forwarder
+    And the local `hostResolver` knows how to identify a local-vs-peer Host via `isLocalHostNode`
+    And the federation glue lives in `internal/server/resolvers/federate_peer_processes.go`
+      so `gqlgen generate` does not rewrite it
+
+  # =======================================================================
+  # AC1 — Reachable peer returns peer-tagged process table
+  # =======================================================================
+
+  @e2e @issue-465
+  Scenario: Querying `peers[].processes` against a reachable peer returns the peer's data
+    Given a "remote" daemon with hostID "remote-host" and ps stub emitting one row tagged "remote-cmd" (pid 7777)
+    And a "local" daemon with hostID "local-mac" and ps stub emitting one row tagged "local-cmd" (pid 1111)
+    And the local daemon is configured with the remote as a peer
+    And the local supervisor's reachability probe has succeeded
+    When I query `{ host { peers { id processes { id pid command } } } }` against the local daemon
+    Then `peers[0].id` equals "Host:remote-host"
+    And `peers[0].processes` contains a row whose command is "remote-cmd"
+    And that row's `id` equals "remote-host:7777" (peer-prefixed, not local)
+    And `peers[0].processes` does NOT contain any row whose command is "local-cmd"
+
+  # =======================================================================
+  # AC2 — Unreachable peer surfaces a typed error (no silent local data)
+  # =======================================================================
+
+  @e2e @issue-465
+  Scenario: Querying `peers[].processes` against an unreachable peer surfaces an error
+    Given a "local" daemon with hostID "local-mac" and ps stub emitting "local-cmd" (pid 1111)
+    And the local daemon is configured with peer "fork-orchardist-punch" pointing at a closed port
+    And the local supervisor has marked that peer unreachable
+    When I query `{ host { peers { processes { command } } } }` against the local daemon
+    Then the GraphQL response includes an `errors` array mentioning the unreachable peer
+    And `peers[0].processes` does NOT contain any row whose command is "local-cmd"
+    And the local daemon's process table is NEVER returned in place of the peer's
+
+  # =======================================================================
+  # AC3 — Local host path is unchanged
+  # =======================================================================
+
+  @e2e @regression
+  Scenario: Querying `host { processes }` on the local host still consults the local ps provider
+    Given a daemon with hostID "local-mac" and a ps stub emitting "local-cmd" (pid 1111)
+    When I query `{ host { processes { command } } }` against that daemon
+    Then the response contains a row whose command is "local-cmd"
+    And no peerproxy.Query call was issued (single-host flow stays local)
+
+  # =======================================================================
+  # AC4 — Process filter is forwarded to the peer
+  # =======================================================================
+
+  @unit @issue-465
+  Scenario Outline: ProcessFilter projects to peer variables only when populated
+    Given a `ProcessFilter` with <fields>
+    When `buildProcessFilterVars` projects the filter
+    Then the returned variable map equals <expectedVars>
+
+    Examples:
+      | fields                                                       | expectedVars                                                |
+      | nil                                                          | nil                                                         |
+      | empty struct                                                 | nil (avoids sending {} which the peer might treat as match-nothing) |
+      | pidIn=[1,2,3]                                                | {pidIn:[1,2,3]}                                             |
+      | commandIn=["claude"]                                         | {commandIn:["claude"]}                                      |
+      | cwdPrefix="/home/boxd/"                                      | {cwdPrefix:"/home/boxd/"}                                   |
+      | pidIn=[1,2,3] commandIn=["claude"] cwdPrefix="/home/boxd/"   | {pidIn:[...], commandIn:[...], cwdPrefix:"/home/boxd/"}     |
+
+  # =======================================================================
+  # AC5 — `process.host` resolves to the peer
+  # =======================================================================
+
+  @unit @issue-465
+  Scenario: Decoded peer processes carry the peer's host pointer
+    Given a peer named "boxd-vm" returned a `host.processes` body with two rows
+    When `decodePeerProcesses` projects the response
+    Then every returned `Process.Host.ID` equals "Host:boxd-vm"
+    And every returned `Process.Host.MachineID` equals "boxd-vm"
+    And every returned `Process.Host.Hostname` equals "boxd-vm"
+
+  # =======================================================================
+  # AC6 — Peerproxy transport extension
+  # =======================================================================
+
+  @unit @issue-465
+  Scenario: peerproxy.Provider.Query forwards arbitrary GraphQL to a configured peer
+    Given a peerproxy.Provider with peer "remote-host" configured
+    When the resolver calls `Provider.Query(ctx, "remote-host", query, vars)`
+    Then the call returns the decoded `QueryResult` from the peer
+    And `Provider.Get` is unchanged (still a node-id forwarder)
+
+  @unit @issue-465
+  Scenario: peerproxy.Provider.Query rejects unknown peers
+    Given a peerproxy.Provider with no peer named "ghost"
+    When the resolver calls `Provider.Query(ctx, "ghost", query, vars)`
+    Then it returns an error mentioning the unknown peer
+
+  # =======================================================================
+  # AC7 — gqlgen-safe layout
+  # =======================================================================
+
+  @structural @issue-465
+  Scenario: Federation glue lives outside gqlgen-generated files
+    Given `internal/server/resolvers/schema.resolvers.go` is regenerated from the schema
+    Then `federate_peer_processes.go` is NOT regenerated and retains its hand-written content
+    And `peer_helpers.go` is NOT regenerated and retains `isLocalHostNode`
+
+  # =======================================================================
+  # AC8 — Peer name derivation is robust to Host shape variations
+  # =======================================================================
+
+  @unit @issue-465
+  Scenario Outline: peerNameFromHost picks the right field by precedence
+    Given a `Host` shaped <input>
+    When `peerNameFromHost` is called
+    Then it returns <expectedName>
+
+    Examples:
+      | input                                                          | expectedName     |
+      | { ID: "Host:other", MachineID: "boxd-1", Hostname: "fallback" }| "boxd-1"         |
+      | { ID: "Host:other", Hostname: "via-hostname" }                 | "via-hostname"   |
+      | { ID: "Host:via-id" }                                          | "via-id"         |
+      | nil                                                            | ""               |
+      | empty `{}`                                                     | ""               |


### PR DESCRIPTION
Closes #465.

## Summary

- Branch `hostResolver.Processes` on `isLocalHostNode`; local path unchanged.
- Peer path forwards a typed GraphQL query to the peer daemon over a new `peerproxy.Provider.Query` and normalises `process.host` to the peer.
- Unreachable peers now surface a typed error rather than silently returning empty/local data.
- Federation glue lives in `internal/server/resolvers/federate_peer_processes.go` so gqlgen doesn't rewrite it on schema regeneration.

## Why this matters

`peers[].processes` was returning the local daemon's `ps` snapshot for every peer (silently re-tagged with the peer host id). The federation layer was wired for `reachable` but not for the data-fetching subfields. An orchardist asking "which Claude session is on which host?" got a confidently-wrong answer — same 6 macOS PIDs returned for every peer including a Linux VM and 5 unreachable ones.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./internal/server/...` passes (only pre-existing `internal/cli/config` failures remain — unrelated to this PR; reproduce on `main`).
- [x] New unit tests in `federate_peer_processes_test.go` cover `peerNameFromHost`, `buildProcessFilterVars`, `decodePeerProcesses`.
- [x] New e2e tests in `peerproxy_e2e_test.go`:
  - `TestPeers_Processes_FederatedPerPeer` — reachable peer returns peer-tagged process row (regression-proves the bug).
  - `TestPeers_Processes_UnreachablePeer` — unreachable peer surfaces typed GraphQL error, never the local daemon's table.
- [ ] Manual verification once deployed: query `{ peers { hostname processes(filter: { commandIn: ["claude"] }) { pid command cwd } } }` against a daemon with multiple peers; confirm Linux paths come back from boxd VMs and macOS paths only from the local host.

## Out of scope

Other `Host.*` subfields (`tmuxSessions`, `claudeInstances`, `hostServices`, ...) presumably have the same gap but are tracked separately. They can reuse the new `peerproxy.Provider.Query` transport this PR introduces.

## Spec

`specs/features/federation-peer-processes.feature` maps every AC to a scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #465

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `Host.processes` GraphQL field now supports querying processes from federated peers with proper peer-specific data isolation.
  * Unreachable peers are handled gracefully with appropriate error responses in GraphQL results.
  * Process data from peers is properly normalized and includes peer-prefixed identifiers.

* **Tests**
  * Added end-to-end tests for federated peer process queries, including reachable and unreachable peer scenarios.
  * Added unit tests for peer federation helpers and query forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #465