### PR TITLE
fix(daemon): claudeInstances pid join — wire production adapters (#468)

### DIFF
--- a/internal/cli/daemon/claudeinstance_wiring.go
+++ b/internal/cli/daemon/claudeinstance_wiring.go
@@ -1,0 +1,157 @@
+// Package daemon — claudeinstance_wiring.go
+//
+// Thin projection adapters that bridge the concrete provider types
+// (*ps.Provider, *tmux.Provider, *claudeaccount.Provider) to the narrow
+// interfaces (psInput, tmuxInput, acctInput) that the claudeinstance
+// package's NewProcessFinder / NewPaneFinder / NewAccountFinder consume.
+//
+// These adapters live here rather than in the claudeinstance package to
+// avoid an import cycle: claudeinstance → ps/tmux/claudeaccount → (nothing),
+// but daemon → all three is fine. The narrow interfaces in claudeinstance
+// are satisfied structurally (Go duck typing) — no explicit "implements"
+// declaration is required.
+//
+// The projection from ps.Process → graphql.Process is a copy of
+// internal/server/resolvers/loader_bridge.go:projectProcessFromCache.
+// Both copies MUST be kept in sync; a comment in loader_bridge.go says so.
+package daemon
+
+import (
+	"context"
+	"time"
+
+	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	claudeaccountprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeaccount"
+	psprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	tmuxprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
+)
+
+// ---------------------------------------------------------------------------
+// psInputAdapter — bridges *psprovider.Provider to psInput.
+// ---------------------------------------------------------------------------
+
+// psInputAdapter wraps the ps provider to implement the narrow psInput
+// interface that claudeinstance.NewProcessFinder and claudeinstance.NewPaneFinder
+// consume.
+type psInputAdapter struct {
+	p *psprovider.Provider
+}
+
+// GetByPid returns the projected *gql.Process for the given pid on hostID, or
+// (nil, false) when the pid is not in the ps cache.
+//
+// The projection mirrors loader_bridge.go:projectProcessFromCache — both copies
+// MUST be kept in sync.
+func (a *psInputAdapter) GetByPid(ctx context.Context, hostID string, pid int) (*gql.Process, bool) {
+	if a.p == nil || pid <= 0 {
+		return nil, false
+	}
+	proc, _, err := a.p.Get(ctx, psprovider.ProcessID{Host: hostID, PID: pid})
+	if err != nil {
+		return nil, false
+	}
+	return projectProcess(&proc, hostID), true
+}
+
+// projectProcess projects a psprovider.Process onto *gql.Process.
+// Mirrors internal/server/resolvers/loader_bridge.go:projectProcessFromCache.
+func projectProcess(p *psprovider.Process, hostID string) *gql.Process {
+	out := &gql.Process{
+		ID:         p.ID.String(),
+		Host:       &gql.Host{ID: hostID},
+		Pid:        int64(p.ID.PID),
+		Ppid:       int64(p.PPID),
+		Command:    p.Command,
+		StartedAt:  p.StartedRaw,
+		CPUPercent: p.CPUPercent,
+		MemBytes:   p.MemBytes,
+	}
+	if !p.StartedAt.IsZero() {
+		out.StartedAt = p.StartedAt.Format(time.RFC3339)
+	}
+	if p.TTY != "" {
+		tty := p.TTY
+		out.Tty = &tty
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// tmuxInputAdapter — bridges *tmuxprovider.Provider to tmuxInput.
+// ---------------------------------------------------------------------------
+
+// tmuxInputAdapter wraps the tmux provider to implement the narrow tmuxInput
+// interface that claudeinstance.NewPaneFinder consumes.
+type tmuxInputAdapter struct {
+	p *tmuxprovider.Provider
+}
+
+// PaneByPid walks the tmux pane snapshot and returns the first pane whose
+// foreground pid matches, or (nil, false) when no match is found.
+func (a *tmuxInputAdapter) PaneByPid(ctx context.Context, hostID string, pid int) (*gql.TmuxPane, bool) {
+	if a.p == nil || pid <= 0 {
+		return nil, false
+	}
+	for _, pn := range a.p.Snapshot().Panes {
+		if string(pn.Key.Host) == hostID && pn.CurrentPid == pid {
+			return projectPane(pn), true
+		}
+	}
+	return nil, false
+}
+
+// PaneBySession walks the tmux pane snapshot and returns the first pane in the
+// named session that has a non-zero foreground pid, or (nil, false).
+func (a *tmuxInputAdapter) PaneBySession(ctx context.Context, hostID, session string) (*gql.TmuxPane, bool) {
+	if a.p == nil || session == "" {
+		return nil, false
+	}
+	for _, pn := range a.p.Snapshot().Panes {
+		if string(pn.Key.Host) == hostID && pn.WindowKey.Session == session {
+			if pn.CurrentPid > 0 {
+				return projectPane(pn), true
+			}
+		}
+	}
+	return nil, false
+}
+
+// projectPane projects a tmuxprovider.Pane onto *gql.TmuxPane.
+func projectPane(pn tmuxprovider.Pane) *gql.TmuxPane {
+	out := &gql.TmuxPane{
+		ID:             "TmuxPane:" + string(pn.Key.Host) + ":" + pn.Key.PaneID,
+		PaneID:         pn.Key.PaneID,
+		CurrentCommand: pn.CurrentCommand,
+	}
+	if pn.CurrentPid > 0 {
+		pid := int64(pn.CurrentPid)
+		out.CurrentPid = &pid
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// acctInputAdapter — bridges *claudeaccountprovider.Provider to acctInput.
+// ---------------------------------------------------------------------------
+
+// acctInputAdapter wraps the claudeaccount provider to implement the narrow
+// acctInput interface that claudeinstance.NewAccountFinder consumes.
+type acctInputAdapter struct {
+	p *claudeaccountprovider.Provider
+}
+
+// ActiveAccount returns the active Claude CLI account for the given host, or
+// (nil, false) when no account is authenticated or the provider errors.
+//
+// v1 returns only the first account; the briefing specifies one account per
+// host for this release (ADR-011 §5.1).
+func (a *acctInputAdapter) ActiveAccount(ctx context.Context, hostID string) (*gql.ClaudeAccount, bool) {
+	if a.p == nil {
+		return nil, false
+	}
+	accounts, err := a.p.List(ctx)
+	if err != nil || len(accounts) == 0 {
+		return nil, false
+	}
+	return a.p.ToGraphQL(accounts[0]), true
+}

--- a/internal/cli/daemon/claudeinstance_wiring.go
+++ b/internal/cli/daemon/claudeinstance_wiring.go
@@ -18,6 +18,8 @@ package daemon
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 	"time"
 
 	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
@@ -77,13 +79,52 @@ func projectProcess(p *psprovider.Process, hostID string) *gql.Process {
 }
 
 // ---------------------------------------------------------------------------
+// Internal narrow interfaces for testability.
+// ---------------------------------------------------------------------------
+
+// tmuxSnapshotter is the narrow surface tmuxInputAdapter reads from the tmux
+// provider. *tmuxprovider.Provider satisfies this via its Snapshot() method.
+// Test stubs implement it inline.
+type tmuxSnapshotter interface {
+	Snapshot() tmuxprovider.RuntimeSnapshot
+}
+
+// psGetter is the narrow surface tmuxInputAdapter needs from the ps provider:
+// just the command string for a given pid. Test stubs implement it inline.
+type psGetter interface {
+	// CommandForPid returns the command basename for the given pid on hostID, or
+	// ("", false) when the pid is not in cache.
+	CommandForPid(ctx context.Context, hostID string, pid int) (string, bool)
+}
+
+// ---------------------------------------------------------------------------
 // tmuxInputAdapter — bridges *tmuxprovider.Provider to tmuxInput.
 // ---------------------------------------------------------------------------
 
 // tmuxInputAdapter wraps the tmux provider to implement the narrow tmuxInput
 // interface that claudeinstance.NewPaneFinder consumes.
+//
+// When ps is non-nil, PaneBySession iterates ALL panes in the session and
+// returns the first one whose foreground process has a Command basename
+// containing "claude". This prevents the bug where a vim pane is returned
+// first (because it has a non-zero pid) and the caller never sees the claude
+// pane in the same session.
+//
+// When ps is nil (tests, no-ps mode), PaneBySession falls back to returning
+// the first pane with a non-zero currentPid — v1 behaviour.
 type tmuxInputAdapter struct {
-	p *tmuxprovider.Provider
+	p  tmuxSnapshotter
+	ps psGetter
+}
+
+// newTmuxInputAdapter constructs a tmuxInputAdapter with an optional ps
+// provider for command-basename cross-checking in PaneBySession.
+func newTmuxInputAdapter(p *tmuxprovider.Provider, ps *psprovider.Provider) *tmuxInputAdapter {
+	a := &tmuxInputAdapter{p: p}
+	if ps != nil {
+		a.ps = &psGetterAdapter{p: ps}
+	}
+	return a
 }
 
 // PaneByPid walks the tmux pane snapshot and returns the first pane whose
@@ -101,19 +142,62 @@ func (a *tmuxInputAdapter) PaneByPid(ctx context.Context, hostID string, pid int
 }
 
 // PaneBySession walks the tmux pane snapshot and returns the first pane in the
-// named session that has a non-zero foreground pid, or (nil, false).
+// named session that is owned by a claude process.
+//
+// When a.ps is non-nil, every candidate pane's foreground pid is looked up in
+// the ps snapshot; only panes whose process Command basename contains "claude"
+// are eligible. This ensures that a session containing [vim, claude] returns
+// the claude pane even when vim is iterated first.
+//
+// When a.ps is nil (tests, no-ps mode), the first pane with a non-zero
+// currentPid is returned — v1 behaviour sufficient when ps data is unavailable.
 func (a *tmuxInputAdapter) PaneBySession(ctx context.Context, hostID, session string) (*gql.TmuxPane, bool) {
 	if a.p == nil || session == "" {
 		return nil, false
 	}
 	for _, pn := range a.p.Snapshot().Panes {
-		if string(pn.Key.Host) == hostID && pn.WindowKey.Session == session {
-			if pn.CurrentPid > 0 {
-				return projectPane(pn), true
-			}
+		if string(pn.Key.Host) != hostID || pn.WindowKey.Session != session {
+			continue
+		}
+		if pn.CurrentPid <= 0 {
+			continue
+		}
+		if a.ps == nil {
+			// No ps provider: return first pane with a non-zero pid (v1 behaviour).
+			return projectPane(pn), true
+		}
+		// ps cross-check: only return the pane if its foreground process Command
+		// basename contains "claude".
+		cmd, ok := a.ps.CommandForPid(ctx, hostID, pn.CurrentPid)
+		if !ok {
+			continue
+		}
+		if strings.Contains(strings.ToLower(filepath.Base(cmd)), "claude") {
+			return projectPane(pn), true
 		}
 	}
 	return nil, false
+}
+
+// psGetterAdapter wraps *psprovider.Provider to satisfy the psGetter interface,
+// bridging the concrete provider type to the narrow interface tmuxInputAdapter
+// needs for testability.
+type psGetterAdapter struct {
+	p *psprovider.Provider
+}
+
+// CommandForPid returns the command basename for the given pid on hostID. It
+// wraps ps.Provider.Get and projects only the Command field. Returns ("", false)
+// when the pid is not in cache or the provider errors.
+func (a *psGetterAdapter) CommandForPid(ctx context.Context, hostID string, pid int) (string, bool) {
+	if a.p == nil || pid <= 0 {
+		return "", false
+	}
+	proc, _, err := a.p.Get(ctx, psprovider.ProcessID{Host: hostID, PID: pid})
+	if err != nil {
+		return "", false
+	}
+	return proc.Command, true
 }
 
 // projectPane projects a tmuxprovider.Pane onto *gql.TmuxPane.

--- a/internal/cli/daemon/claudeinstance_wiring_test.go
+++ b/internal/cli/daemon/claudeinstance_wiring_test.go
@@ -1,0 +1,183 @@
+package daemon
+
+// claudeinstance_wiring_test.go — unit tests for tmuxInputAdapter.PaneBySession.
+//
+// These tests exercise the core fix for issue #468: when a tmux session contains
+// multiple panes (e.g. [vim, claude]), PaneBySession must iterate ALL panes and
+// return only the one owned by a "claude" process — not the first pane with a
+// non-zero pid regardless of command.
+//
+// Tests use inline stubs for tmuxSnapshotter and psGetter so no real tmux or ps
+// providers are needed.
+
+import (
+	"context"
+	"testing"
+
+	tmuxprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
+)
+
+// ---------------------------------------------------------------------------
+// Stubs for the narrow internal interfaces.
+// ---------------------------------------------------------------------------
+
+// staticSnapshotter implements tmuxSnapshotter with a fixed RuntimeSnapshot.
+type staticSnapshotter struct {
+	snap tmuxprovider.RuntimeSnapshot
+}
+
+func (s *staticSnapshotter) Snapshot() tmuxprovider.RuntimeSnapshot {
+	return s.snap
+}
+
+// staticPsGetter implements psGetter with a fixed pid→command map.
+type staticPsGetter struct {
+	commands map[int]string // pid → command basename
+}
+
+func (g *staticPsGetter) CommandForPid(_ context.Context, _ string, pid int) (string, bool) {
+	cmd, ok := g.commands[pid]
+	return cmd, ok
+}
+
+// ---------------------------------------------------------------------------
+// Helper to build a Snapshot with specific panes.
+// ---------------------------------------------------------------------------
+
+// makePane builds a tmuxprovider.Pane with the given session, paneID, and
+// currentPid. host is always "local".
+func makePane(paneID, session string, currentPid int) tmuxprovider.Pane {
+	return tmuxprovider.Pane{
+		Key:        tmuxprovider.PaneKey{Host: tmuxprovider.HostID("local"), PaneID: paneID},
+		WindowKey:  tmuxprovider.WindowKey{Host: tmuxprovider.HostID("local"), Session: session},
+		CurrentPid: currentPid,
+	}
+}
+
+// snapshotWithPanes builds a RuntimeSnapshot containing exactly the given panes.
+func snapshotWithPanes(panes ...tmuxprovider.Pane) tmuxprovider.RuntimeSnapshot {
+	m := make(map[tmuxprovider.PaneKey]tmuxprovider.Pane, len(panes))
+	for _, p := range panes {
+		m[p.Key] = p
+	}
+	return tmuxprovider.RuntimeSnapshot{
+		Sessions: map[tmuxprovider.SessionKey]tmuxprovider.Session{},
+		Windows:  map[tmuxprovider.WindowKey]tmuxprovider.Window{},
+		Panes:    m,
+		Clients:  map[tmuxprovider.ClientKey]tmuxprovider.Client{},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests for tmuxInputAdapter.PaneBySession
+// ---------------------------------------------------------------------------
+
+// TestTmuxInputAdapter_PaneBySession_ClaudeProcessWins verifies that when a
+// session has [vim, claude] panes, PaneBySession returns the claude pane (%11),
+// not vim (%10). This is the core regression from issue #468.
+func TestTmuxInputAdapter_PaneBySession_ClaudeProcessWins(t *testing.T) {
+	snap := snapshotWithPanes(
+		makePane("%10", "issue468", 1000), // vim — non-zero pid, but NOT claude
+		makePane("%11", "issue468", 2000), // claude — should be returned
+	)
+	ps := &staticPsGetter{commands: map[int]string{
+		1000: "vim",
+		2000: "claude",
+	}}
+
+	a := &tmuxInputAdapter{
+		p:  &staticSnapshotter{snap: snap},
+		ps: ps,
+	}
+
+	pane, ok := a.PaneBySession(context.Background(), "local", "issue468")
+	if !ok {
+		t.Fatal("PaneBySession: expected ok=true, got false")
+	}
+	if pane == nil {
+		t.Fatal("PaneBySession: expected non-nil pane, got nil")
+	}
+	if pane.PaneID != "%11" {
+		t.Errorf("PaneBySession: got pane %q, want %%11 (claude pane)", pane.PaneID)
+	}
+}
+
+// TestTmuxInputAdapter_PaneBySession_NoPanes_ReturnsNil verifies that an
+// empty session (no panes at all) returns nil, false.
+func TestTmuxInputAdapter_PaneBySession_NoPanes_ReturnsNil(t *testing.T) {
+	snap := snapshotWithPanes() // empty
+	ps := &staticPsGetter{commands: map[int]string{}}
+
+	a := &tmuxInputAdapter{
+		p:  &staticSnapshotter{snap: snap},
+		ps: ps,
+	}
+
+	pane, ok := a.PaneBySession(context.Background(), "local", "issue468")
+	if ok {
+		t.Error("PaneBySession (no panes): expected ok=false, got true")
+	}
+	if pane != nil {
+		t.Errorf("PaneBySession (no panes): expected nil pane, got %v", pane)
+	}
+}
+
+// TestTmuxInputAdapter_PaneBySession_NoClaudeProcess_ReturnsNil verifies that
+// when a session has [vim, vim] panes (no claude process), PaneBySession
+// returns nil, false.
+func TestTmuxInputAdapter_PaneBySession_NoClaudeProcess_ReturnsNil(t *testing.T) {
+	snap := snapshotWithPanes(
+		makePane("%10", "no-claude", 1000), // vim
+		makePane("%12", "no-claude", 1001), // also vim
+	)
+	ps := &staticPsGetter{commands: map[int]string{
+		1000: "vim",
+		1001: "vim",
+	}}
+
+	a := &tmuxInputAdapter{
+		p:  &staticSnapshotter{snap: snap},
+		ps: ps,
+	}
+
+	pane, ok := a.PaneBySession(context.Background(), "local", "no-claude")
+	if ok {
+		t.Error("PaneBySession (no claude): expected ok=false, got true")
+	}
+	if pane != nil {
+		t.Errorf("PaneBySession (no claude): expected nil pane, got %v", pane)
+	}
+}
+
+// TestTmuxInputAdapter_PaneBySession_NilPs_ReturnsFirstNonZeroPid verifies
+// that when ps is nil (no cross-check), PaneBySession returns the first pane
+// with a non-zero currentPid — v1 behaviour.
+func TestTmuxInputAdapter_PaneBySession_NilPs_ReturnsFirstNonZeroPid(t *testing.T) {
+	snap := snapshotWithPanes(
+		makePane("%10", "alpha", 0),    // zero pid — skip
+		makePane("%11", "alpha", 1234), // first non-zero pid
+		makePane("%12", "alpha", 5678), // also non-zero, but second
+	)
+
+	a := &tmuxInputAdapter{
+		p:  &staticSnapshotter{snap: snap},
+		ps: nil, // no ps — v1 fallback
+	}
+
+	pane, ok := a.PaneBySession(context.Background(), "local", "alpha")
+	if !ok {
+		t.Fatal("PaneBySession (nil ps): expected ok=true, got false")
+	}
+	if pane == nil {
+		t.Fatal("PaneBySession (nil ps): expected non-nil pane, got nil")
+	}
+	// When ps is nil we expect the first pane with non-zero pid.
+	// Map iteration order is non-deterministic in Go, so we just assert
+	// we got one of the non-zero-pid panes (not %10 which has pid 0).
+	if pane.PaneID == "%10" {
+		t.Errorf("PaneBySession (nil ps): got pane %%10 (pid=0), want a non-zero-pid pane")
+	}
+	if pane.CurrentPid == nil || *pane.CurrentPid == 0 {
+		t.Errorf("PaneBySession (nil ps): got pane with zero/nil CurrentPid, want non-zero")
+	}
+}

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -146,9 +146,20 @@ func runStart(parentCtx context.Context, addr string) error {
 		return fmt.Errorf("build git provider: %w", err)
 	}
 
+	claudeAccountProvider := claudeaccount.New("local", logger)
+
+	psAdapter := &psInputAdapter{p: psProvider}
 	claudeInstanceProvider := claudeinstance.New(
 		"local",
-		claudeinstance.NewComposer("local", nil, nil, nil),
+		claudeinstance.NewComposer(
+			"local",
+			claudeinstance.NewPaneFinder(
+				&tmuxInputAdapter{p: tmuxProvider},
+				psAdapter,
+			),
+			claudeinstance.NewProcessFinder(psAdapter),
+			claudeinstance.NewAccountFinder(&acctInputAdapter{p: claudeAccountProvider}),
+		),
 	)
 
 	hsvc, hsvcErr := buildHostServiceProvider(ctx)
@@ -181,7 +192,7 @@ func runStart(parentCtx context.Context, addr string) error {
 		server.WithPS(psProvider),
 		server.WithTmux(tmuxProvider),
 		server.WithClaudeProjects(claudeProjectsProvider),
-		server.WithClaudeAccount(claudeaccount.New("local", logger)),
+		server.WithClaudeAccount(claudeAccountProvider),
 		server.WithClaudeInstance(claudeInstanceProvider),
 		server.WithContracts(contracts.New(logger)),
 		server.WithGh(ghProvider),

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -154,8 +154,7 @@ func runStart(parentCtx context.Context, addr string) error {
 		claudeinstance.NewComposer(
 			"local",
 			claudeinstance.NewPaneFinder(
-				&tmuxInputAdapter{p: tmuxProvider},
-				psAdapter,
+				newTmuxInputAdapter(tmuxProvider, psProvider),
 			),
 			claudeinstance.NewProcessFinder(psAdapter),
 			claudeinstance.NewAccountFinder(&acctInputAdapter{p: claudeAccountProvider}),

--- a/internal/server/providers/claudeinstance/composer.go
+++ b/internal/server/providers/claudeinstance/composer.go
@@ -223,14 +223,22 @@ func (c *Composer) findPane(ctx context.Context, hb Heartbeat) *graphql.TmuxPane
 	return nil
 }
 
-// resolvePid prefers the heartbeat's ClaudePid (ADR-011 shape). Falls
-// back to the matched pane's currentPid when the heartbeat predates the
-// pid-recording shape. Returns 0 when neither is available; the
-// composer surfaces such instances as `no_claude` because liveness
-// cannot be checked without a pid.
+// resolvePid returns the best available pid for the Claude process, in
+// priority order:
+//
+//  1. Heartbeat ClaudePid — authoritative when the hook script records it.
+//  2. pane.CurrentPid — primary fallback; the tmux provider reads the
+//     foreground pid of the pane directly, so this is accurate even when
+//     the heartbeat predates the pid-recording shape.
+//  3. pidFromPaneID — legacy stub (always returns 0/false today; reserved
+//     for a future PaneFinder extension).
+//  4. 0 — no pid available; the composer surfaces these as `no_claude`.
 func (c *Composer) resolvePid(hb Heartbeat, pane *graphql.TmuxPane) int {
 	if hb.ClaudePid > 0 {
 		return hb.ClaudePid
+	}
+	if pane != nil && pane.CurrentPid != nil && *pane.CurrentPid > 0 {
+		return int(*pane.CurrentPid)
 	}
 	if pane != nil && pane.ID != "" {
 		if pid, ok := pidFromPaneID(pane.ID); ok {

--- a/internal/server/providers/claudeinstance/composer_test.go
+++ b/internal/server/providers/claudeinstance/composer_test.go
@@ -266,6 +266,71 @@ func TestComposer_Compose_UnknownStateStaysNoClaude(t *testing.T) {
 	}
 }
 
+// TestComposer_ResolvePid_HeartbeatPidWins asserts that when hb.ClaudePid is
+// non-zero, resolvePid returns it regardless of any pane values (feature file
+// lines 174-179: "prefers heartbeat ClaudePid over pane.CurrentPid when ClaudePid
+// is non-zero").
+func TestComposer_ResolvePid_HeartbeatPidWins(t *testing.T) {
+	c := &Composer{}
+	panePid := int64(88631)
+	pane := &graphql.TmuxPane{
+		ID:         "TmuxPane:local:%59",
+		CurrentPid: &panePid,
+	}
+	hb := Heartbeat{ClaudePid: 12345}
+	got := c.resolvePid(hb, pane)
+	if got != 12345 {
+		t.Errorf("resolvePid = %d, want 12345 (heartbeat ClaudePid must win)", got)
+	}
+}
+
+// TestComposer_ResolvePid_FallsBackToPaneCurrentPid asserts that when
+// hb.ClaudePid is 0 and the matched pane has a non-nil, positive CurrentPid,
+// resolvePid returns int(*pane.CurrentPid) (feature file lines 181-186:
+// "falls back to pane.CurrentPid when heartbeat ClaudePid is zero and a pane
+// is matched").
+func TestComposer_ResolvePid_FallsBackToPaneCurrentPid(t *testing.T) {
+	c := &Composer{}
+	panePid := int64(88631)
+	pane := &graphql.TmuxPane{
+		ID:         "TmuxPane:local:%59",
+		CurrentPid: &panePid,
+	}
+	hb := Heartbeat{ClaudePid: 0}
+	got := c.resolvePid(hb, pane)
+	if got != 88631 {
+		t.Errorf("resolvePid = %d, want 88631 (pane.CurrentPid fallback)", got)
+	}
+}
+
+// TestComposer_ResolvePid_NilPaneReturnsZero asserts that when hb.ClaudePid is
+// 0 and pane is nil, resolvePid returns 0 (feature file lines 188-193: "returns 0
+// when heartbeat ClaudePid is zero and no pane is matched").
+func TestComposer_ResolvePid_NilPaneReturnsZero(t *testing.T) {
+	c := &Composer{}
+	hb := Heartbeat{ClaudePid: 0}
+	got := c.resolvePid(hb, nil)
+	if got != 0 {
+		t.Errorf("resolvePid = %d, want 0 (nil pane)", got)
+	}
+}
+
+// TestComposer_ResolvePid_NilCurrentPidReturnsZero asserts that when
+// hb.ClaudePid is 0 and pane.CurrentPid is nil, resolvePid returns 0
+// (second nil-CurrentPid case from feature file lines 188-193).
+func TestComposer_ResolvePid_NilCurrentPidReturnsZero(t *testing.T) {
+	c := &Composer{}
+	pane := &graphql.TmuxPane{
+		ID:         "TmuxPane:local:%59",
+		CurrentPid: nil, // explicitly nil — no pid recorded by tmux provider
+	}
+	hb := Heartbeat{ClaudePid: 0}
+	got := c.resolvePid(hb, pane)
+	if got != 0 {
+		t.Errorf("resolvePid = %d, want 0 (nil pane.CurrentPid)", got)
+	}
+}
+
 // TestParseInstanceID asserts the round-trip from buildID → parseInstanceID.
 func TestParseInstanceID(t *testing.T) {
 	id := buildID("local", 12345, "alpha")

--- a/internal/server/providers/claudeinstance/finders.go
+++ b/internal/server/providers/claudeinstance/finders.go
@@ -16,8 +16,6 @@ package claudeinstance
 
 import (
 	"context"
-	"path/filepath"
-	"strings"
 
 	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
 )
@@ -88,34 +86,29 @@ func (f *processFinder) FindByPid(ctx context.Context, hostID string, pid int) (
 // paneFinder
 // ---------------------------------------------------------------------------
 
-// paneFinder implements PaneFinder via the tmuxInput (and optional psInput)
-// narrow interfaces.
+// paneFinder implements PaneFinder via the tmuxInput narrow interface.
+//
+// The cmd-basename cross-check (only return panes whose foreground process is
+// "claude") has been moved into the tmuxInput adapter layer
+// (tmuxInputAdapter.PaneBySession in daemon/claudeinstance_wiring.go).
+// paneFinder is now a pure pass-through: it delegates to the tmuxInput and
+// returns whatever the adapter says. This lets the adapter iterate ALL panes
+// in a session, rather than the caller rejecting the single pane the adapter
+// returns — fixing the [vim, claude] multi-pane bug (issue #468).
 type paneFinder struct {
 	tmux tmuxInput
-	ps   psInput // optional: when non-nil, FindBySession cross-checks cmd contains "claude"
 }
 
-// NewPaneFinder wraps a tmuxInput provider as a PaneFinder. The optional ps
-// parameter enables cmd-basename cross-checking in FindBySession: when wired,
-// only panes whose currentPid resolves to a process whose Command basename
-// contains "claude" are returned.
-//
-// When ps is nil the cmd check is skipped and the first pane with a non-zero
-// currentPid is returned (v1 behaviour sufficient for AC #5 and AC #6).
-//
-// NOTE: feature file scenario line 64 expects cmd cross-checking. Wire ps when
-// available to honour that scenario.
+// NewPaneFinder wraps a tmuxInput provider as a PaneFinder. The adapter is
+// expected to already own the cmd-basename cross-check when ps is available
+// (see tmuxInputAdapter.PaneBySession in daemon/claudeinstance_wiring.go).
 //
 // When p is nil, a nil PaneFinder interface is returned.
-func NewPaneFinder(p tmuxInput, ps ...psInput) PaneFinder {
+func NewPaneFinder(p tmuxInput) PaneFinder {
 	if p == nil {
 		return nil
 	}
-	pf := &paneFinder{tmux: p}
-	if len(ps) > 0 {
-		pf.ps = ps[0]
-	}
-	return pf
+	return &paneFinder{tmux: p}
 }
 
 // FindByPid satisfies PaneFinder. Returns (nil, false) when claudePid <= 0.
@@ -126,31 +119,14 @@ func (f *paneFinder) FindByPid(ctx context.Context, hostID string, claudePid int
 	return f.tmux.PaneByPid(ctx, hostID, claudePid)
 }
 
-// FindBySession satisfies PaneFinder. Returns the first pane in the named tmux
-// session. When the paneFinder was constructed with a psInput, only panes whose
-// foreground process has a Command basename containing "claude" are eligible.
+// FindBySession satisfies PaneFinder. Delegates to the tmuxInput adapter,
+// which is expected to own the cmd-basename cross-check when ps is available.
 // Returns (nil, false) when tmuxSession is empty.
 func (f *paneFinder) FindBySession(ctx context.Context, hostID, tmuxSession string) (*gql.TmuxPane, bool) {
 	if tmuxSession == "" {
 		return nil, false
 	}
-	pane, ok := f.tmux.PaneBySession(ctx, hostID, tmuxSession)
-	if !ok || pane == nil {
-		return nil, false
-	}
-	if f.ps == nil || pane.CurrentPid == nil || *pane.CurrentPid <= 0 {
-		return pane, true
-	}
-	// ps cross-check: only return the pane if its foreground process looks
-	// like a claude process (Command basename contains "claude").
-	proc, found := f.ps.GetByPid(ctx, hostID, int(*pane.CurrentPid))
-	if !found || proc == nil {
-		return nil, false
-	}
-	if !strings.Contains(strings.ToLower(filepath.Base(proc.Command)), "claude") {
-		return nil, false
-	}
-	return pane, true
+	return f.tmux.PaneBySession(ctx, hostID, tmuxSession)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/server/providers/claudeinstance/finders.go
+++ b/internal/server/providers/claudeinstance/finders.go
@@ -1,0 +1,178 @@
+package claudeinstance
+
+// finders.go — production adapters that bridge the sibling provider packages
+// (ps, tmux, claudeaccount) to the narrow interfaces (ProcessFinder,
+// PaneFinder, AccountFinder) that Composer consumes.
+//
+// Each adapter is a thin projection layer. The canonical projection shape for
+// ps.Process → graphql.Process lives in
+// internal/server/resolvers/loader_bridge.go:projectProcessFromCache — the
+// inline duplication below is intentional to avoid a resolvers → claudeinstance
+// import cycle. Both copies MUST be kept in sync.
+//
+// Constructors follow a nil-safe pattern: when the underlying provider is nil
+// the constructor returns a nil interface value (not a typed-nil wrapper), so
+// the Composer's "if c.procs == nil" guards remain reliable.
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+
+	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// ---------------------------------------------------------------------------
+// Narrow input interfaces — the seam between production providers and tests.
+// ---------------------------------------------------------------------------
+
+// psInput is the narrow read surface NewProcessFinder consumes. The
+// production *psprovider.Provider does not implement this directly; daemon
+// wiring supplies a wrapping adapter. Test stubs implement it inline.
+type psInput interface {
+	// GetByPid returns the projected graphql.Process for the given pid on
+	// hostID, or (nil, false) when the pid is not in cache.
+	GetByPid(ctx context.Context, hostID string, pid int) (*gql.Process, bool)
+}
+
+// tmuxInput is the narrow read surface NewPaneFinder consumes.
+type tmuxInput interface {
+	// PaneByPid returns the pane whose foreground pid matches, or (nil, false).
+	PaneByPid(ctx context.Context, hostID string, pid int) (*gql.TmuxPane, bool)
+	// PaneBySession returns the first suitable pane in the named tmux session,
+	// or (nil, false) when the session is absent or has no candidate panes.
+	PaneBySession(ctx context.Context, hostID, session string) (*gql.TmuxPane, bool)
+}
+
+// acctInput is the narrow read surface NewAccountFinder consumes.
+type acctInput interface {
+	// ActiveAccount returns the active Claude account for hostID, or (nil,
+	// false) when no account is authenticated.
+	ActiveAccount(ctx context.Context, hostID string) (*gql.ClaudeAccount, bool)
+}
+
+// ---------------------------------------------------------------------------
+// processFinder
+// ---------------------------------------------------------------------------
+
+// processFinder implements ProcessFinder via the psInput narrow interface.
+type processFinder struct {
+	ps psInput
+}
+
+// NewProcessFinder wraps a psInput provider as a ProcessFinder. When p is nil
+// the function returns a nil ProcessFinder interface — Composer's nil guard
+// handles that cleanly.
+//
+// For daemon wiring, supply a *psprovider.Provider wrapped in a thin adapter
+// that projects ps.Process to *graphql.Process. Test stubs implement psInput
+// directly.
+func NewProcessFinder(p psInput) ProcessFinder {
+	if p == nil {
+		return nil
+	}
+	return &processFinder{ps: p}
+}
+
+// FindByPid satisfies ProcessFinder. Delegates to the injected psInput, which
+// must perform the projection from the raw provider type. Returns (nil, false)
+// on miss or when pid <= 0.
+func (f *processFinder) FindByPid(ctx context.Context, hostID string, pid int) (*gql.Process, bool) {
+	if pid <= 0 {
+		return nil, false
+	}
+	return f.ps.GetByPid(ctx, hostID, pid)
+}
+
+// ---------------------------------------------------------------------------
+// paneFinder
+// ---------------------------------------------------------------------------
+
+// paneFinder implements PaneFinder via the tmuxInput (and optional psInput)
+// narrow interfaces.
+type paneFinder struct {
+	tmux tmuxInput
+	ps   psInput // optional: when non-nil, FindBySession cross-checks cmd contains "claude"
+}
+
+// NewPaneFinder wraps a tmuxInput provider as a PaneFinder. The optional ps
+// parameter enables cmd-basename cross-checking in FindBySession: when wired,
+// only panes whose currentPid resolves to a process whose Command basename
+// contains "claude" are returned.
+//
+// When ps is nil the cmd check is skipped and the first pane with a non-zero
+// currentPid is returned (v1 behaviour sufficient for AC #5 and AC #6).
+//
+// NOTE: feature file scenario line 64 expects cmd cross-checking. Wire ps when
+// available to honour that scenario.
+//
+// When p is nil, a nil PaneFinder interface is returned.
+func NewPaneFinder(p tmuxInput, ps ...psInput) PaneFinder {
+	if p == nil {
+		return nil
+	}
+	pf := &paneFinder{tmux: p}
+	if len(ps) > 0 {
+		pf.ps = ps[0]
+	}
+	return pf
+}
+
+// FindByPid satisfies PaneFinder. Returns (nil, false) when claudePid <= 0.
+func (f *paneFinder) FindByPid(ctx context.Context, hostID string, claudePid int) (*gql.TmuxPane, bool) {
+	if claudePid <= 0 {
+		return nil, false
+	}
+	return f.tmux.PaneByPid(ctx, hostID, claudePid)
+}
+
+// FindBySession satisfies PaneFinder. Returns the first pane in the named tmux
+// session. When the paneFinder was constructed with a psInput, only panes whose
+// foreground process has a Command basename containing "claude" are eligible.
+// Returns (nil, false) when tmuxSession is empty.
+func (f *paneFinder) FindBySession(ctx context.Context, hostID, tmuxSession string) (*gql.TmuxPane, bool) {
+	if tmuxSession == "" {
+		return nil, false
+	}
+	pane, ok := f.tmux.PaneBySession(ctx, hostID, tmuxSession)
+	if !ok || pane == nil {
+		return nil, false
+	}
+	if f.ps == nil || pane.CurrentPid == nil || *pane.CurrentPid <= 0 {
+		return pane, true
+	}
+	// ps cross-check: only return the pane if its foreground process looks
+	// like a claude process (Command basename contains "claude").
+	proc, found := f.ps.GetByPid(ctx, hostID, int(*pane.CurrentPid))
+	if !found || proc == nil {
+		return nil, false
+	}
+	if !strings.Contains(strings.ToLower(filepath.Base(proc.Command)), "claude") {
+		return nil, false
+	}
+	return pane, true
+}
+
+// ---------------------------------------------------------------------------
+// accountFinder
+// ---------------------------------------------------------------------------
+
+// accountFinder implements AccountFinder via the acctInput narrow interface.
+type accountFinder struct {
+	acct acctInput
+}
+
+// NewAccountFinder wraps an acctInput provider as an AccountFinder. When p is
+// nil the function returns a nil AccountFinder interface.
+func NewAccountFinder(p acctInput) AccountFinder {
+	if p == nil {
+		return nil
+	}
+	return &accountFinder{acct: p}
+}
+
+// Active satisfies AccountFinder. Returns the first active account, or (nil,
+// false) when none is available.
+func (f *accountFinder) Active(ctx context.Context, hostID string) (*gql.ClaudeAccount, bool) {
+	return f.acct.ActiveAccount(ctx, hostID)
+}

--- a/internal/server/providers/claudeinstance/finders_test.go
+++ b/internal/server/providers/claudeinstance/finders_test.go
@@ -1,0 +1,281 @@
+package claudeinstance
+
+// finders_test.go — unit tests for the production adapter constructors in
+// finders.go: NewProcessFinder, NewPaneFinder, NewAccountFinder.
+//
+// Each adapter is tested for: happy path, not-found, nil-provider path.
+//
+// Tests live in package claudeinstance (not claudeinstance_test) so they
+// can construct the unexported input-interface stubs without naming them
+// externally — Go structural typing handles the rest.
+
+import (
+	"context"
+	"testing"
+
+	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// ---------------------------------------------------------------------------
+// Minimal stubs for the narrow input interfaces.
+// Named with "finder" prefix to avoid collisions with the
+// fakePaneFinder/fakeProcessFinder/fakeAccountFinder types in composer_test.go.
+// ---------------------------------------------------------------------------
+
+// finderPsStub implements psInput. Returns the injected process for matching
+// pids; (nil, false) for misses.
+type finderPsStub struct {
+	byPid map[int]*gql.Process
+}
+
+func (s *finderPsStub) GetByPid(_ context.Context, _ string, pid int) (*gql.Process, bool) {
+	p, ok := s.byPid[pid]
+	return p, ok
+}
+
+// finderTmuxStub implements tmuxInput.
+type finderTmuxStub struct {
+	byPid     map[int]*gql.TmuxPane
+	bySession map[string]*gql.TmuxPane
+}
+
+func (s *finderTmuxStub) PaneByPid(_ context.Context, _ string, pid int) (*gql.TmuxPane, bool) {
+	pane, ok := s.byPid[pid]
+	return pane, ok
+}
+
+func (s *finderTmuxStub) PaneBySession(_ context.Context, _, session string) (*gql.TmuxPane, bool) {
+	pane, ok := s.bySession[session]
+	return pane, ok
+}
+
+// finderAcctStub implements acctInput.
+type finderAcctStub struct {
+	account *gql.ClaudeAccount
+}
+
+func (s *finderAcctStub) ActiveAccount(_ context.Context, _ string) (*gql.ClaudeAccount, bool) {
+	if s.account == nil {
+		return nil, false
+	}
+	return s.account, true
+}
+
+// ---------------------------------------------------------------------------
+// processFinder tests
+// ---------------------------------------------------------------------------
+
+func TestNewProcessFinder_NilProvider_ReturnsNil(t *testing.T) {
+	f := NewProcessFinder(nil)
+	if f != nil {
+		t.Error("expected nil ProcessFinder when provider is nil, got non-nil")
+	}
+}
+
+func TestProcessFinder_FindByPid_HappyPath(t *testing.T) {
+	proc := &gql.Process{ID: "Process:local:1234", Pid: 1234, Command: "claude"}
+	stub := &finderPsStub{byPid: map[int]*gql.Process{1234: proc}}
+	f := NewProcessFinder(stub)
+
+	got, ok := f.FindByPid(context.Background(), "local", 1234)
+	if !ok {
+		t.Fatal("FindByPid: expected ok=true, got false")
+	}
+	if got != proc {
+		t.Errorf("FindByPid: got %v, want %v", got, proc)
+	}
+}
+
+func TestProcessFinder_FindByPid_NotFound(t *testing.T) {
+	stub := &finderPsStub{byPid: map[int]*gql.Process{}} // empty
+	f := NewProcessFinder(stub)
+
+	got, ok := f.FindByPid(context.Background(), "local", 9999)
+	if ok {
+		t.Error("FindByPid: expected ok=false for unknown pid, got true")
+	}
+	if got != nil {
+		t.Errorf("FindByPid: expected nil result, got %v", got)
+	}
+}
+
+func TestProcessFinder_FindByPid_ZeroPid_ReturnsFalse(t *testing.T) {
+	// pid <= 0 must return (nil, false) without consulting the backend.
+	stub := &finderPsStub{byPid: map[int]*gql.Process{0: {ID: "should-not-be-returned"}}}
+	f := NewProcessFinder(stub)
+
+	got, ok := f.FindByPid(context.Background(), "local", 0)
+	if ok {
+		t.Error("FindByPid(pid=0): expected ok=false")
+	}
+	if got != nil {
+		t.Errorf("FindByPid(pid=0): expected nil result, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// paneFinder tests
+// ---------------------------------------------------------------------------
+
+func TestNewPaneFinder_NilProvider_ReturnsNil(t *testing.T) {
+	f := NewPaneFinder(nil)
+	if f != nil {
+		t.Error("expected nil PaneFinder when provider is nil, got non-nil")
+	}
+}
+
+func TestPaneFinder_FindByPid_HappyPath(t *testing.T) {
+	pid := int64(88631)
+	pane := &gql.TmuxPane{ID: "TmuxPane:local:%59", CurrentPid: &pid}
+	stub := &finderTmuxStub{byPid: map[int]*gql.TmuxPane{88631: pane}}
+	f := NewPaneFinder(stub)
+
+	got, ok := f.FindByPid(context.Background(), "local", 88631)
+	if !ok {
+		t.Fatal("FindByPid: expected ok=true, got false")
+	}
+	if got != pane {
+		t.Errorf("FindByPid: got %v, want %v", got, pane)
+	}
+}
+
+func TestPaneFinder_FindByPid_NotFound(t *testing.T) {
+	stub := &finderTmuxStub{byPid: map[int]*gql.TmuxPane{}}
+	f := NewPaneFinder(stub)
+
+	got, ok := f.FindByPid(context.Background(), "local", 99999)
+	if ok {
+		t.Error("FindByPid: expected ok=false for unknown pid, got true")
+	}
+	if got != nil {
+		t.Errorf("FindByPid: expected nil result, got %v", got)
+	}
+}
+
+func TestPaneFinder_FindByPid_ZeroPid_ReturnsFalse(t *testing.T) {
+	stub := &finderTmuxStub{byPid: map[int]*gql.TmuxPane{0: {ID: "should-not-be-returned"}}}
+	f := NewPaneFinder(stub)
+
+	got, ok := f.FindByPid(context.Background(), "local", 0)
+	if ok {
+		t.Error("FindByPid(pid=0): expected ok=false")
+	}
+	if got != nil {
+		t.Errorf("FindByPid(pid=0): expected nil result, got %v", got)
+	}
+}
+
+func TestPaneFinder_FindBySession_HappyPath(t *testing.T) {
+	pid := int64(88631)
+	pane := &gql.TmuxPane{ID: "TmuxPane:local:%59", CurrentPid: &pid}
+	stub := &finderTmuxStub{bySession: map[string]*gql.TmuxPane{"alpha": pane}}
+	f := NewPaneFinder(stub)
+
+	got, ok := f.FindBySession(context.Background(), "local", "alpha")
+	if !ok {
+		t.Fatal("FindBySession: expected ok=true, got false")
+	}
+	if got != pane {
+		t.Errorf("FindBySession: got %v, want %v", got, pane)
+	}
+}
+
+func TestPaneFinder_FindBySession_NotFound(t *testing.T) {
+	stub := &finderTmuxStub{bySession: map[string]*gql.TmuxPane{}}
+	f := NewPaneFinder(stub)
+
+	got, ok := f.FindBySession(context.Background(), "local", "nosuchsession")
+	if ok {
+		t.Error("FindBySession: expected ok=false for unknown session, got true")
+	}
+	if got != nil {
+		t.Errorf("FindBySession: expected nil result, got %v", got)
+	}
+}
+
+func TestPaneFinder_FindBySession_EmptySession_ReturnsFalse(t *testing.T) {
+	stub := &finderTmuxStub{bySession: map[string]*gql.TmuxPane{"": {ID: "should-not-be-returned"}}}
+	f := NewPaneFinder(stub)
+
+	got, ok := f.FindBySession(context.Background(), "local", "")
+	if ok {
+		t.Error("FindBySession(session=''): expected ok=false")
+	}
+	if got != nil {
+		t.Errorf("FindBySession(session=''): expected nil result, got %v", got)
+	}
+}
+
+func TestPaneFinder_FindBySession_WithPsCrossCheck_ClaudeProcess(t *testing.T) {
+	// When ps is wired and the pane's foreground pid resolves to a process
+	// whose Command contains "claude", the pane should be returned.
+	pid := int64(42)
+	pane := &gql.TmuxPane{ID: "TmuxPane:local:%1", CurrentPid: &pid}
+	tmuxStub := &finderTmuxStub{bySession: map[string]*gql.TmuxPane{"alpha": pane}}
+	psStub := &finderPsStub{byPid: map[int]*gql.Process{42: {Command: "claude"}}}
+
+	f := NewPaneFinder(tmuxStub, psStub)
+	got, ok := f.FindBySession(context.Background(), "local", "alpha")
+	if !ok {
+		t.Fatal("FindBySession with claude ps: expected ok=true")
+	}
+	if got != pane {
+		t.Errorf("FindBySession: got %v, want %v", got, pane)
+	}
+}
+
+func TestPaneFinder_FindBySession_WithPsCrossCheck_NonClaudeProcess(t *testing.T) {
+	// When ps is wired and the pane's foreground pid resolves to a non-claude
+	// process, the pane should NOT be returned.
+	pid := int64(42)
+	pane := &gql.TmuxPane{ID: "TmuxPane:local:%1", CurrentPid: &pid}
+	tmuxStub := &finderTmuxStub{bySession: map[string]*gql.TmuxPane{"alpha": pane}}
+	psStub := &finderPsStub{byPid: map[int]*gql.Process{42: {Command: "zsh"}}}
+
+	f := NewPaneFinder(tmuxStub, psStub)
+	got, ok := f.FindBySession(context.Background(), "local", "alpha")
+	if ok {
+		t.Error("FindBySession with non-claude ps: expected ok=false")
+	}
+	if got != nil {
+		t.Errorf("FindBySession with non-claude ps: expected nil, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// accountFinder tests
+// ---------------------------------------------------------------------------
+
+func TestNewAccountFinder_NilProvider_ReturnsNil(t *testing.T) {
+	f := NewAccountFinder(nil)
+	if f != nil {
+		t.Error("expected nil AccountFinder when provider is nil, got non-nil")
+	}
+}
+
+func TestAccountFinder_Active_HappyPath(t *testing.T) {
+	acct := &gql.ClaudeAccount{ID: "ClaudeAccount:local:dev@example.com"}
+	stub := &finderAcctStub{account: acct}
+	f := NewAccountFinder(stub)
+
+	got, ok := f.Active(context.Background(), "local")
+	if !ok {
+		t.Fatal("Active: expected ok=true, got false")
+	}
+	if got != acct {
+		t.Errorf("Active: got %v, want %v", got, acct)
+	}
+}
+
+func TestAccountFinder_Active_NotFound(t *testing.T) {
+	stub := &finderAcctStub{account: nil} // no account configured
+	f := NewAccountFinder(stub)
+
+	got, ok := f.Active(context.Background(), "local")
+	if ok {
+		t.Error("Active: expected ok=false when no account, got true")
+	}
+	if got != nil {
+		t.Errorf("Active: expected nil result, got %v", got)
+	}
+}

--- a/internal/server/providers/claudeinstance/finders_test.go
+++ b/internal/server/providers/claudeinstance/finders_test.go
@@ -206,39 +206,22 @@ func TestPaneFinder_FindBySession_EmptySession_ReturnsFalse(t *testing.T) {
 	}
 }
 
-func TestPaneFinder_FindBySession_WithPsCrossCheck_ClaudeProcess(t *testing.T) {
-	// When ps is wired and the pane's foreground pid resolves to a process
-	// whose Command contains "claude", the pane should be returned.
-	pid := int64(42)
-	pane := &gql.TmuxPane{ID: "TmuxPane:local:%1", CurrentPid: &pid}
-	tmuxStub := &finderTmuxStub{bySession: map[string]*gql.TmuxPane{"alpha": pane}}
-	psStub := &finderPsStub{byPid: map[int]*gql.Process{42: {Command: "claude"}}}
+// TestPaneFinder_FindBySession_PassThrough verifies that paneFinder.FindBySession
+// is a pure pass-through to the tmuxInput adapter. The cmd-basename cross-check
+// has moved into tmuxInputAdapter.PaneBySession (daemon/claudeinstance_wiring.go);
+// the finder trusts whatever the adapter returns.
+func TestPaneFinder_FindBySession_PassThrough(t *testing.T) {
+	pid := int64(2000)
+	claudePane := &gql.TmuxPane{ID: "TmuxPane:local:%11", PaneID: "%11", CurrentPid: &pid}
+	stub := &finderTmuxStub{bySession: map[string]*gql.TmuxPane{"issue468": claudePane}}
 
-	f := NewPaneFinder(tmuxStub, psStub)
-	got, ok := f.FindBySession(context.Background(), "local", "alpha")
+	f := NewPaneFinder(stub)
+	got, ok := f.FindBySession(context.Background(), "local", "issue468")
 	if !ok {
-		t.Fatal("FindBySession with claude ps: expected ok=true")
+		t.Fatal("FindBySession pass-through: expected ok=true")
 	}
-	if got != pane {
-		t.Errorf("FindBySession: got %v, want %v", got, pane)
-	}
-}
-
-func TestPaneFinder_FindBySession_WithPsCrossCheck_NonClaudeProcess(t *testing.T) {
-	// When ps is wired and the pane's foreground pid resolves to a non-claude
-	// process, the pane should NOT be returned.
-	pid := int64(42)
-	pane := &gql.TmuxPane{ID: "TmuxPane:local:%1", CurrentPid: &pid}
-	tmuxStub := &finderTmuxStub{bySession: map[string]*gql.TmuxPane{"alpha": pane}}
-	psStub := &finderPsStub{byPid: map[int]*gql.Process{42: {Command: "zsh"}}}
-
-	f := NewPaneFinder(tmuxStub, psStub)
-	got, ok := f.FindBySession(context.Background(), "local", "alpha")
-	if ok {
-		t.Error("FindBySession with non-claude ps: expected ok=false")
-	}
-	if got != nil {
-		t.Errorf("FindBySession with non-claude ps: expected nil, got %v", got)
+	if got != claudePane {
+		t.Errorf("FindBySession: got %v, want %v", got, claudePane)
 	}
 }
 

--- a/internal/server/providers/claudeinstance/regression_pid_join_test.go
+++ b/internal/server/providers/claudeinstance/regression_pid_join_test.go
@@ -1,0 +1,215 @@
+package claudeinstance_test
+
+// regression_pid_join_test.go — issue #468 regression guard.
+//
+// This test proves that the production-adapter wiring path is BROKEN:
+// the three concrete finders (NewProcessFinder, NewPaneFinder,
+// NewAccountFinder) do not exist yet, so this file intentionally
+// fails to compile. That compile error IS the regression signal —
+// subsequent tasks will create those constructors and make this test
+// buildable (and then passing once resolvePid is fixed to use
+// pane.CurrentPid as a fallback).
+//
+// Scenario exercised (from claude-instances-pid-join.feature AC 5 + AC 6):
+//   - heartbeat: tmux_session="alpha", state="working", no claudePid
+//   - tmux pane "%59" in session "alpha" reports currentPid=88631
+//   - ps snapshot: pid 88631 with command "claude"
+//   - expected: result[0].Process != nil, result[0].Pane != nil,
+//               result[0].State == graphql.InstanceStateWorking
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gql "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeinstance"
+)
+
+// ---------------------------------------------------------------------------
+// Narrow interfaces for the stub underlying providers.
+// These are the contracts NewProcessFinder, NewPaneFinder, and
+// NewAccountFinder will eventually accept. Keeping them narrow here
+// lets the stubs below stay minimal (no goroutines, no file I/O).
+// ---------------------------------------------------------------------------
+
+// psProvider is the read surface NewProcessFinder needs from the ps package.
+type psProvider interface {
+	// GetByPid returns the process for the given pid, or (nil, false) on miss.
+	GetByPid(ctx context.Context, hostID string, pid int) (*gql.Process, bool)
+}
+
+// tmuxProvider is the read surface NewPaneFinder needs from the tmux package.
+type tmuxProvider interface {
+	// PaneByPid returns the *gql.TmuxPane whose foreground pid matches,
+	// or (nil, false) when no pane has that pid.
+	PaneByPid(ctx context.Context, hostID string, pid int) (*gql.TmuxPane, bool)
+	// PaneBySession returns the first pane in the named session, or
+	// (nil, false) when the session is absent or has no panes.
+	PaneBySession(ctx context.Context, hostID, session string) (*gql.TmuxPane, bool)
+}
+
+// claudeAccountProvider is the read surface NewAccountFinder needs.
+type claudeAccountProvider interface {
+	// ActiveAccount returns the active Claude account for the host,
+	// or (nil, false) when no account is authenticated.
+	ActiveAccount(ctx context.Context, hostID string) (*gql.ClaudeAccount, bool)
+}
+
+// ---------------------------------------------------------------------------
+// Stub implementations — deterministic, no I/O.
+// ---------------------------------------------------------------------------
+
+// stubPsProvider returns exactly one process: pid 88631 with command "claude".
+type stubPsProvider struct{}
+
+func (s *stubPsProvider) GetByPid(_ context.Context, _ string, pid int) (*gql.Process, bool) {
+	if pid == 88631 {
+		return &gql.Process{
+			ID:      "Process:local:88631",
+			Pid:     int64(88631),
+			Command: "claude",
+		}, true
+	}
+	return nil, false
+}
+
+// stubTmuxProvider exposes one pane "%59" in session "alpha" with currentPid=88631.
+type stubTmuxProvider struct{}
+
+func (s *stubTmuxProvider) PaneByPid(_ context.Context, _ string, pid int) (*gql.TmuxPane, bool) {
+	if pid == 88631 {
+		return alphaPane(), true
+	}
+	return nil, false
+}
+
+func (s *stubTmuxProvider) PaneBySession(_ context.Context, _, session string) (*gql.TmuxPane, bool) {
+	if session == "alpha" {
+		return alphaPane(), true
+	}
+	return nil, false
+}
+
+func alphaPane() *gql.TmuxPane {
+	pid := int64(88631)
+	return &gql.TmuxPane{
+		ID:         "TmuxPane:local:%59",
+		CurrentPid: &pid,
+	}
+}
+
+// stubClaudeAccountProvider returns a single account for any host.
+type stubClaudeAccountProvider struct{}
+
+func (s *stubClaudeAccountProvider) ActiveAccount(_ context.Context, _ string) (*gql.ClaudeAccount, bool) {
+	return &gql.ClaudeAccount{ID: "ClaudeAccount:local:dev@example.com"}, true
+}
+
+// ---------------------------------------------------------------------------
+// Regression test — FAILS TO COMPILE until NewProcessFinder, NewPaneFinder,
+// and NewAccountFinder are created in the claudeinstance package.
+// ---------------------------------------------------------------------------
+
+// TestRegression_PidJoin_ProductionAdapters_Issue468 demonstrates that
+// building a Composer with the three production adapter constructors
+// (which don't exist yet) and running it against a heartbeat that has no
+// claudePid still produces a non-null Process, non-null Pane, and
+// state==working.
+//
+// Current failure mode:
+//
+//	(a) COMPILE: NewProcessFinder / NewPaneFinder / NewAccountFinder
+//	    are undefined — the production wiring gap is AC#2 in the feature file.
+//
+//	(b) RUNTIME (after adapters are created): resolvePid returns 0 because
+//	    pidFromPaneID is a no-op stub and the heartbeat carries no claudePid.
+//	    This is AC#5: "composer.resolvePid falls back to pane.CurrentPid".
+func TestRegression_PidJoin_ProductionAdapters_Issue468(t *testing.T) {
+	// --- heartbeat file: no claudePid, state=working, fresh timestamp ---
+	dir := t.TempDir()
+	now := time.Now()
+	freshTimestamp := now.Add(-2 * time.Second).Format(time.RFC3339)
+	payload := map[string]any{
+		"tmux_session":    "alpha",
+		"state":           "working",
+		"timestamp":       freshTimestamp,
+		"lastHeartbeatAt": freshTimestamp,
+		// NOTE: no claudePid — the heartbeat predates pid-recording.
+		// The fix must source the pid from pane.CurrentPid.
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal heartbeat: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "orchard-claude-alpha.json"), b, 0o600); err != nil {
+		t.Fatalf("write heartbeat: %v", err)
+	}
+
+	// --- wire the three production adapters with stub underlying providers ---
+	//
+	// These calls DO NOT COMPILE YET — NewProcessFinder, NewPaneFinder, and
+	// NewAccountFinder are the missing production adapters documented in
+	// claude-instances-pid-join.feature AC#2. Once those constructors exist,
+	// the test will compile and then fail at the assertions below, proving
+	// the second half of the bug (resolvePid ignores pane.CurrentPid).
+	psStub := &stubPsProvider{}
+	tmuxStub := &stubTmuxProvider{}
+	acctStub := &stubClaudeAccountProvider{}
+
+	processFinder := claudeinstance.NewProcessFinder(psStub)   // undefined
+	paneFinder := claudeinstance.NewPaneFinder(tmuxStub)       // undefined
+	accountFinder := claudeinstance.NewAccountFinder(acctStub) // undefined
+
+	// fixed clock so staleness logic is deterministic
+	clock := func() time.Time { return now }
+
+	// fakeLiveness (defined in e2e_test.go) marks pid 88631 alive so
+	// deriveState does not short-circuit to no_claude on the liveness check.
+	liveness := fakeLiveness{alive: map[int]bool{88631: true}}
+
+	composer := claudeinstance.NewComposerWith(
+		"local",
+		paneFinder,
+		processFinder,
+		accountFinder,
+		liveness,
+		clock,
+		claudeinstance.HeartbeatStaleAfter,
+	)
+
+	reader := claudeinstance.NewFileReader(dir)
+	hbs, err := reader.ReadAll(context.Background())
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(hbs) != 1 {
+		t.Fatalf("want 1 heartbeat, got %d", len(hbs))
+	}
+
+	results := composer.Compose(context.Background(), hbs)
+	if len(results) != 1 {
+		t.Fatalf("want 1 composed instance, got %d", len(results))
+	}
+
+	inst := results[0]
+
+	// AC#6: pane must be non-nil (heartbeat tmux_session "alpha" maps to a live pane).
+	if inst.Pane == nil {
+		t.Error("issue #468 regression: Pane is nil; expected non-nil because heartbeat.tmux_session='alpha' maps to tmux pane %59")
+	}
+
+	// AC#5: process must be non-nil (pane.CurrentPid=88631 maps to a live process).
+	// This fails today because resolvePid ignores pane.CurrentPid (pidFromPaneID is a no-op).
+	if inst.Process == nil {
+		t.Error("issue #468 regression: Process is nil; expected non-nil because pane.currentPid=88631 maps to a claude process")
+	}
+
+	// AC#7: state must be working (heartbeat fresh + state=working + pid live).
+	if inst.State != gql.InstanceStateWorking {
+		t.Errorf("issue #468 regression: State=%q, want %q", inst.State, gql.InstanceStateWorking)
+	}
+}

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -728,8 +728,28 @@ func (r *tmuxPaneResolver) Process(ctx context.Context, obj *graphql1.TmuxPane) 
 	return projectProcess(&proc, host), nil
 }
 
-// ClaudeInstance is the resolver for tmuxPane.claudeInstance.
+// ClaudeInstance resolves the ClaudeInstance that is running inside this
+// pane. The lookup walks all cached instances from the claudeinstance.Provider
+// and returns the first one whose Pane.ID matches obj.ID. This is O(N) in the
+// number of tracked claude processes (typically < 10 on any one host), so no
+// dataloader is needed here.
+//
+// Returns (nil, nil) when:
+//   - r.ClaudeInstance is not wired (provider not available)
+//   - no tracked instance has a pane matching this pane's ID
 func (r *tmuxPaneResolver) ClaudeInstance(ctx context.Context, obj *graphql1.TmuxPane) (*graphql1.ClaudeInstance, error) {
+	if r.Resolver.ClaudeInstance == nil {
+		return nil, nil
+	}
+	instances, err := r.Resolver.ClaudeInstance.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, inst := range instances {
+		if inst.Pane != nil && inst.Pane.ID == obj.ID {
+			return inst, nil
+		}
+	}
 	return nil, nil
 }
 

--- a/internal/server/resolvers/tmux_pane_claude_instance_test.go
+++ b/internal/server/resolvers/tmux_pane_claude_instance_test.go
@@ -1,0 +1,166 @@
+package resolvers
+
+// Tests for tmuxPaneResolver.ClaudeInstance (AC 4 of issue #468).
+//
+// Scenarios covered:
+//  1. Provider has an instance whose Pane.ID matches obj.ID → resolver returns it.
+//  2. Provider has an instance whose Pane.ID does NOT match → resolver returns (nil, nil).
+//  3. r.ClaudeInstance is nil → resolver returns (nil, nil).
+//
+// Deeper integration coverage (multiple instances, pane resolve chain, state
+// derivation) is exercised end-to-end via
+// internal/server/providers/claudeinstance/e2e_test.go, which boots a real
+// httptest GraphQL server and queries the full resolver chain.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeinstance"
+)
+
+// --------------------------------------------------------------------------
+// Test-local fakes — minimal implementations of the claudeinstance
+// dependency interfaces so we don't need a real tmux/ps/account provider.
+// --------------------------------------------------------------------------
+
+// staticPaneFinder always returns a single pre-built pane regardless of which
+// pid or session is requested. It satisfies claudeinstance.PaneFinder.
+type staticPaneFinder struct{ pane *graphql1.TmuxPane }
+
+func (f *staticPaneFinder) FindByPid(_ context.Context, _ string, _ int) (*graphql1.TmuxPane, bool) {
+	if f.pane == nil {
+		return nil, false
+	}
+	return f.pane, true
+}
+
+func (f *staticPaneFinder) FindBySession(_ context.Context, _, _ string) (*graphql1.TmuxPane, bool) {
+	if f.pane == nil {
+		return nil, false
+	}
+	return f.pane, true
+}
+
+// alwaysAlive satisfies claudeinstance.LivenessChecker and reports every pid
+// as alive so state derivation never collapses to no_claude in tests.
+type alwaysAlive struct{}
+
+func (alwaysAlive) IsAlive(_ int) bool { return true }
+
+// --------------------------------------------------------------------------
+// Helper: build a claudeinstance.Provider pre-seeded with one instance
+// whose Pane.ID is paneID. The heartbeat is written to a temp dir and
+// loaded via provider.Start so the cache is hydrated before the test runs.
+// --------------------------------------------------------------------------
+func buildProviderWithPane(t *testing.T, paneID string) *claudeinstance.Provider {
+	t.Helper()
+
+	heartbeatDir := t.TempDir()
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	freshTimestamp := now.Add(-2 * time.Second).Format(time.RFC3339)
+	clock := func() time.Time { return now }
+
+	// Write a single heartbeat file with a known pid so the instance id is
+	// deterministic (ClaudeInstance:local:10042) and the liveness check passes.
+	payload := map[string]any{
+		"tmux_session":    "test-session",
+		"session_id":      "uuid-test",
+		"state":           "working",
+		"timestamp":       freshTimestamp,
+		"claudePid":       10042,
+		"lastHeartbeatAt": freshTimestamp,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal heartbeat: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(heartbeatDir, "orchard-claude-test-session.json"), b, 0o600); err != nil {
+		t.Fatalf("write heartbeat: %v", err)
+	}
+
+	// The static pane finder returns a TmuxPane whose ID is paneID, so the
+	// composer attaches that pane to the instance it builds.
+	pane := &graphql1.TmuxPane{ID: paneID}
+	composer := claudeinstance.NewComposerWith(
+		"local",
+		&staticPaneFinder{pane: pane},
+		nil, // no process finder needed for these tests
+		nil, // no account finder needed
+		alwaysAlive{},
+		clock,
+		claudeinstance.HeartbeatStaleAfter,
+	)
+	reader := claudeinstance.NewFileReader(heartbeatDir)
+	provider := claudeinstance.NewWith("local", reader, composer, clock)
+
+	if err := provider.Start(context.Background()); err != nil {
+		t.Fatalf("provider.Start: %v", err)
+	}
+	return provider
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+// TestTmuxPaneClaudeInstance_MatchingPane verifies that when the provider
+// contains a ClaudeInstance whose Pane.ID equals obj.ID, the resolver returns
+// that instance (non-nil).
+func TestTmuxPaneClaudeInstance_MatchingPane(t *testing.T) {
+	const paneID = "TmuxPane:local:%59"
+
+	provider := buildProviderWithPane(t, paneID)
+	r := &tmuxPaneResolver{&Resolver{ClaudeInstance: provider}}
+	obj := &graphql1.TmuxPane{ID: paneID}
+
+	got, err := r.ClaudeInstance(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("ClaudeInstance() unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ClaudeInstance() returned nil, want non-nil *graphql1.ClaudeInstance")
+	}
+	if got.Pane == nil || got.Pane.ID != paneID {
+		t.Errorf("ClaudeInstance().Pane.ID = %v, want %q", got.Pane, paneID)
+	}
+}
+
+// TestTmuxPaneClaudeInstance_NoMatchingPane verifies that when no instance in
+// the provider has a pane matching obj.ID, the resolver returns (nil, nil).
+func TestTmuxPaneClaudeInstance_NoMatchingPane(t *testing.T) {
+	// Provider is seeded with a pane whose ID does NOT match the query object.
+	provider := buildProviderWithPane(t, "TmuxPane:local:%59")
+	r := &tmuxPaneResolver{&Resolver{ClaudeInstance: provider}}
+	// Ask for a different pane — %99, which no instance is associated with.
+	obj := &graphql1.TmuxPane{ID: "TmuxPane:local:%99"}
+
+	got, err := r.ClaudeInstance(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("ClaudeInstance() unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("ClaudeInstance() = %+v, want nil (no matching pane)", got)
+	}
+}
+
+// TestTmuxPaneClaudeInstance_NilProvider verifies that when r.ClaudeInstance
+// is nil (provider not wired), the resolver returns (nil, nil) without
+// panicking.
+func TestTmuxPaneClaudeInstance_NilProvider(t *testing.T) {
+	r := &tmuxPaneResolver{&Resolver{ClaudeInstance: nil}}
+	obj := &graphql1.TmuxPane{ID: "TmuxPane:local:%42"}
+
+	got, err := r.ClaudeInstance(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("ClaudeInstance() unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("ClaudeInstance() = %+v, want nil (nil provider)", got)
+	}
+}

--- a/internal/server/resolvers/tmux_pane_process_test.go
+++ b/internal/server/resolvers/tmux_pane_process_test.go
@@ -1,0 +1,237 @@
+package resolvers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	psprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	tmuxprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
+)
+
+// --------------------------------------------------------------------------
+// Fake tmux CommandRunner
+// --------------------------------------------------------------------------
+
+// fakeTmuxRunner drives the tmux adapter without a real tmux server.
+// It serves the minimum set of tmux sub-commands FetchAll needs.
+type fakeTmuxRunner struct {
+	hostID string
+	// paneLines are already-formatted pane rows in the nine-field \x01-sep format
+	// that listPanes expects.
+	paneLines []string
+}
+
+const fieldSepTest = "\x01"
+
+func (f *fakeTmuxRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	if name != "tmux" {
+		return nil, fmt.Errorf("fakeTmuxRunner: unexpected command %q", name)
+	}
+	// Skip any leading -S <socket> flags to get the sub-command.
+	sub := ""
+	for _, a := range args {
+		if a == "info" || a == "list-sessions" || a == "list-windows" ||
+			a == "list-panes" || a == "list-clients" || a == "display-message" {
+			sub = a
+			break
+		}
+	}
+	switch sub {
+	case "info":
+		return []byte("ok"), nil
+	case "list-sessions":
+		// Return one dummy session so windows/panes parse correctly.
+		line := "test-session" + fieldSepTest + "1746000000" + fieldSepTest +
+			"0" + fieldSepTest + "1746000000" + fieldSepTest + "1" + fieldSepTest + "0"
+		return []byte(line + "\n"), nil
+	case "list-windows":
+		// One window for session "test-session", index 0.
+		line := "test-session" + fieldSepTest + "0" + fieldSepTest +
+			"test-window" + fieldSepTest + "1" + fieldSepTest + "1" + fieldSepTest + "%0"
+		return []byte(line + "\n"), nil
+	case "list-panes":
+		if len(f.paneLines) == 0 {
+			return []byte{}, nil
+		}
+		return []byte(strings.Join(f.paneLines, "\n") + "\n"), nil
+	case "list-clients":
+		return []byte{}, nil
+	case "display-message":
+		return []byte("1\n"), nil
+	default:
+		return nil, fmt.Errorf("fakeTmuxRunner: unhandled tmux sub-command (args=%v)", args)
+	}
+}
+
+// paneRow builds a single pane line in the nine-field format expected by
+// listPanes. sessionName, paneID, and pid are the only fields that matter
+// for these tests; the rest get safe defaults.
+func paneRow(sessionName, paneID string, pid int) string {
+	return strings.Join([]string{
+		sessionName, // session_name
+		"0",         // window_index
+		paneID,      // pane_id
+		"",          // pane_title
+		"zsh",       // pane_current_command
+		fmt.Sprintf("%d", pid), // pane_pid
+		"80",  // pane_width
+		"24",  // pane_height
+		"0",   // pane_dead
+	}, fieldSepTest)
+}
+
+// --------------------------------------------------------------------------
+// Fake ps CommandRunner
+// --------------------------------------------------------------------------
+
+// psRow holds a single (pid, command) pair for the fake ps runner.
+type psRow struct {
+	pid int
+	cmd string
+}
+
+// fakePsRunnerProcess drives the ps adapter with a fixed single-process list.
+type fakePsRunnerProcess struct {
+	hostID string
+	rows   []psRow
+}
+
+const psHeaderTest = "PID PPID USER TTY %CPU RSS STARTED COMMAND"
+
+func (f *fakePsRunnerProcess) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	if name != "ps" {
+		return nil, fmt.Errorf("fakePsRunner: unexpected command %q", name)
+	}
+	lines := []string{psHeaderTest}
+	for _, r := range f.rows {
+		// Columns: PID PPID USER TTY %CPU RSS STARTED COMMAND
+		lines = append(lines, fmt.Sprintf(
+			"%d 1 root ?? 0.0 1024 Sun May  4 10:00:00 2026 %s",
+			r.pid, r.cmd,
+		))
+	}
+	return []byte(strings.Join(lines, "\n") + "\n"), nil
+}
+
+// --------------------------------------------------------------------------
+// Test helpers
+// --------------------------------------------------------------------------
+
+const testHost = "local"
+
+// buildTmuxProvider creates a tmux.Provider seeded with the given pane rows
+// and starts it (initial FetchAll from the fake runner).
+func buildTmuxProvider(t *testing.T, rows []string) *tmuxprovider.Provider {
+	t.Helper()
+	runner := &fakeTmuxRunner{hostID: testHost, paneLines: rows}
+	adapter := tmuxprovider.NewAdapter(tmuxprovider.HostID(testHost)).WithRunner(runner)
+	p := tmuxprovider.New(adapter, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("tmux provider Start: %v", err)
+	}
+	return p
+}
+
+// buildPsProvider creates a ps.Provider seeded with the given processes
+// and starts it.
+func buildPsProvider(t *testing.T, procs []psRow) *psprovider.Provider {
+	t.Helper()
+	runner := &fakePsRunnerProcess{hostID: testHost, rows: procs}
+	adapter := psprovider.NewAdapter(testHost).WithRunner(runner)
+	p := psprovider.New(adapter, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := p.Start(ctx); err != nil {
+		t.Fatalf("ps provider Start: %v", err)
+	}
+	return p
+}
+
+// paneGQLID constructs the TmuxPane GraphQL node ID the resolver expects.
+func paneGQLID(host, paneID string) string {
+	return "TmuxPane:" + host + ":" + paneID
+}
+
+// --------------------------------------------------------------------------
+// Tests for tmuxPaneResolver.Process (AC 3 of issue #468)
+// --------------------------------------------------------------------------
+
+// TestTmuxPaneProcess_MatchingPid verifies that a pane with CurrentPid 88631
+// backed by a ps provider containing that pid returns a non-nil *graphql1.Process
+// whose Pid field equals 88631.
+func TestTmuxPaneProcess_MatchingPid(t *testing.T) {
+	const pid = 88631
+	const paneID = "%42"
+
+	tmuxProv := buildTmuxProvider(t, []string{
+		paneRow("test-session", paneID, pid),
+	})
+	psProv := buildPsProvider(t, []psRow{{pid: pid, cmd: "node"}})
+
+	r := &tmuxPaneResolver{&Resolver{Tmux: tmuxProv, PS: psProv}}
+	obj := &graphql1.TmuxPane{ID: paneGQLID(testHost, paneID)}
+
+	got, err := r.Process(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Process() unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Process() returned nil, want non-nil *graphql1.Process")
+	}
+	if got.Pid != int64(pid) {
+		t.Errorf("Process().Pid = %d, want %d", got.Pid, pid)
+	}
+}
+
+// TestTmuxPaneProcess_NoMatchingPid verifies that a pane with CurrentPid 99999
+// backed by a ps provider that does NOT have that pid returns (nil, nil).
+func TestTmuxPaneProcess_NoMatchingPid(t *testing.T) {
+	const pid = 99999
+	const paneID = "%43"
+
+	tmuxProv := buildTmuxProvider(t, []string{
+		paneRow("test-session", paneID, pid),
+	})
+	// ps provider has NO processes — pid 99999 won't be found.
+	psProv := buildPsProvider(t, nil)
+
+	r := &tmuxPaneResolver{&Resolver{Tmux: tmuxProv, PS: psProv}}
+	obj := &graphql1.TmuxPane{ID: paneGQLID(testHost, paneID)}
+
+	got, err := r.Process(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Process() unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Process() = %+v, want nil (no matching pid)", got)
+	}
+}
+
+// TestTmuxPaneProcess_ZeroPid verifies that a pane with CurrentPid == 0
+// returns (nil, nil) without consulting the ps provider.
+func TestTmuxPaneProcess_ZeroPid(t *testing.T) {
+	const paneID = "%44"
+
+	// Pane seeded with pid=0.
+	tmuxProv := buildTmuxProvider(t, []string{
+		paneRow("test-session", paneID, 0),
+	})
+	// PS is nil — if the resolver touches it we'll get a nil-deref panic,
+	// proving the short-circuit is working.
+	r := &tmuxPaneResolver{&Resolver{Tmux: tmuxProv, PS: nil}}
+	obj := &graphql1.TmuxPane{ID: paneGQLID(testHost, paneID)}
+
+	got, err := r.Process(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("Process() unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("Process() = %+v, want nil (zero pid)", got)
+	}
+}

--- a/specs/features/claude-instances-pid-join.feature
+++ b/specs/features/claude-instances-pid-join.feature
@@ -1,0 +1,407 @@
+Feature: claudeInstances pid join — wire heartbeats to live processes
+  As an orchardist consuming the orchard daemon's GraphQL schema
+  I want every ClaudeInstance whose heartbeat session hosts a live claude process
+  to expose a non-null `process` and `pane`, with `state` reflecting real liveness
+  So that the dashboard can route work by ClaudeInstance instead of falling back
+  to `host.processes(filter: { commandIn: ["claude"] })`
+
+  # Issue #468. Three independent gaps in production wiring:
+  #   1. Composer constructed with `nil, nil, nil` finders in daemon.go:151
+  #   2. Hook script doesn't carry claude_pid (out of scope per AC 10)
+  #   3. tmuxPaneResolver.Process and .ClaudeInstance are stubbed (nil, nil)
+  #
+  # Fix scope (AC #1–#5):
+  #   - Add three thin adapters: ProcessFinder, PaneFinder, AccountFinder
+  #   - Replace `nil, nil, nil` in daemon.go with those adapters
+  #   - Implement tmuxPaneResolver.Process and tmuxPaneResolver.ClaudeInstance
+  #   - Source pid from pane.CurrentPid (NOT from heartbeat — out of scope)
+
+  Background:
+    Given the daemon serves a GraphQL schema at 127.0.0.1:7777
+    And the ClaudeInstance type exists with fields (process, pane, account, state, sessionUuid, ...)
+    And the ps.Provider, tmux.Provider, and claudeaccount.Provider already snapshot live host data
+    And the claudeinstance composer's join logic is unit-tested with fakes (composer_test.go)
+    And `pidFromPaneID` remains a no-op stub (AC 9)
+
+  # ===================================================================
+  # AC 1 — Production composer wired with concrete finders
+  # AC 2 — Three production adapters exist
+  # ===================================================================
+
+  @unit
+  Scenario: ProcessFinder.FindByPid wraps ps.Provider.Get and returns a Process for a live pid
+    Given a ps.Provider snapshot containing a process with pid 88631 on host "local"
+    When ProcessFinder.FindByPid is called with host "local" and pid 88631
+    Then it returns the corresponding *graphql.Process
+    And the returned Process.pid equals 88631
+
+  @unit
+  Scenario: ProcessFinder.FindByPid returns nil for a pid that is not present in the ps snapshot
+    Given a ps.Provider snapshot that does not contain pid 99999 on host "local"
+    When ProcessFinder.FindByPid is called with host "local" and pid 99999
+    Then it returns nil with no error
+
+  @unit
+  Scenario: PaneFinder.FindByPid walks tmux.Provider panes and returns the pane whose currentPid matches
+    Given a tmux.Provider snapshot with pane "%59" reporting currentPid 88631 on host "local"
+    When PaneFinder.FindByPid is called with host "local" and pid 88631
+    Then it returns the *graphql.TmuxPane for pane "%59"
+
+  @unit
+  Scenario: PaneFinder.FindByPid returns nil when no pane on the host has the given currentPid
+    Given a tmux.Provider snapshot with no pane reporting currentPid 88631 on host "local"
+    When PaneFinder.FindByPid is called with host "local" and pid 88631
+    Then it returns nil with no error
+
+  @unit
+  Scenario: PaneFinder.FindBySession returns the first pane whose currentPid is owned by a claude process
+    Given a tmux session "issue468" on host "local" with two panes
+    And pane "%10" has currentPid 1000 owned by command "vim"
+    And pane "%11" has currentPid 2000 owned by command "claude"
+    When PaneFinder.FindBySession is called with host "local" and session "issue468"
+    Then it returns the *graphql.TmuxPane for pane "%11"
+
+  @unit
+  Scenario: PaneFinder.FindBySession returns nil when no pane in the session runs a claude process
+    Given a tmux session "no-claude-here" on host "local" with two panes
+    And no pane in the session has a currentPid owned by command "claude"
+    When PaneFinder.FindBySession is called with host "local" and session "no-claude-here"
+    Then it returns nil with no error
+
+  @unit
+  Scenario: PaneFinder.FindBySession returns nil for a session that does not exist
+    Given a tmux.Provider snapshot containing no session named "ghost-session" on host "local"
+    When PaneFinder.FindBySession is called with host "local" and session "ghost-session"
+    Then it returns nil with no error
+
+  @unit
+  Scenario: AccountFinder.Active wraps claudeaccount.Provider.Active and returns the active account
+    Given a claudeaccount.Provider whose Active(ctx) returns a populated *ClaudeAccount on host "local"
+    When AccountFinder.Active is called with host "local"
+    Then it returns the same *ClaudeAccount value
+
+  @unit
+  Scenario: AccountFinder.Active returns nil when claudeaccount.Provider has no active account
+    Given a claudeaccount.Provider whose Active(ctx) returns nil on host "local"
+    When AccountFinder.Active is called with host "local"
+    Then it returns nil with no error
+
+  @integration
+  Scenario: Daemon wires the composer with non-nil finders for tmux, ps, and claude account
+    Given internal/cli/daemon/daemon.go is reviewed
+    When claudeinstance.NewComposer is constructed
+    Then its PaneFinder argument is a non-nil adapter wrapping the live tmux.Provider
+    And its ProcessFinder argument is a non-nil adapter wrapping the live ps.Provider
+    And its AccountFinder argument is a non-nil adapter wrapping the live claudeaccount.Provider
+    And the literal `claudeinstance.NewComposer("local", nil, nil, nil)` no longer appears in the file
+
+  # ===================================================================
+  # AC 3 — tmuxPaneResolver.Process resolves to a non-null Process
+  # ===================================================================
+
+  @integration
+  Scenario: tmuxPaneResolver.Process returns the Process whose pid matches pane.currentPid
+    Given a TmuxPane with id "%59" and currentPid 88631 on host "local"
+    And ps.Provider knows of a process with pid 88631, command "claude" on host "local"
+    When the GraphQL query selects tmuxPanes { process { pid command } } for that pane
+    Then the resolver returns a non-null Process
+    And the returned Process.pid equals 88631
+    And the returned Process.command contains "claude"
+
+  @integration
+  Scenario: tmuxPaneResolver.Process returns null when the pane's currentPid does not match any known process
+    Given a TmuxPane with currentPid 99999 on host "local"
+    And ps.Provider has no process with pid 99999 on host "local"
+    When the GraphQL query selects tmuxPanes { process { pid } } for that pane
+    Then the resolver returns null
+
+  @integration
+  Scenario: tmuxPaneResolver.Process returns null when the pane has no currentPid
+    Given a TmuxPane whose currentPid is 0 / unset on host "local"
+    When the GraphQL query selects tmuxPanes { process { pid } } for that pane
+    Then the resolver returns null
+    And ps.Provider is not consulted
+
+  # ===================================================================
+  # AC 4 — tmuxPaneResolver.ClaudeInstance resolves to a non-null ClaudeInstance
+  # ===================================================================
+
+  @integration
+  Scenario: tmuxPaneResolver.ClaudeInstance returns the ClaudeInstance whose pane.id matches the obj
+    Given a TmuxPane with id "%59" on host "local"
+    And the claudeinstance.Provider has an instance whose matched pane.id is "%59"
+    When the GraphQL query selects tmuxPanes { claudeInstance { sessionUuid } } for that pane
+    Then the resolver returns a non-null ClaudeInstance
+    And the returned ClaudeInstance's pane.id equals "%59"
+
+  @integration
+  Scenario: tmuxPaneResolver.ClaudeInstance returns null when no heartbeat maps to the pane
+    Given a TmuxPane with id "%99" on host "local"
+    And no claudeinstance.Provider entry has a matched pane with id "%99"
+    When the GraphQL query selects tmuxPanes { claudeInstance } for that pane
+    Then the resolver returns null
+
+  # ===================================================================
+  # AC 5 — claudeInstances[].process is non-null when pane has a live claude pid
+  # AC 6 — claudeInstances[].pane is non-null when heartbeat tmux_session matches a live session
+  # ===================================================================
+
+  @integration
+  Scenario: claudeInstances[].pane resolves when the heartbeat's tmux_session matches a live tmux session
+    Given a heartbeat file with tmux_session "orchardist" on host "local"
+    And a tmux session "orchardist" on host "local" with a pane whose currentPid is owned by a claude process
+    When the GraphQL query selects claudeInstances { pane { id } }
+    Then the instance whose heartbeat tmux_session is "orchardist" reports a non-null pane
+    And the pane's id matches the matched tmux pane
+
+  @integration
+  Scenario: claudeInstances[].process resolves to a non-null Process when the matched pane has a claude currentPid
+    Given a heartbeat file with tmux_session "orchardist" on host "local"
+    And a tmux session "orchardist" on host "local" with a pane reporting currentPid 88631
+    And ps.Provider knows pid 88631 with command "claude" on host "local"
+    When the GraphQL query selects claudeInstances { process { pid } }
+    Then the instance reports a non-null process
+    And process.pid equals 88631
+
+  @integration
+  Scenario: claudeInstances[].process is null when the heartbeat's tmux_session does not match any live tmux session
+    Given a heartbeat file with tmux_session "long-gone-session" on host "local"
+    And no tmux session named "long-gone-session" exists in the tmux snapshot
+    When the GraphQL query selects claudeInstances { process pane }
+    Then the instance reports a null process
+    And the instance reports a null pane
+
+  @unit
+  Scenario: composer.resolvePid prefers heartbeat ClaudePid over pane.CurrentPid when ClaudePid is non-zero
+    Given a heartbeat with ClaudePid 12345 on host "local"
+    And a matched pane reporting currentPid 88631
+    When composer.resolvePid is invoked
+    Then it returns 12345
+
+  @unit
+  Scenario: composer.resolvePid falls back to pane.CurrentPid when heartbeat ClaudePid is zero and a pane is matched
+    Given a heartbeat with ClaudePid 0 on host "local"
+    And a matched pane reporting currentPid 88631
+    When composer.resolvePid is invoked
+    Then it returns 88631
+
+  @unit
+  Scenario: composer.resolvePid returns 0 when heartbeat ClaudePid is zero and no pane is matched
+    Given a heartbeat with ClaudePid 0 on host "local"
+    And no pane is matched (pane: nil)
+    When composer.resolvePid is invoked
+    Then it returns 0
+
+  # ===================================================================
+  # AC 7 — state reports working/idle/input (not no_claude) when heartbeat is fresh,
+  #        state is one of those values, AND the pid corresponds to a live process
+  # ===================================================================
+
+  @integration
+  Scenario: claudeInstances[].state reports working when heartbeat is fresh, says working, and pid is live
+    Given a heartbeat with state "working" and a timestamp within the last 30 seconds
+    And the resolved pid corresponds to a process present in ps.Provider
+    When the GraphQL query selects claudeInstances { state }
+    Then the instance state is "working"
+
+  @integration
+  Scenario: claudeInstances[].state reports idle when heartbeat says idle, is fresh, and pid is live
+    Given a heartbeat with state "idle" and a timestamp within the last 30 seconds
+    And the resolved pid corresponds to a process present in ps.Provider
+    When the GraphQL query selects claudeInstances { state }
+    Then the instance state is "idle"
+
+  @integration
+  Scenario: claudeInstances[].state reports input when heartbeat says input, is fresh, and pid is live
+    Given a heartbeat with state "input" and a timestamp within the last 30 seconds
+    And the resolved pid corresponds to a process present in ps.Provider
+    When the GraphQL query selects claudeInstances { state }
+    Then the instance state is "input"
+
+  @integration
+  Scenario: claudeInstances[].state falls back to no_claude when heartbeat is older than 30 seconds
+    Given a heartbeat with state "working" and a timestamp older than 30 seconds
+    And the resolved pid corresponds to a process present in ps.Provider
+    When the GraphQL query selects claudeInstances { state }
+    Then the instance state is "no_claude"
+
+  @integration
+  Scenario: claudeInstances[].state falls back to no_claude when the resolved pid is not live
+    Given a heartbeat with state "working" and a timestamp within the last 30 seconds
+    And the resolved pid does NOT correspond to any process present in ps.Provider
+    When the GraphQL query selects claudeInstances { state }
+    Then the instance state is "no_claude"
+
+  @integration
+  Scenario: claudeInstances[].state falls back to no_claude when heartbeat state is unrecognized
+    Given a heartbeat with state "garbage-value" and a timestamp within the last 30 seconds
+    And the resolved pid corresponds to a process present in ps.Provider
+    When the GraphQL query selects claudeInstances { state }
+    Then the instance state is "no_claude"
+
+  # ===================================================================
+  # AC 8 — End-to-end repro is fixed on a multi-claude host
+  # ===================================================================
+
+  @e2e
+  Scenario: Host with N live claude processes reports N instances with non-null process, pane, and state != no_claude
+    Given the daemon is running on 127.0.0.1:7777
+    And the host has N live claude processes spread across N tmux sessions
+    And N corresponding heartbeat files exist with state "working" and timestamps within the last 30 seconds
+    When a GraphQL query selects { claudeInstances { state pane { id } process { pid } } }
+    Then at least N rows have a non-null process
+    And at least N rows have a non-null pane
+    And at least N rows report a state other than "no_claude"
+
+  @e2e
+  Scenario: Original repro from issue 468 — 7 live claudes, 6 heartbeat-tracked instances
+    Given the host has 7 live claude processes
+    And the daemon has 6 heartbeat-tracked instances whose tmux_session each maps to a live tmux session running claude
+    When a GraphQL query selects { claudeInstances { process { pid } pane { id } state } }
+    Then 6 instances report a non-null process (was 0 before fix)
+    And 6 instances report a non-null pane (was 0 before fix)
+    And no more than 1 instance reports state "no_claude" (was 5 before fix)
+
+  # ===================================================================
+  # AC 9 — pidFromPaneID stub is left untouched
+  # ===================================================================
+
+  @unit
+  Scenario: pidFromPaneID remains a no-op stub
+    Given the composer.go pidFromPaneID function
+    When the implementation is inspected
+    Then the function body is unchanged from main
+    And the function still returns 0 for any pane ID input
+    And the doc comment still notes "no-op fallback today"
+
+  # ===================================================================
+  # AC 10 — Hook script change is out of scope; pid is sourced from pane.CurrentPid
+  # ===================================================================
+
+  @unit
+  Scenario: Heartbeat parser still accepts both claudePid and claude_pid (no schema regression)
+    Given a heartbeat file written with the field name "claudePid": 12345
+    And another heartbeat file written with the field name "claude_pid": 67890
+    When each file is parsed by adapter.go
+    Then the first heartbeat's ClaudePid equals 12345
+    And the second heartbeat's ClaudePid equals 67890
+
+  @integration
+  Scenario: Fix works on heartbeats that lack claudePid entirely
+    Given a heartbeat file with no claudePid / claude_pid field
+    And tmux_session "orchardist" exists with a pane whose currentPid is a live claude process
+    When the GraphQL query selects claudeInstances { process { pid } pane { id } state }
+    Then the instance reports a non-null process whose pid equals the pane's currentPid
+    And the instance reports a non-null pane
+    And the instance state is not "no_claude" (assuming heartbeat is fresh and state is working/idle/input)
+
+  @unit
+  Scenario: hook script orchard-state.sh is unchanged by this PR
+    Given the hook script crates/orchard/hooks/orchard-state.sh on main
+    When the file is compared after this PR
+    Then the file content is byte-identical (the fix does not modify the hook)
+
+  # ===================================================================
+  # AC 11 — Tests pass
+  # ===================================================================
+
+  @e2e
+  Scenario: go test for the changed packages is green
+    Given the working tree contains all changes for issue 468
+    When the developer runs `go test ./internal/server/providers/claudeinstance/... ./internal/server/resolvers/...`
+    Then every test passes
+    And new adapter unit tests are present alongside the new code
+    And new resolver integration coverage exercises the composer chain end-to-end (not pure unit)
+
+  # ===================================================================
+  # AC 12 — No regressions for cases that were already null
+  # ===================================================================
+
+  @integration
+  Scenario: Heartbeat with no matching tmux session still produces null process, null pane, no_claude
+    Given a heartbeat file whose tmux_session matches no live tmux session on the host
+    When the GraphQL query selects claudeInstances { process pane state }
+    Then the instance reports a null process
+    And the instance reports a null pane
+    And the instance state is "no_claude"
+
+  @integration
+  Scenario: Query.tmuxSessions and Query.tmuxPanes return identical shape pre/post-fix
+    Given the daemon snapshot is identical before and after the fix
+    When a GraphQL query selects { tmuxSessions { id } tmuxPanes { id currentPid } }
+    Then the response shape and identifiers are unchanged from main
+
+  @integration
+  Scenario: Query.host.processes returns identical shape pre/post-fix
+    Given the same ps.Provider snapshot
+    When a GraphQL query selects { host { processes(filter: { commandIn: ["claude"] }) { pid command } } }
+    Then the response is unchanged from main
+
+  @integration
+  Scenario: claudeInstances top-level shape (length, ids) is unchanged for inputs with no possible join
+    Given a daemon state where every heartbeat lacks a matching tmux session
+    When a GraphQL query selects { claudeInstances { sessionUuid id } }
+    Then the count and identifiers are identical to main's output for the same inputs
+
+  # --- AC Coverage Map ---
+  # AC 1: "Production composer is wired with concrete finders"
+  #   -> @integration "Daemon wires the composer with non-nil finders for tmux, ps, and claude account"
+  #
+  # AC 2: "Three production adapters exist (ProcessFinder, PaneFinder, AccountFinder) with happy + not-found unit tests"
+  #   -> @unit "ProcessFinder.FindByPid wraps ps.Provider.Get and returns a Process for a live pid"
+  #   -> @unit "ProcessFinder.FindByPid returns nil for a pid that is not present in the ps snapshot"
+  #   -> @unit "PaneFinder.FindByPid walks tmux.Provider panes and returns the pane whose currentPid matches"
+  #   -> @unit "PaneFinder.FindByPid returns nil when no pane on the host has the given currentPid"
+  #   -> @unit "PaneFinder.FindBySession returns the first pane whose currentPid is owned by a claude process"
+  #   -> @unit "PaneFinder.FindBySession returns nil when no pane in the session runs a claude process"
+  #   -> @unit "PaneFinder.FindBySession returns nil for a session that does not exist"
+  #   -> @unit "AccountFinder.Active wraps claudeaccount.Provider.Active and returns the active account"
+  #   -> @unit "AccountFinder.Active returns nil when claudeaccount.Provider has no active account"
+  #
+  # AC 3: "tmuxPaneResolver.Process resolves to a non-null Process when pane.currentPid matches a known process"
+  #   -> @integration "tmuxPaneResolver.Process returns the Process whose pid matches pane.currentPid"
+  #   -> @integration "tmuxPaneResolver.Process returns null when the pane's currentPid does not match any known process"
+  #   -> @integration "tmuxPaneResolver.Process returns null when the pane has no currentPid"
+  #
+  # AC 4: "tmuxPaneResolver.ClaudeInstance resolves to a non-null ClaudeInstance when pane hosts a tracked claude"
+  #   -> @integration "tmuxPaneResolver.ClaudeInstance returns the ClaudeInstance whose pane.id matches the obj"
+  #   -> @integration "tmuxPaneResolver.ClaudeInstance returns null when no heartbeat maps to the pane"
+  #
+  # AC 5: "Query.claudeInstances[].process resolves to non-null when pane has a live claude pid"
+  #   -> @integration "claudeInstances[].process resolves to a non-null Process when the matched pane has a claude currentPid"
+  #   -> @integration "claudeInstances[].process is null when the heartbeat's tmux_session does not match any live tmux session"
+  #   -> @unit "composer.resolvePid prefers heartbeat ClaudePid over pane.CurrentPid when ClaudePid is non-zero"
+  #   -> @unit "composer.resolvePid falls back to pane.CurrentPid when heartbeat ClaudePid is zero and a pane is matched"
+  #   -> @unit "composer.resolvePid returns 0 when heartbeat ClaudePid is zero and no pane is matched"
+  #
+  # AC 6: "Query.claudeInstances[].pane resolves to non-null when tmux_session matches a live session"
+  #   -> @integration "claudeInstances[].pane resolves when the heartbeat's tmux_session matches a live tmux session"
+  #
+  # AC 7: "state reports working/idle/input when fresh + recognized + live, no_claude otherwise"
+  #   -> @integration "claudeInstances[].state reports working when heartbeat is fresh, says working, and pid is live"
+  #   -> @integration "claudeInstances[].state reports idle when heartbeat says idle, is fresh, and pid is live"
+  #   -> @integration "claudeInstances[].state reports input when heartbeat says input, is fresh, and pid is live"
+  #   -> @integration "claudeInstances[].state falls back to no_claude when heartbeat is older than 30 seconds"
+  #   -> @integration "claudeInstances[].state falls back to no_claude when the resolved pid is not live"
+  #   -> @integration "claudeInstances[].state falls back to no_claude when heartbeat state is unrecognized"
+  #
+  # AC 8: "End-to-end repro is fixed: N live claudes -> N rows with process != null, pane != null, state != no_claude"
+  #   -> @e2e "Host with N live claude processes reports N instances with non-null process, pane, and state != no_claude"
+  #   -> @e2e "Original repro from issue 468 — 7 live claudes, 6 heartbeat-tracked instances"
+  #
+  # AC 9: "pidFromPaneID stub is left untouched"
+  #   -> @unit "pidFromPaneID remains a no-op stub"
+  #
+  # AC 10: "Hook script change is out of scope; pid sourced from pane.CurrentPid; firstNonZero precedence still preferred when claudePid is present"
+  #   -> @unit "Heartbeat parser still accepts both claudePid and claude_pid (no schema regression)"
+  #   -> @integration "Fix works on heartbeats that lack claudePid entirely"
+  #   -> @unit "hook script orchard-state.sh is unchanged by this PR"
+  #
+  # AC 11: "go test for the changed packages is green; new adapters have unit tests; resolver layer has integration coverage"
+  #   -> @e2e "go test for the changed packages is green"
+  #
+  # AC 12: "No regressions in existing queries (tmuxSessions, tmuxPanes, host.processes, claudeInstances top-level)"
+  #   -> @integration "Heartbeat with no matching tmux session still produces null process, null pane, no_claude"
+  #   -> @integration "Query.tmuxSessions and Query.tmuxPanes return identical shape pre/post-fix"
+  #   -> @integration "Query.host.processes returns identical shape pre/post-fix"
+  #   -> @integration "claudeInstances top-level shape (length, ids) is unchanged for inputs with no possible join"


### PR DESCRIPTION
## Why

Closes #468.

`Query.claudeInstances` is supposed to surface every live Claude Code session on the host, with a resolved OS process and tmux pane. In practice it doesn't: every instance reports `process: null` and `pane: null`, and only the single most recently touched heartbeat escapes `state: no_claude` — even when 7 claude processes are alive at the same time. The `ClaudeInstance` abstraction is the daemon's central pitch; if it can't be trusted, every orchardist falls back to `host.processes(filter: { commandIn: ["claude"] })` and reverse-engineers from there.

Investigation found three independent gaps, all in production wiring (the composer logic itself is correct):

1. The composer is constructed with `nil, nil, nil` finders in `internal/cli/daemon/daemon.go`, so every cross-provider lookup short-circuits.
2. `tmuxPaneResolver.Process` and `tmuxPaneResolver.ClaudeInstance` are stub `(nil, nil)` returns — the pane → process and pane → claude back-edges are unwired.
3. The heartbeat hook script never writes `claudePid`, so the composer's pid source has been falling back to a no-op stub (`pidFromPaneID`).

Full investigation, ACs, and plan in the issue body.

## What changed

This PR is being driven incrementally — first commit is the failing regression test that pins the bug, subsequent commits will land the fix one boundary at a time per the plan in the issue body.

Currently in this PR:

- **Failing regression test** (`internal/server/providers/claudeinstance/regression_pid_join_test.go`) — calls `claudeinstance.NewProcessFinder` / `NewPaneFinder` / `NewAccountFinder` which don't exist yet, so the build fails. The compile error IS the regression signal until those constructors land.
- **Feature file** (`specs/features/claude-instances-pid-join.feature`) — 33 scenarios mapping every issue AC to `@unit` / `@integration` / `@e2e` Gherkin.

Subsequent commits (in flight on this branch):

- Three thin adapter types (`ProcessFinder`, `PaneFinder`, `AccountFinder`) wrapping the live `ps.Provider` / `tmux.Provider` / `claudeaccount.Provider`.
- `composer.resolvePid` reads `pane.CurrentPid` when the heartbeat lacks a pid (the tmux provider already exposes this).
- `daemon.go` constructs the composer with the three real adapters instead of `nil, nil, nil`.
- `tmuxPaneResolver.Process` and `tmuxPaneResolver.ClaudeInstance` get real implementations.

The hook script change is **explicitly out of scope** — the fix works without it.

## How it works

The composer's join logic was already correct and unit-tested with fakes; the failure was that no production adapter ever bridged the live providers to the composer's interface contract. The fix is at the boundary: write three small adapter types in the same package as the composer (SOLID-D — the boundary lives next to the contract owner), wire them in `daemon.go`, and source the pid from `pane.CurrentPid` instead of the no-op `pidFromPaneID` stub.

## Test plan

- Failing regression test: `go test ./internal/server/providers/claudeinstance/... -run TestRegression_PidJoin_ProductionAdapters_Issue468` — currently fails with three undefined-symbol compile errors, which is the regression signal.
- Once the adapters land: same test will pass, asserting `result[0].Process != nil`, `result[0].Pane != nil`, `result[0].State == InstanceStateWorking` against fixture providers.
- New unit tests for each adapter (FindByPid happy/not-found, FindBySession with cmd cross-check, Active happy/not-found).
- New integration tests for the resolver stubs.
- End-to-end verification on drudrukungfu: query `claudeInstances` against the running daemon; confirm AC #8 (every alive heartbeat shows `process != null`).
- `/prove-it 468` to map every AC to evidence.
- `/review` (parallel: principles, hygiene, test, security, proof-reviewer).

## Anything surprising?

- The hook script (`~/.claude/hooks/orchard-state.sh`) lives in `drewdrewthis/orchard-codex`, not this repo. Touching it would couple this fix across two repos. The plan deliberately routes around it via `pane.CurrentPid`, leaving the heartbeat schema's optional `claudePid` field intact for a future cross-repo change.
- `pidFromPaneID` is left as a no-op stub. Strategy A makes it irrelevant; removing it is a separate cleanup PR.
- Linux/systemd hosts (#464) inherit the upstream tmux provider bug. On those hosts, panes won't resolve and instances will fall back to `no_claude`. Out of scope here.


# Related issue

- #468

# Related issue

- #468

# Related issue

- #468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to query Claude instances from tmux panes.
  * Added ability to query processes from tmux panes.

* **Bug Fixes**
  * Improved process discovery and resolution for Claude instances running in tmux sessions (issue #468).

* **Tests**
  * Added comprehensive unit and integration test coverage for instance and process resolution functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/508)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #468

# Related issue

- #468