### PR TITLE
feat(chat): chat-core lib + orchard-chat CLI for v1 substrate (#495)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chat-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gethostname",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "time",
+ "ulid",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1625,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3029,6 +3052,18 @@ dependencies = [
  "tokio",
  "tui-scrollview",
  "worktree-core",
+]
+
+[[package]]
+name = "orchard-chat"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chat-core",
+ "clap",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -5572,6 +5607,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "web-time",
+]
+
+[[package]]
 name = "unic-char-property"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6356,6 +6401,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -6413,6 +6473,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6431,6 +6497,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6446,6 +6518,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6479,6 +6557,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6494,6 +6578,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6515,6 +6605,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6530,6 +6626,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/chat-core",
     "crates/orchard",
+    "crates/orchard-chat",
     "crates/orchard-dispatcher",
     "crates/orchard-gui/src-tauri",
     "crates/orchard-worktree",

--- a/crates/chat-core/Cargo.toml
+++ b/crates/chat-core/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "chat-core"
+version = "0.1.0"
+edition = "2024"
+description = "Cross-machine chat substrate: append-only JSONL rooms + tmux send-keys fanout with Level 2 receipts"
+license = "MIT"
+repository = "https://github.com/drewdrewthis/git-orchard-rs"
+
+[lib]
+name = "chat_core"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+ulid = "1"
+time = { version = "0.3", features = ["formatting", "macros", "parsing", "serde-well-known"] }
+gethostname = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/chat-core/README.md
+++ b/crates/chat-core/README.md
@@ -109,10 +109,25 @@ event type can be appended without breaking forward-compat readers.
 
 | Variant | Meaning |
 |---|---|
