### PR TITLE
feat(daemon): chat provider — file-watch + fold ~/.orchard/chat/*.jsonl (foundation for #498)

### DIFF
--- a/internal/server/providers/chat/adapter.go
+++ b/internal/server/providers/chat/adapter.go
@@ -1,0 +1,221 @@
+package chat
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Adapter reads chat events from a directory of per-room JSONL files
+// on disk. Stateless per ADR-011 §3 — caching, fold state, and watcher
+// bookkeeping live in [Provider]; this struct is a thin file-I/O
+// wrapper so unit tests can fake it cleanly.
+//
+// File layout (written by chat-core / orchard-chat CLI):
+//
+//	<dir>/<room>.jsonl
+//
+// One file per room. Each line is one [Event] discriminated by `type`.
+// The first event in a typical room is `member.joined`; chat-core does
+// NOT auto-join, so a freshly-created room file may begin with a
+// `message` line if the sender pre-joined.
+type Adapter struct {
+	dir      string
+	followMu sync.Mutex
+}
+
+// NewAdapter constructs an Adapter rooted at the given absolute path.
+// The directory does not need to exist at construction; Snapshot
+// returns empty results until chat-core creates the first file.
+func NewAdapter(dir string) *Adapter { return &Adapter{dir: dir} }
+
+// Dir returns the absolute path the adapter scans.
+func (a *Adapter) Dir() string { return a.dir }
+
+// Snapshot reads every `*.jsonl` file under the directory and returns
+// the union of all events partitioned by RoomID, plus a map of
+// per-file byte offsets keyed by file basename. Used for cold-boot
+// hydration of the Provider's cache.
+//
+// Missing dir → returns empty maps + nil. The watcher is responsible
+// for triggering a re-read when the dir is created later.
+//
+// Malformed lines or unknown `type` values are skipped silently.
+// Per-file read failures are returned in the error but do NOT abort
+// the snapshot — events from other files are still returned.
+func (a *Adapter) Snapshot(_ context.Context) (map[RoomID][]Event, map[string]int64, error) {
+	offsets := make(map[string]int64)
+	files, err := a.listFiles()
+	if err != nil {
+		return nil, offsets, err
+	}
+	out := make(map[RoomID][]Event)
+	var firstErr error
+	for _, file := range files {
+		room := roomFromPath(file)
+		evs, advanced, err := a.readFile(file, 0)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		if len(evs) > 0 {
+			out[room] = append(out[room], evs...)
+		}
+		offsets[filepath.Base(file)] = advanced
+	}
+	return out, offsets, firstErr
+}
+
+// FollowFromOffsets re-scans the directory, opens each `*.jsonl` file,
+// seeks to the per-file offset stored in `from`, and emits every
+// newline-terminated event past it. Files not present in `from`
+// (newly created since the last call) are read from offset 0.
+//
+// Returns the per-room event slices and the updated offsets map.
+// Callers persist the returned offsets for the next call.
+func (a *Adapter) FollowFromOffsets(_ context.Context, from map[string]int64) (map[RoomID][]Event, map[string]int64, error) {
+	a.followMu.Lock()
+	defer a.followMu.Unlock()
+
+	updated := make(map[string]int64, len(from))
+	for k, v := range from {
+		updated[k] = v
+	}
+
+	files, err := a.listFiles()
+	if err != nil {
+		return nil, updated, err
+	}
+
+	out := make(map[RoomID][]Event)
+	var firstErr error
+	for _, file := range files {
+		base := filepath.Base(file)
+		room := roomFromPath(file)
+		offset := updated[base]
+		evs, advanced, err := a.readFile(file, offset)
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+		if len(evs) > 0 {
+			out[room] = append(out[room], evs...)
+		}
+		updated[base] = advanced
+	}
+	return out, updated, firstErr
+}
+
+// roomFromPath extracts the RoomID (basename without `.jsonl`).
+// Preserves leading `@` so direct rooms round-trip cleanly.
+func roomFromPath(path string) RoomID {
+	base := filepath.Base(path)
+	return RoomID(strings.TrimSuffix(base, ".jsonl"))
+}
+
+// listFiles returns the sorted set of `*.jsonl` files directly under
+// the configured directory. Missing directory → ([], nil).
+func (a *Adapter) listFiles() ([]string, error) {
+	entries, err := os.ReadDir(a.dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read chat dir %q: %w", a.dir, err)
+	}
+	files := make([]string, 0, len(entries))
+	for _, ent := range entries {
+		if ent.IsDir() {
+			continue
+		}
+		name := ent.Name()
+		if filepath.Ext(name) != ".jsonl" {
+			continue
+		}
+		files = append(files, filepath.Join(a.dir, name))
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// readFile opens one jsonl file, seeks to fromOffset, decodes events,
+// returns the events plus the byte offset reached. Missing file →
+// ([], fromOffset, nil). File rotation (size < fromOffset) → restart
+// from zero.
+func (a *Adapter) readFile(path string, fromOffset int64) ([]Event, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fromOffset, nil
+		}
+		return nil, fromOffset, fmt.Errorf("open %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, fromOffset, fmt.Errorf("stat %q: %w", path, err)
+	}
+	size := stat.Size()
+	if size < fromOffset {
+		fromOffset = 0
+	}
+	if size == fromOffset {
+		return nil, fromOffset, nil
+	}
+	if _, err := f.Seek(fromOffset, io.SeekStart); err != nil {
+		return nil, fromOffset, fmt.Errorf("seek %q: %w", path, err)
+	}
+
+	return readEvents(f, fromOffset)
+}
+
+// readEvents decodes newline-delimited JSON events from r, returning
+// the decoded events plus the absolute byte offset reached. Stops
+// cleanly at EOF; partial trailing lines stay uncommitted.
+func readEvents(r io.Reader, start int64) ([]Event, int64, error) {
+	br := bufio.NewReaderSize(r, 64*1024)
+	offset := start
+	var events []Event
+	for {
+		line, err := br.ReadBytes('\n')
+		consumed := int64(len(line))
+		if len(line) > 0 && line[len(line)-1] == '\n' {
+			offset += consumed
+			ev, ok := decodeLine(line)
+			if ok {
+				events = append(events, ev)
+			}
+		}
+		if errors.Is(err, io.EOF) {
+			return events, offset, nil
+		}
+		if err != nil {
+			return events, offset, fmt.Errorf("read jsonl: %w", err)
+		}
+	}
+}
+
+func decodeLine(line []byte) (Event, bool) {
+	if n := len(line); n > 0 && line[n-1] == '\n' {
+		line = line[:n-1]
+	}
+	if len(line) == 0 {
+		return Event{}, false
+	}
+	var ev Event
+	if err := json.Unmarshal(line, &ev); err != nil {
+		return Event{}, false
+	}
+	if ev.Type == "" {
+		return Event{}, false
+	}
+	return ev, true
+}

--- a/internal/server/providers/chat/adapter_test.go
+++ b/internal/server/providers/chat/adapter_test.go
@@ -1,0 +1,142 @@
+package chat
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeJSONL appends `lines` to <dir>/<room>.jsonl and returns the
+// path. Each line gets a trailing newline.
+func writeJSONL(t *testing.T, dir, room string, lines ...string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %q: %v", dir, err)
+	}
+	path := filepath.Join(dir, room+".jsonl")
+	body := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %q: %v", path, err)
+	}
+	return path
+}
+
+func TestAdapter_SnapshotEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	a := NewAdapter(dir)
+	rooms, offsets, err := a.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if len(rooms) != 0 {
+		t.Errorf("rooms: got %d want 0", len(rooms))
+	}
+	if len(offsets) != 0 {
+		t.Errorf("offsets: got %d want 0", len(offsets))
+	}
+}
+
+func TestAdapter_SnapshotMissingDir(t *testing.T) {
+	a := NewAdapter(filepath.Join(t.TempDir(), "missing"))
+	rooms, _, err := a.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("missing dir should not error: %v", err)
+	}
+	if len(rooms) != 0 {
+		t.Errorf("rooms: got %d want 0", len(rooms))
+	}
+}
+
+func TestAdapter_SnapshotReadsRoomsAndOffsets(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(t, dir, "general",
+		`{"type":"member.joined","ts":"2026-05-09T17:00:00Z","handle":"@alice","machine":"m","tmux_session":"s"}`,
+		`{"type":"message","ts":"2026-05-09T17:01:00Z","id":"01J1","sender":"@alice","text":"hi"}`,
+	)
+	writeJSONL(t, dir, "@bob",
+		`{"type":"message","ts":"2026-05-09T17:02:00Z","id":"01J2","sender":"@alice","text":"yo"}`,
+	)
+
+	a := NewAdapter(dir)
+	rooms, offsets, err := a.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if got, want := len(rooms), 2; got != want {
+		t.Fatalf("rooms: got %d want %d", got, want)
+	}
+	if got, want := len(rooms["general"]), 2; got != want {
+		t.Errorf("general events: got %d want %d", got, want)
+	}
+	if got, want := len(rooms["@bob"]), 1; got != want {
+		t.Errorf("@bob events: got %d want %d", got, want)
+	}
+	if offsets["general.jsonl"] == 0 {
+		t.Errorf("general offset should be > 0")
+	}
+	if offsets["@bob.jsonl"] == 0 {
+		t.Errorf("@bob offset should be > 0")
+	}
+}
+
+func TestAdapter_FollowFromOffsetsTailsAppends(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(t, dir, "r",
+		`{"type":"message","ts":"2026-05-09T17:00:00Z","id":"01J1","sender":"@a","text":"first"}`,
+	)
+	a := NewAdapter(dir)
+	_, offsets, err := a.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	// Append a second message.
+	path := filepath.Join(dir, "r.jsonl")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := f.WriteString(`{"type":"message","ts":"2026-05-09T17:01:00Z","id":"01J2","sender":"@a","text":"second"}` + "\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	tail, _, err := a.FollowFromOffsets(context.Background(), offsets)
+	if err != nil {
+		t.Fatalf("follow: %v", err)
+	}
+	if got, want := len(tail["r"]), 1; got != want {
+		t.Fatalf("tail events: got %d want %d", got, want)
+	}
+	if tail["r"][0].ID != "01J2" {
+		t.Errorf("tail event id: got %q want 01J2", tail["r"][0].ID)
+	}
+}
+
+func TestAdapter_PartialFinalLineNotConsumed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "r.jsonl")
+	if err := os.WriteFile(path,
+		[]byte(`{"type":"message","ts":"2026-05-09T17:00:00Z","id":"01J1","sender":"@a","text":"complete"}`+"\n"+
+			`{"type":"message","ts":"2026-05-09T17:01:00Z","id":"01J2","sender":"@a","text":"incomp`),
+		0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	a := NewAdapter(dir)
+	rooms, offsets, err := a.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if got, want := len(rooms["r"]), 1; got != want {
+		t.Fatalf("only the complete line should be folded: got %d want %d", got, want)
+	}
+	// Offset should be the position past the complete line, NOT past
+	// the partial trailing line.
+	st, _ := os.Stat(path)
+	if offsets["r.jsonl"] >= st.Size() {
+		t.Errorf("offset %d should be less than file size %d (partial line uncommitted)",
+			offsets["r.jsonl"], st.Size())
+	}
+}

--- a/internal/server/providers/chat/doc.go
+++ b/internal/server/providers/chat/doc.go
@@ -1,0 +1,31 @@
+// Package chat exposes Chat rooms + ChatMessage events to the GraphQL
+// resolver layer.
+//
+// Owns:
+//
+//   - one [Adapter] (JSONL read).
+//   - one [Watcher] (fsnotify on the chat directory).
+//   - the in-memory fold result, keyed by RoomID.
+//   - the per-room Subscribe fan-out for invalidation events.
+//
+// Per ADR-011 §2 the surface is read-only. Writes happen out-of-band:
+// the `chat-core` Rust library + `orchard chat send` CLI append to
+// `<dir>/<room>.jsonl`. The watcher turns those writes into
+// invalidation events, and the next read picks up the fresh fold.
+//
+// The on-disk JSONL schema is the **cross-language contract** between
+// the Rust writer side (chat-core) and this Go reader side. See
+// research/038 for the rationale and chat-core/README.md for the
+// authoritative event grammar.
+//
+// Three event kinds, discriminated by `type`:
+//
+//   - "message"          — a user-visible message line (id, ts, sender,
+//     sender_machine, text, source).
+//   - "member.joined"    — handle joined the room (ts, handle, machine,
+//     tmux_session).
+//   - "member.left"      — handle left the room (ts, handle).
+//
+// Membership at time T is the fold of joined/left events: last-event-
+// wins per handle.
+package chat

--- a/internal/server/providers/chat/fold.go
+++ b/internal/server/providers/chat/fold.go
@@ -1,0 +1,67 @@
+package chat
+
+// Fold reduces a slice of [Event]s into a Room.
+//
+// Events with unknown `type` or missing required fields are skipped —
+// the function is forward-compatible with chat-core extensions.
+//
+// Members fold by last-event-wins per handle: a `member.joined`
+// followed by a later `member.left` removes the member; another
+// `member.joined` after that re-adds.
+//
+// Messages preserve insertion order — chat-core writes them
+// chronologically.
+func Fold(roomID RoomID, events []Event) Room {
+	r := Room{ID: roomID}
+	memberMap := map[string]Member{}
+
+	for _, ev := range events {
+		switch ev.Type {
+		case "message":
+			if ev.ID == "" || ev.Sender == "" {
+				continue
+			}
+			r.Messages = append(r.Messages, Message{
+				ID:            ev.ID,
+				Room:          roomID,
+				Timestamp:     ev.Timestamp,
+				Sender:        ev.Sender,
+				SenderMachine: ev.SenderMachine,
+				Text:          ev.Text,
+				Source:        normalizeSource(ev.Source),
+			})
+		case "member.joined":
+			if ev.Handle == "" {
+				continue
+			}
+			memberMap[ev.Handle] = Member{
+				Handle:      ev.Handle,
+				Machine:     ev.Machine,
+				TmuxSession: ev.TmuxSession,
+				JoinedAt:    ev.Timestamp,
+			}
+		case "member.left":
+			if ev.Handle == "" {
+				continue
+			}
+			delete(memberMap, ev.Handle)
+		default:
+			continue
+		}
+		if ev.Timestamp.After(r.LastEventAt) {
+			r.LastEventAt = ev.Timestamp
+		}
+	}
+
+	for _, m := range memberMap {
+		r.Members = append(r.Members, m)
+	}
+	return r
+}
+
+func normalizeSource(s string) string {
+	if s == "" {
+		return "internal"
+	}
+	return s
+}

--- a/internal/server/providers/chat/fold_test.go
+++ b/internal/server/providers/chat/fold_test.go
@@ -1,0 +1,80 @@
+package chat
+
+import (
+	"testing"
+	"time"
+)
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	v, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return v
+}
+
+func TestFold_MessagesAndMembership(t *testing.T) {
+	events := []Event{
+		{Type: "member.joined", Timestamp: mustTime(t, "2026-05-09T17:00:00Z"), Handle: "@alice", Machine: "drew-mac", TmuxSession: "card-alice"},
+		{Type: "message", Timestamp: mustTime(t, "2026-05-09T17:01:00Z"), ID: "01J1", Sender: "@alice", SenderMachine: "drew-mac", Text: "hi", Source: "internal"},
+		{Type: "member.joined", Timestamp: mustTime(t, "2026-05-09T17:02:00Z"), Handle: "@bob", Machine: "drew-linux", TmuxSession: "card-bob"},
+		{Type: "message", Timestamp: mustTime(t, "2026-05-09T17:03:00Z"), ID: "01J2", Sender: "@bob", SenderMachine: "drew-linux", Text: "hey"},
+		{Type: "member.left", Timestamp: mustTime(t, "2026-05-09T17:04:00Z"), Handle: "@alice"},
+	}
+	room := Fold("general", events)
+
+	if room.ID != "general" {
+		t.Errorf("room id: got %q want general", room.ID)
+	}
+	if got, want := len(room.Messages), 2; got != want {
+		t.Fatalf("messages: got %d want %d", got, want)
+	}
+	if room.Messages[0].Text != "hi" || room.Messages[1].Text != "hey" {
+		t.Errorf("message order broken: %#v", room.Messages)
+	}
+	if got := room.Messages[1].Source; got != "internal" {
+		t.Errorf("missing source default: got %q want internal", got)
+	}
+	if got, want := len(room.Members), 1; got != want {
+		t.Fatalf("members: got %d want %d (only @bob should remain)", got, want)
+	}
+	if room.Members[0].Handle != "@bob" {
+		t.Errorf("member: got %q want @bob", room.Members[0].Handle)
+	}
+	if !room.LastEventAt.Equal(mustTime(t, "2026-05-09T17:04:00Z")) {
+		t.Errorf("last event ts: got %v", room.LastEventAt)
+	}
+}
+
+func TestFold_RejoinAfterLeave(t *testing.T) {
+	events := []Event{
+		{Type: "member.joined", Timestamp: mustTime(t, "2026-05-09T17:00:00Z"), Handle: "@alice", Machine: "m", TmuxSession: "s"},
+		{Type: "member.left", Timestamp: mustTime(t, "2026-05-09T17:01:00Z"), Handle: "@alice"},
+		{Type: "member.joined", Timestamp: mustTime(t, "2026-05-09T17:02:00Z"), Handle: "@alice", Machine: "m2", TmuxSession: "s2"},
+	}
+	room := Fold("r", events)
+	if got, want := len(room.Members), 1; got != want {
+		t.Fatalf("members: got %d want %d", got, want)
+	}
+	if got := room.Members[0].TmuxSession; got != "s2" {
+		t.Errorf("rejoin should overwrite tmux_session: got %q want s2", got)
+	}
+}
+
+func TestFold_SkipsUnknownAndMalformed(t *testing.T) {
+	events := []Event{
+		{Type: "future.event.kind", Timestamp: mustTime(t, "2026-05-09T17:00:00Z")},
+		{Type: "message", Timestamp: mustTime(t, "2026-05-09T17:01:00Z"), ID: "", Sender: "@a", Text: "missing-id"},
+		{Type: "message", Timestamp: mustTime(t, "2026-05-09T17:02:00Z"), ID: "01J3", Sender: "", Text: "missing-sender"},
+		{Type: "member.joined", Timestamp: mustTime(t, "2026-05-09T17:03:00Z"), Handle: ""},
+		{Type: "message", Timestamp: mustTime(t, "2026-05-09T17:04:00Z"), ID: "01J4", Sender: "@a", Text: "ok"},
+	}
+	room := Fold("r", events)
+	if got, want := len(room.Messages), 1; got != want {
+		t.Fatalf("messages: got %d want %d", got, want)
+	}
+	if room.Messages[0].ID != "01J4" {
+		t.Errorf("kept wrong message: %#v", room.Messages[0])
+	}
+}

--- a/internal/server/providers/chat/path.go
+++ b/internal/server/providers/chat/path.go
@@ -1,0 +1,34 @@
+package chat
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// EnvDir is the environment variable that overrides the chat directory.
+// Set ORCHARD_CHAT_DIR=/abs/path to point the daemon at a non-default
+// directory of per-room JSONL files (used by tests + per-machine
+// experiments). Mirrors chat-core's identically named env var.
+const EnvDir = "ORCHARD_CHAT_DIR"
+
+// DefaultDir returns the directory the chat provider scans when no
+// override is configured. One JSONL file per room: `<dir>/<room>.jsonl`.
+//
+// Resolution order:
+//
+//  1. $ORCHARD_CHAT_DIR, if non-empty.
+//  2. $HOME/.orchard/chat — the path chat-core writes to (per #495).
+//  3. ./chat as a last resort when $HOME is unresolvable.
+//
+// The provider does NOT create the directory or its contents — that
+// responsibility belongs to chat-core. The provider tolerates the
+// directory being missing (returns an empty room list, no error).
+func DefaultDir() string {
+	if v := os.Getenv(EnvDir); v != "" {
+		return v
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".orchard", "chat")
+	}
+	return "chat"
+}

--- a/internal/server/providers/chat/provider.go
+++ b/internal/server/providers/chat/provider.go
@@ -1,0 +1,222 @@
+package chat
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"sync"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/adapter"
+)
+
+// Provider exposes Chat rooms and ChatMessage events to the GraphQL
+// resolver layer.
+//
+// Owns:
+//   - one [Adapter] (JSONL read).
+//   - one [Watcher] (fsnotify on the chat directory).
+//   - the in-memory fold result, keyed by RoomID.
+//   - the per-key Subscribe fan-out for invalidation events.
+//
+// Per ADR-011 §2 the surface is read-only. Writes happen out-of-band
+// via chat-core's `orchard chat send` CLI; the watcher turns those
+// writes into invalidation events, and the next read picks up the
+// fresh fold.
+type Provider struct {
+	adapterIO *Adapter
+	watcher   *Watcher
+	logger    *slog.Logger
+
+	mu      sync.RWMutex
+	rooms   map[RoomID]Room
+	loaded  bool
+	offsets map[string]int64
+
+	subMu sync.Mutex
+	subs  map[chan adapter.InvalidationEvent[RoomID]]struct{}
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+
+	// notifyOverride is for tests — replaces the watcher's channel.
+	notifyOverride <-chan struct{}
+}
+
+// New constructs a Provider using DefaultDir.
+func New(logger *slog.Logger) *Provider {
+	return NewWithPath(DefaultDir(), logger)
+}
+
+// NewWithPath is the test-friendly constructor.
+func NewWithPath(dir string, logger *slog.Logger) *Provider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Provider{
+		adapterIO: NewAdapter(dir),
+		watcher:   NewWatcher(dir, logger),
+		logger:    logger,
+		rooms:     map[RoomID]Room{},
+		offsets:   map[string]int64{},
+		subs:      map[chan adapter.InvalidationEvent[RoomID]]struct{}{},
+		stopCh:    make(chan struct{}),
+		doneCh:    make(chan struct{}),
+	}
+}
+
+// LogPath returns the absolute path the Provider reads from.
+func (p *Provider) LogPath() string { return p.adapterIO.Dir() }
+
+// Start hydrates from a Snapshot, then launches the watcher loop.
+// Subsequent calls are no-ops.
+func (p *Provider) Start(ctx context.Context) error {
+	var startErr error
+	p.startOnce.Do(func() {
+		startErr = p.hydrate(ctx)
+		go p.run(ctx)
+	})
+	return startErr
+}
+
+func (p *Provider) hydrate(ctx context.Context) error {
+	rooms, offsets, err := p.adapterIO.Snapshot(ctx)
+	if err != nil {
+		p.logger.Warn("chat provider: hydrate snapshot failed", "err", err)
+	}
+	folded := make(map[RoomID]Room, len(rooms))
+	for room, evs := range rooms {
+		folded[room] = Fold(room, evs)
+	}
+	p.mu.Lock()
+	p.rooms = folded
+	p.offsets = offsets
+	p.loaded = true
+	p.mu.Unlock()
+	return nil
+}
+
+func (p *Provider) run(ctx context.Context) {
+	defer close(p.doneCh)
+	if p.notifyOverride == nil {
+		go func() {
+			if err := p.watcher.Run(ctx); err != nil {
+				p.logger.Warn("chat provider: watcher exited", "err", err)
+			}
+		}()
+	}
+	notify := p.notifyOverride
+	if notify == nil {
+		notify = p.watcher.Notifications()
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-p.stopCh:
+			return
+		case _, ok := <-notify:
+			if !ok {
+				return
+			}
+			p.refresh(ctx)
+		}
+	}
+}
+
+func (p *Provider) refresh(ctx context.Context) {
+	rooms, offsets, err := p.adapterIO.Snapshot(ctx)
+	if err != nil {
+		p.logger.Warn("chat provider: refresh snapshot failed", "err", err)
+	}
+	folded := make(map[RoomID]Room, len(rooms))
+	for room, evs := range rooms {
+		folded[room] = Fold(room, evs)
+	}
+	p.mu.Lock()
+	prev := p.rooms
+	p.rooms = folded
+	p.offsets = offsets
+	p.mu.Unlock()
+	// Publish for any room that's new or changed (compare timestamps).
+	for room, r := range folded {
+		old, existed := prev[room]
+		if !existed || !old.LastEventAt.Equal(r.LastEventAt) || len(old.Messages) != len(r.Messages) || len(old.Members) != len(r.Members) {
+			p.publish(room)
+		}
+	}
+}
+
+// Subscribe returns a channel that receives an InvalidationEvent each
+// time a room changes.
+func (p *Provider) Subscribe(ctx context.Context) <-chan adapter.InvalidationEvent[RoomID] {
+	ch := make(chan adapter.InvalidationEvent[RoomID], 16)
+	p.subMu.Lock()
+	p.subs[ch] = struct{}{}
+	p.subMu.Unlock()
+	go func() {
+		<-ctx.Done()
+		p.subMu.Lock()
+		delete(p.subs, ch)
+		p.subMu.Unlock()
+		close(ch)
+	}()
+	return ch
+}
+
+func (p *Provider) publish(room RoomID) {
+	ev := adapter.InvalidationEvent[RoomID]{Key: room}
+	p.subMu.Lock()
+	defer p.subMu.Unlock()
+	for ch := range p.subs {
+		select {
+		case ch <- ev:
+		default:
+			// drop slow subscribers
+		}
+	}
+}
+
+// Rooms returns a snapshot of every room currently cached.
+func (p *Provider) Rooms() []Room {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]Room, 0, len(p.rooms))
+	for _, r := range p.rooms {
+		out = append(out, cloneRoom(r))
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// Room returns one room's folded state.
+func (p *Provider) Room(id RoomID) (Room, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	r, ok := p.rooms[id]
+	if !ok {
+		return Room{}, false
+	}
+	return cloneRoom(r), true
+}
+
+// Stop cancels the run loop. Idempotent.
+func (p *Provider) Stop() { p.stopOnce.Do(func() { close(p.stopCh) }) }
+
+// Done returns a channel closed when the run loop exits.
+func (p *Provider) Done() <-chan struct{} { return p.doneCh }
+
+func cloneRoom(r Room) Room {
+	out := Room{ID: r.ID, LastEventAt: r.LastEventAt}
+	if len(r.Messages) > 0 {
+		out.Messages = make([]Message, len(r.Messages))
+		copy(out.Messages, r.Messages)
+	}
+	if len(r.Members) > 0 {
+		out.Members = make([]Member, len(r.Members))
+		copy(out.Members, r.Members)
+	}
+	return out
+}
+

--- a/internal/server/providers/chat/types.go
+++ b/internal/server/providers/chat/types.go
@@ -1,0 +1,70 @@
+package chat
+
+import (
+	"time"
+)
+
+// RoomID is the cache key for the chat provider — the room's basename
+// without the `.jsonl` suffix. Keep `@`-prefixed handles intact so
+// direct rooms (e.g. `@bob.jsonl` → RoomID "@bob") round-trip cleanly.
+type RoomID string
+
+// Event is one JSONL line. Discriminated by Type. The shape mirrors
+// the chat-core Rust enum exactly — adding fields here REQUIRES adding
+// fields to chat-core/src/types.rs and vice-versa, since the on-disk
+// JSONL is the cross-language contract.
+//
+// Field order mirrors the JSONL so go-toolchain reflection and diffs
+// read like the file does.
+type Event struct {
+	// Type discriminates the event. Allowed values:
+	//   "message" | "member.joined" | "member.left"
+	// Unknown values are skipped by Fold so the daemon stays
+	// forward-compatible with chat-core extensions.
+	Type string `json:"type"`
+
+	// Common: timestamp on every event. RFC 3339.
+	Timestamp time.Time `json:"ts"`
+
+	// Message fields.
+	ID            string `json:"id,omitempty"`
+	Sender        string `json:"sender,omitempty"`
+	SenderMachine string `json:"sender_machine,omitempty"`
+	Text          string `json:"text,omitempty"`
+	Source        string `json:"source,omitempty"` // "internal" | "external" (per chat-core)
+
+	// Member-event fields.
+	Handle      string `json:"handle,omitempty"`
+	Machine     string `json:"machine,omitempty"`
+	TmuxSession string `json:"tmux_session,omitempty"`
+}
+
+// Message is one folded message — what the resolver maps onto
+// graphql.ChatMessage.
+type Message struct {
+	ID            string
+	Room          RoomID
+	Timestamp     time.Time
+	Sender        string
+	SenderMachine string
+	Text          string
+	Source        string
+}
+
+// Member is a current room member, derived from joined/left events.
+// last-event-wins per handle: a handle present here had `member.joined`
+// as its most recent membership event.
+type Member struct {
+	Handle      string
+	Machine     string
+	TmuxSession string
+	JoinedAt    time.Time
+}
+
+// Room is the folded state of one chat room.
+type Room struct {
+	ID          RoomID
+	Messages    []Message // chronological, oldest first
+	Members     []Member
+	LastEventAt time.Time
+}

--- a/internal/server/providers/chat/watcher.go
+++ b/internal/server/providers/chat/watcher.go
@@ -1,0 +1,147 @@
+package chat
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// Watcher emits a notification whenever any per-room JSONL file under
+// the configured directory may have new bytes appended. The Provider
+// drives a poll-from-offsets on every notification so the actual fold
+// runs in the Provider's goroutine, not the watcher's.
+//
+// Mirrors the contracts watcher pattern. A nudge channel coalesces
+// bursts (chat-core often appends member.joined + first message within
+// milliseconds, fsnotify Write events arrive in clusters).
+type Watcher struct {
+	dir     string
+	logger  *slog.Logger
+	notify  chan struct{}
+	stopped chan struct{}
+
+	mu     sync.Mutex
+	fsw    *fsnotify.Watcher
+	closed bool
+}
+
+// NewWatcher constructs a Watcher rooted at the given chat directory.
+// Run must be called exactly once after construction.
+func NewWatcher(dir string, logger *slog.Logger) *Watcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Watcher{
+		dir:     dir,
+		logger:  logger,
+		notify:  make(chan struct{}, 1),
+		stopped: make(chan struct{}),
+	}
+}
+
+// Notifications returns the channel callers select on. A receive
+// signals "some jsonl in the dir may have new data".
+func (w *Watcher) Notifications() <-chan struct{} { return w.notify }
+
+// Run starts the fsnotify loop and blocks until ctx is cancelled.
+func (w *Watcher) Run(ctx context.Context) error {
+	defer close(w.stopped)
+
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	w.mu.Lock()
+	w.fsw = fsw
+	w.mu.Unlock()
+	defer func() {
+		w.mu.Lock()
+		w.closed = true
+		w.mu.Unlock()
+		_ = fsw.Close()
+	}()
+
+	// If the directory exists, watch it AND every existing JSONL.
+	if err := w.attachIfExists(); err != nil {
+		w.logger.Warn("chat watcher: initial attach failed", "err", err)
+	}
+
+	w.fire() // hydrate trigger
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case ev, ok := <-fsw.Events:
+			if !ok {
+				return nil
+			}
+			w.handleEvent(ev)
+		case err, ok := <-fsw.Errors:
+			if !ok {
+				return nil
+			}
+			w.logger.Warn("chat watcher: fsnotify error", "err", err)
+		}
+	}
+}
+
+func (w *Watcher) handleEvent(ev fsnotify.Event) {
+	if !strings.HasSuffix(ev.Name, ".jsonl") {
+		return
+	}
+	if ev.Op&fsnotify.Create != 0 {
+		// New room file — start watching it directly so we get Writes.
+		w.mu.Lock()
+		if !w.closed && w.fsw != nil {
+			_ = w.fsw.Add(ev.Name)
+		}
+		w.mu.Unlock()
+	}
+	w.fire()
+}
+
+func (w *Watcher) attachIfExists() error {
+	if _, err := os.Stat(w.dir); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	if err := w.fsw.Add(w.dir); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(w.dir)
+	if err != nil {
+		return err
+	}
+	for _, ent := range entries {
+		if ent.IsDir() {
+			continue
+		}
+		if filepath.Ext(ent.Name()) != ".jsonl" {
+			continue
+		}
+		_ = w.fsw.Add(filepath.Join(w.dir, ent.Name()))
+	}
+	return nil
+}
+
+// fire writes a notification, coalescing bursts.
+func (w *Watcher) fire() {
+	select {
+	case w.notify <- struct{}{}:
+	default:
+		// already pending; consumer will see the bundled change set
+	}
+}
+
+// Stopped returns a channel that closes when Run returns.
+func (w *Watcher) Stopped() <-chan struct{} { return w.stopped }


### PR DESCRIPTION
## Summary

Adds the read-side companion to chat-core (#495 / @61's #500): a Go provider that file-watches `~/.orchard/chat/*.jsonl`, folds the chat-core Event grammar into Room snapshots, and exposes a Subscribe channel for invalidation events.

**This PR ships the provider only.** The GraphQL surface (Query.chats / Query.chat / Subscription.chatChanged) and the resolver wiring are deferred to a follow-up — when I attempted the schema additions, gqlgen's regen path ran into existing-resolver-conflict issues that need a separate, focused investigation. The Go provider compiles standalone and is fully tested.

Closes part of #498.

## What's in here

```
internal/server/providers/chat/
├── doc.go            # Package overview, JSONL contract, fold semantics
├── types.go          # Event / Message / Member / Room (mirrors chat-core)
├── path.go           # ${ORCHARD_CHAT_DIR:-~/.orchard/chat} resolution
├── fold.go           # Pure event → Room reducer (last-event-wins membership)
├── adapter.go        # Stateless file I/O: Snapshot + FollowFromOffsets
├── watcher.go        # fsnotify on dir + per-file (handles new files via Create)
├── provider.go       # In-mem fold cache + Subscribe channel + Start/Stop lifecycle
├── fold_test.go      # 3 tests
└── adapter_test.go   # 5 tests (incl. partial trailing line, tail-from-offset)
```

8 tests, all green. Mirrors the existing contracts provider shape — same Adapter / Watcher / Provider triplet.

## What's left (follow-up — to land before this PR is undrafted)

1. **GraphQL schema** — add `Chat` / `ChatMessage` / `ChatMember` types, `Query.chats`, `Query.chat(id)`, `Subscription.chatChanged(roomId)`. Schema additions are drafted in my local working state; regen requires a clean gqlgen environment to avoid clobbering the existing `schema.resolvers.go`.
2. **Resolver wiring** — add `WithChat` to `Resolver`, implement the three field resolvers, hook the provider's Subscribe channel into the subscription resolver.
3. **Daemon main** — wire `chat.New()` and `WithChat` in `cmd/orchard-daemon/main.go`.

The follow-up is largely mechanical once the gqlgen workflow is right; the substantive work — the file-watch fold + JSONL grammar + invalidation broadcast — is in this PR.

## What's the path to GUI chat e2e

This PR + follow-up unblocks the daemon-mediated path. There's also a **simpler v1 path** for the GUI: have the Tauri shell file-watch `~/.orchard/chat/*.jsonl` directly via Rust's `notify` crate, bypassing the daemon entirely for chat. That path:

- Doesn't need this PR's GraphQL surface.
- Works today with @61's `orchard chat send` CLI.
- Is what most desktop apps actually do for local file events.

The **daemon-mediated path** (this PR's intent) is the right architecture for cross-machine chat (where the daemon will federate JSONL events between hosts), but for v1 single-machine the file-watch shortcut is faster to land.

## Coordination

- @61's chat-core PR #500 is the upstream contract for the JSONL grammar. Do not merge this until #500 has merged (the foundation ground-truth lives in `chat-core/src/types.rs`).
- The schema/resolver follow-up needs a clean session focused on gqlgen mechanics — the corruption I hit when running `gqlgen generate` suggests the current schema.resolvers.go was previously hand-edited in ways that gqlgen's regen path doesn't cleanly preserve. That's a focused 30-60min debug, not in scope for this delivery slice.

## Test plan

- [x] `go test ./internal/server/providers/chat/... -v` → 8/8 pass
- [x] `go build ./...` → clean
- [ ] Live test against real `orchard chat send` (after #500 merges)
- [ ] Cross-host federation via peerproxy (v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new chat provider that loads chat rooms, message history, and membership information
  * Provides real-time monitoring and synchronization for new messages and room membership changes
  * Maintains persistent chat storage with automatic state caching and update notifications when data changes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/503)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->