-| `delivered` | `send-keys` succeeded AND `capture-pane -p` confirmed the prefixed message text appears in the recipient's scrollback. Includes `scrollback_verified_at`. |
-| `byte_only` | `send-keys` succeeded but scrollback verify timed out (~500ms). Bytes are in the input buffer; the recipient hasn't visibly processed them. |
+| `delivered` | `send-keys` succeeded AND a verifier confirmed the prefixed message landed at `verified_at`. `verified_via` records which verifier won — `transcript` (strongest: recipient's Claude transcript JSONL ingested it) or `scrollback` (`tmux capture-pane -p` saw it). |
+| `byte_only` | `send-keys` succeeded but every verifier timed out. Bytes are in the input buffer; we don't know if the recipient processed them. Common when the recipient is a non-Claude pane that's actively redrawing. |
 | `failed` | `send-keys` itself errored — for example, no such tmux session. |
 | `skipped` | Sender's own pane, empty handle, or other pre-flight skip. |
+
+### Verify ladder
+
+Within `delivered`, the substrate tries the strongest receipt first:
+
+1. **Transcript verify (Level 3).** Resolve the recipient's working directory via `tmux display-message -p '#{pane_current_path}'`, slugify it (replace `/` and `.` with `-`), open the freshest `.jsonl` in `~/.claude/projects/<slug>/`, and look for a `type: "user"` row whose `message.content` contains our prefix. If found within ~2s, the recipient REPL ingested the message — strongest possible same-machine proof.
+2. **Scrollback verify (Level 2).** If no Claude transcript is locatable, or transcript-verify times out, fall back to `tmux capture-pane -p` looking for the prefix in the recipient's pane scrollback (~500ms budget).
+3. **ByteOnly (Level 1).** Both above failed; `send-keys` returned 0 but we have no proof the recipient processed it.
+
+The transcript path solves a known failure mode against active Claude REPLs:
+the pane is constantly redrawing, so `capture-pane` can miss the prefix
+even though the bytes landed. The transcript file is append-only — once
+the entry's there, the REPL has it.
+
+### Determinism
 
 The JSONL line is appended **before** fanout starts. A fanout failure does
 not roll back the append — the message is in history. Callers MUST NOT

--- a/crates/chat-core/README.md
+++ b/crates/chat-core/README.md
@@ -1,0 +1,145 @@
+# chat-core
+
+Cross-machine chat substrate for orchard. Append-only JSONL rooms with
+tmux send-keys fanout and Level 2 receipts.
+
+This crate is the source-of-truth for the **chat JSONL format**. The Go
+daemon will read this format in a future issue; any reader (TUI pane,
+GUI view, daemon watcher, third-party tail) MUST treat the JSONL schema
+documented below as the cross-language contract.
+
+## Storage layout
+
+```
+$ORCHARD_CHAT_DIR/<room>.jsonl   (default: ~/.orchard/chat/<room>.jsonl)
+```
+
+- **One file per room.** No metadata file, no subdirectories.
+- **Direct sends** (`@handle` targets) are persisted under `@<handle>.jsonl`
+  so their history is queryable. The leading `@` is part of the filename.
+- **Rooms exist iff their JSONL exists.** Creating a room is just appending
+  to a fresh file; deleting a room is removing the file.
+- The directory is created lazily on the first append.
+- Tests can root the chat dir in a tempdir via `ORCHARD_CHAT_DIR`.
+
+## JSONL row schema
+
+Each line is a single JSON object. The top-level `type` field discriminates
+the row kind. Three types are defined; readers MUST silently skip rows with
+an unknown `type` (forwards-compat).
+
+### `type: "message"`
+
+A user-visible chat message.
+
+```json
+{
+  "type": "message",
+  "id": "01J9X3FZJW6Y8K1QV2A0Q5PF7H",
+  "ts": "2026-05-09T17:12:33.812Z",
+  "sender": "@alice",
+  "sender_machine": "drew-mac",
+  "text": "PR went green",
+  "source": "internal"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string (ULID) | 26-char Crockford base32. Monotonic per-process. |
+| `ts` | string (RFC3339) | UTC, milliseconds, `Z` suffix. |
+| `sender` | string | Handle, including the leading `@`. |
+| `sender_machine` | string | Hostname without `.local` suffix, lowercased. |
+| `text` | string | Message body. No length cap; ≤4KB recommended for atomicity. |
+| `source` | string | `"internal"` for chat sends; `"external"` reserved for future ingest paths. Defaults to `"internal"` when absent. |
+
+### `type: "member.joined"`
+
+A handle joined the room.
+
+```json
+{
+  "type": "member.joined",
+  "ts": "2026-05-09T17:11:00.000Z",
+  "handle": "@alice",
+  "machine": "drew-mac",
+  "tmux_session": "card-alice"
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `ts` | string (RFC3339) | UTC, milliseconds. |
+| `handle` | string | The joining handle (with leading `@`). |
+| `machine` | string | Hostname of the joining machine. |
+| `tmux_session` | string | tmux session name on `machine` (no leading `@`). |
+
+### `type: "member.left"`
+
+A handle left the room.
+
+```json
+{"type":"member.left","ts":"2026-05-09T18:00:00.000Z","handle":"@alice"}
+```
+
+## Membership derivation
+
+Membership at time T = scan the file, fold `member.joined` / `member.left`
+events chronologically, last-event-wins per handle. A handle is a current
+member if its most recent event is `member.joined`. Re-joining after a
+leave puts the handle back with the new event's metadata.
+
+This is O(file size). Acceptable at v1 scale (rooms with hundreds to low
+thousands of lines). If a file ever grows large enough to matter, a snapshot
+event type can be appended without breaking forward-compat readers.
+
+## Concurrency
+
+- Writes use POSIX `O_APPEND`. POSIX guarantees that `write(2)` of ≤
+  `PIPE_BUF` (4096 bytes on Linux, 512 on macOS) is atomic — interleaved
+  writers will not tear each other's lines.
+- **No flock anywhere.** Cross-machine concurrency is not in scope for v1;
+  same-machine concurrency relies on `O_APPEND`.
+- Readers tolerate partial last-line writes (a tail without a newline) by
+  treating the unterminated suffix as not-yet-readable.
+
+## Receipts
+
+`tmux_fanout` returns one of four `FanoutOutcome` variants per recipient:
+
+| Variant | Meaning |
+|---|---|
+| `delivered` | `send-keys` succeeded AND `capture-pane -p` confirmed the prefixed message text appears in the recipient's scrollback. Includes `scrollback_verified_at`. |
+| `byte_only` | `send-keys` succeeded but scrollback verify timed out (~500ms). Bytes are in the input buffer; the recipient hasn't visibly processed them. |
+| `failed` | `send-keys` itself errored — for example, no such tmux session. |
+| `skipped` | Sender's own pane, empty handle, or other pre-flight skip. |
+
+The JSONL line is appended **before** fanout starts. A fanout failure does
+not roll back the append — the message is in history. Callers MUST NOT
+retry on partial failure; the message id is the same and recipients who
+already received would double up.
+
+## CLI
+
+The `orchard-chat` binary is the user-facing surface. Routed by the
+`orchard` dispatcher:
+
+- `orchard send <target> <text>` — bare-verb shortcut for `orchard chat send`.
+- `orchard chat send|join|leave|members|list|history|tail …` — full surface.
+
+All subcommands accept `-j`/`--json` for machine-readable output. Sender
+identity comes from `$TMUX` / current tmux session name, with `--as <handle>`
+overriding. Outside tmux without `--as`, the CLI exits 3 with a clear message.
+
+See the issue body of [#495](https://github.com/drewdrewthis/git-orchard-rs/issues/495)
+for the full design rationale and AC list.
+
+## Tests
+
+```bash
+cargo test -p chat-core            # unit tests (no tmux needed)
+cargo test -p orchard-chat         # CLI tests, including two-session tmux end-to-end
+```
+
+The integration tests skip themselves with a stderr message if `tmux` is
+not installed.

--- a/crates/chat-core/src/fanout.rs
+++ b/crates/chat-core/src/fanout.rs
@@ -108,11 +108,7 @@ pub fn format_paste(sender: &str, text: &str) -> String {
 /// Each [`Recipient`] carries both the logical handle (used for receipts /
 /// JSONL) and the literal tmux session to deliver to. The sender's own
 /// handle is always skipped.
-pub fn tmux_fanout(
-    recipients: &[Recipient],
-    sender: &str,
-    text: &str,
-) -> Vec<FanoutOutcome> {
+pub fn tmux_fanout(recipients: &[Recipient], sender: &str, text: &str) -> Vec<FanoutOutcome> {
     let paste = format_paste(sender, text);
     let sender_handle = sender.trim_start_matches('@');
     let mut out = Vec::with_capacity(recipients.len());
@@ -234,8 +230,8 @@ fn verify_scrollback(session: &str, paste: &str) -> Result<String, String> {
         if out.status.success() {
             let captured = String::from_utf8_lossy(&out.stdout);
             if captured.contains(paste) {
-                use time::format_description::well_known::Rfc3339;
                 use time::OffsetDateTime;
+                use time::format_description::well_known::Rfc3339;
                 let ts = OffsetDateTime::now_utc()
                     .format(&Rfc3339)
                     .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
@@ -252,9 +248,9 @@ fn verify_scrollback(session: &str, paste: &str) -> Result<String, String> {
 
 fn short_ts() -> String {
     // HH:MM:SS for human-readable scrollback. Full RFC3339 lives in JSONL.
+    use time::OffsetDateTime;
     use time::format_description::FormatItem;
     use time::macros::format_description;
-    use time::OffsetDateTime;
     const FMT: &[FormatItem<'_>] = format_description!("[hour]:[minute]:[second]");
     OffsetDateTime::now_utc()
         .format(&FMT)

--- a/crates/chat-core/src/fanout.rs
+++ b/crates/chat-core/src/fanout.rs
@@ -1,0 +1,205 @@
+//! tmux fanout with Level 2 receipts.
+//!
+//! Two-step delivery:
+//! 1. `tmux send-keys -t <session> -l <prefixed-text>` then `tmux send-keys
+//!    -t <session> Enter` — bytes-delivered.
+//! 2. `tmux capture-pane -p -t <session>` with sleep-and-retry — verifies
+//!    the prefixed message appears in the pane scrollback.
+//!
+//! Step 1 returning 0 only proves bytes-delivered to the input buffer;
+//! recipients can have stacked input that swallows our line. Step 2 is the
+//! real receipt.
+
+use serde::Serialize;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+/// Per-recipient outcome of a fanout.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FanoutOutcome {
+    /// `send-keys` succeeded AND `capture-pane` confirmed the prefixed text
+    /// landed in the recipient's scrollback by `scrollback_verified_at`.
+    Delivered {
+        recipient: String,
+        scrollback_verified_at: String,
+    },
+    /// `send-keys` succeeded but scrollback verify timed out — bytes are in
+    /// the input buffer but the recipient hasn't visibly processed them.
+    ByteOnly { recipient: String, reason: String },
+    /// `send-keys` itself errored (e.g. no such session). The message has
+    /// NOT reached the recipient's input buffer.
+    Failed { recipient: String, error: String },
+    /// Skipped silently (sender's own pane, offline member, etc.).
+    Skipped { recipient: String, reason: String },
+}
+
+impl FanoutOutcome {
+    pub fn recipient(&self) -> &str {
+        match self {
+            FanoutOutcome::Delivered { recipient, .. }
+            | FanoutOutcome::ByteOnly { recipient, .. }
+            | FanoutOutcome::Failed { recipient, .. }
+            | FanoutOutcome::Skipped { recipient, .. } => recipient,
+        }
+    }
+
+    pub fn is_delivered(&self) -> bool {
+        matches!(self, FanoutOutcome::Delivered { .. })
+    }
+}
+
+/// The prefix used in fanout output. `[<ts>] @<sender>: <text>` is consistent
+/// across room broadcasts and direct sends.
+pub fn format_paste(sender: &str, text: &str) -> String {
+    let ts = short_ts();
+    let sender_at = if sender.starts_with('@') {
+        sender.to_string()
+    } else {
+        format!("@{sender}")
+    };
+    format!("[{ts}] {sender_at}: {text}")
+}
+
+/// Send `text` to every recipient via tmux send-keys, with Level 2 receipt
+/// verification.
+///
+/// `recipients` is a list of handles. Each handle maps directly to a tmux
+/// session of the same name (without the `@` sigil). The sender's own handle
+/// is always skipped.
+pub fn tmux_fanout(
+    recipients: &[String],
+    sender: &str,
+    text: &str,
+) -> Vec<FanoutOutcome> {
+    let paste = format_paste(sender, text);
+    let sender_session = sender.trim_start_matches('@');
+    let mut out = Vec::with_capacity(recipients.len());
+    for r in recipients {
+        let target_session = r.trim_start_matches('@');
+        if target_session.is_empty() {
+            out.push(FanoutOutcome::Skipped {
+                recipient: r.clone(),
+                reason: "empty handle".to_string(),
+            });
+            continue;
+        }
+        if target_session == sender_session {
+            out.push(FanoutOutcome::Skipped {
+                recipient: r.clone(),
+                reason: "sender".to_string(),
+            });
+            continue;
+        }
+        if !tmux_session_exists(target_session) {
+            out.push(FanoutOutcome::Failed {
+                recipient: r.clone(),
+                error: "no such tmux session".to_string(),
+            });
+            continue;
+        }
+        // Step 1: send-keys.
+        match send_keys(target_session, &paste) {
+            Ok(()) => {}
+            Err(e) => {
+                out.push(FanoutOutcome::Failed {
+                    recipient: r.clone(),
+                    error: e,
+                });
+                continue;
+            }
+        }
+        // Step 2: scrollback verify.
+        match verify_scrollback(target_session, &paste) {
+            Ok(verified_at) => out.push(FanoutOutcome::Delivered {
+                recipient: r.clone(),
+                scrollback_verified_at: verified_at,
+            }),
+            Err(reason) => out.push(FanoutOutcome::ByteOnly {
+                recipient: r.clone(),
+                reason,
+            }),
+        }
+    }
+    out
+}
+
+fn tmux_session_exists(session: &str) -> bool {
+    Command::new("tmux")
+        .args(["has-session", "-t", session])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Send a literal line + Enter via `tmux send-keys`.
+///
+/// Two invocations: one with `-l` for the literal text (no key translation),
+/// then a second sending `Enter`. This avoids `;` / `$` / etc. being
+/// interpreted as tmux command separators.
+fn send_keys(session: &str, paste: &str) -> Result<(), String> {
+    let out = Command::new("tmux")
+        .args(["send-keys", "-l", "-t", session, paste])
+        .output()
+        .map_err(|e| format!("invoking tmux send-keys: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "tmux send-keys failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    let out2 = Command::new("tmux")
+        .args(["send-keys", "-t", session, "Enter"])
+        .output()
+        .map_err(|e| format!("invoking tmux send-keys Enter: {e}"))?;
+    if !out2.status.success() {
+        return Err(format!(
+            "tmux send-keys Enter failed: {}",
+            String::from_utf8_lossy(&out2.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
+/// Verify the prefix appears in the recipient's pane scrollback, retrying
+/// for up to ~500ms total.
+///
+/// Returns the RFC3339 timestamp at which verification succeeded. On
+/// timeout, returns `Err("scrollback verify timeout")`.
+fn verify_scrollback(session: &str, paste: &str) -> Result<String, String> {
+    let deadline = Instant::now() + Duration::from_millis(500);
+    let mut sleep_ms = 30u64;
+    loop {
+        let out = Command::new("tmux")
+            .args(["capture-pane", "-p", "-t", session])
+            .output()
+            .map_err(|e| format!("invoking tmux capture-pane: {e}"))?;
+        if out.status.success() {
+            let captured = String::from_utf8_lossy(&out.stdout);
+            if captured.contains(paste) {
+                use time::format_description::well_known::Rfc3339;
+                use time::OffsetDateTime;
+                let ts = OffsetDateTime::now_utc()
+                    .format(&Rfc3339)
+                    .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+                return Ok(ts);
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err("scrollback verify timeout".to_string());
+        }
+        std::thread::sleep(Duration::from_millis(sleep_ms));
+        sleep_ms = (sleep_ms * 2).min(150);
+    }
+}
+
+fn short_ts() -> String {
+    // HH:MM:SS for human-readable scrollback. Full RFC3339 lives in JSONL.
+    use time::format_description::FormatItem;
+    use time::macros::format_description;
+    use time::OffsetDateTime;
+    const FMT: &[FormatItem<'_>] = format_description!("[hour]:[minute]:[second]");
+    OffsetDateTime::now_utc()
+        .format(&FMT)
+        .unwrap_or_else(|_| "??:??:??".to_string())
+}

--- a/crates/chat-core/src/fanout.rs
+++ b/crates/chat-core/src/fanout.rs
@@ -37,18 +37,36 @@ impl Recipient {
     }
 }
 
+/// How a `Delivered` outcome was verified.
+///
+/// - `Transcript` — strongest. Found the prefix as a `type:"user"` entry in
+///   the recipient's Claude transcript JSONL. Means the REPL ingested it.
+/// - `Scrollback` — weaker. Found the prefix in `tmux capture-pane -p`
+///   output. Bytes hit the pane but we don't know if a Claude REPL accepted
+///   it (vs e.g. a bash prompt that just echoed it).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerifiedVia {
+    Transcript,
+    Scrollback,
+}
+
 /// Per-recipient outcome of a fanout.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FanoutOutcome {
-    /// `send-keys` succeeded AND `capture-pane` confirmed the prefixed text
-    /// landed in the recipient's scrollback by `scrollback_verified_at`.
+    /// `send-keys` succeeded AND a verifier (transcript or scrollback)
+    /// confirmed the prefixed text landed at `verified_at`. `verified_via`
+    /// records which mechanism succeeded — transcript is the stronger
+    /// proof (recipient REPL ingested it); scrollback is the fallback.
     Delivered {
         recipient: String,
-        scrollback_verified_at: String,
+        verified_via: VerifiedVia,
+        verified_at: String,
     },
-    /// `send-keys` succeeded but scrollback verify timed out — bytes are in
-    /// the input buffer but the recipient hasn't visibly processed them.
+    /// `send-keys` succeeded but every verifier timed out — bytes are in
+    /// the input buffer but neither transcript nor scrollback confirmed
+    /// the recipient processed them.
     ByteOnly { recipient: String, reason: String },
     /// `send-keys` itself errored (e.g. no such session). The message has
     /// NOT reached the recipient's input buffer.
@@ -137,17 +155,36 @@ pub fn tmux_fanout(
                 continue;
             }
         }
-        // Step 2: scrollback verify.
-        match verify_scrollback(target_session, &paste) {
-            Ok(verified_at) => out.push(FanoutOutcome::Delivered {
+        // Step 2: verify ladder.
+        //
+        // Try the transcript first — strongest proof, robust against the
+        // active-Claude-REPL redraw that breaks scrollback verify. If the
+        // recipient isn't a Claude REPL (or its transcript can't be located
+        // within the budget), fall back to scrollback verify. If both
+        // fail, ByteOnly.
+        let outcome = match crate::transcript::verify_via_transcript(
+            target_session,
+            &paste,
+            std::time::Duration::from_millis(2_000),
+        ) {
+            Ok(verified_at) => FanoutOutcome::Delivered {
                 recipient: r.handle.clone(),
-                scrollback_verified_at: verified_at,
-            }),
-            Err(reason) => out.push(FanoutOutcome::ByteOnly {
-                recipient: r.handle.clone(),
-                reason,
-            }),
-        }
+                verified_via: VerifiedVia::Transcript,
+                verified_at,
+            },
+            Err(_) => match verify_scrollback(target_session, &paste) {
+                Ok(verified_at) => FanoutOutcome::Delivered {
+                    recipient: r.handle.clone(),
+                    verified_via: VerifiedVia::Scrollback,
+                    verified_at,
+                },
+                Err(reason) => FanoutOutcome::ByteOnly {
+                    recipient: r.handle.clone(),
+                    reason,
+                },
+            },
+        };
+        out.push(outcome);
     }
     out
 }

--- a/crates/chat-core/src/fanout.rs
+++ b/crates/chat-core/src/fanout.rs
@@ -14,6 +14,29 @@ use serde::Serialize;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+/// One target of a fanout: a logical handle plus the tmux session to deliver to.
+///
+/// `handle` is what shows up in receipts and JSONL (`@alice`, `@drudrukungfu_2`).
+/// `tmux_session` is the literal session name that `tmux send-keys -t` accepts —
+/// dashes preserved, not slugified. The two diverge whenever a session has
+/// characters `derive_handle` slugifies (dashes, dots, etc.), so the caller MUST
+/// supply both. For room broadcasts, look these up via `chat_core::list_members`;
+/// for direct `@handle` sends, the handle and session are the same string.
+#[derive(Debug, Clone)]
+pub struct Recipient {
+    pub handle: String,
+    pub tmux_session: String,
+}
+
+impl Recipient {
+    pub fn new(handle: impl Into<String>, tmux_session: impl Into<String>) -> Self {
+        Self {
+            handle: handle.into(),
+            tmux_session: tmux_session.into(),
+        }
+    }
+}
+
 /// Per-recipient outcome of a fanout.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
@@ -64,47 +87,52 @@ pub fn format_paste(sender: &str, text: &str) -> String {
 /// Send `text` to every recipient via tmux send-keys, with Level 2 receipt
 /// verification.
 ///
-/// `recipients` is a list of handles. Each handle maps directly to a tmux
-/// session of the same name (without the `@` sigil). The sender's own handle
-/// is always skipped.
+/// Each [`Recipient`] carries both the logical handle (used for receipts /
+/// JSONL) and the literal tmux session to deliver to. The sender's own
+/// handle is always skipped.
 pub fn tmux_fanout(
-    recipients: &[String],
+    recipients: &[Recipient],
     sender: &str,
     text: &str,
 ) -> Vec<FanoutOutcome> {
     let paste = format_paste(sender, text);
-    let sender_session = sender.trim_start_matches('@');
+    let sender_handle = sender.trim_start_matches('@');
     let mut out = Vec::with_capacity(recipients.len());
     for r in recipients {
-        let target_session = r.trim_start_matches('@');
+        let recipient_handle = r.handle.trim_start_matches('@');
+        let target_session = r.tmux_session.as_str();
         if target_session.is_empty() {
             out.push(FanoutOutcome::Skipped {
-                recipient: r.clone(),
-                reason: "empty handle".to_string(),
+                recipient: r.handle.clone(),
+                reason: "empty tmux session".to_string(),
             });
             continue;
         }
-        if target_session == sender_session {
+        if recipient_handle == sender_handle {
             out.push(FanoutOutcome::Skipped {
-                recipient: r.clone(),
+                recipient: r.handle.clone(),
                 reason: "sender".to_string(),
             });
             continue;
         }
-        if !tmux_session_exists(target_session) {
-            out.push(FanoutOutcome::Failed {
-                recipient: r.clone(),
-                error: "no such tmux session".to_string(),
-            });
-            continue;
-        }
-        // Step 1: send-keys.
+        // Step 1: send-keys. We don't pre-flight with `has-session` because
+        // tmux's `-t <name>` resolution accepts session, window, or pane
+        // targets, but `has-session` only matches sessions. If the target
+        // doesn't resolve, `send-keys` itself returns a non-zero exit with a
+        // clear error message — we propagate that.
         match send_keys(target_session, &paste) {
             Ok(()) => {}
             Err(e) => {
+                // Normalize the most common case so callers can pattern-match
+                // on it without parsing tmux's localized strings.
+                let normalized = if e.contains("can't find") || e.contains("no current target") {
+                    format!("no such tmux session: {target_session}")
+                } else {
+                    e
+                };
                 out.push(FanoutOutcome::Failed {
-                    recipient: r.clone(),
-                    error: e,
+                    recipient: r.handle.clone(),
+                    error: normalized,
                 });
                 continue;
             }
@@ -112,24 +140,16 @@ pub fn tmux_fanout(
         // Step 2: scrollback verify.
         match verify_scrollback(target_session, &paste) {
             Ok(verified_at) => out.push(FanoutOutcome::Delivered {
-                recipient: r.clone(),
+                recipient: r.handle.clone(),
                 scrollback_verified_at: verified_at,
             }),
             Err(reason) => out.push(FanoutOutcome::ByteOnly {
-                recipient: r.clone(),
+                recipient: r.handle.clone(),
                 reason,
             }),
         }
     }
     out
-}
-
-fn tmux_session_exists(session: &str) -> bool {
-    Command::new("tmux")
-        .args(["has-session", "-t", session])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
 }
 
 /// Send a literal line + Enter via `tmux send-keys`.

--- a/crates/chat-core/src/handle.rs
+++ b/crates/chat-core/src/handle.rs
@@ -1,0 +1,105 @@
+//! Handle derivation: tmux session name → user-facing handle.
+//!
+//! Slugify rules:
+//! - Lowercase ASCII alphanum and underscores only.
+//! - Non-alphanum runs collapse to a single underscore.
+//! - Leading/trailing underscores stripped.
+//! - Truncate to ≤24 chars on a word boundary (no trailing underscore).
+//! - On collision with an already-taken set, suffix `_2`, `_3`, … until free.
+//!
+//! The handle is returned **without** the leading `@` — the `@` is a UI
+//! convention (the JSONL `sender` field includes it; CLI args parse it).
+
+/// Slugify a tmux session name to a chat handle.
+///
+/// `display_name` is currently unused but reserved for future UX (e.g. taking
+/// the user's preferred display name when the tmux name is auto-generated).
+pub fn derive_handle(tmux_session_name: &str, _display_name: Option<&str>) -> String {
+    let mut out = String::with_capacity(24);
+    let mut prev_was_underscore = false;
+
+    for ch in tmux_session_name.chars() {
+        let mapped = if ch.is_ascii_alphanumeric() {
+            Some(ch.to_ascii_lowercase())
+        } else {
+            // Any non-alphanum becomes a separator. Collapse runs.
+            None
+        };
+        match mapped {
+            Some(c) => {
+                out.push(c);
+                prev_was_underscore = false;
+            }
+            None => {
+                if !prev_was_underscore && !out.is_empty() {
+                    out.push('_');
+                    prev_was_underscore = true;
+                }
+            }
+        }
+    }
+    // Strip trailing underscore if any.
+    while out.ends_with('_') {
+        out.pop();
+    }
+    if out.is_empty() {
+        return "anon".to_string();
+    }
+
+    truncate_on_word_boundary(&out, 24)
+}
+
+/// Same as [`derive_handle`] but disambiguates against `taken`.
+///
+/// Returns `base` if free, else `base_2`, `base_3`, … until a free slot is
+/// found. The suffix is appended *after* truncation, so the final string may
+/// exceed 24 chars when many collisions stack — acceptable for a v1 fanout
+/// surface where collisions are user-visible and rare.
+pub fn derive_handle_with_collisions(
+    tmux_session_name: &str,
+    display_name: Option<&str>,
+    taken: &[&str],
+) -> String {
+    let base = derive_handle(tmux_session_name, display_name);
+    if !taken.contains(&base.as_str()) {
+        return base;
+    }
+    let mut n: u32 = 2;
+    loop {
+        let candidate = format!("{base}_{n}");
+        if !taken.contains(&candidate.as_str()) {
+            return candidate;
+        }
+        n += 1;
+        if n > 999 {
+            // Pathological case: just return with the count.
+            return candidate;
+        }
+    }
+}
+
+fn truncate_on_word_boundary(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    // Cut at `max`, then walk back to the last `_` to avoid splitting a word
+    // mid-character. If there's no `_` in the prefix, hard-cut.
+    let mut cut = max;
+    let bytes = s.as_bytes();
+    while cut > 0 && bytes[cut - 1] != b'_' && cut == max {
+        // Hard-cut path: just take the first `max` chars.
+        return s[..max].trim_end_matches('_').to_string();
+    }
+    // Walk backward to last underscore for clean break (only if it's within
+    // the last 8 chars, otherwise hard-cut yields a more legible name).
+    let lookback_floor = max.saturating_sub(8);
+    while cut > lookback_floor && bytes[cut - 1] != b'_' {
+        cut -= 1;
+    }
+    if cut == lookback_floor {
+        // No nearby underscore; hard-cut.
+        return s[..max].trim_end_matches('_').to_string();
+    }
+    // cut points just past an underscore (or at the start). Trim the underscore.
+    s[..cut].trim_end_matches('_').to_string()
+}

--- a/crates/chat-core/src/identity.rs
+++ b/crates/chat-core/src/identity.rs
@@ -1,0 +1,13 @@
+//! Machine identity for `sender_machine` stamping.
+
+/// Returns the current machine's hostname, lowercased and with the
+/// `.local` suffix stripped (matching macOS conventions).
+///
+/// Falls back to `"unknown"` if the syscall fails.
+pub fn current_machine() -> String {
+    let raw = gethostname::gethostname()
+        .into_string()
+        .unwrap_or_else(|_| "unknown".to_string());
+    let lower = raw.to_lowercase();
+    lower.strip_suffix(".local").unwrap_or(&lower).to_string()
+}

--- a/crates/chat-core/src/lib.rs
+++ b/crates/chat-core/src/lib.rs
@@ -49,7 +49,7 @@ pub mod paths;
 pub mod store;
 pub mod types;
 
-pub use fanout::{FanoutOutcome, tmux_fanout};
+pub use fanout::{FanoutOutcome, Recipient, tmux_fanout};
 pub use handle::{derive_handle, derive_handle_with_collisions};
 pub use identity::current_machine;
 pub use paths::{chat_dir, room_path};

--- a/crates/chat-core/src/lib.rs
+++ b/crates/chat-core/src/lib.rs
@@ -1,0 +1,59 @@
+//! Cross-machine chat substrate.
+//!
+//! `chat-core` is the single source of truth for chat reads and writes. It
+//! backs the `orchard-chat` CLI binary and any future TUI/GUI surface. Higher
+//! layers compose on top — agents post via the CLI, daemons watch the JSONL
+//! files, GUIs render histories. This library is local-first and pure-ish:
+//! every public function reads or writes one JSONL file and may shell out to
+//! `tmux` for fanout.
+//!
+//! # Substrate
+//!
+//! One JSONL file per room, at `${ORCHARD_CHAT_DIR}/<room>.jsonl` (default
+//! `~/.orchard/chat/`). The file stores three event types discriminated by
+//! a top-level `type` field:
+//!
+//! ```jsonl
+//! {"type":"message","id":"01J..","ts":"...","sender":"@alice","sender_machine":"drew-mac","text":"hi","source":"internal"}
+//! {"type":"member.joined","ts":"...","handle":"@alice","machine":"drew-mac","tmux_session":"card-alice"}
+//! {"type":"member.left","ts":"...","handle":"@alice"}
+//! ```
+//!
+//! Rooms exist iff their JSONL exists. Membership at time T is derived by
+//! folding `member.joined`/`member.left` events chronologically (last-event-
+//! wins per handle).
+//!
+//! # Concurrency
+//!
+//! POSIX `O_APPEND` is atomic for writes ≤ `PIPE_BUF` (4096 bytes on Linux,
+//! 512 on macOS — both larger than our typical line). No flock anywhere.
+//! Multiple writers on the same machine append-without-tearing; cross-machine
+//! is not in scope for v1.
+//!
+//! # Receipts
+//!
+//! `tmux_fanout` returns Level 2 receipts: bytes-delivered AND scrollback-
+//! verified via `tmux capture-pane -p`. Level 3 (recipient-acknowledged via
+//! transcript watching) is deferred to a follow-up.
+//!
+//! # Identity
+//!
+//! Handles map directly to tmux session names (`@bob` → tmux session `bob`).
+//! No registry. `derive_handle` slugifies a tmux session name to lowercase
+//! alphanum+underscores, with collision suffixes.
+
+pub mod fanout;
+pub mod handle;
+pub mod identity;
+pub mod paths;
+pub mod store;
+pub mod types;
+
+pub use fanout::{FanoutOutcome, tmux_fanout};
+pub use handle::{derive_handle, derive_handle_with_collisions};
+pub use identity::current_machine;
+pub use paths::{chat_dir, room_path};
+pub use store::{
+    append_message, join, leave, list_members, list_rooms, read_history, send,
+};
+pub use types::{Event, Member, Message, MessageId, SendOutcome, Target};

--- a/crates/chat-core/src/lib.rs
+++ b/crates/chat-core/src/lib.rs
@@ -54,7 +54,5 @@ pub use fanout::{FanoutOutcome, Recipient, VerifiedVia, tmux_fanout};
 pub use handle::{derive_handle, derive_handle_with_collisions};
 pub use identity::current_machine;
 pub use paths::{chat_dir, room_path};
-pub use store::{
-    append_message, join, leave, list_members, list_rooms, read_history, send,
-};
+pub use store::{append_message, join, leave, list_members, list_rooms, read_history, send};
 pub use types::{Event, Member, Message, MessageId, SendOutcome, Target};

--- a/crates/chat-core/src/lib.rs
+++ b/crates/chat-core/src/lib.rs
@@ -47,9 +47,10 @@ pub mod handle;
 pub mod identity;
 pub mod paths;
 pub mod store;
+pub mod transcript;
 pub mod types;
 
-pub use fanout::{FanoutOutcome, Recipient, tmux_fanout};
+pub use fanout::{FanoutOutcome, Recipient, VerifiedVia, tmux_fanout};
 pub use handle::{derive_handle, derive_handle_with_collisions};
 pub use identity::current_machine;
 pub use paths::{chat_dir, room_path};

--- a/crates/chat-core/src/paths.rs
+++ b/crates/chat-core/src/paths.rs
@@ -1,0 +1,48 @@
+//! Resolves the on-disk root for chat JSONL files.
+//!
+//! Default: `~/.orchard/chat/`. Overridable via `ORCHARD_CHAT_DIR` for tests
+//! and isolated installs. Resolution and directory creation are eager — the
+//! first call ensures the directory exists.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+/// Returns the chat data directory, creating it if missing.
+///
+/// Honors `$ORCHARD_CHAT_DIR` first; falls back to `$HOME/.orchard/chat/`.
+/// Returns an error if the directory cannot be created or the home directory
+/// cannot be resolved.
+pub fn chat_dir() -> Result<PathBuf> {
+    let dir = if let Ok(custom) = std::env::var("ORCHARD_CHAT_DIR") {
+        PathBuf::from(custom)
+    } else {
+        let home = std::env::var("HOME")
+            .context("HOME not set; cannot resolve default chat dir")?;
+        PathBuf::from(home).join(".orchard").join("chat")
+    };
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("creating chat dir {}", dir.display()))?;
+    Ok(dir)
+}
+
+/// Returns the path to a room's JSONL file, creating the parent dir.
+///
+/// `room` is a logical name (no leading `#`, no slashes). Direct-send rooms
+/// like `@bob` keep the `@` literal in the filename — `paths::room_path("@bob")`
+/// yields `…/chat/@bob.jsonl`.
+pub fn room_path(room: &str) -> Result<PathBuf> {
+    if room.contains('/') || room.contains('\\') {
+        anyhow::bail!("invalid room name (no path separators): {room}");
+    }
+    Ok(chat_dir()?.join(format!("{room}.jsonl")))
+}
+
+/// Returns the path to a room's JSONL file, scoped to a specific dir.
+///
+/// Useful internally; tests typically just set `ORCHARD_CHAT_DIR`.
+pub fn room_path_in(dir: &Path, room: &str) -> Result<PathBuf> {
+    if room.contains('/') || room.contains('\\') {
+        anyhow::bail!("invalid room name (no path separators): {room}");
+    }
+    Ok(dir.join(format!("{room}.jsonl")))
+}

--- a/crates/chat-core/src/paths.rs
+++ b/crates/chat-core/src/paths.rs
@@ -16,8 +16,8 @@ pub fn chat_dir() -> Result<PathBuf> {
     let dir = if let Ok(custom) = std::env::var("ORCHARD_CHAT_DIR") {
         PathBuf::from(custom)
     } else {
-        let home = std::env::var("HOME")
-            .context("HOME not set; cannot resolve default chat dir")?;
+        let home =
+            std::env::var("HOME").context("HOME not set; cannot resolve default chat dir")?;
         PathBuf::from(home).join(".orchard").join("chat")
     };
     std::fs::create_dir_all(&dir)

--- a/crates/chat-core/src/store.rs
+++ b/crates/chat-core/src/store.rs
@@ -29,11 +29,7 @@ use crate::types::{Event, Member, Message, MessageId, SendOutcome, Target};
 /// (e.g. from `$TMUX` or `--as`). For room broadcasts, the recipient list
 /// is derived from current membership minus the sender. For direct sends,
 /// the recipient is the single tmux session matching the handle.
-pub fn send(
-    target: &Target,
-    sender: &str,
-    text: &str,
-) -> Result<SendOutcome> {
+pub fn send(target: &Target, sender: &str, text: &str) -> Result<SendOutcome> {
     let room = target.room_name();
     let id = append_message(&room, sender, text)?;
 
@@ -79,12 +75,7 @@ pub fn append_message(room: &str, sender: &str, text: &str) -> Result<MessageId>
 }
 
 /// Append a `member.joined` event.
-pub fn join(
-    room: &str,
-    handle: &str,
-    machine: &str,
-    tmux_session: &str,
-) -> Result<()> {
+pub fn join(room: &str, handle: &str, machine: &str, tmux_session: &str) -> Result<()> {
     let event = Event::MemberJoined {
         ts: now_rfc3339(),
         handle: handle.to_string(),
@@ -111,8 +102,7 @@ pub fn read_history(room: &str, limit: usize) -> Result<Vec<Message>> {
         return Ok(Vec::new());
     }
     let mut messages = Vec::new();
-    let f = std::fs::File::open(&path)
-        .with_context(|| format!("opening {}", path.display()))?;
+    let f = std::fs::File::open(&path).with_context(|| format!("opening {}", path.display()))?;
     for line in BufReader::new(f).lines() {
         let line = line?;
         if line.trim().is_empty() {
@@ -156,8 +146,7 @@ pub fn list_members(room: &str) -> Result<Vec<Member>> {
     }
     use std::collections::HashMap;
     let mut state: HashMap<String, Option<Member>> = HashMap::new();
-    let f = std::fs::File::open(&path)
-        .with_context(|| format!("opening {}", path.display()))?;
+    let f = std::fs::File::open(&path).with_context(|| format!("opening {}", path.display()))?;
     for line in BufReader::new(f).lines() {
         let line = line?;
         if line.trim().is_empty() {
@@ -218,8 +207,7 @@ fn append_event(room: &str, event: &Event) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
-    let line = serde_json::to_string(event)
-        .context("serializing event to JSON")?;
+    let line = serde_json::to_string(event).context("serializing event to JSON")?;
     append_line(&path, &line)
 }
 
@@ -240,8 +228,8 @@ fn append_line(path: &Path, line: &str) -> Result<()> {
 }
 
 fn now_rfc3339() -> String {
-    use time::format_description::well_known::Rfc3339;
     use time::OffsetDateTime;
+    use time::format_description::well_known::Rfc3339;
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())

--- a/crates/chat-core/src/store.rs
+++ b/crates/chat-core/src/store.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use ulid::Ulid;
 
-use crate::fanout::tmux_fanout;
+use crate::fanout::{Recipient, tmux_fanout};
 use crate::identity::current_machine;
 use crate::paths::{chat_dir, room_path};
 use crate::types::{Event, Member, Message, MessageId, SendOutcome, Target};
@@ -37,13 +37,18 @@ pub fn send(
     let room = target.room_name();
     let id = append_message(&room, sender, text)?;
 
-    let recipients: Vec<String> = match target {
+    let recipients: Vec<Recipient> = match target {
         Target::Room(r) => list_members(r)?
             .into_iter()
-            .map(|m| m.handle)
-            .filter(|h| h != sender)
+            .filter(|m| m.handle != sender)
+            .map(|m| Recipient::new(m.handle, m.tmux_session))
             .collect(),
-        Target::Direct(handle) => vec![handle.clone()],
+        // Direct send: handle == tmux session name (no slugify); the sigil
+        // is decoration. `@bob` → tmux session `bob`.
+        Target::Direct(handle) => {
+            let session = handle.trim_start_matches('@').to_string();
+            vec![Recipient::new(format!("@{session}"), session)]
+        }
     };
 
     let outcomes = tmux_fanout(&recipients, sender, text);

--- a/crates/chat-core/src/store.rs
+++ b/crates/chat-core/src/store.rs
@@ -1,0 +1,243 @@
+//! JSONL store: append messages, append membership events, fold to current
+//! state.
+//!
+//! All writes use POSIX `O_APPEND` atomicity. Reads are streaming line scans
+//! — no in-memory index, fold-on-read. At our scale (rooms with hundreds to
+//! low thousands of lines), this is fast enough; if it ever isn't, that's a
+//! tomorrow problem.
+
+use std::fs::OpenOptions;
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use ulid::Ulid;
+
+use crate::fanout::tmux_fanout;
+use crate::identity::current_machine;
+use crate::paths::{chat_dir, room_path};
+use crate::types::{Event, Member, Message, MessageId, SendOutcome, Target};
+
+/// Compose: append the message to the room's JSONL, then fan out via tmux.
+///
+/// The JSONL append is the durable receipt — if it succeeds and fanout
+/// fails for some recipients, the message is still in history and replays
+/// will redeliver. Callers MUST NOT retry on partial failure; the message
+/// id is the same and recipients who already received would double up.
+///
+/// `sender` is required — caller has already resolved the sender's handle
+/// (e.g. from `$TMUX` or `--as`). For room broadcasts, the recipient list
+/// is derived from current membership minus the sender. For direct sends,
+/// the recipient is the single tmux session matching the handle.
+pub fn send(
+    target: &Target,
+    sender: &str,
+    text: &str,
+) -> Result<SendOutcome> {
+    let room = target.room_name();
+    let id = append_message(&room, sender, text)?;
+
+    let recipients: Vec<String> = match target {
+        Target::Room(r) => list_members(r)?
+            .into_iter()
+            .map(|m| m.handle)
+            .filter(|h| h != sender)
+            .collect(),
+        Target::Direct(handle) => vec![handle.clone()],
+    };
+
+    let outcomes = tmux_fanout(&recipients, sender, text);
+    Ok(SendOutcome {
+        message_id: id,
+        room,
+        fanout: outcomes,
+    })
+}
+
+/// Append a `type: "message"` row and return its ULID.
+///
+/// `ts` is RFC3339 with milliseconds; `sender_machine` is auto-stamped from
+/// `gethostname`.
+pub fn append_message(room: &str, sender: &str, text: &str) -> Result<MessageId> {
+    let id = Ulid::new().to_string();
+    let ts = now_rfc3339();
+    let event = Event::Message {
+        id: id.clone(),
+        ts,
+        sender: sender.to_string(),
+        sender_machine: current_machine(),
+        text: text.to_string(),
+        source: "internal".to_string(),
+    };
+    append_event(room, &event)?;
+    Ok(id)
+}
+
+/// Append a `member.joined` event.
+pub fn join(
+    room: &str,
+    handle: &str,
+    machine: &str,
+    tmux_session: &str,
+) -> Result<()> {
+    let event = Event::MemberJoined {
+        ts: now_rfc3339(),
+        handle: handle.to_string(),
+        machine: machine.to_string(),
+        tmux_session: tmux_session.to_string(),
+    };
+    append_event(room, &event)
+}
+
+/// Append a `member.left` event.
+pub fn leave(room: &str, handle: &str) -> Result<()> {
+    let event = Event::MemberLeft {
+        ts: now_rfc3339(),
+        handle: handle.to_string(),
+    };
+    append_event(room, &event)
+}
+
+/// Read messages from a room, newest-last, capped at `limit`. Membership
+/// events do not count toward the limit.
+pub fn read_history(room: &str, limit: usize) -> Result<Vec<Message>> {
+    let path = room_path(room)?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let mut messages = Vec::new();
+    let f = std::fs::File::open(&path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    for line in BufReader::new(f).lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(Event::Message {
+            id,
+            ts,
+            sender,
+            sender_machine,
+            text,
+            source,
+        }) = serde_json::from_str::<Event>(&line)
+        {
+            messages.push(Message {
+                id,
+                ts,
+                sender,
+                sender_machine,
+                text,
+                source,
+            });
+        }
+        // Membership events and malformed lines silently skipped.
+    }
+    if limit > 0 && messages.len() > limit {
+        let start = messages.len() - limit;
+        messages = messages.split_off(start);
+    }
+    Ok(messages)
+}
+
+/// Derive current membership by folding joined/left events chronologically.
+///
+/// Last-event-wins per handle. A re-join after a leave puts the handle back.
+/// Output is sorted by handle for stable display.
+pub fn list_members(room: &str) -> Result<Vec<Member>> {
+    let path = room_path(room)?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    use std::collections::HashMap;
+    let mut state: HashMap<String, Option<Member>> = HashMap::new();
+    let f = std::fs::File::open(&path)
+        .with_context(|| format!("opening {}", path.display()))?;
+    for line in BufReader::new(f).lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<Event>(&line) {
+            Ok(Event::MemberJoined {
+                ts,
+                handle,
+                machine,
+                tmux_session,
+            }) => {
+                state.insert(
+                    handle.clone(),
+                    Some(Member {
+                        handle,
+                        machine,
+                        tmux_session,
+                        joined_at: ts,
+                    }),
+                );
+            }
+            Ok(Event::MemberLeft { handle, .. }) => {
+                state.insert(handle, None);
+            }
+            _ => {}
+        }
+    }
+    let mut members: Vec<Member> = state.into_values().flatten().collect();
+    members.sort_by(|a, b| a.handle.cmp(&b.handle));
+    Ok(members)
+}
+
+/// List all rooms (each `<name>.jsonl` in [`chat_dir`]).
+///
+/// Returns just the room names, no extension.
+pub fn list_rooms() -> Result<Vec<String>> {
+    let dir = chat_dir()?;
+    let mut rooms = Vec::new();
+    if !dir.exists() {
+        return Ok(rooms);
+    }
+    for entry in std::fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("jsonl") {
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                rooms.push(stem.to_string());
+            }
+        }
+    }
+    rooms.sort();
+    Ok(rooms)
+}
+
+fn append_event(room: &str, event: &Event) -> Result<()> {
+    let path = room_path(room)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let line = serde_json::to_string(event)
+        .context("serializing event to JSON")?;
+    append_line(&path, &line)
+}
+
+/// Append `line + \n` to `path` using `O_APPEND`. Caller is responsible for
+/// keeping the line under PIPE_BUF (4096 on Linux, 512 on macOS) for atomicity.
+fn append_line(path: &Path, line: &str) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(path)
+        .with_context(|| format!("opening {} for append", path.display()))?;
+    let mut buf = String::with_capacity(line.len() + 1);
+    buf.push_str(line);
+    buf.push('\n');
+    file.write_all(buf.as_bytes())
+        .with_context(|| format!("appending to {}", path.display()))?;
+    Ok(())
+}
+
+fn now_rfc3339() -> String {
+    use time::format_description::well_known::Rfc3339;
+    use time::OffsetDateTime;
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}

--- a/crates/chat-core/src/transcript.rs
+++ b/crates/chat-core/src/transcript.rs
@@ -1,0 +1,276 @@
+//! Level 3 receipts via Claude transcript JSONL.
+//!
+//! `tmux capture-pane` verification has a known failure mode against active
+//! Claude REPLs: the pane is constantly redrawing, so the prefix our paste
+//! contains can be scrolled off / repainted before the verify retry window
+//! closes. Result: false-negative `ByteOnly` outcomes when the message
+//! actually landed.
+//!
+//! This module gives us a stronger receipt path: read the recipient's
+//! Claude transcript JSONL and look for a `type: "user"` entry whose
+//! `message.content` (string form) contains our prefix. The transcript is
+//! append-only and authoritative — once the entry is there, the REPL has
+//! ingested the message.
+//!
+//! # Path discovery
+//!
+//! Claude Code stores transcripts at:
+//!
+//! ```text
+//! ~/.claude/projects/<slug>/<session_uuid>.jsonl
+//! ```
+//!
+//! Where `<slug>` is the recipient's working directory with `/` and `.`
+//! replaced by `-`. The recipient's working directory is fetched from
+//! tmux (`tmux display-message -p -t <session> '#{pane_current_path}'`).
+//! Multiple `.jsonl` files may exist for one project (one per Claude
+//! session that ever ran there); we use the most recently modified.
+//!
+//! # Limitations
+//!
+//! - Only works when the recipient is a Claude Code REPL — `bash`, `vim`,
+//!   etc. don't write transcripts. Callers fall back to capture-pane verify.
+//! - Slight latency: Claude buffers transcript writes (~100-500ms typical).
+//!   The verify deadline accommodates this.
+//! - Cross-host: the transcript is local to the recipient. v1 only verifies
+//!   same-machine targets; cross-machine receipt is a v2 problem (likely via
+//!   the daemon exposing transcript reads over the federation).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+/// Try to verify that the recipient's Claude REPL has ingested a message
+/// containing `needle` in its transcript. Returns the RFC3339 timestamp of
+/// successful verify, or an error reason on timeout / discovery failure.
+///
+/// `tmux_session` is the literal target name (the same one passed to
+/// `send-keys -t`). The function shells out to tmux to resolve the recipient
+/// pane's `pane_current_path`, slugifies it, finds the freshest `.jsonl` in
+/// `~/.claude/projects/<slug>/`, and tail-polls it for a `type:"user"` row
+/// whose content contains `needle`.
+pub fn verify_via_transcript(
+    tmux_session: &str,
+    needle: &str,
+    deadline: Duration,
+) -> Result<String, String> {
+    let cwd = pane_current_path(tmux_session)
+        .ok_or_else(|| "could not resolve recipient cwd".to_string())?;
+    let slug = slugify_path(&cwd);
+    let project_dir = home_dir()
+        .ok_or_else(|| "HOME not set".to_string())?
+        .join(".claude")
+        .join("projects")
+        .join(&slug);
+    if !project_dir.exists() {
+        return Err(format!(
+            "no Claude transcript dir for recipient: {}",
+            project_dir.display()
+        ));
+    }
+
+    let stop_at = Instant::now() + deadline;
+    let mut sleep_ms = 100u64;
+    loop {
+        if let Some(path) = newest_jsonl(&project_dir)
+            && let Ok(verified) = scan_for_user_message(&path, needle)
+            && verified
+        {
+            use time::format_description::well_known::Rfc3339;
+            use time::OffsetDateTime;
+            let ts = OffsetDateTime::now_utc()
+                .format(&Rfc3339)
+                .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
+            return Ok(ts);
+        }
+        if Instant::now() >= stop_at {
+            return Err("transcript verify timeout".to_string());
+        }
+        std::thread::sleep(Duration::from_millis(sleep_ms));
+        sleep_ms = (sleep_ms * 2).min(400);
+    }
+}
+
+/// Resolve the recipient's working directory by querying tmux.
+fn pane_current_path(tmux_session: &str) -> Option<String> {
+    let out = Command::new("tmux")
+        .args([
+            "display-message",
+            "-p",
+            "-t",
+            tmux_session,
+            "#{pane_current_path}",
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
+/// Map a path to Claude Code's project-dir slug.
+///
+/// Rule (matches what Claude Code itself does): replace every `/` and `.`
+/// with `-`. Leading separator from absolute paths becomes a leading `-`.
+/// Examples:
+/// - `/home/user/orchard` → `-home-user-orchard`
+/// - `/x/.claude/y` → `-x--claude-y`
+pub fn slugify_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for ch in path.chars() {
+        match ch {
+            '/' | '.' => out.push('-'),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+fn newest_jsonl(dir: &std::path::Path) -> Option<PathBuf> {
+    let mut newest: Option<(PathBuf, std::time::SystemTime)> = None;
+    let entries = std::fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata()
+            && let Ok(mtime) = meta.modified()
+        {
+            match &newest {
+                Some((_, prev)) if *prev >= mtime => {}
+                _ => newest = Some((path, mtime)),
+            }
+        }
+    }
+    newest.map(|(p, _)| p)
+}
+
+/// Scan a JSONL file for a `type:"user"` entry whose message content
+/// contains `needle`. Tail-only: skip lines that don't parse / aren't user.
+///
+/// Returns `Ok(true)` if a match is found. `Ok(false)` if no match. `Err`
+/// on read errors that prevent any progress.
+fn scan_for_user_message(
+    path: &std::path::Path,
+    needle: &str,
+) -> std::io::Result<bool> {
+    use std::io::{BufRead, BufReader};
+    let f = std::fs::File::open(path)?;
+    for line in BufReader::new(f).lines() {
+        let line = line?;
+        if line.is_empty() {
+            continue;
+        }
+        // Cheap pre-filter: if the needle isn't anywhere in the line, skip
+        // JSON parsing entirely.
+        if !line.contains(needle) {
+            continue;
+        }
+        let v: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if v.get("type").and_then(|t| t.as_str()) != Some("user") {
+            continue;
+        }
+        let content = v
+            .get("message")
+            .and_then(|m| m.get("content"));
+        if content_contains(content, needle) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn content_contains(content: Option<&serde_json::Value>, needle: &str) -> bool {
+    match content {
+        Some(serde_json::Value::String(s)) => s.contains(needle),
+        Some(serde_json::Value::Array(parts)) => parts.iter().any(|p| {
+            p.get("text")
+                .and_then(|t| t.as_str())
+                .map(|s| s.contains(needle))
+                .unwrap_or(false)
+        }),
+        _ => false,
+    }
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_replaces_slashes_and_dots() {
+        assert_eq!(slugify_path("/home/user/orchard"), "-home-user-orchard");
+        assert_eq!(slugify_path("/x/.claude/y"), "-x--claude-y");
+        assert_eq!(slugify_path("relative/path"), "relative-path");
+        assert_eq!(slugify_path(""), "");
+    }
+
+    #[test]
+    fn content_contains_matches_string_form() {
+        let v = serde_json::json!("[14:07:22] @alice: hello");
+        assert!(content_contains(Some(&v), "@alice"));
+        assert!(!content_contains(Some(&v), "@bob"));
+    }
+
+    #[test]
+    fn content_contains_matches_array_form() {
+        let v = serde_json::json!([
+            {"type": "text", "text": "intro"},
+            {"type": "text", "text": "[14:07:22] @alice: hello"},
+        ]);
+        assert!(content_contains(Some(&v), "@alice"));
+    }
+
+    #[test]
+    fn content_contains_handles_none() {
+        assert!(!content_contains(None, "x"));
+    }
+
+    #[test]
+    fn scan_finds_matching_user_line_and_skips_others() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let path = td.path().join("session.jsonl");
+        let lines = vec![
+            r#"{"type":"summary","summary":"foo"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"hi"}}"#,
+            r#"{"type":"user","message":{"role":"user","content":"intro"}}"#,
+            r#"{"type":"user","message":{"role":"user","content":"[14:07:22] @alice: payload"}}"#,
+        ];
+        std::fs::write(&path, lines.join("\n") + "\n").unwrap();
+
+        assert!(scan_for_user_message(&path, "@alice: payload").unwrap());
+        assert!(!scan_for_user_message(&path, "@bob: payload").unwrap());
+    }
+
+    #[test]
+    fn newest_jsonl_picks_latest_mtime() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let old_path = td.path().join("a.jsonl");
+        let new_path = td.path().join("b.jsonl");
+        std::fs::write(&old_path, "{}\n").unwrap();
+        std::thread::sleep(Duration::from_millis(20));
+        std::fs::write(&new_path, "{}\n").unwrap();
+
+        let picked = newest_jsonl(td.path()).expect("found a jsonl");
+        assert_eq!(picked, new_path);
+    }
+
+    #[test]
+    fn newest_jsonl_ignores_non_jsonl() {
+        let td = tempfile::tempdir().expect("tempdir");
+        std::fs::write(td.path().join("a.jsonl"), "{}\n").unwrap();
+        std::fs::write(td.path().join("note.txt"), "ignore me\n").unwrap();
+        let picked = newest_jsonl(td.path()).expect("found a jsonl");
+        assert_eq!(picked, td.path().join("a.jsonl"));
+    }
+}

--- a/crates/chat-core/src/transcript.rs
+++ b/crates/chat-core/src/transcript.rs
@@ -76,8 +76,8 @@ pub fn verify_via_transcript(
             && let Ok(verified) = scan_for_user_message(&path, needle)
             && verified
         {
-            use time::format_description::well_known::Rfc3339;
             use time::OffsetDateTime;
+            use time::format_description::well_known::Rfc3339;
             let ts = OffsetDateTime::now_utc()
                 .format(&Rfc3339)
                 .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string());
@@ -153,10 +153,7 @@ fn newest_jsonl(dir: &std::path::Path) -> Option<PathBuf> {
 ///
 /// Returns `Ok(true)` if a match is found. `Ok(false)` if no match. `Err`
 /// on read errors that prevent any progress.
-fn scan_for_user_message(
-    path: &std::path::Path,
-    needle: &str,
-) -> std::io::Result<bool> {
+fn scan_for_user_message(path: &std::path::Path, needle: &str) -> std::io::Result<bool> {
     use std::io::{BufRead, BufReader};
     let f = std::fs::File::open(path)?;
     for line in BufReader::new(f).lines() {
@@ -176,9 +173,7 @@ fn scan_for_user_message(
         if v.get("type").and_then(|t| t.as_str()) != Some("user") {
             continue;
         }
-        let content = v
-            .get("message")
-            .and_then(|m| m.get("content"));
+        let content = v.get("message").and_then(|m| m.get("content"));
         if content_contains(content, needle) {
             return Ok(true);
         }

--- a/crates/chat-core/src/types.rs
+++ b/crates/chat-core/src/types.rs
@@ -1,0 +1,104 @@
+//! Public type surface: events, messages, members, send/fanout outcomes.
+
+use serde::{Deserialize, Serialize};
+
+/// Routing target for a send: either a room broadcast (`#room`) or a direct
+/// recipient (`@handle`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Target {
+    Room(String),
+    Direct(String),
+}
+
+impl Target {
+    /// Parse a target string. The leading sigil (`#` or `@`) disambiguates
+    /// routing. Returns `None` if the string has no recognized sigil.
+    pub fn parse(s: &str) -> Option<Self> {
+        if let Some(rest) = s.strip_prefix('#') {
+            if rest.is_empty() {
+                None
+            } else {
+                Some(Target::Room(rest.to_string()))
+            }
+        } else if let Some(rest) = s.strip_prefix('@') {
+            if rest.is_empty() {
+                None
+            } else {
+                Some(Target::Direct(rest.to_string()))
+            }
+        } else {
+            None
+        }
+    }
+
+    /// The implicit "room name" used to durably store messages even for
+    /// direct sends. For `@bob` we use the literal `@bob` as the room name
+    /// so its history is queryable; for `#general` it's `general`.
+    pub fn room_name(&self) -> String {
+        match self {
+            Target::Room(name) => name.clone(),
+            Target::Direct(handle) => format!("@{handle}"),
+        }
+    }
+}
+
+/// A persisted message id (ULID).
+pub type MessageId = String;
+
+/// A user-visible message line in a room.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Message {
+    pub id: MessageId,
+    pub ts: String,
+    pub sender: String,
+    pub sender_machine: String,
+    pub text: String,
+    #[serde(default = "default_source")]
+    pub source: String,
+}
+
+fn default_source() -> String {
+    "internal".to_string()
+}
+
+/// A member of a room (derived from joined/left events).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Member {
+    pub handle: String,
+    pub machine: String,
+    pub tmux_session: String,
+    pub joined_at: String,
+}
+
+/// One JSONL row. Discriminated on `type`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Event {
+    Message {
+        id: MessageId,
+        ts: String,
+        sender: String,
+        sender_machine: String,
+        text: String,
+        #[serde(default = "default_source")]
+        source: String,
+    },
+    #[serde(rename = "member.joined")]
+    MemberJoined {
+        ts: String,
+        handle: String,
+        machine: String,
+        tmux_session: String,
+    },
+    #[serde(rename = "member.left")]
+    MemberLeft { ts: String, handle: String },
+}
+
+/// Outcome of a `send` call: the durable message id (proof it landed in
+/// JSONL) plus per-recipient fanout outcomes.
+#[derive(Debug, Clone, Serialize)]
+pub struct SendOutcome {
+    pub message_id: MessageId,
+    pub room: String,
+    pub fanout: Vec<crate::FanoutOutcome>,
+}

--- a/crates/chat-core/tests/fanout_tests.rs
+++ b/crates/chat-core/tests/fanout_tests.rs
@@ -1,0 +1,52 @@
+//! Unit tests for `tmux_fanout`'s skip logic.
+//!
+//! Tests that don't require a live tmux session — just the predicate paths
+//! (skip-sender, skip-empty, format-paste). Real send-keys/capture-pane
+//! verification is in `two_session_chat.rs`.
+
+use chat_core::{FanoutOutcome, tmux_fanout};
+
+#[test]
+fn skips_sender_self() {
+    let outcomes = tmux_fanout(&["alice".to_string()], "@alice", "hello");
+    assert_eq!(outcomes.len(), 1);
+    match &outcomes[0] {
+        FanoutOutcome::Skipped { recipient, reason } => {
+            assert_eq!(recipient, "alice");
+            assert_eq!(reason, "sender");
+        }
+        other => panic!("expected Skipped::sender, got {other:?}"),
+    }
+}
+
+#[test]
+fn skips_sender_when_at_prefix_matches() {
+    // `@alice` and `alice` are the same handle — sigil is decoration.
+    let outcomes = tmux_fanout(&["@alice".to_string()], "alice", "hello");
+    assert_eq!(outcomes.len(), 1);
+    assert!(matches!(&outcomes[0], FanoutOutcome::Skipped { reason, .. } if reason == "sender"));
+}
+
+#[test]
+fn skips_empty_handle() {
+    let outcomes = tmux_fanout(&["@".to_string()], "@bob", "hello");
+    assert_eq!(outcomes.len(), 1);
+    match &outcomes[0] {
+        FanoutOutcome::Skipped { reason, .. } => assert_eq!(reason, "empty handle"),
+        other => panic!("expected Skipped::empty, got {other:?}"),
+    }
+}
+
+#[test]
+fn fails_offline_recipient() {
+    // Pick a session name unlikely to exist.
+    let bogus = "this-session-must-not-exist-1234567890";
+    let outcomes = tmux_fanout(&[bogus.to_string()], "@alice", "hi");
+    assert_eq!(outcomes.len(), 1);
+    match &outcomes[0] {
+        FanoutOutcome::Failed { error, .. } => {
+            assert_eq!(error, "no such tmux session");
+        }
+        other => panic!("expected Failed for offline session, got {other:?}"),
+    }
+}

--- a/crates/chat-core/tests/fanout_tests.rs
+++ b/crates/chat-core/tests/fanout_tests.rs
@@ -4,15 +4,19 @@
 //! (skip-sender, skip-empty, format-paste). Real send-keys/capture-pane
 //! verification is in `two_session_chat.rs`.
 
-use chat_core::{FanoutOutcome, tmux_fanout};
+use chat_core::{FanoutOutcome, Recipient, tmux_fanout};
 
 #[test]
 fn skips_sender_self() {
-    let outcomes = tmux_fanout(&["alice".to_string()], "@alice", "hello");
+    let outcomes = tmux_fanout(
+        &[Recipient::new("@alice", "alice")],
+        "@alice",
+        "hello",
+    );
     assert_eq!(outcomes.len(), 1);
     match &outcomes[0] {
         FanoutOutcome::Skipped { recipient, reason } => {
-            assert_eq!(recipient, "alice");
+            assert_eq!(recipient, "@alice");
             assert_eq!(reason, "sender");
         }
         other => panic!("expected Skipped::sender, got {other:?}"),
@@ -22,17 +26,25 @@ fn skips_sender_self() {
 #[test]
 fn skips_sender_when_at_prefix_matches() {
     // `@alice` and `alice` are the same handle — sigil is decoration.
-    let outcomes = tmux_fanout(&["@alice".to_string()], "alice", "hello");
+    let outcomes = tmux_fanout(
+        &[Recipient::new("@alice", "alice")],
+        "alice",
+        "hello",
+    );
     assert_eq!(outcomes.len(), 1);
     assert!(matches!(&outcomes[0], FanoutOutcome::Skipped { reason, .. } if reason == "sender"));
 }
 
 #[test]
-fn skips_empty_handle() {
-    let outcomes = tmux_fanout(&["@".to_string()], "@bob", "hello");
+fn skips_empty_tmux_session() {
+    let outcomes = tmux_fanout(
+        &[Recipient::new("@bob", "")],
+        "@alice",
+        "hello",
+    );
     assert_eq!(outcomes.len(), 1);
     match &outcomes[0] {
-        FanoutOutcome::Skipped { reason, .. } => assert_eq!(reason, "empty handle"),
+        FanoutOutcome::Skipped { reason, .. } => assert_eq!(reason, "empty tmux session"),
         other => panic!("expected Skipped::empty, got {other:?}"),
     }
 }
@@ -41,12 +53,39 @@ fn skips_empty_handle() {
 fn fails_offline_recipient() {
     // Pick a session name unlikely to exist.
     let bogus = "this-session-must-not-exist-1234567890";
-    let outcomes = tmux_fanout(&[bogus.to_string()], "@alice", "hi");
+    let outcomes = tmux_fanout(
+        &[Recipient::new(format!("@{bogus}"), bogus)],
+        "@alice",
+        "hi",
+    );
     assert_eq!(outcomes.len(), 1);
     match &outcomes[0] {
         FanoutOutcome::Failed { error, .. } => {
-            assert_eq!(error, "no such tmux session");
+            assert!(error.starts_with("no such tmux session"), "got: {error}");
         }
         other => panic!("expected Failed for offline session, got {other:?}"),
+    }
+}
+
+#[test]
+fn handle_and_session_can_diverge() {
+    // The bug from live testing: handle `@git_orchard_rs_spawn2` (slugified)
+    // must still route to actual tmux session `git-orchard-rs-spawn2`
+    // (dashes preserved). The Recipient struct keeps these distinct.
+    let bogus = "this-also-does-not-exist-rs-spawn2";
+    let outcomes = tmux_fanout(
+        &[Recipient::new("@this_also_does_not_exist_rs_spawn2", bogus)],
+        "@alice",
+        "hi",
+    );
+    assert_eq!(outcomes.len(), 1);
+    match &outcomes[0] {
+        FanoutOutcome::Failed { recipient, error } => {
+            // Recipient field carries the human-facing handle…
+            assert_eq!(recipient, "@this_also_does_not_exist_rs_spawn2");
+            // …but the error message names the actual session that was looked up.
+            assert!(error.contains(bogus), "error should name session: {error}");
+        }
+        other => panic!("expected Failed, got {other:?}"),
     }
 }

--- a/crates/chat-core/tests/fanout_tests.rs
+++ b/crates/chat-core/tests/fanout_tests.rs
@@ -8,11 +8,7 @@ use chat_core::{FanoutOutcome, Recipient, tmux_fanout};
 
 #[test]
 fn skips_sender_self() {
-    let outcomes = tmux_fanout(
-        &[Recipient::new("@alice", "alice")],
-        "@alice",
-        "hello",
-    );
+    let outcomes = tmux_fanout(&[Recipient::new("@alice", "alice")], "@alice", "hello");
     assert_eq!(outcomes.len(), 1);
     match &outcomes[0] {
         FanoutOutcome::Skipped { recipient, reason } => {
@@ -26,22 +22,14 @@ fn skips_sender_self() {
 #[test]
 fn skips_sender_when_at_prefix_matches() {
     // `@alice` and `alice` are the same handle — sigil is decoration.
-    let outcomes = tmux_fanout(
-        &[Recipient::new("@alice", "alice")],
-        "alice",
-        "hello",
-    );
+    let outcomes = tmux_fanout(&[Recipient::new("@alice", "alice")], "alice", "hello");
     assert_eq!(outcomes.len(), 1);
     assert!(matches!(&outcomes[0], FanoutOutcome::Skipped { reason, .. } if reason == "sender"));
 }
 
 #[test]
 fn skips_empty_tmux_session() {
-    let outcomes = tmux_fanout(
-        &[Recipient::new("@bob", "")],
-        "@alice",
-        "hello",
-    );
+    let outcomes = tmux_fanout(&[Recipient::new("@bob", "")], "@alice", "hello");
     assert_eq!(outcomes.len(), 1);
     match &outcomes[0] {
         FanoutOutcome::Skipped { reason, .. } => assert_eq!(reason, "empty tmux session"),

--- a/crates/chat-core/tests/handle_tests.rs
+++ b/crates/chat-core/tests/handle_tests.rs
@@ -1,0 +1,63 @@
+//! Unit tests for `derive_handle` slugify + collision suffixing.
+
+use chat_core::{derive_handle, derive_handle_with_collisions};
+
+#[test]
+fn lowercases_and_drops_non_alphanum() {
+    assert_eq!(derive_handle("Alice", None), "alice");
+    assert_eq!(derive_handle("Issue-123/Foo", None), "issue_123_foo");
+    assert_eq!(derive_handle("ALPHA-BETA", None), "alpha_beta");
+}
+
+#[test]
+fn collapses_runs_of_separators() {
+    assert_eq!(derive_handle("foo---bar", None), "foo_bar");
+    assert_eq!(derive_handle("foo  bar", None), "foo_bar");
+    assert_eq!(derive_handle("foo/-/bar", None), "foo_bar");
+}
+
+#[test]
+fn strips_trailing_underscores() {
+    assert_eq!(derive_handle("alice-", None), "alice");
+    assert_eq!(derive_handle("alice---", None), "alice");
+    assert_eq!(derive_handle("alice_", None), "alice");
+}
+
+#[test]
+fn truncates_to_24_chars() {
+    let long = "a".repeat(50);
+    let out = derive_handle(&long, None);
+    assert!(out.len() <= 24, "got {} chars: {out:?}", out.len());
+}
+
+#[test]
+fn truncates_on_word_boundary_when_close() {
+    // "issue_123_long_branch_name" is 26 chars; truncate near a `_` boundary.
+    let out = derive_handle("issue-123-long-branch-name", None);
+    assert!(out.len() <= 24);
+    assert!(!out.ends_with('_'), "no trailing underscore: {out}");
+}
+
+#[test]
+fn empty_input_yields_anon() {
+    assert_eq!(derive_handle("", None), "anon");
+    assert_eq!(derive_handle("---", None), "anon");
+}
+
+#[test]
+fn collision_suffixes_with_2_3_etc() {
+    let taken: Vec<&str> = vec!["alice"];
+    let out = derive_handle_with_collisions("Alice", None, &taken);
+    assert_eq!(out, "alice_2");
+
+    let taken: Vec<&str> = vec!["alice", "alice_2", "alice_3"];
+    let out = derive_handle_with_collisions("Alice", None, &taken);
+    assert_eq!(out, "alice_4");
+}
+
+#[test]
+fn no_collision_returns_base() {
+    let taken: Vec<&str> = vec!["bob", "carol"];
+    let out = derive_handle_with_collisions("Alice", None, &taken);
+    assert_eq!(out, "alice");
+}

--- a/crates/chat-core/tests/store_tests.rs
+++ b/crates/chat-core/tests/store_tests.rs
@@ -31,7 +31,10 @@ fn isolated_chat_dir() -> ChatDirGuard {
     unsafe {
         std::env::set_var("ORCHARD_CHAT_DIR", td.path());
     }
-    ChatDirGuard { _td: td, _guard: guard }
+    ChatDirGuard {
+        _td: td,
+        _guard: guard,
+    }
 }
 
 #[test]

--- a/crates/chat-core/tests/store_tests.rs
+++ b/crates/chat-core/tests/store_tests.rs
@@ -1,0 +1,225 @@
+//! Unit tests for the store layer (append, history, join/leave, fold).
+//!
+//! Each test creates an isolated tempdir, sets `ORCHARD_CHAT_DIR`, and runs
+//! against fresh state. Tests do NOT shell out to tmux — that's covered by
+//! the two_session_chat integration test.
+//!
+//! `serial: true` is enforced via a global mutex around env-var manipulation
+//! because `std::env::set_var` is process-wide. Cargo runs tests in a single
+//! process by default; one test setting the env affects another.
+
+use std::sync::{Mutex, OnceLock};
+
+use chat_core::{
+    Event, Member, append_message, join, leave, list_members, list_rooms, read_history,
+};
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct ChatDirGuard {
+    _td: tempfile::TempDir,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+fn isolated_chat_dir() -> ChatDirGuard {
+    let guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let td = tempfile::tempdir().expect("tempdir");
+    // SAFETY: protected by env_lock() above; only one test mutates env at a time.
+    unsafe {
+        std::env::set_var("ORCHARD_CHAT_DIR", td.path());
+    }
+    ChatDirGuard { _td: td, _guard: guard }
+}
+
+#[test]
+fn append_then_read_round_trip() {
+    let _g = isolated_chat_dir();
+    let id1 = append_message("general", "@alice", "hello").unwrap();
+    let id2 = append_message("general", "@bob", "hi").unwrap();
+
+    let history = read_history("general", 0).unwrap();
+    assert_eq!(history.len(), 2);
+    assert_eq!(history[0].id, id1);
+    assert_eq!(history[0].sender, "@alice");
+    assert_eq!(history[0].text, "hello");
+    assert_eq!(history[1].id, id2);
+    assert_eq!(history[1].sender, "@bob");
+    assert!(!history[0].sender_machine.is_empty());
+}
+
+#[test]
+fn read_history_filters_out_membership_events() {
+    let _g = isolated_chat_dir();
+    join("general", "@alice", "host", "alice").unwrap();
+    append_message("general", "@alice", "msg-1").unwrap();
+    leave("general", "@alice").unwrap();
+    append_message("general", "@bob", "msg-2").unwrap();
+
+    let history = read_history("general", 0).unwrap();
+    assert_eq!(history.len(), 2, "membership events must not count");
+    assert_eq!(history[0].text, "msg-1");
+    assert_eq!(history[1].text, "msg-2");
+}
+
+#[test]
+fn read_history_respects_limit() {
+    let _g = isolated_chat_dir();
+    for i in 0..5 {
+        append_message("general", "@alice", &format!("msg-{i}")).unwrap();
+    }
+    let history = read_history("general", 3).unwrap();
+    assert_eq!(history.len(), 3);
+    assert_eq!(history[0].text, "msg-2");
+    assert_eq!(history[2].text, "msg-4");
+}
+
+#[test]
+fn list_members_folds_join_then_leave() {
+    let _g = isolated_chat_dir();
+    join("general", "@alice", "host-a", "alice").unwrap();
+    join("general", "@bob", "host-b", "bob").unwrap();
+    leave("general", "@alice").unwrap();
+
+    let members = list_members("general").unwrap();
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].handle, "@bob");
+    assert_eq!(members[0].machine, "host-b");
+    assert_eq!(members[0].tmux_session, "bob");
+}
+
+#[test]
+fn list_members_handles_rejoin_after_leave() {
+    let _g = isolated_chat_dir();
+    join("general", "@alice", "host-a", "alice").unwrap();
+    leave("general", "@alice").unwrap();
+    // Re-join: handle is back, with new tmux_session
+    join("general", "@alice", "host-a", "alice-2").unwrap();
+
+    let members = list_members("general").unwrap();
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].handle, "@alice");
+    assert_eq!(members[0].tmux_session, "alice-2");
+}
+
+#[test]
+fn list_members_returns_empty_for_missing_room() {
+    let _g = isolated_chat_dir();
+    let members = list_members("nonexistent").unwrap();
+    assert!(members.is_empty());
+}
+
+#[test]
+fn list_rooms_returns_only_jsonl_files() {
+    let _g = isolated_chat_dir();
+    append_message("alpha", "@a", "x").unwrap();
+    append_message("beta", "@b", "y").unwrap();
+    append_message("gamma", "@c", "z").unwrap();
+
+    let mut rooms = list_rooms().unwrap();
+    rooms.sort();
+    assert_eq!(rooms, vec!["alpha", "beta", "gamma"]);
+}
+
+#[test]
+fn jsonl_row_schema_is_typed() {
+    let _g = isolated_chat_dir();
+    let id = append_message("general", "@alice", "hello").unwrap();
+    join("general", "@alice", "host", "alice").unwrap();
+    leave("general", "@alice").unwrap();
+
+    let path = chat_core::room_path("general").unwrap();
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let lines: Vec<&str> = raw.lines().collect();
+    assert_eq!(lines.len(), 3);
+
+    // First line: type=message
+    let m: Event = serde_json::from_str(lines[0]).unwrap();
+    match m {
+        Event::Message {
+            id: got_id,
+            ts,
+            sender,
+            sender_machine,
+            text,
+            source,
+        } => {
+            assert_eq!(got_id, id);
+            assert!(!ts.is_empty());
+            assert_eq!(sender, "@alice");
+            assert!(!sender_machine.is_empty());
+            assert_eq!(text, "hello");
+            assert_eq!(source, "internal");
+        }
+        _ => panic!("expected Message"),
+    }
+
+    // Second line: type=member.joined
+    let j: Event = serde_json::from_str(lines[1]).unwrap();
+    match j {
+        Event::MemberJoined {
+            ts,
+            handle,
+            machine,
+            tmux_session,
+        } => {
+            assert!(!ts.is_empty());
+            assert_eq!(handle, "@alice");
+            assert_eq!(machine, "host");
+            assert_eq!(tmux_session, "alice");
+        }
+        _ => panic!("expected MemberJoined"),
+    }
+
+    // Third line: type=member.left
+    let l: Event = serde_json::from_str(lines[2]).unwrap();
+    match l {
+        Event::MemberLeft { ts, handle } => {
+            assert!(!ts.is_empty());
+            assert_eq!(handle, "@alice");
+        }
+        _ => panic!("expected MemberLeft"),
+    }
+}
+
+#[test]
+fn message_id_is_ulid_shape() {
+    let _g = isolated_chat_dir();
+    let id = append_message("general", "@alice", "hi").unwrap();
+    // ULID is 26 chars, Crockford base32 alphabet (no I/L/O/U).
+    assert_eq!(id.len(), 26, "ULID should be 26 chars, got {id:?}");
+    for c in id.chars() {
+        assert!(
+            c.is_ascii_alphanumeric() && !"ILOUilou".contains(c),
+            "ULID char must be Crockford base32, got {c} in {id}"
+        );
+    }
+}
+
+#[test]
+fn append_does_not_clobber_existing_history() {
+    let _g = isolated_chat_dir();
+    append_message("general", "@alice", "first").unwrap();
+    append_message("general", "@bob", "second").unwrap();
+    append_message("general", "@alice", "third").unwrap();
+
+    let history = read_history("general", 0).unwrap();
+    let texts: Vec<&str> = history.iter().map(|m| m.text.as_str()).collect();
+    assert_eq!(texts, vec!["first", "second", "third"]);
+}
+
+#[test]
+fn members_sorted_by_handle() {
+    let _g = isolated_chat_dir();
+    join("room", "@charlie", "h", "charlie").unwrap();
+    join("room", "@alice", "h", "alice").unwrap();
+    join("room", "@bob", "h", "bob").unwrap();
+
+    let members = list_members("room").unwrap();
+    let handles: Vec<&str> = members.iter().map(|m| m.handle.as_str()).collect();
+    assert_eq!(handles, vec!["@alice", "@bob", "@charlie"]);
+    // Anchor that Member is reachable via the public re-export.
+    let _: Member = members.into_iter().next().unwrap();
+}

--- a/crates/orchard-chat/Cargo.toml
+++ b/crates/orchard-chat/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "orchard-chat"
+version = "0.1.0"
+edition = "2024"
+description = "Agent-to-agent chat CLI: thin clap wrapper on chat-core (orchard send/chat verbs)"
+license = "MIT"
+repository = "https://github.com/drewdrewthis/git-orchard-rs"
+
+[[bin]]
+name = "orchard-chat"
+path = "src/main.rs"
+
+[dependencies]
+chat-core = { path = "../chat-core" }
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+anyhow = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/orchard-chat/src/cmd/history.rs
+++ b/crates/orchard-chat/src/cmd/history.rs
@@ -1,0 +1,44 @@
+//! `orchard chat history <room> [-n N]`.
+
+use std::process::ExitCode;
+
+use clap::Args as ClapArgs;
+
+#[derive(ClapArgs, Debug)]
+pub struct Args {
+    pub room: String,
+
+    /// Limit to the last N message-type rows (0 = all). Defaults to 50.
+    #[arg(short = 'n', long = "limit", default_value_t = 50)]
+    pub limit: usize,
+
+    #[arg(short = 'j', long = "json")]
+    pub json: bool,
+}
+
+pub fn run(args: Args) -> ExitCode {
+    let room = args.room.trim_start_matches('#').to_string();
+    let messages = match chat_core::read_history(&room, args.limit) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("orchard chat history: {e:#}");
+            return ExitCode::from(2);
+        }
+    };
+    if args.json {
+        match serde_json::to_string(&messages) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("orchard chat history: serializing: {e}");
+                return ExitCode::from(2);
+            }
+        }
+    } else if messages.is_empty() {
+        println!("(no messages in #{room})");
+    } else {
+        for m in &messages {
+            println!("[{}] {}: {}", m.ts, m.sender, m.text);
+        }
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/orchard-chat/src/cmd/join.rs
+++ b/crates/orchard-chat/src/cmd/join.rs
@@ -1,0 +1,79 @@
+//! `orchard chat join <room>`.
+
+use std::process::ExitCode;
+
+use clap::Args as ClapArgs;
+
+use crate::cmd::sender;
+
+#[derive(ClapArgs, Debug)]
+pub struct Args {
+    /// Room name (with or without leading `#`).
+    pub room: String,
+
+    /// Override the joining handle (otherwise auto-derived from `$TMUX`).
+    #[arg(long = "as", value_name = "HANDLE")]
+    pub as_handle: Option<String>,
+
+    /// Override the tmux session name (defaults to `$TMUX` session).
+    #[arg(long = "session")]
+    pub session: Option<String>,
+
+    /// JSON output.
+    #[arg(short = 'j', long = "json")]
+    pub json: bool,
+}
+
+pub fn run(args: Args) -> ExitCode {
+    let room = args.room.trim_start_matches('#').to_string();
+    if room.is_empty() {
+        eprintln!("orchard chat join: room name required");
+        return ExitCode::from(3);
+    }
+    let handle = match sender::resolve(args.as_handle.as_deref()) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("orchard chat join: {e}");
+            return ExitCode::from(3);
+        }
+    };
+    let session = args
+        .session
+        .or_else(|| current_tmux_session())
+        .unwrap_or_else(|| handle.trim_start_matches('@').to_string());
+    let machine = chat_core::current_machine();
+    if let Err(e) = chat_core::join(&room, &handle, &machine, &session) {
+        eprintln!("orchard chat join: {e:#}");
+        return ExitCode::from(2);
+    }
+    if args.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "kind": "joined",
+                "room": room,
+                "handle": handle,
+                "machine": machine,
+                "tmux_session": session,
+            })
+        );
+    } else {
+        println!("joined #{room} as {handle} (tmux: {session})");
+    }
+    ExitCode::SUCCESS
+}
+
+fn current_tmux_session() -> Option<String> {
+    if std::env::var_os("TMUX").is_none() {
+        return None;
+    }
+    let out = std::process::Command::new("tmux")
+        .args(["display-message", "-p", "#S"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}

--- a/crates/orchard-chat/src/cmd/leave.rs
+++ b/crates/orchard-chat/src/cmd/leave.rs
@@ -1,0 +1,50 @@
+//! `orchard chat leave <room>`.
+
+use std::process::ExitCode;
+
+use clap::Args as ClapArgs;
+
+use crate::cmd::sender;
+
+#[derive(ClapArgs, Debug)]
+pub struct Args {
+    pub room: String,
+
+    #[arg(long = "as", value_name = "HANDLE")]
+    pub as_handle: Option<String>,
+
+    #[arg(short = 'j', long = "json")]
+    pub json: bool,
+}
+
+pub fn run(args: Args) -> ExitCode {
+    let room = args.room.trim_start_matches('#').to_string();
+    if room.is_empty() {
+        eprintln!("orchard chat leave: room name required");
+        return ExitCode::from(3);
+    }
+    let handle = match sender::resolve(args.as_handle.as_deref()) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("orchard chat leave: {e}");
+            return ExitCode::from(3);
+        }
+    };
+    if let Err(e) = chat_core::leave(&room, &handle) {
+        eprintln!("orchard chat leave: {e:#}");
+        return ExitCode::from(2);
+    }
+    if args.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "kind": "left",
+                "room": room,
+                "handle": handle,
+            })
+        );
+    } else {
+        println!("left #{room} as {handle}");
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/orchard-chat/src/cmd/list.rs
+++ b/crates/orchard-chat/src/cmd/list.rs
@@ -1,0 +1,42 @@
+//! `orchard chat list` — list all rooms (each `<name>.jsonl` in chat dir).
+
+use std::process::ExitCode;
+
+use clap::Args as ClapArgs;
+
+#[derive(ClapArgs, Debug)]
+pub struct Args {
+    #[arg(short = 'j', long = "json")]
+    pub json: bool,
+}
+
+pub fn run(args: Args) -> ExitCode {
+    let rooms = match chat_core::list_rooms() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("orchard chat list: {e:#}");
+            return ExitCode::from(2);
+        }
+    };
+    if args.json {
+        match serde_json::to_string(&rooms) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("orchard chat list: serializing: {e}");
+                return ExitCode::from(2);
+            }
+        }
+    } else if rooms.is_empty() {
+        println!("(no rooms)");
+    } else {
+        for r in &rooms {
+            // Distinguish `#room` from `@handle` direct-send rooms.
+            if r.starts_with('@') {
+                println!("{r}");
+            } else {
+                println!("#{r}");
+            }
+        }
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/orchard-chat/src/cmd/members.rs
+++ b/crates/orchard-chat/src/cmd/members.rs
@@ -1,0 +1,43 @@
+//! `orchard chat members <room>`.
+
+use std::process::ExitCode;
+
+use clap::Args as ClapArgs;
+
+#[derive(ClapArgs, Debug)]
+pub struct Args {
+    pub room: String,
+
+    #[arg(short = 'j', long = "json")]
+    pub json: bool,
+}
+
+pub fn run(args: Args) -> ExitCode {
+    let room = args.room.trim_start_matches('#').to_string();
+    let members = match chat_core::list_members(&room) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("orchard chat members: {e:#}");
+            return ExitCode::from(2);
+        }
+    };
+    if args.json {
+        match serde_json::to_string(&members) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("orchard chat members: serializing: {e}");
+                return ExitCode::from(2);
+            }
+        }
+    } else if members.is_empty() {
+        println!("(no members in #{room})");
+    } else {
+        for m in &members {
+            println!(
+                "{}\t{}\t{}\t{}",
+                m.handle, m.machine, m.tmux_session, m.joined_at
+            );
+        }
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/orchard-chat/src/cmd/mod.rs
+++ b/crates/orchard-chat/src/cmd/mod.rs
@@ -1,0 +1,12 @@
+//! CLI subcommand modules — one per verb. Each module exposes `Args` and
+//! `run` and returns a `ExitCode` directly (not `Result`) so it can use
+//! the spec's exit-code table without adapter glue.
+
+pub mod history;
+pub mod join;
+pub mod leave;
+pub mod list;
+pub mod members;
+pub mod send;
+pub mod tail;
+pub mod sender;

--- a/crates/orchard-chat/src/cmd/mod.rs
+++ b/crates/orchard-chat/src/cmd/mod.rs
@@ -8,5 +8,5 @@ pub mod leave;
 pub mod list;
 pub mod members;
 pub mod send;
-pub mod tail;
 pub mod sender;
+pub mod tail;

--- a/crates/orchard-chat/src/cmd/send.rs
+++ b/crates/orchard-chat/src/cmd/send.rs
@@ -1,0 +1,120 @@
+//! `orchard chat send <target> <text>` (also reachable as `orchard send …`).
+
+use std::process::ExitCode;
+
+use clap::Args as ClapArgs;
+
+use chat_core::{FanoutOutcome, SendOutcome, Target};
+
+use crate::cmd::sender;
+
+#[derive(ClapArgs, Debug)]
+pub struct Args {
+    /// `#room` (broadcast) or `@handle` (direct).
+    pub target: String,
+
+    /// The message text.
+    pub text: String,
+
+    /// Override the sender handle (otherwise auto-derived from `$TMUX`).
+    #[arg(long = "as", value_name = "HANDLE")]
+    pub as_handle: Option<String>,
+
+    /// Emit machine-readable JSON (full `SendOutcome` shape) on stdout.
+    #[arg(short = 'j', long = "json")]
+    pub json: bool,
+}
+
+pub fn run(args: Args) -> ExitCode {
+    let target = match Target::parse(&args.target) {
+        Some(t) => t,
+        None => {
+            eprintln!(
+                "orchard chat send: target must start with '#' (room) or '@' (handle); got {:?}",
+                args.target
+            );
+            return ExitCode::from(3);
+        }
+    };
+    let sender = match sender::resolve(args.as_handle.as_deref()) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("orchard chat send: {e}");
+            return ExitCode::from(3);
+        }
+    };
+    let outcome = match chat_core::send(&target, &sender, &args.text) {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("orchard chat send: failed to append message: {e:#}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let exit = derive_exit_code(&outcome);
+    if args.json {
+        match serde_json::to_string(&outcome) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("orchard chat send: failed to serialize outcome: {e}");
+                return ExitCode::from(2);
+            }
+        }
+    } else {
+        report_human(&outcome);
+    }
+    if exit != 0 {
+        report_partial_to_stderr(&outcome);
+    }
+    ExitCode::from(exit)
+}
+
+fn derive_exit_code(outcome: &SendOutcome) -> u8 {
+    // Empty fanout (no recipients) → full success. The message is in JSONL
+    // and there was nobody to deliver to (e.g. broadcasting to a room where
+    // you're the only member, or sending `@self`). The skip-sender path is
+    // also "no real recipient" — exclude it from problem-counting too, so
+    // sending to yourself doesn't surface as exit 1.
+    let problems = outcome.fanout.iter().filter(|o| !is_ok_outcome(o)).count();
+    if problems == 0 { 0 } else { 1 }
+}
+
+fn is_ok_outcome(o: &FanoutOutcome) -> bool {
+    match o {
+        FanoutOutcome::Delivered { .. } => true,
+        // Sender-self isn't a real recipient — skipping it is expected, not
+        // a partial failure.
+        FanoutOutcome::Skipped { reason, .. } if reason == "sender" => true,
+        _ => false,
+    }
+}
+
+fn report_human(outcome: &SendOutcome) {
+    let delivered = outcome
+        .fanout
+        .iter()
+        .filter(|o| o.is_delivered())
+        .count();
+    let total = outcome.fanout.len();
+    println!(
+        "sent message {} to {} ({}/{} delivered)",
+        outcome.message_id, outcome.room, delivered, total
+    );
+}
+
+fn report_partial_to_stderr(outcome: &SendOutcome) {
+    for o in &outcome.fanout {
+        match o {
+            FanoutOutcome::Delivered { .. } => {}
+            FanoutOutcome::ByteOnly { recipient, reason } => {
+                eprintln!("  byte-only @{recipient}: {reason}");
+            }
+            FanoutOutcome::Failed { recipient, error } => {
+                eprintln!("  failed @{recipient}: {error}");
+            }
+            FanoutOutcome::Skipped { recipient, reason } => {
+                eprintln!("  skipped @{recipient}: {reason}");
+            }
+        }
+    }
+}

--- a/crates/orchard-chat/src/cmd/send.rs
+++ b/crates/orchard-chat/src/cmd/send.rs
@@ -90,11 +90,7 @@ fn is_ok_outcome(o: &FanoutOutcome) -> bool {
 }
 
 fn report_human(outcome: &SendOutcome) {
-    let delivered = outcome
-        .fanout
-        .iter()
-        .filter(|o| o.is_delivered())
-        .count();
+    let delivered = outcome.fanout.iter().filter(|o| o.is_delivered()).count();
     let total = outcome.fanout.len();
     println!(
         "sent message {} to {} ({}/{} delivered)",

--- a/crates/orchard-chat/src/cmd/send.rs
+++ b/crates/orchard-chat/src/cmd/send.rs
@@ -107,14 +107,27 @@ fn report_partial_to_stderr(outcome: &SendOutcome) {
         match o {
             FanoutOutcome::Delivered { .. } => {}
             FanoutOutcome::ByteOnly { recipient, reason } => {
-                eprintln!("  byte-only @{recipient}: {reason}");
+                eprintln!("  byte-only {}: {reason}", with_at(recipient));
             }
             FanoutOutcome::Failed { recipient, error } => {
-                eprintln!("  failed @{recipient}: {error}");
+                eprintln!("  failed {}: {error}", with_at(recipient));
             }
             FanoutOutcome::Skipped { recipient, reason } => {
-                eprintln!("  skipped @{recipient}: {reason}");
+                eprintln!("  skipped {}: {reason}", with_at(recipient));
             }
         }
+    }
+}
+
+/// Recipients can come in either with or without the leading `@` sigil
+/// (depending on whether the target was `Target::Direct(handle)` whose
+/// `handle` may not include the sigil or via membership where `Member.handle`
+/// always does). This helper makes the formatted output uniform without
+/// double-printing the sigil.
+fn with_at(recipient: &str) -> String {
+    if recipient.starts_with('@') {
+        recipient.to_string()
+    } else {
+        format!("@{recipient}")
     }
 }

--- a/crates/orchard-chat/src/cmd/sender.rs
+++ b/crates/orchard-chat/src/cmd/sender.rs
@@ -1,0 +1,50 @@
+//! Sender resolution helper.
+//!
+//! Per #495 AC-8:
+//! 1. Explicit `--as <handle>` flag wins.
+//! 2. Otherwise auto-derive from `$TMUX` / current tmux session name.
+//! 3. Otherwise fail loudly with exit code 3.
+
+use std::process::Command;
+
+use anyhow::Result;
+
+/// Resolve the sender's handle.
+///
+/// `as_override` is the value of `--as` (already stripped of leading `@` or
+/// not — we accept both). Returns the handle WITH a leading `@` so JSONL
+/// entries are uniform.
+pub fn resolve(as_override: Option<&str>) -> Result<String> {
+    if let Some(h) = as_override {
+        return Ok(normalize(h));
+    }
+    if let Some(h) = current_tmux_session() {
+        return Ok(format!("@{}", chat_core::derive_handle(&h, None)));
+    }
+    Err(anyhow::anyhow!(
+        "cannot derive sender (not in a tmux session); use --as <handle>"
+    ))
+}
+
+fn normalize(h: &str) -> String {
+    if h.starts_with('@') {
+        h.to_string()
+    } else {
+        format!("@{h}")
+    }
+}
+
+fn current_tmux_session() -> Option<String> {
+    if std::env::var_os("TMUX").is_none() {
+        return None;
+    }
+    let out = Command::new("tmux")
+        .args(["display-message", "-p", "#S"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}

--- a/crates/orchard-chat/src/cmd/tail.rs
+++ b/crates/orchard-chat/src/cmd/tail.rs
@@ -1,0 +1,109 @@
+//! `orchard chat tail <room>` — print full history then follow new appends.
+
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::process::ExitCode;
+use std::time::Duration;
+
+use clap::Args as ClapArgs;
+
+use chat_core::Event;
+
+#[derive(ClapArgs, Debug)]
+pub struct Args {
+    pub room: String,
+
+    /// Print raw JSONL lines instead of formatted. Useful for piping.
+    #[arg(long = "raw")]
+    pub raw: bool,
+}
+
+pub fn run(args: Args) -> ExitCode {
+    let room = args.room.trim_start_matches('#').to_string();
+    let path = match chat_core::room_path(&room) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("orchard chat tail: {e:#}");
+            return ExitCode::from(3);
+        }
+    };
+
+    // Ensure the file exists so we can tail it even if no one's joined.
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .ok();
+    }
+
+    let mut file = match std::fs::File::open(&path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("orchard chat tail: opening {}: {e}", path.display());
+            return ExitCode::from(2);
+        }
+    };
+
+    // Phase 1: backfill — read everything from the start.
+    let mut buf_reader = BufReader::new(&file);
+    for line in (&mut buf_reader).lines().map_while(Result::ok) {
+        emit_line(&line, args.raw);
+    }
+    // Capture position for follow phase.
+    let pos = buf_reader.stream_position().unwrap_or(0);
+    drop(buf_reader);
+    file.seek(SeekFrom::Start(pos)).ok();
+
+    // Phase 2: follow.
+    let mut reader = BufReader::new(file);
+    loop {
+        let mut buf = String::new();
+        match reader.read_line(&mut buf) {
+            Ok(0) => {
+                std::thread::sleep(Duration::from_millis(200));
+            }
+            Ok(_) => {
+                let line = buf.trim_end();
+                if !line.is_empty() {
+                    emit_line(line, args.raw);
+                }
+            }
+            Err(e) => {
+                eprintln!("orchard chat tail: read error: {e}");
+                return ExitCode::from(2);
+            }
+        }
+    }
+}
+
+fn emit_line(line: &str, raw: bool) {
+    if raw {
+        println!("{line}");
+        return;
+    }
+    match serde_json::from_str::<Event>(line) {
+        Ok(Event::Message {
+            ts, sender, text, ..
+        }) => {
+            println!("[{ts}] {sender}: {text}");
+        }
+        Ok(Event::MemberJoined {
+            ts,
+            handle,
+            tmux_session,
+            ..
+        }) => {
+            println!("[{ts}] {handle} joined (tmux: {tmux_session})");
+        }
+        Ok(Event::MemberLeft { ts, handle }) => {
+            println!("[{ts}] {handle} left");
+        }
+        Err(_) => {
+            // Malformed line — print raw as a hint.
+            println!("(unparsed) {line}");
+        }
+    }
+}

--- a/crates/orchard-chat/src/main.rs
+++ b/crates/orchard-chat/src/main.rs
@@ -1,0 +1,73 @@
+//! `orchard-chat` — agent-to-agent chat CLI.
+//!
+//! Thin clap wrapper on [`chat_core`]. Backs the `orchard chat <verb>` and
+//! `orchard send <target> <text>` verbs in the orchard dispatcher (per
+//! ADR-013 + #495).
+//!
+//! # Exit codes
+//!
+//! Stable per #495 AC-12:
+//!
+//! | Code | Meaning |
+//! |------|---------|
+//! | 0    | Full success — message landed AND fanout fully verified |
+//! | 1    | Partial — message landed, some fanout `ByteOnly`/`Failed`/`Skipped` |
+//! | 2    | Message did NOT land (append failure) |
+//! | 3    | Usage error (no sender resolvable, bad target, missing arg) |
+//!
+//! Per-recipient detail prints to stderr on partial. JSON mode emits the
+//! full `SendOutcome` shape on stdout.
+
+use std::process::ExitCode;
+
+use clap::Parser;
+
+mod cmd;
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "orchard-chat",
+    about = "Agent-to-agent chat: send to #room or @handle via tmux send-keys + JSONL receipts.",
+    version
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Parser, Debug)]
+enum Command {
+    /// Send a message to a `#room` (broadcast) or `@handle` (direct).
+    Send(cmd::send::Args),
+
+    /// Join a room (appends a `member.joined` event to the room's JSONL).
+    Join(cmd::join::Args),
+
+    /// Leave a room (appends a `member.left` event).
+    Leave(cmd::leave::Args),
+
+    /// List current members of a room.
+    Members(cmd::members::Args),
+
+    /// List all rooms (each `<name>.jsonl` in the chat dir).
+    List(cmd::list::Args),
+
+    /// Print the last N messages of a room.
+    History(cmd::history::Args),
+
+    /// Print the full history of a room, then follow new appends.
+    Tail(cmd::tail::Args),
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Send(args) => cmd::send::run(args),
+        Command::Join(args) => cmd::join::run(args),
+        Command::Leave(args) => cmd::leave::run(args),
+        Command::Members(args) => cmd::members::run(args),
+        Command::List(args) => cmd::list::run(args),
+        Command::History(args) => cmd::history::run(args),
+        Command::Tail(args) => cmd::tail::run(args),
+    }
+}

--- a/crates/orchard-chat/tests/two_session_chat.rs
+++ b/crates/orchard-chat/tests/two_session_chat.rs
@@ -1,0 +1,392 @@
+//! End-to-end integration test (#495 AC-18): two real tmux sessions,
+//! one sends, the other receives — full Level 2 receipt verification.
+//!
+//! Skips itself with a clear stderr message if `tmux` is unavailable so CI
+//! environments without tmux installed don't false-fail.
+//!
+//! This test invokes the compiled `orchard-chat` binary (resolved via
+//! `CARGO_BIN_EXE_orchard-chat` set by Cargo). The chat dir is rooted in a
+//! tempdir via `ORCHARD_CHAT_DIR` so it does not pollute `~/.orchard/`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn cli_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_orchard-chat"))
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+struct TmuxServerGuard {
+    socket: String,
+    sessions: Vec<String>,
+}
+
+impl TmuxServerGuard {
+    fn new() -> Self {
+        // Use a unique socket per test run to isolate from any user tmux server.
+        let socket = format!(
+            "orchard-chat-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        );
+        Self {
+            socket,
+            sessions: Vec::new(),
+        }
+    }
+
+    fn create_session(&mut self, name: &str) {
+        let out = Command::new("tmux")
+            .args([
+                "-L",
+                &self.socket,
+                "new-session",
+                "-d",
+                "-s",
+                name,
+                "-x",
+                "120",
+                "-y",
+                "40",
+            ])
+            .output()
+            .expect("tmux new-session");
+        if !out.status.success() {
+            panic!(
+                "tmux new-session failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        self.sessions.push(name.to_string());
+    }
+
+    fn capture_pane(&self, session: &str) -> String {
+        let out = Command::new("tmux")
+            .args(["-L", &self.socket, "capture-pane", "-p", "-t", session])
+            .output()
+            .expect("tmux capture-pane");
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    }
+}
+
+impl Drop for TmuxServerGuard {
+    fn drop(&mut self) {
+        // kill-server is the cleanest teardown — drops every session on this
+        // socket and the tmux daemon along with them.
+        let _ = Command::new("tmux")
+            .args(["-L", &self.socket, "kill-server"])
+            .output();
+    }
+}
+
+/// Run the orchard-chat CLI with `ORCHARD_CHAT_DIR` set to `chat_dir` and
+/// the tmux socket env-shadowed so child tmux invocations connect to our
+/// isolated server. Returns (stdout, stderr, exit code).
+fn run_cli(
+    cli: &PathBuf,
+    chat_dir: &std::path::Path,
+    tmux_socket: &str,
+    args: &[&str],
+) -> (String, String, i32) {
+    // Prepend a tmux wrapper script so the CLI's tmux invocations also use
+    // the test socket. Simpler approach: alias TMUX_TMPDIR doesn't help; the
+    // -L flag is the only reliable switch. Since the CLI's chat-core uses
+    // the bare `tmux` binary without -L, we install a wrapper on PATH.
+    let wrapper_dir = tempfile::tempdir().expect("wrapper tempdir");
+    let real_tmux = which_tmux();
+    let wrapper_path = wrapper_dir.path().join("tmux");
+    let script = format!(
+        "#!/bin/sh\nexec {} -L {} \"$@\"\n",
+        shell_escape(&real_tmux),
+        shell_escape(tmux_socket)
+    );
+    std::fs::write(&wrapper_path, script).expect("write wrapper");
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod wrapper");
+
+    let path_env = format!(
+        "{}:{}",
+        wrapper_dir.path().display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let out = Command::new(cli)
+        .args(args)
+        .env("ORCHARD_CHAT_DIR", chat_dir)
+        .env("PATH", &path_env)
+        // Unset TMUX so sender::resolve falls back; we always pass --as.
+        .env_remove("TMUX")
+        .output()
+        .expect("run orchard-chat");
+
+    drop(wrapper_dir); // After the child exits, the wrapper isn't needed.
+
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+fn which_tmux() -> String {
+    let out = Command::new("which")
+        .arg("tmux")
+        .output()
+        .expect("which tmux");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn shell_escape(s: &str) -> String {
+    if s.chars().all(|c| c.is_ascii_alphanumeric() || "/_.-".contains(c)) {
+        s.to_string()
+    } else {
+        format!("'{}'", s.replace('\'', "'\\''"))
+    }
+}
+
+#[test]
+fn two_session_chat_end_to_end() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not installed");
+        return;
+    }
+
+    let cli = cli_path();
+    let chat_td = tempfile::tempdir().expect("chat tempdir");
+    let chat_dir = chat_td.path();
+
+    let mut server = TmuxServerGuard::new();
+    server.create_session("alice");
+    server.create_session("bob");
+
+    // Both sessions join #test
+    let (_, stderr, code) = run_cli(
+        &cli,
+        chat_dir,
+        &server.socket,
+        &["join", "#test", "--as", "@alice", "--session", "alice"],
+    );
+    assert_eq!(code, 0, "alice join: {stderr}");
+    let (_, stderr, code) = run_cli(
+        &cli,
+        chat_dir,
+        &server.socket,
+        &["join", "#test", "--as", "@bob", "--session", "bob"],
+    );
+    assert_eq!(code, 0, "bob join: {stderr}");
+
+    // Alice sends to #test
+    let (stdout, stderr, code) = run_cli(
+        &cli,
+        chat_dir,
+        &server.socket,
+        &["send", "#test", "hello-bob", "--as", "@alice", "--json"],
+    );
+    assert_eq!(code, 0, "alice send (stdout: {stdout}, stderr: {stderr})");
+
+    // (a) JSONL contains the line with type:"message"
+    let jsonl_path = chat_dir.join("test.jsonl");
+    let raw = std::fs::read_to_string(&jsonl_path).expect("read jsonl");
+    let mut found_msg = false;
+    let mut alice_joined = false;
+    let mut bob_joined = false;
+    for line in raw.lines() {
+        let v: serde_json::Value =
+            serde_json::from_str(line).expect("parse jsonl line");
+        match v["type"].as_str() {
+            Some("message") => {
+                if v["text"].as_str() == Some("hello-bob")
+                    && v["sender"].as_str() == Some("@alice")
+                {
+                    found_msg = true;
+                }
+            }
+            Some("member.joined") => match v["handle"].as_str() {
+                Some("@alice") => alice_joined = true,
+                Some("@bob") => bob_joined = true,
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    assert!(found_msg, "JSONL missing the message line: {raw}");
+    assert!(alice_joined, "JSONL missing alice join: {raw}");
+    assert!(bob_joined, "JSONL missing bob join: {raw}");
+
+    // (b) tmux capture-pane on bob shows the prefixed paste — retry up to ~1s.
+    //
+    // We've already returned 0 from the CLI so the scrollback verify
+    // succeeded. But re-confirm here from the test's perspective so the
+    // assertion is independent of the CLI's verify path.
+    let deadline = Instant::now() + Duration::from_secs(1);
+    let mut bob_capture = String::new();
+    while Instant::now() < deadline {
+        bob_capture = server.capture_pane("bob");
+        if bob_capture.contains("hello-bob") && bob_capture.contains("@alice") {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        bob_capture.contains("hello-bob") && bob_capture.contains("@alice"),
+        "bob's pane should show the prefixed paste; got:\n{bob_capture}"
+    );
+
+    // (c) alice's pane should NOT show the paste.
+    let alice_capture = server.capture_pane("alice");
+    assert!(
+        !alice_capture.contains("hello-bob"),
+        "alice's pane should NOT echo the message; got:\n{alice_capture}"
+    );
+
+    // (d) members #test returns both handles
+    let (stdout, stderr, code) = run_cli(
+        &cli,
+        chat_dir,
+        &server.socket,
+        &["members", "#test", "--json"],
+    );
+    assert_eq!(code, 0, "members (stderr: {stderr})");
+    assert!(
+        stdout.contains("@alice") && stdout.contains("@bob"),
+        "members should include both; got:\n{stdout}"
+    );
+
+    // (e) the --json SendOutcome contains a Delivered outcome with verified_at
+    //     for bob. Re-send with --json so we can parse it.
+    let (stdout, stderr, code) = run_cli(
+        &cli,
+        chat_dir,
+        &server.socket,
+        &["send", "#test", "second-message", "--as", "@alice", "--json"],
+    );
+    assert_eq!(code, 0, "second send (stderr: {stderr})");
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("parse SendOutcome json");
+    let fanout = v["fanout"].as_array().expect("fanout array");
+    let bob_outcome = fanout
+        .iter()
+        .find(|o| o["recipient"] == "@bob")
+        .expect("bob in fanout");
+    assert_eq!(
+        bob_outcome["kind"], "delivered",
+        "bob outcome should be delivered: {bob_outcome}"
+    );
+    assert!(
+        bob_outcome["scrollback_verified_at"]
+            .as_str()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false),
+        "bob outcome should have scrollback_verified_at: {bob_outcome}"
+    );
+}
+
+#[test]
+fn direct_send_routes_to_handle_session() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not installed");
+        return;
+    }
+    let cli = cli_path();
+    let chat_td = tempfile::tempdir().expect("chat tempdir");
+    let chat_dir = chat_td.path();
+
+    let mut server = TmuxServerGuard::new();
+    server.create_session("alice");
+    server.create_session("bob");
+
+    // Direct send `@bob` — no join needed, handle resolves directly to a
+    // tmux session of the same name.
+    let (stdout, stderr, code) = run_cli(
+        &cli,
+        chat_dir,
+        &server.socket,
+        &["send", "@bob", "direct-ping", "--as", "@alice", "--json"],
+    );
+    assert_eq!(
+        code, 0,
+        "alice direct send (stdout: {stdout}, stderr: {stderr})"
+    );
+
+    // Verify bob's pane received it.
+    let deadline = Instant::now() + Duration::from_secs(1);
+    let mut got = false;
+    while Instant::now() < deadline {
+        if server.capture_pane("bob").contains("direct-ping") {
+            got = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(got, "bob's pane should show 'direct-ping' from direct send");
+
+    // Direct sends store under `@bob.jsonl` so history is queryable.
+    assert!(
+        chat_dir.join("@bob.jsonl").exists(),
+        "@bob.jsonl should exist after direct send"
+    );
+}
+
+#[test]
+fn unknown_handle_fails_gracefully() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not installed");
+        return;
+    }
+    let cli = cli_path();
+    let chat_td = tempfile::tempdir().expect("chat tempdir");
+    let chat_dir = chat_td.path();
+
+    let mut server = TmuxServerGuard::new();
+    server.create_session("alice");
+    // Note: no `nobody` session exists.
+
+    let (stdout, _stderr, code) = run_cli(
+        &cli,
+        chat_dir,
+        &server.socket,
+        &["send", "@nobody", "ping", "--as", "@alice", "--json"],
+    );
+    // Exit code 1: message landed in JSONL but fanout failed.
+    assert_eq!(code, 1, "expected partial-failure exit, got {code}");
+
+    // The JSONL has the message, but the fanout outcome is Failed.
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("parse outcome json");
+    let fanout = v["fanout"].as_array().expect("fanout array");
+    assert_eq!(fanout.len(), 1);
+    assert_eq!(fanout[0]["kind"], "failed");
+    assert_eq!(fanout[0]["error"], "no such tmux session");
+}
+
+#[test]
+fn missing_target_sigil_returns_usage_error() {
+    if !tmux_available() {
+        eprintln!("skipping: tmux not installed");
+        return;
+    }
+    let cli = cli_path();
+    let chat_td = tempfile::tempdir().expect("chat tempdir");
+    let server = TmuxServerGuard::new();
+
+    let (_stdout, stderr, code) = run_cli(
+        &cli,
+        chat_td.path(),
+        &server.socket,
+        &["send", "general", "no-sigil", "--as", "@alice"],
+    );
+    assert_eq!(code, 3, "expected usage error, stderr: {stderr}");
+    assert!(stderr.contains("'#'") || stderr.contains("'@'"));
+}

--- a/crates/orchard-chat/tests/two_session_chat.rs
+++ b/crates/orchard-chat/tests/two_session_chat.rs
@@ -285,11 +285,19 @@ fn two_session_chat_end_to_end() {
         "bob outcome should be delivered: {bob_outcome}"
     );
     assert!(
-        bob_outcome["scrollback_verified_at"]
+        bob_outcome["verified_at"]
             .as_str()
             .map(|s| !s.is_empty())
             .unwrap_or(false),
-        "bob outcome should have scrollback_verified_at: {bob_outcome}"
+        "bob outcome should have verified_at: {bob_outcome}"
+    );
+    // bob is a bash session in this test, so transcript-verify won't find a
+    // Claude transcript dir and will fall back to scrollback. The
+    // verified_via field discriminates the proof.
+    assert!(
+        bob_outcome["verified_via"] == "transcript"
+            || bob_outcome["verified_via"] == "scrollback",
+        "verified_via should be transcript or scrollback: {bob_outcome}"
     );
 }
 

--- a/crates/orchard-chat/tests/two_session_chat.rs
+++ b/crates/orchard-chat/tests/two_session_chat.rs
@@ -149,7 +149,9 @@ fn which_tmux() -> String {
 }
 
 fn shell_escape(s: &str) -> String {
-    if s.chars().all(|c| c.is_ascii_alphanumeric() || "/_.-".contains(c)) {
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || "/_.-".contains(c))
+    {
         s.to_string()
     } else {
         format!("'{}'", s.replace('\'', "'\\''"))
@@ -203,12 +205,10 @@ fn two_session_chat_end_to_end() {
     let mut alice_joined = false;
     let mut bob_joined = false;
     for line in raw.lines() {
-        let v: serde_json::Value =
-            serde_json::from_str(line).expect("parse jsonl line");
+        let v: serde_json::Value = serde_json::from_str(line).expect("parse jsonl line");
         match v["type"].as_str() {
             Some("message") => {
-                if v["text"].as_str() == Some("hello-bob")
-                    && v["sender"].as_str() == Some("@alice")
+                if v["text"].as_str() == Some("hello-bob") && v["sender"].as_str() == Some("@alice")
                 {
                     found_msg = true;
                 }
@@ -270,11 +270,17 @@ fn two_session_chat_end_to_end() {
         &cli,
         chat_dir,
         &server.socket,
-        &["send", "#test", "second-message", "--as", "@alice", "--json"],
+        &[
+            "send",
+            "#test",
+            "second-message",
+            "--as",
+            "@alice",
+            "--json",
+        ],
     );
     assert_eq!(code, 0, "second send (stderr: {stderr})");
-    let v: serde_json::Value =
-        serde_json::from_str(stdout.trim()).expect("parse SendOutcome json");
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("parse SendOutcome json");
     let fanout = v["fanout"].as_array().expect("fanout array");
     let bob_outcome = fanout
         .iter()
@@ -295,8 +301,7 @@ fn two_session_chat_end_to_end() {
     // Claude transcript dir and will fall back to scrollback. The
     // verified_via field discriminates the proof.
     assert!(
-        bob_outcome["verified_via"] == "transcript"
-            || bob_outcome["verified_via"] == "scrollback",
+        bob_outcome["verified_via"] == "transcript" || bob_outcome["verified_via"] == "scrollback",
         "verified_via should be transcript or scrollback: {bob_outcome}"
     );
 }
@@ -371,8 +376,7 @@ fn unknown_handle_fails_gracefully() {
     assert_eq!(code, 1, "expected partial-failure exit, got {code}");
 
     // The JSONL has the message, but the fanout outcome is Failed.
-    let v: serde_json::Value =
-        serde_json::from_str(stdout.trim()).expect("parse outcome json");
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).expect("parse outcome json");
     let fanout = v["fanout"].as_array().expect("fanout array");
     assert_eq!(fanout.len(), 1);
     assert_eq!(fanout[0]["kind"], "failed");

--- a/crates/orchard-chat/tests/two_session_chat.rs
+++ b/crates/orchard-chat/tests/two_session_chat.rs
@@ -368,7 +368,13 @@ fn unknown_handle_fails_gracefully() {
     let fanout = v["fanout"].as_array().expect("fanout array");
     assert_eq!(fanout.len(), 1);
     assert_eq!(fanout[0]["kind"], "failed");
-    assert_eq!(fanout[0]["error"], "no such tmux session");
+    let err = fanout[0]["error"]
+        .as_str()
+        .expect("error should be a string");
+    assert!(
+        err.starts_with("no such tmux session"),
+        "expected 'no such tmux session…', got: {err}"
+    );
 }
 
 #[test]

--- a/crates/orchard-dispatcher/src/main.rs
+++ b/crates/orchard-dispatcher/src/main.rs
@@ -37,6 +37,14 @@ use std::process::{Command, ExitCode};
 /// second primary unit (e.g. remotes becoming first-class) requires a new ADR.
 const WORKTREE_BARE_VERBS: &[&str] = &["new", "rm", "prune", "mv", "ls", "path"];
 
+/// Bare-verb shortcuts that resolve to the chat unit (per #495).
+///
+/// `orchard send #general "hi"` ≡ `orchard chat send #general "hi"`. Chat
+/// isn't a "primary unit" in the ADR-013 sense, but `send` reads natural
+/// at the top level and stays unambiguous because room/handle targets carry
+/// their own sigil.
+const CHAT_BARE_VERBS: &[&str] = &["send"];
+
 /// Verbs that map directly to a helper binary `orchard-<verb>`.
 const NAMESPACE_VERBS: &[&str] = &["tui", "daemon", "worktree", "chat"];
 
@@ -100,6 +108,9 @@ Worktree shortcuts (the worktree is Orchard's primary unit):
   orchard ls [--json]           ≡ orchard worktree ls [--json]
   orchard path <id>             ≡ orchard worktree path <id>
 
+Chat shortcuts:
+  orchard send <target> <text>  ≡ orchard chat send <target> <text>
+
 Discovery:
   Helper binaries are looked up first in the directory containing this
   `orchard` executable, then on $PATH. See ADR-013 for details.
@@ -127,6 +138,12 @@ fn main() -> ExitCode {
             let mut forwarded = vec![verb.to_string()];
             forwarded.extend(args.iter().skip(1).cloned());
             exec("worktree", &forwarded)
+        }
+        Some(verb) if CHAT_BARE_VERBS.contains(&verb) => {
+            // `orchard send #general "hi"` → `orchard-chat send #general "hi"`
+            let mut forwarded = vec![verb.to_string()];
+            forwarded.extend(args.iter().skip(1).cloned());
+            exec("chat", &forwarded)
         }
         Some(verb) if NAMESPACE_VERBS.contains(&verb) => {
             let forwarded: Vec<String> = args.iter().skip(1).cloned().collect();
@@ -255,6 +272,31 @@ mod tests {
     }
 
     #[test]
+    fn chat_bare_verbs_do_not_collide_with_other_verb_sets() {
+        for v in CHAT_BARE_VERBS {
+            assert!(
+                !NAMESPACE_VERBS.contains(v),
+                "chat bare verb '{v}' must not also be a namespace verb"
+            );
+            assert!(
+                !WORKTREE_BARE_VERBS.contains(v),
+                "chat bare verb '{v}' must not also be a worktree bare verb"
+            );
+            assert!(
+                !TUI_VERBS.contains(v),
+                "chat bare verb '{v}' must not also be a TUI verb"
+            );
+        }
+    }
+
+    #[test]
+    fn chat_bare_verbs_match_issue_495() {
+        // Locked to the #495 contract. Adding a chat verb (e.g. `broadcast`)
+        // is a deliberate ADR-style decision — bump this test along with it.
+        assert_eq!(CHAT_BARE_VERBS, &["send"]);
+    }
+
+    #[test]
     fn worktree_bare_verbs_match_adr() {
         // ADR-013 §3 specifies the exact set; if this list changes, update the ADR too.
         assert_eq!(
@@ -285,6 +327,12 @@ mod tests {
             assert!(
                 HELP.contains(&format!("orchard {v} ")) || HELP.contains(&format!("orchard {v}\n")),
                 "HELP must document the bare verb '{v}'"
+            );
+        }
+        for v in CHAT_BARE_VERBS {
+            assert!(
+                HELP.contains(&format!("orchard {v} ")) || HELP.contains(&format!("orchard {v}\n")),
+                "HELP must document the chat bare verb '{v}'"
             );
         }
     }

--- a/crates/orchard-dispatcher/tests/dispatch.rs
+++ b/crates/orchard-dispatcher/tests/dispatch.rs
@@ -114,8 +114,7 @@ fn bare_verb_ls_dispatches_to_orchard_worktree_ls() {
 #[test]
 fn bare_verb_send_dispatches_to_orchard_chat_send() {
     let dir = with_helpers(&[("chat", 0)]);
-    let (stdout, _stderr, code) =
-        run_dispatcher(dir.path(), &["send", "#general", "hello"]);
+    let (stdout, _stderr, code) = run_dispatcher(dir.path(), &["send", "#general", "hello"]);
     assert_eq!(code, 0);
     assert!(
         stdout.contains("[helper:chat] argv=send #general hello"),

--- a/crates/orchard-dispatcher/tests/dispatch.rs
+++ b/crates/orchard-dispatcher/tests/dispatch.rs
@@ -112,6 +112,18 @@ fn bare_verb_ls_dispatches_to_orchard_worktree_ls() {
 }
 
 #[test]
+fn bare_verb_send_dispatches_to_orchard_chat_send() {
+    let dir = with_helpers(&[("chat", 0)]);
+    let (stdout, _stderr, code) =
+        run_dispatcher(dir.path(), &["send", "#general", "hello"]);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.contains("[helper:chat] argv=send #general hello"),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
 fn tui_verb_heal_routes_to_orchard_tui_with_verb_prepended() {
     // `orchard heal --fix` must exec `orchard-tui heal --fix`. The verb
     // itself stays as the first argv entry so orchard-tui's argv parser


### PR DESCRIPTION
## Summary

Ships the v1 chat substrate per #495: `chat-core` library + `orchard-chat` CLI + dispatcher routing for `orchard send <target>`. Backed by 27 unit tests, 4 two-session tmux integration tests, and an interactive smoke test (verified prefixed paste lands in recipient pane, sender pane stays clean, members + history listed correctly).

- **`crates/chat-core/`** — single-file JSONL-per-room substrate. POSIX `O_APPEND` atomicity, no flock. Membership derived from append-only `member.joined`/`member.left` events. `tmux_fanout` returns Level 2 receipts via `tmux capture-pane -p` scrollback verification. JSONL schema documented as cross-language contract (Go daemon will read this format in #498).
- **`crates/orchard-chat/`** — clap CLI. Subcommands: `send`, `join`, `leave`, `members`, `list`, `history`, `tail`. All accept `--json`. Sender resolved from `$TMUX` with `--as <handle>` override; outside tmux without `--as` exits 3. Exit codes: 0 full success, 1 partial fanout, 2 append failure, 3 usage error. `Skipped { reason: "sender" }` does NOT count as partial — sending to yourself in a one-member room is exit 0.
- **Dispatcher** — `orchard send` is now a chat-bare-verb shortcut that routes to `orchard-chat send`, alongside the existing worktree bare-verbs (`new`, `rm`, `prune`, …). `orchard chat <verb>` continues to route via the namespace-verb path.

## Closes

Closes #495.

## Out of scope (each is a follow-up)

- Daemon read-side provider — Go file-watcher + GraphQL surface (#498, parent session driving)
- TUI chat pane / GUI chat view (#499 wires GUI ChatBackend to daemon GraphQL — parent session)
- Cross-host replication and qualified handles (`@bob@drew-mac`)
- External-human-via-tunneled-URL (room-share)
- Deprecating 016's broker / plugin / start-orchardist boot wiring
- Level 3 receipts (recipient-acknowledged via transcript watching)

## AC coverage (#495)

| AC | Status | Where |
|---|---|---|
| 1. New crate `crates/chat-core/` with public API + `///` doc comments | ✅ | `crates/chat-core/src/lib.rs`, all submodules |
| 2. Single-file substrate, no flock, `O_APPEND` atomicity | ✅ | `store.rs::append_line` |
| 3. Storage exactly `~/.orchard/chat/<room>.jsonl`, `ORCHARD_CHAT_DIR` override | ✅ | `paths.rs::chat_dir` |
| 4. JSONL row schema with `type` discriminator (`message`/`member.joined`/`member.left`), ULID ids, RFC3339 ts | ✅ | `types.rs::Event`, README |
| 5. `list_members` derives membership by folding events, last-event-wins | ✅ | `store.rs::list_members` + `store_tests.rs` |
| 6. `read_history` filters to `type:"message"` only | ✅ | `store.rs::read_history` + test |
| 7. `derive_handle` slugify + collision suffix | ✅ | `handle.rs` + 8 tests |
| 8. Sender required, lib does no auto-detect, CLI auto-derives from `$TMUX` | ✅ | `chat_core::send` signature, `cmd/sender.rs::resolve` |
| 9. `sender_machine` auto-stamped from hostname | ✅ | `identity.rs::current_machine` |
| 10. Unified `send` verb, `#`/`@` sigil disambiguates, missing session → `Failed { reason: "no such tmux session" }` | ✅ | `Target::parse`, `fanout.rs::tmux_fanout` |
| 11. CLI subcommands all present, `--json` everywhere | ✅ | `crates/orchard-chat/src/cmd/*.rs` |
| 12. Exit codes 0/1/2/3 | ✅ | `cmd/send.rs::derive_exit_code` |
| 13. CLI does not retry on partial failure | ✅ | one-shot `chat_core::send` call |
| 14. Level 2 receipts via `capture-pane` retry, `Delivered { scrollback_verified_at }` / `ByteOnly { reason }` | ✅ | `fanout.rs::verify_scrollback` |
| 15. Tmux fanout format consistent across room/direct, sender pane skipped | ✅ | `fanout.rs::format_paste` + `tmux_fanout` |
| 16. `tail` prints full file then follows | ✅ | `cmd/tail.rs` |
| 17. Unit tests covering all listed scenarios | ✅ | 23 tests in `chat-core/tests/` |
| 18. Two-session integration test (a-e all asserted) | ✅ | `crates/orchard-chat/tests/two_session_chat.rs::two_session_chat_end_to_end` |
| 19. README documenting JSONL as cross-language contract | ✅ | `crates/chat-core/README.md` |
| 20. Workspace `cargo build --release` clean, all tests pass | ✅ | release build clean (4m12s), all crate-scoped suites green |
| 21. Successful demo: two tmux sessions, prefixed paste lands within ~1s, `Delivered` with verified-at | ✅ | interactive smoke test passed |

## Test plan

- [x] `cargo test -p chat-core` — 23 unit tests
- [x] `cargo test -p orchard-chat` — 4 integration tests including two_session_chat_end_to_end
- [x] `cargo test -p orchard-dispatcher` — 27 tests (12 unit + 15 integration including new bare-verb test)
- [x] `cargo build --release` — clean, all binaries (orchard, orchard-tui, orchard-daemon, orchard-worktree, orchard-chat)
- [x] Interactive tmux smoke test: two real sessions on a private socket, alice → #demo, bob receives prefixed paste, alice's pane has no echo, history + members listed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local-first chat with durable JSONL rooms, direct messaging, membership tracking, handle/machine derivation, tmux-backed delivery (including transcript-based receipts) and CLI: send, join, leave, list, members, history, tail (human/JSON modes)

* **Documentation**
  * Detailed chat storage, JSONL schema, concurrency guarantees, CLI behavior, and receipt semantics

* **Tests**
  * Unit and end-to-end tests for fanout, handle derivation, store, transcript verification, CLI, and tmux integration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #495

# Related issue

- #495

# Related issue

- #495

# Related issue

- #495

# Related issue

- #495

# Related issue

- #495

# Related issue

- #495

# Related issue

- #495

# Related issue

- #495