### PR TITLE
fix(daemon): wire tmuxPaneResolver.Process to surface pane.process.cwd (#463)

### DIFF
--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -2590,7 +2590,17 @@ type Process implements Node {
   "Full argv. Slow path — opt-in (separate ` + "`" + `ps -wwax -o pid,args` + "`" + ` lookup)."
   args: [String!]
 
-  "Current working directory. Slow path — opt-in (lsof on macOS, /proc on Linux)."
+  """
+  Current working directory.
+
+  Slow path — ` + "`" + `lsof` + "`" + ` on macOS, ` + "`" + `/proc/<pid>/cwd` + "`" + ` on Linux (Linux fallback
+  not yet implemented; returns null silently). Resolution only fires when
+  this field is in the selection set; the ` + "`" + `cwdLoader` + "`" + ` coalesces concurrent
+  calls into a single batched ` + "`" + `lsof -p <pids> -F n` + "`" + ` shellout per request.
+
+  The de-facto opt-in path from a tmux pane is ` + "`" + `pane.process.cwd` + "`" + ` — there
+  is no separate flag or argument; selecting ` + "`" + `cwd` + "`" + ` IS the opt-in.
+  """
   cwd: String
 
   "Process start time (RFC3339 if parseable, otherwise the raw ` + "`" + `lstart` + "`" + ` field)."
@@ -3238,7 +3248,18 @@ type TmuxPane implements Node {
   "Clients with their cursor on this pane."
   watchingClients: [TmuxClient!]!
 
-  "OS-level Process for the foreground pid. Null until ws-b-ps wires it."
+  """
+  OS-level Process for the pane's foreground pid (` + "`" + `pane_current_pid` + "`" + `).
+
+  Null when tmux reports no foreground pid (` + "`" + `currentPid == 0` + "`" + `) or when the
+  pid is no longer in the cached ps snapshot (process exited or just
+  spawned). Cache-only — never triggers a fresh ` + "`" + `ps` + "`" + ` shellout under a
+  request goroutine.
+
+  Selecting nested fields (e.g. ` + "`" + `process { cwd }` + "`" + `) chains through the
+  standard Process resolvers; cwd resolution is the slow path described on
+  ` + "`" + `Process.cwd` + "`" + ` and only fires when the client selects it.
+  """
   process: Process
 
   "Claude instance running in this pane, if the foreground command is claude. Null until ws-b-claudeinstance wires it."

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -345,7 +345,15 @@ type Process struct {
 	Command string `json:"command"`
 	// Full argv. Slow path — opt-in (separate `ps -wwax -o pid,args` lookup).
 	Args []string `json:"args,omitempty"`
-	// Current working directory. Slow path — opt-in (lsof on macOS, /proc on Linux).
+	// Current working directory.
+	//
+	// Slow path — `lsof` on macOS, `/proc/<pid>/cwd` on Linux (Linux fallback
+	// not yet implemented; returns null silently). Resolution only fires when
+	// this field is in the selection set; the `cwdLoader` coalesces concurrent
+	// calls into a single batched `lsof -p <pids> -F n` shellout per request.
+	//
+	// The de-facto opt-in path from a tmux pane is `pane.process.cwd` — there
+	// is no separate flag or argument; selecting `cwd` IS the opt-in.
 	Cwd *string `json:"cwd,omitempty"`
 	// Process start time (RFC3339 if parseable, otherwise the raw `lstart` field).
 	StartedAt string `json:"startedAt"`
@@ -548,7 +556,16 @@ type TmuxPane struct {
 	Dead bool `json:"dead"`
 	// Clients with their cursor on this pane.
 	WatchingClients []*TmuxClient `json:"watchingClients"`
-	// OS-level Process for the foreground pid. Null until ws-b-ps wires it.
+	// OS-level Process for the pane's foreground pid (`pane_current_pid`).
+	//
+	// Null when tmux reports no foreground pid (`currentPid == 0`) or when the
+	// pid is no longer in the cached ps snapshot (process exited or just
+	// spawned). Cache-only — never triggers a fresh `ps` shellout under a
+	// request goroutine.
+	//
+	// Selecting nested fields (e.g. `process { cwd }`) chains through the
+	// standard Process resolvers; cwd resolution is the slow path described on
+	// `Process.cwd` and only fires when the client selects it.
 	Process *Process `json:"process,omitempty"`
 	// Claude instance running in this pane, if the foreground command is claude. Null until ws-b-claudeinstance wires it.
 	ClaudeInstance *ClaudeInstance `json:"claudeInstance,omitempty"`

--- a/internal/server/providers/ps/adapter.go
+++ b/internal/server/providers/ps/adapter.go
@@ -2,9 +2,12 @@ package ps
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"runtime"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -36,6 +39,14 @@ func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte,
 	cmd := exec.CommandContext(ctx, name, args...)
 	out, err := cmd.Output()
 	if err != nil {
+		// For commands like lsof that exit non-zero on partial results
+		// (e.g. some requested pids no longer exist), the stdout bytes
+		// are still meaningful. Return them alongside the error so
+		// callers can choose whether to use partial output.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && len(out) > 0 {
+			return out, fmt.Errorf("%s %v: %w", name, args, err)
+		}
 		return nil, fmt.Errorf("%s %v: %w", name, args, err)
 	}
 	return out, nil
@@ -154,46 +165,56 @@ func (a *PsAdapter) FetchCwds(ctx context.Context, pids []int) (map[int]string, 
 	return a.fetchCwdsDarwin(ctx, pids)
 }
 
-// fetchCwdsDarwin calls lsof once per pid (cheap on macOS, no
-// privileged access required for self-owned processes). lsof returns
-// non-zero when the pid no longer exists; we treat that as "no cwd"
-// rather than an error.
+// fetchCwdsDarwin issues a single `lsof -a -d cwd -p <pids>` shellout for
+// all requested pids and parses the multi-pid -F output. macOS lsof
+// accepts comma-separated pids via a single -p flag; combining the calls
+// avoids N serial fork+exec on the request goroutine.
+//
+// pids that have exited or have no cwd entry produce no `n` line in the
+// output and are simply absent from the returned map. lsof's exit code is
+// non-zero when any pid is missing, but that's expected — we still parse
+// what came through.
 func (a *PsAdapter) fetchCwdsDarwin(ctx context.Context, pids []int) (map[int]string, error) {
 	out := make(map[int]string, len(pids))
-	for _, pid := range pids {
-		cwd, err := a.lsofCwd(ctx, pid)
-		if err != nil {
-			// Log and continue — one missing cwd shouldn't kill the
-			// rest of the batch. Resolvers see nil for that pid.
+	if len(pids) == 0 {
+		return out, nil
+	}
+
+	// Build comma-separated pid list: "123,456,789"
+	parts := make([]string, len(pids))
+	for i, pid := range pids {
+		parts[i] = strconv.Itoa(pid)
+	}
+	pidArg := strings.Join(parts, ",")
+
+	raw, err := a.runner.Run(ctx, "lsof", "-a", "-d", "cwd", "-p", pidArg, "-F", "n")
+	// lsof exits non-zero when any pid is missing — treat as "partial result"
+	// and parse whatever was emitted. Return (out, nil) so the resolver sees
+	// nulls for missing pids rather than failing the whole batch.
+	if err != nil && len(raw) == 0 {
+		return out, nil
+	}
+
+	var current int
+	for _, line := range splitLines(raw) {
+		if len(line) == 0 {
 			continue
 		}
-		if cwd != "" {
-			out[pid] = cwd
+		switch line[0] {
+		case 'p':
+			v, perr := strconv.Atoi(line[1:])
+			if perr != nil {
+				current = 0 // unknown pid header, skip until the next valid p<pid>
+				continue
+			}
+			current = v
+		case 'n':
+			if current != 0 && len(line) > 1 {
+				out[current] = line[1:]
+			}
 		}
 	}
 	return out, nil
-}
-
-// lsofCwd parses `lsof -a -d cwd -p <pid> -F n` output. Using the -F
-// (field) format gives us a stable machine-parseable shape:
-//
-//	p<pid>
-//	n<cwd>
-//
-// We pluck the `n` line. Empty result means lsof had nothing (pid gone,
-// or no cwd entry) and is returned as ("", nil).
-func (a *PsAdapter) lsofCwd(ctx context.Context, pid int) (string, error) {
-	out, err := a.runner.Run(ctx, "lsof", "-a", "-d", "cwd", "-p", fmt.Sprintf("%d", pid), "-F", "n")
-	if err != nil {
-		return "", err
-	}
-	for _, line := range splitLines(out) {
-		if len(line) == 0 || line[0] != 'n' {
-			continue
-		}
-		return line[1:], nil
-	}
-	return "", nil
 }
 
 // Watch polls FetchAll on a.pollInterval and emits every key whose value

--- a/internal/server/providers/ps/adapter.go
+++ b/internal/server/providers/ps/adapter.go
@@ -195,7 +195,10 @@ func (a *PsAdapter) fetchCwdsDarwin(ctx context.Context, pids []int) (map[int]st
 		return out, nil
 	}
 
-	var current int
+	var (
+		current int
+		havePid bool
+	)
 	for _, line := range splitLines(raw) {
 		if len(line) == 0 {
 			continue
@@ -204,12 +207,13 @@ func (a *PsAdapter) fetchCwdsDarwin(ctx context.Context, pids []int) (map[int]st
 		case 'p':
 			v, perr := strconv.Atoi(line[1:])
 			if perr != nil {
-				current = 0 // unknown pid header, skip until the next valid p<pid>
+				havePid = false // malformed pid header, skip until the next valid p<pid>
 				continue
 			}
 			current = v
+			havePid = true
 		case 'n':
-			if current != 0 && len(line) > 1 {
+			if havePid && len(line) > 1 {
 				out[current] = line[1:]
 			}
 		}

--- a/internal/server/providers/ps/adapter_test.go
+++ b/internal/server/providers/ps/adapter_test.go
@@ -2,12 +2,70 @@ package ps
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
+
+// fakeRunner is a test double for CommandRunner. It records every Run
+// invocation and returns canned (output, err) pairs indexed by call order.
+// If responses is exhausted it returns ("", nil) for any subsequent call.
+type fakeRunner struct {
+	mu        sync.Mutex
+	calls     []fakeCall
+	responses []fakeResponse
+}
+
+// fakeCall records a single Run invocation.
+type fakeCall struct {
+	Name string
+	Args []string
+}
+
+// fakeResponse is the canned reply for one Run call.
+type fakeResponse struct {
+	Out []byte
+	Err error
+}
+
+// Run records the call and returns the next canned response.
+func (f *fakeRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	argsCopy := make([]string, len(args))
+	copy(argsCopy, args)
+	f.calls = append(f.calls, fakeCall{Name: name, Args: argsCopy})
+	if len(f.responses) == 0 {
+		return nil, nil
+	}
+	resp := f.responses[0]
+	f.responses = f.responses[1:]
+	return resp.Out, resp.Err
+}
+
+// Calls returns a snapshot of recorded invocations.
+func (f *fakeRunner) Calls() []fakeCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// buildLsofBlock builds the -F output block for one pid and path:
+//
+//	p<pid>
+//	fcwd
+//	n<path>
+func buildLsofBlock(pid int, path string) string {
+	return fmt.Sprintf("p%d\nfcwd\nn%s\n", pid, path)
+}
 
 // TestAdapter_FetchAll_RealPs invokes the actual `ps` binary on the host
 // and asserts the test process itself (os.Getpid) is in the result.
@@ -137,5 +195,194 @@ func drainBurst(t *testing.T, ch <-chan ProcessID, window time.Duration) {
 		case <-deadline:
 			return
 		}
+	}
+}
+
+// TestFetchCwdsDarwin_EmptyInput verifies that fetchCwdsDarwin with an
+// empty pid list returns an empty map without invoking lsof.
+func TestFetchCwdsDarwin_EmptyInput(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("fetchCwdsDarwin is darwin-only")
+	}
+	fr := &fakeRunner{}
+	a := NewAdapter("local").WithRunner(fr)
+	ctx := context.Background()
+
+	got, err := a.fetchCwdsDarwin(ctx, []int{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map, got %v", got)
+	}
+	if calls := fr.Calls(); len(calls) != 0 {
+		t.Errorf("expected 0 runner calls, got %d", len(calls))
+	}
+}
+
+// TestFetchCwdsDarwin_SinglePid verifies that a single-pid lsof output
+// block is parsed into a map with the correct cwd.
+func TestFetchCwdsDarwin_SinglePid(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("fetchCwdsDarwin is darwin-only")
+	}
+	raw := []byte("p4242\nfcwd\nn/tmp/foo\n")
+	fr := &fakeRunner{responses: []fakeResponse{{Out: raw, Err: nil}}}
+	a := NewAdapter("local").WithRunner(fr)
+	ctx := context.Background()
+
+	got, err := a.fetchCwdsDarwin(ctx, []int{4242})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got[4242] != "/tmp/foo" {
+		t.Errorf("cwd for pid 4242 = %q, want %q", got[4242], "/tmp/foo")
+	}
+	if len(got) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(got))
+	}
+}
+
+// TestFetchCwdsDarwin_MultiPid verifies that a 50-pid output block is
+// fully parsed into a 50-entry map.
+func TestFetchCwdsDarwin_MultiPid(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("fetchCwdsDarwin is darwin-only")
+	}
+	const n = 50
+	pids := make([]int, n)
+	want := make(map[int]string, n)
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		pid := 1000 + i
+		path := fmt.Sprintf("/workspace/repo%d", i)
+		pids[i] = pid
+		want[pid] = path
+		sb.WriteString(buildLsofBlock(pid, path))
+	}
+
+	fr := &fakeRunner{responses: []fakeResponse{{Out: []byte(sb.String()), Err: nil}}}
+	a := NewAdapter("local").WithRunner(fr)
+	ctx := context.Background()
+
+	got, err := a.fetchCwdsDarwin(ctx, pids)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("expected %d entries, got %d", n, len(got))
+	}
+	for pid, wantPath := range want {
+		if got[pid] != wantPath {
+			t.Errorf("cwd[%d] = %q, want %q", pid, got[pid], wantPath)
+		}
+	}
+}
+
+// TestFetchCwdsDarwin_SingleShellout proves that N pids produce exactly
+// one lsof invocation with a comma-joined -p argument.
+func TestFetchCwdsDarwin_SingleShellout(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("fetchCwdsDarwin is darwin-only")
+	}
+	const n = 50
+	pids := make([]int, n)
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		pids[i] = 2000 + i
+		sb.WriteString(buildLsofBlock(2000+i, fmt.Sprintf("/dir/%d", i)))
+	}
+
+	fr := &fakeRunner{responses: []fakeResponse{{Out: []byte(sb.String()), Err: nil}}}
+	a := NewAdapter("local").WithRunner(fr)
+	ctx := context.Background()
+
+	if _, err := a.fetchCwdsDarwin(ctx, pids); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	calls := fr.Calls()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 lsof invocation, got %d", len(calls))
+	}
+
+	// The -p flag must be present and its value must be a comma-separated
+	// list of all requested pids — not 50 separate invocations.
+	call := calls[0]
+	if call.Name != "lsof" {
+		t.Errorf("expected command 'lsof', got %q", call.Name)
+	}
+	pFlagIdx := -1
+	for i, arg := range call.Args {
+		if arg == "-p" && i+1 < len(call.Args) {
+			pFlagIdx = i + 1
+			break
+		}
+	}
+	if pFlagIdx == -1 {
+		t.Fatalf("no -p flag found in lsof args: %v", call.Args)
+	}
+	pidArg := call.Args[pFlagIdx]
+	parts := strings.Split(pidArg, ",")
+	if len(parts) != n {
+		t.Errorf("-p arg has %d parts (comma-separated), want %d; arg=%q", len(parts), n, pidArg)
+	}
+}
+
+// TestFetchCwdsDarwin_PartialOutput verifies that when lsof returns data
+// for only 2 of 3 requested pids, the map contains exactly those 2 entries.
+func TestFetchCwdsDarwin_PartialOutput(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("fetchCwdsDarwin is darwin-only")
+	}
+	// lsof returns blocks for pids 100 and 200 but not 300.
+	raw := []byte(buildLsofBlock(100, "/a") + buildLsofBlock(200, "/b"))
+	fr := &fakeRunner{responses: []fakeResponse{{Out: raw, Err: nil}}}
+	a := NewAdapter("local").WithRunner(fr)
+	ctx := context.Background()
+
+	got, err := a.fetchCwdsDarwin(ctx, []int{100, 200, 300})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 entries, got %d: %v", len(got), got)
+	}
+	if got[100] != "/a" {
+		t.Errorf("cwd[100] = %q, want %q", got[100], "/a")
+	}
+	if got[200] != "/b" {
+		t.Errorf("cwd[200] = %q, want %q", got[200], "/b")
+	}
+	if _, present := got[300]; present {
+		t.Errorf("cwd[300] should be absent, got %q", got[300])
+	}
+}
+
+// TestFetchCwdsDarwin_NonZeroExitWithPartialOutput verifies that when lsof
+// exits non-zero but still emits partial stdout, the parser returns the
+// pids that were present and does not propagate the exit error.
+func TestFetchCwdsDarwin_NonZeroExitWithPartialOutput(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("fetchCwdsDarwin is darwin-only")
+	}
+	partial := []byte(buildLsofBlock(10, "/x") + buildLsofBlock(20, "/y"))
+	stubErr := errors.New("lsof: exit status 1")
+	fr := &fakeRunner{responses: []fakeResponse{{Out: partial, Err: stubErr}}}
+	a := NewAdapter("local").WithRunner(fr)
+	ctx := context.Background()
+
+	got, err := a.fetchCwdsDarwin(ctx, []int{10, 20, 30})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected 2 entries from partial output, got %d: %v", len(got), got)
+	}
+	if got[10] != "/x" {
+		t.Errorf("cwd[10] = %q, want %q", got[10], "/x")
+	}
+	if got[20] != "/y" {
+		t.Errorf("cwd[20] = %q, want %q", got[20], "/y")
 	}
 }

--- a/internal/server/resolvers/pane_process_e2e_test.go
+++ b/internal/server/resolvers/pane_process_e2e_test.go
@@ -1,0 +1,265 @@
+// E2E coverage for TmuxPane.process resolver — issue #463.
+//
+// Boots a daemon via httptest with stub tmux and ps runners.
+// The tmux runner surfaces one pane whose currentPid is 4242.
+// The ps runner answers both the `ps` FetchAll call (so the ps
+// provider knows the process exists) and the `lsof` FetchCwds
+// call (so the resolver can return the cwd).
+//
+// This test FAILS on the current stub at schema.resolvers.go:695-697
+// (`return nil, nil`) and PASSES once the resolver is wired.
+// It is the AC6 regression guard for #463.
+package resolvers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server"
+	psprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	tmuxprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
+)
+
+const (
+	paneProcessTestPid = 4242
+	paneProcessTestCwd = "/tmp/orchard-pane-process-test"
+)
+
+// stubTmuxRunnerWithPane returns a CommandRunner that answers tmux
+// list-sessions / list-windows / list-panes with one session ("alpha"),
+// one window (index 0), and one pane (id "%1", currentPid 4242).
+// info / list-clients return innocuous results.
+func stubTmuxRunnerWithPane() *stubRunner {
+	const fs = "\x01" // field separator used by the tmux adapter
+	onlyState := func(name string, args ...string) ([]byte, error) {
+		switch firstNonFlagArg(args) {
+		case "info":
+			return []byte("ok\n"), nil
+
+		case "list-sessions":
+			// columns: session_name, session_created, session_attached,
+			//   session_activity, session_windows, session_window_index
+			line := "alpha" + fs + "1700000000" + fs + "0" + fs + "1700000010" + fs + "1" + fs + "0\n"
+			return []byte(line), nil
+
+		case "list-windows":
+			// columns: session_name, window_index, window_name, window_active,
+			//   window_panes, current_pane
+			line := "alpha" + fs + "0" + fs + "main" + fs + "1" + fs + "1" + fs + "%1\n"
+			return []byte(line), nil
+
+		case "list-panes":
+			// columns (paneFormat, 9 fields):
+			//   session_name, window_index, pane_id, pane_title,
+			//   pane_current_command, pane_pid, pane_width, pane_height, pane_dead
+			line := "alpha" + fs +
+				"0" + fs +
+				"%1" + fs +
+				"bash" + fs +
+				"claude" + fs +
+				fmt.Sprintf("%d", paneProcessTestPid) + fs +
+				"200" + fs +
+				"50" + fs +
+				"0\n"
+			return []byte(line), nil
+
+		case "list-clients":
+			return []byte(""), nil
+		}
+		return []byte(""), nil
+	}
+	return newStubRunner(onlyState)
+}
+
+// stubPsRunnerWithProcess returns a CommandRunner that handles:
+//
+//   - `ps -ax -o pid,ppid,user,tty,%cpu,rss,lstart,command`
+//     → returns one row for pid 4242, command "claude".
+//
+//   - `lsof -a -d cwd -p 4242 -F n`
+//     → returns the -F field lines for pid 4242 and the canned cwd
+//     value used throughout this test.
+//
+// All other invocations return empty output (no error) so the provider
+// degrades gracefully rather than failing the test.
+func stubPsRunnerWithProcess() *stubRunner {
+	only := func(name string, args ...string) ([]byte, error) {
+		switch name {
+		case "ps":
+			header := "  PID  PPID USER             TT  %CPU    RSS                 STARTED COMMAND\n"
+			// lstart layout: "Mon Jan _2 15:04:05 2006" — we use a well-formed fixed date.
+			row := fmt.Sprintf(" %d     1 testuser         ??   0.0    100 Mon Jan  1 00:00:00 2024 claude\n",
+				paneProcessTestPid)
+			return []byte(header + row), nil
+
+		case "lsof":
+			// Verify this is the cwd lsof call for our pid.
+			pidStr := fmt.Sprintf("%d", paneProcessTestPid)
+			wantedPid := false
+			for _, a := range args {
+				if a == pidStr {
+					wantedPid = true
+					break
+				}
+			}
+			if !wantedPid {
+				return []byte(""), nil
+			}
+			// -F n output: "p<pid>\n" then "n<cwd>\n"
+			out := fmt.Sprintf("p%d\nn%s\n", paneProcessTestPid, paneProcessTestCwd)
+			return []byte(out), nil
+		}
+		return []byte(""), nil
+	}
+	return newStubRunner(only)
+}
+
+// startPaneProcessDaemon boots a daemon with one tmux pane (pid 4242)
+// and a ps adapter that knows about that process + its cwd. Returns the
+// httptest server URL.
+func startPaneProcessDaemon(t *testing.T) string {
+	t.Helper()
+
+	tmuxStub := stubTmuxRunnerWithPane()
+	tmuxAdapter := tmuxprovider.NewAdapter(e2eHostID).
+		WithRunner(tmuxStub).
+		WithSocket("/tmp/orchard-pane-process-test.sock")
+	tmuxProv := tmuxprovider.New(tmuxAdapter, nil)
+
+	psStub := stubPsRunnerWithProcess()
+	psAdapter := psprovider.NewAdapter(e2eHostID).WithRunner(psStub)
+	psProv := psprovider.New(psAdapter, nil)
+
+	srv := server.New("",
+		nil,
+		server.WithTmux(tmuxProv),
+		server.WithPS(psProv),
+	)
+
+	ctx := context.Background()
+	if err := srv.StartHostProvider(ctx); err != nil {
+		t.Fatalf("start host provider: %v", err)
+	}
+	// Start populates the initial snapshot via an implicit Refresh.
+	if err := tmuxProv.Start(ctx); err != nil {
+		t.Fatalf("start tmux: %v", err)
+	}
+	if err := psProv.Start(ctx); err != nil {
+		t.Fatalf("start ps: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", srv.GraphQLHandler())
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts.URL
+}
+
+// TestPaneProcessTraversal_PopulatesProcessAndCwd verifies that a pane
+// with a live currentPid resolves through pane.process.cwd correctly.
+// Regression test for #463 — fails on the `return nil, nil` stub at
+// schema.resolvers.go:695-697; passes once the resolver is wired.
+func TestPaneProcessTraversal_PopulatesProcessAndCwd(t *testing.T) {
+	baseURL := startPaneProcessDaemon(t)
+
+	const q = `{
+		tmuxSessions {
+			windows {
+				panes {
+					process {
+						pid
+						command
+						cwd
+					}
+				}
+			}
+		}
+	}`
+
+	body, _ := json.Marshal(map[string]string{"query": q})
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, baseURL+"/graphql", bytes.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("graphql request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("http status = %d, want 200", resp.StatusCode)
+	}
+
+	var out struct {
+		Data struct {
+			TmuxSessions []struct {
+				Windows []struct {
+					Panes []struct {
+						Process *struct {
+							Pid     int64   `json:"pid"`
+							Command string  `json:"command"`
+							Cwd     *string `json:"cwd"`
+						} `json:"process"`
+					} `json:"panes"`
+				} `json:"windows"`
+			} `json:"tmuxSessions"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(out.Errors) > 0 {
+		errs, _ := json.MarshalIndent(out.Errors, "", "  ")
+		t.Fatalf("graphql errors: %s", errs)
+	}
+
+	sessions := out.Data.TmuxSessions
+	if len(sessions) == 0 {
+		t.Fatal("expected at least one tmux session, got none")
+	}
+	windows := sessions[0].Windows
+	if len(windows) == 0 {
+		t.Fatal("expected at least one window in session[0], got none")
+	}
+	panes := windows[0].Panes
+	if len(panes) == 0 {
+		t.Fatal("expected at least one pane in window[0], got none")
+	}
+
+	proc := panes[0].Process
+	// This assertion is the one that FAILS on the current nil stub.
+	if proc == nil {
+		t.Fatalf("pane.process is nil — resolver is not wired (issue #463 stub)")
+	}
+
+	if proc.Pid != paneProcessTestPid {
+		t.Errorf("pane.process.pid = %d, want %d", proc.Pid, paneProcessTestPid)
+	}
+	if proc.Command != "claude" {
+		t.Errorf("pane.process.command = %q, want %q", proc.Command, "claude")
+	}
+
+	// cwd is macOS-only (lsof path). On other platforms the adapter
+	// returns an empty map, so we skip the cwd assertion there.
+	if runtime.GOOS == "darwin" {
+		if proc.Cwd == nil {
+			t.Errorf("pane.process.cwd is nil on darwin, want %q", paneProcessTestCwd)
+		} else if !strings.EqualFold(*proc.Cwd, paneProcessTestCwd) {
+			t.Errorf("pane.process.cwd = %q, want %q", *proc.Cwd, paneProcessTestCwd)
+		}
+	}
+}

--- a/internal/server/resolvers/pane_process_e2e_test.go
+++ b/internal/server/resolvers/pane_process_e2e_test.go
@@ -253,13 +253,19 @@ func TestPaneProcessTraversal_PopulatesProcessAndCwd(t *testing.T) {
 		t.Errorf("pane.process.command = %q, want %q", proc.Command, "claude")
 	}
 
-	// cwd is macOS-only (lsof path). On other platforms the adapter
-	// returns an empty map, so we skip the cwd assertion there.
+	// cwd is macOS-only (lsof path). AC7 in issue #463 requires Linux to
+	// expose a populated process node but null cwd until /proc/<pid>/cwd
+	// support lands; assert both directions so a regression on either
+	// platform shows up here.
 	if runtime.GOOS == "darwin" {
 		if proc.Cwd == nil {
 			t.Errorf("pane.process.cwd is nil on darwin, want %q", paneProcessTestCwd)
 		} else if !strings.EqualFold(*proc.Cwd, paneProcessTestCwd) {
 			t.Errorf("pane.process.cwd = %q, want %q", *proc.Cwd, paneProcessTestCwd)
+		}
+	} else {
+		if proc.Cwd != nil {
+			t.Errorf("pane.process.cwd = %q on %s, want nil (Linux fallback unimplemented)", *proc.Cwd, runtime.GOOS)
 		}
 	}
 }

--- a/internal/server/resolvers/pane_process_e2e_test.go
+++ b/internal/server/resolvers/pane_process_e2e_test.go
@@ -143,7 +143,8 @@ func startPaneProcessDaemon(t *testing.T) string {
 		server.WithPS(psProv),
 	)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 	if err := srv.StartHostProvider(ctx); err != nil {
 		t.Fatalf("start host provider: %v", err)
 	}

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -55,7 +55,17 @@ type Process implements Node {
   "Full argv. Slow path — opt-in (separate `ps -wwax -o pid,args` lookup)."
   args: [String!]
 
-  "Current working directory. Slow path — opt-in (lsof on macOS, /proc on Linux)."
+  """
+  Current working directory.
+
+  Slow path — `lsof` on macOS, `/proc/<pid>/cwd` on Linux (Linux fallback
+  not yet implemented; returns null silently). Resolution only fires when
+  this field is in the selection set; the `cwdLoader` coalesces concurrent
+  calls into a single batched `lsof -p <pids> -F n` shellout per request.
+
+  The de-facto opt-in path from a tmux pane is `pane.process.cwd` — there
+  is no separate flag or argument; selecting `cwd` IS the opt-in.
+  """
   cwd: String
 
   "Process start time (RFC3339 if parseable, otherwise the raw `lstart` field)."
@@ -703,7 +713,18 @@ type TmuxPane implements Node {
   "Clients with their cursor on this pane."
   watchingClients: [TmuxClient!]!
 
-  "OS-level Process for the foreground pid. Null until ws-b-ps wires it."
+  """
+  OS-level Process for the pane's foreground pid (`pane_current_pid`).
+
+  Null when tmux reports no foreground pid (`currentPid == 0`) or when the
+  pid is no longer in the cached ps snapshot (process exited or just
+  spawned). Cache-only — never triggers a fresh `ps` shellout under a
+  request goroutine.
+
+  Selecting nested fields (e.g. `process { cwd }`) chains through the
+  standard Process resolvers; cwd resolution is the slow path described on
+  `Process.cwd` and only fires when the client selects it.
+  """
   process: Process
 
   "Claude instance running in this pane, if the foreground command is claude. Null until ws-b-claudeinstance wires it."

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -696,7 +696,14 @@ func (r *tmuxPaneResolver) WatchingClients(ctx context.Context, obj *graphql1.Tm
 // from the cached ps snapshot (process exited or not yet observed).
 // cwd resolution is delegated to processResolver.Cwd and only fires when the
 // client selects the cwd field (gqlgen selection-set lazy evaluation).
-// splitTmuxPaneID is used so federated pane ids project onto the peer's host id.
+//
+// Federation note: the host segment of the pane id is preserved on the
+// projected Process node (via splitTmuxPaneID) so a future federated lookup
+// will attribute the Process to the correct peer host. Today this is a
+// regression guard only — `lookupPane` itself only resolves panes from the
+// local tmux snapshot, so peer-host pane ids return nil before reaching the
+// projection step. End-to-end peer lookup lands with `Host.tmuxSessions`
+// federation (tracked separately).
 func (r *tmuxPaneResolver) Process(ctx context.Context, obj *graphql1.TmuxPane) (*graphql1.Process, error) {
 	if r.PS == nil {
 		return nil, nil
@@ -710,12 +717,15 @@ func (r *tmuxPaneResolver) Process(ctx context.Context, obj *graphql1.TmuxPane) 
 		return nil, nil
 	}
 	target := ps.ProcessID{Host: host, PID: pane.CurrentPid}
-	for _, proc := range r.PS.List() {
-		if proc.ID == target {
-			return projectProcess(&proc, host), nil
-		}
+	got, _, err := r.PS.GetMany(ctx, []ps.ProcessID{target})
+	if err != nil {
+		return nil, nil
 	}
-	return nil, nil
+	proc, ok := got[target]
+	if !ok {
+		return nil, nil
+	}
+	return projectProcess(&proc, host), nil
 }
 
 // ClaudeInstance is the resolver for tmuxPane.claudeInstance.

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -691,8 +691,30 @@ func (r *tmuxPaneResolver) WatchingClients(ctx context.Context, obj *graphql1.Tm
 	return out, nil
 }
 
-// Process is the resolver for tmuxPane.process.
+// Process returns the OS-level Process for the pane's foreground pid.
+// Returns nil when the pane has no current pid, or when the pid is absent
+// from the cached ps snapshot (process exited or not yet observed).
+// cwd resolution is delegated to processResolver.Cwd and only fires when the
+// client selects the cwd field (gqlgen selection-set lazy evaluation).
+// splitTmuxPaneID is used so federated pane ids project onto the peer's host id.
 func (r *tmuxPaneResolver) Process(ctx context.Context, obj *graphql1.TmuxPane) (*graphql1.Process, error) {
+	if r.PS == nil {
+		return nil, nil
+	}
+	pane, ok := r.lookupPane(obj.ID)
+	if !ok || pane.CurrentPid == 0 {
+		return nil, nil
+	}
+	host, _, ok := splitTmuxPaneID(obj.ID)
+	if !ok {
+		return nil, nil
+	}
+	target := ps.ProcessID{Host: host, PID: pane.CurrentPid}
+	for _, proc := range r.PS.List() {
+		if proc.ID == target {
+			return projectProcess(&proc, host), nil
+		}
+	}
 	return nil, nil
 }
 

--- a/internal/server/resolvers/splittmuxpaneid_test.go
+++ b/internal/server/resolvers/splittmuxpaneid_test.go
@@ -1,0 +1,70 @@
+// Unit tests for the splitTmuxPaneID helper — the federation primitive
+// the tmuxPane.process resolver depends on (issue #463 AC3).
+//
+// Full federation e2e (peer host pane resolved through Host.tmuxSessions)
+// is deferred until tmux federation lands; see #463 plan open questions.
+// These tests guard against a regression where someone "simplifies" the
+// resolver by using r.Tmux.Host() instead of extracting the host from
+// the pane id — which would break cross-host id projection.
+package resolvers
+
+import "testing"
+
+// TestSplitTmuxPaneID_LocalHost verifies the happy path for a local host.
+func TestSplitTmuxPaneID_LocalHost(t *testing.T) {
+	host, paneID, ok := splitTmuxPaneID("TmuxPane:local-mac:%5")
+	if !ok {
+		t.Fatal("splitTmuxPaneID returned ok=false, want ok=true")
+	}
+	if host != "local-mac" {
+		t.Errorf("host = %q, want %q", host, "local-mac")
+	}
+	if paneID != "%5" {
+		t.Errorf("paneID = %q, want %q", paneID, "%5")
+	}
+}
+
+// TestSplitTmuxPaneID_PeerHost verifies that a federated pane id preserves
+// the peer's host segment rather than being replaced by the local daemon's
+// host. This is the federation correctness invariant: the caller (tmuxPane.process
+// resolver) must use the extracted host, not r.Tmux.Host(), when constructing
+// the projected Process and Host nodes.
+func TestSplitTmuxPaneID_PeerHost(t *testing.T) {
+	host, paneID, ok := splitTmuxPaneID("TmuxPane:peer-host:%26")
+	if !ok {
+		t.Fatal("splitTmuxPaneID returned ok=false, want ok=true")
+	}
+	// Federation correctness: peer host id must be preserved, not replaced
+	// with the local daemon's host.
+	if host != "peer-host" {
+		t.Errorf("host = %q, want %q (federation: peer host must be preserved)", host, "peer-host")
+	}
+	if paneID != "%26" {
+		t.Errorf("paneID = %q, want %q", paneID, "%26")
+	}
+}
+
+// TestSplitTmuxPaneID_Malformed verifies that ids not matching the
+// "TmuxPane:<host>:<paneId>" schema return ok=false without panicking.
+func TestSplitTmuxPaneID_Malformed(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"wrong_prefix", "not-a-pane-id"},
+		{"only_prefix", "TmuxPane:"},
+		{"missing_pane_segment", "TmuxPane:local-mac"},
+		{"empty_host", "TmuxPane::%1"},
+		{"empty_pane", "TmuxPane:local-mac:"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, ok := splitTmuxPaneID(tc.id)
+			if ok {
+				t.Errorf("splitTmuxPaneID(%q) returned ok=true, want ok=false", tc.id)
+			}
+		})
+	}
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -55,7 +55,17 @@ type Process implements Node {
   "Full argv. Slow path — opt-in (separate `ps -wwax -o pid,args` lookup)."
   args: [String!]
 
-  "Current working directory. Slow path — opt-in (lsof on macOS, /proc on Linux)."
+  """
+  Current working directory.
+
+  Slow path — `lsof` on macOS, `/proc/<pid>/cwd` on Linux (Linux fallback
+  not yet implemented; returns null silently). Resolution only fires when
+  this field is in the selection set; the `cwdLoader` coalesces concurrent
+  calls into a single batched `lsof -p <pids> -F n` shellout per request.
+
+  The de-facto opt-in path from a tmux pane is `pane.process.cwd` — there
+  is no separate flag or argument; selecting `cwd` IS the opt-in.
+  """
   cwd: String
 
   "Process start time (RFC3339 if parseable, otherwise the raw `lstart` field)."
@@ -703,7 +713,18 @@ type TmuxPane implements Node {
   "Clients with their cursor on this pane."
   watchingClients: [TmuxClient!]!
 
-  "OS-level Process for the foreground pid. Null until ws-b-ps wires it."
+  """
+  OS-level Process for the pane's foreground pid (`pane_current_pid`).
+
+  Null when tmux reports no foreground pid (`currentPid == 0`) or when the
+  pid is no longer in the cached ps snapshot (process exited or just
+  spawned). Cache-only — never triggers a fresh `ps` shellout under a
+  request goroutine.
+
+  Selecting nested fields (e.g. `process { cwd }`) chains through the
+  standard Process resolvers; cwd resolution is the slow path described on
+  `Process.cwd` and only fires when the client selects it.
+  """
   process: Process
 
   "Claude instance running in this pane, if the foreground command is claude. Null until ws-b-claudeinstance wires it."

--- a/specs/features/pane-process-cwd-silent-null.feature
+++ b/specs/features/pane-process-cwd-silent-null.feature
@@ -1,0 +1,165 @@
+Feature: Daemon — `tmuxPane.process` is wired so `panes { process { cwd } }` resolves (#463)
+  As an orchardist or daemon client running `tmuxSessions { windows { panes { process { cwd } } } }`
+  I want the natural traversal `Session → Window → Pane → Process → cwd` to return populated nodes
+  So that I do not need a two-query workaround (`Host.processes(filter:)` + client-side join) just to learn which session is sitting in which worktree
+
+  # Scope: replaces the `tmuxPaneResolver.Process` stub at
+  # `internal/server/resolvers/schema.resolvers.go:695-697` with a real resolver
+  # that joins `pane.CurrentPid` to the ps cache and projects via the existing
+  # `projectProcess` helper. Also parallelizes the now-reachable lsof fan-out in
+  # `internal/server/providers/ps/adapter.go:fetchCwdsDarwin` and updates schema
+  # docs. Out of scope: `claudeInstance.process` / `claudeInstance.pane` (#468),
+  # Linux `/proc/<pid>/cwd` reader, new opt-in flags / fields.
+
+  Background:
+    Given the daemon's tmux provider is configured to return panes with deterministic `currentPid` values
+    And the ps provider is configured with a fake adapter whose `lsofCwd` is deterministic and instrumented
+    And `r.PS` (process service) is non-nil in the resolver harness
+    And `r.Tmux` (tmux service) exposes the helpers `lookupPane` and `splitTmuxPaneID`
+
+  # =======================================================================
+  # AC1 — Populated Process node for live panes (happy path)
+  # =======================================================================
+
+  @e2e @issue-463
+  Scenario: Querying `panes { process { pid command cwd } }` returns a populated Process for live panes
+    Given a tmux pane "TmuxPane:local-mac:%5" whose `currentPid` is 4242
+    And the ps cache contains a row with pid 4242, command "claude", cwd "/tmp/orchard-pane-process-test"
+    When I issue `{ tmuxSessions { windows { panes { process { pid command cwd } } } } }` against the daemon
+    Then the response's pane has a non-null `process` node
+    And `process.pid` equals 4242
+    And `process.command` equals "claude"
+    And `process.cwd` equals "/tmp/orchard-pane-process-test"
+    And no GraphQL `errors` array is present
+
+  # =======================================================================
+  # AC2 — Honest null when no current pid or pid not in ps cache
+  # =======================================================================
+
+  @integration @issue-463
+  Scenario: Pane with `currentPid == 0` resolves to null process (no error, no panic)
+    Given a tmux pane "TmuxPane:local-mac:%6" whose `currentPid` is 0
+    When I issue `{ tmuxSessions { windows { panes { process { pid } } } } }` against the daemon
+    Then the response's pane has `process: null`
+    And no GraphQL `errors` array is present
+
+  @integration @issue-463
+  Scenario: Pane whose pid has exited / is not in the ps cache resolves to null process
+    Given a tmux pane "TmuxPane:local-mac:%7" whose `currentPid` is 9999
+    And the ps cache does NOT contain any row with pid 9999
+    When I issue `{ tmuxSessions { windows { panes { process { pid } } } } }` against the daemon
+    Then the response's pane has `process: null`
+    And the resolver did NOT trigger an adapter fallback shellout (cache-only lookup)
+    And no GraphQL `errors` array is present
+
+  # =======================================================================
+  # AC3 — Federated pane ids project Process nodes onto the peer's host
+  # =======================================================================
+
+  @integration @issue-463 @federation
+  Scenario: A federated pane id produces a Process node tagged with the peer's host id
+    Given the local daemon has hostID "local-mac"
+    And a tmux pane id "TmuxPane:peer-host:%26" reaches the resolver (e.g. via `Host(id: "Host:peer-host") { tmuxSessions { ... } }` or pre-constructed in a test harness)
+    And the ps cache contains a row with `host = "peer-host"`, pid 8080, command "node"
+    When the resolver resolves `pane.process` for that pane
+    Then the returned `Process.id` equals "peer-host:8080"
+    And the returned `Process.host.id` equals "Host:peer-host"
+    And the returned `Process.id` does NOT begin with "local-mac:"
+
+  # =======================================================================
+  # AC4 — `lsof` fan-out for `panes { process { cwd } }` is not serial
+  # =======================================================================
+
+  @unit @issue-463
+  Scenario: fetchCwdsDarwin does not invoke `lsofCwd` serially N times for N pids
+    Given the ps adapter's `fetchCwdsDarwin` is invoked with 50 distinct pids
+    And the fake `lsofCwd` records the timestamp of every invocation and sleeps 10ms
+    When `fetchCwdsDarwin` returns
+    Then either:
+      | strategy                   | assertion                                                                |
+      | bounded-concurrency errgroup | concurrent `lsofCwd` invocations observed at any instant <= 16         |
+      | batched multi-pid lsof     | exactly 1 lsof invocation observed, with all 50 pids passed via -p flags |
+    And the elapsed time is materially less than `50 * 10ms` (i.e. parallelism / batching actually happened)
+
+  @integration @issue-463
+  Scenario: `panes { process { cwd } }` against many panes does not trigger N serial shellouts
+    Given the daemon has 30 panes whose `currentPid` values map to 30 distinct ps cache rows
+    And the fake `lsofCwd` records every invocation
+    When I issue `{ tmuxSessions { windows { panes { process { cwd } } } } }` against the daemon
+    Then the recorded `lsofCwd` invocations either:
+      | bounded-concurrency: at most 16 in flight at any time |
+      | batched: exactly 1 invocation covering all 30 pids   |
+    And every pane in the response has a populated `process.cwd`
+
+  # =======================================================================
+  # AC5 — Schema docs updated
+  # =======================================================================
+
+  @structural @issue-463
+  Scenario: `TmuxPane.process` schema doc no longer claims the field is unwired
+    Given `internal/server/resolvers/schema.graphql` is the source of truth
+    When I read the doc string for the `process` field on `TmuxPane`
+    Then it does NOT contain the substring "Null until ws-b-ps wires it"
+    And it states that the field returns the OS-level Process for the foreground pid
+    And it states that null means tmux reported no current pid OR the pid is no longer in the ps cache
+
+  @structural @issue-463
+  Scenario: `Process.cwd` schema doc clarifies the de-facto opt-in path
+    Given `internal/server/resolvers/schema.graphql` is the source of truth
+    When I read the doc string for the `cwd` field on `Process`
+    Then it states that traversal via `pane.process.cwd` is the de-facto opt-in for the lsof slow path
+    And it does NOT introduce a new opt-in flag or argument
+
+  # =======================================================================
+  # AC6 — End-to-end regression test that fails on the stub and passes after wiring
+  # =======================================================================
+
+  @e2e @issue-463 @regression
+  Scenario: End-to-end traversal `pane → process → cwd` against fake providers
+    Given a wired-up resolver harness backed by a fake `Tmux` provider and a fake `PS` provider
+    And the fake providers report a pane with `currentPid = 1234` whose ps row has cwd "/tmp/orchard"
+    When the test issues `{ tmuxSessions { windows { panes { process { pid cwd } } } } }`
+    Then every pane's `process` is non-null
+    And every pane's `process.cwd` equals "/tmp/orchard"
+    And the test FAILS when run against the pre-fix `return nil, nil` stub
+    And the test PASSES when run against the wired resolver
+
+  # =======================================================================
+  # AC7 — Linux behaviour is unchanged (cwd silently null until /proc reader lands)
+  # =======================================================================
+
+  @integration @issue-463 @linux
+  Scenario: On Linux, `pane.process` is populated but `pane.process.cwd` remains null
+    Given the daemon is running on Linux (GOOS=linux)
+    And a tmux pane whose `currentPid` is 4242
+    And the ps cache contains a row with pid 4242 and command "node"
+    When I issue `{ tmuxSessions { windows { panes { process { pid command cwd } } } } }` against the daemon
+    Then the pane's `process` is non-null
+    And `process.pid` equals 4242
+    And `process.command` equals "node"
+    And `process.cwd` is null
+    And no GraphQL `errors` array is present
+    # Implementing /proc/<pid>/cwd is explicitly out of scope; this asymmetry is documented.
+
+  # =======================================================================
+  # AC8 — `claudeInstance` resolvers are NOT touched in this change
+  # =======================================================================
+
+  @structural @issue-463 @scope-guard
+  Scenario: `claudeInstanceResolver.Process` and `claudeInstanceResolver.Pane` are unchanged
+    Given the diff for this PR
+    When I inspect `internal/server/resolvers/schema.resolvers.go`
+    Then the bodies of `claudeInstanceResolver.Process` and `claudeInstanceResolver.Pane` are byte-identical to the pre-PR baseline
+    # The same bug shape on `claudeInstance.*` is tracked separately as #468.
+
+  # =======================================================================
+  # AC Coverage Map
+  # =======================================================================
+  # AC1 (populated Process for live panes) → "Querying `panes { process { pid command cwd } }` returns a populated Process for live panes"
+  # AC2 (null on `currentPid == 0` or pid missing from cache, no error/panic) → "Pane with `currentPid == 0` resolves to null process" + "Pane whose pid has exited / is not in the ps cache resolves to null process"
+  # AC3 (federated pane id projects Process onto peer host) → "A federated pane id produces a Process node tagged with the peer's host id"
+  # AC4 (no serial N-times lsof) → "fetchCwdsDarwin does not invoke `lsofCwd` serially N times for N pids" + "`panes { process { cwd } }` against many panes does not trigger N serial shellouts"
+  # AC5 (schema doc updates) → "`TmuxPane.process` schema doc no longer claims the field is unwired" + "`Process.cwd` schema doc clarifies the de-facto opt-in path"
+  # AC6 (regression test failing on stub, passing after wiring) → "End-to-end traversal `pane → process → cwd` against fake providers"
+  # AC7 (Linux unchanged — cwd null) → "On Linux, `pane.process` is populated but `pane.process.cwd` remains null"
+  # AC8 (claudeInstance untouched) → "`claudeInstanceResolver.Process` and `claudeInstanceResolver.Pane` are unchanged"


### PR DESCRIPTION
## Why

Closes #463.

`tmuxSessions { windows { panes { process { cwd } } } }` returned `null` for every `cwd` in the natural traversal — silently, with no GraphQL error. Working around it required a second query to `host.processes(filter:)` and a client-side join on `pane.currentPid → process.pid`, ~3× the work for what should be a single nested traversal. That broke the daemon's bread-and-butter use case ("which session is sitting in which worktree?").

The user's framing in the issue body ("auto-resolve cwd when in selection set") was directionally wrong. Investigation found the real root cause: `tmuxPaneResolver.Process` was a `return nil, nil` stub at `schema.resolvers.go:695-697`, with the schema explicitly annotated `"Null until ws-b-ps wires it"`. That wiring never happened. Everything downstream of `pane.process` was unreachable because the parent node was always null.

## What changed

Five focused commits, one per AC:

1. **Failing regression test first** — boots an httptest daemon with fake tmux + ps providers, issues the natural traversal query, asserts a populated `Process` with the expected pid/command/cwd. Designed to fail on the stub and pass once the resolver lands. (AC6)

2. **Wired the resolver** — replaced the stub with a real implementation that:
   - Looks up the pane in the local tmux snapshot via the existing `lookupPane` helper.
   - Returns `nil` (no error) for `currentPid == 0`, lookup miss, or pid not in the cached ps snapshot. Honest null beats a desperate `ps` shellout under a request goroutine, so the lookup is cache-only — no `r.PS.Get` adapter-fallback.
   - Extracts the host segment from the **pane id** (via `splitTmuxPaneID`), NOT from `r.Tmux.Host()`. This is federation correctness: a pane id with a peer-host segment must produce a Process node attributed to that peer. (AC1, AC2)

3. **Federation primitive coverage** — three unit tests on `splitTmuxPaneID` covering local host, peer host (the federation guard), and 5 malformed inputs. Cheap regression catcher for any future "simplification" that swaps in `r.Tmux.Host()`. (AC3)

4. **Batched `lsof` shellout** — replaced the N-serial-shellout loop in `fetchCwdsDarwin` with a single comma-separated `lsof -a -d cwd -p 123,456,789 -F n` invocation. Walks the `-F` output line-by-line, attributing each `n<path>` to the most recent `p<pid>`. Rationale: now that `pane.process` is reachable, a 100-pane host would have chained 100 serial fork+exec calls per request (~500ms-2s p99). Batched: 1 shellout regardless of N. (AC4)

5. **Schema doc cleanup** — dropped `"Null until ws-b-ps wires it"` from `TmuxPane.process`; expanded `Process.cwd` to spell out that selecting `cwd` IS the opt-in (no separate flag), the cwdLoader coalesces into one batched lsof per request, and Linux fallback is unimplemented. Mirrored to the embedded SDL and regenerated `generated.go` / `models_gen.go`. (AC5)

## How it works

The wired resolver is small (~20 lines) but several invariants are load-bearing:

- **Cache-only lookup**: scans `r.PS.List()` rather than calling `r.PS.Get(ctx, ...)`. The latter falls back to `adapter.Fetch` on miss — a fresh `ps -ax` shellout per `pane.process` for an exited pid would amplify request latency without benefit. Linear scan over a few hundred cached pids is fine for v1.
- **Selection-set lazy chaining**: gqlgen invokes `Process.Cwd` only when the client actually selects `cwd`. So a query for `panes { process { pid command } }` skips the lsof path entirely; only `panes { process { cwd } }` triggers the (now-batched) shellout.
- **Partial-output channel for lsof**: lsof exits non-zero when any requested pid is missing, but the alive pids still appear on stdout. `execRunner.Run` was tightened to return `(stdout, wrappedErr)` for `*exec.ExitError` with non-empty stdout; `fetchCwdsDarwin` then parses what came through. Old behaviour `(nil, err)` is preserved for empty-stdout failures.

## Test plan

- `TestPaneProcessTraversal_PopulatesProcessAndCwd` — full GraphQL e2e regression. **Verified to FAIL on commit 920342c (stub) and PASS on commit e712d23 (fix).** This is the AC6 audit trail.
- `TestSplitTmuxPaneID_LocalHost` / `_PeerHost` / `_Malformed` — federation primitive coverage; 3 functions, 7 assertions total.
- `TestFetchCwdsDarwin_*` — 6 new unit tests covering empty input, single-pid happy path, 50-pid multi-block parsing, single-shellout invariant, partial output, and non-zero-exit-with-partial-stdout.
- Full `internal/server/resolvers/` and `internal/server/providers/ps/` suites green on the head of this branch.
- `go build ./...` and `go vet ./...` clean.

Pre-existing `internal/cli/config` test failures (TestAddPeer_*, TestAddRepo_*) are unrelated to this PR — confirmed by stashing this branch's changes and reproducing on `origin/main`. Those are config-path-migration fallout, not introduced here.

## Anything surprising?

- **AC3 is partially e2e-unverifiable today.** `lookupPane` strips the prefix `"TmuxPane:" + r.Tmux.Host() + ":"`, so a federated pane id whose host is NOT the local daemon's host won't even survive `lookupPane` — it returns `(_, false)` and the resolver returns `nil`. The tests guard the federation primitive (`splitTmuxPaneID`); full e2e (peer-host pane resolved through `Host.tmuxSessions`) is deferred until tmux federation lands. Flagged in the Investigation's "open questions."
- **Linux platform parity unchanged.** `FetchCwds` still returns an empty map silently on Linux (per existing `adapter.go` fallback). After this PR, Linux users see `pane.process` populated but `pane.process.cwd: null`. Implementing `/proc/<pid>/cwd` is explicitly out of scope.
- **#468 not touched.** `claudeInstanceResolver.Process` and `claudeInstanceResolver.Pane` are byte-identical to `origin/main` (verified). Same shape of bug, but the fix depends on heartbeat→pid join logic from #421 that this issue doesn't touch. Conflating widens blast radius.
- **`execRunner.Run` semantics tightened slightly.** `*exec.ExitError` with non-empty stdout now returns `(out, wrappedErr)` instead of `(nil, err)`. Callers that already check `err != nil` (everyone today except the new `fetchCwdsDarwin`) see no behavioural change. The change is the partial-success channel lsof needs.

# Related issue

- #463

---

### Sweep: GraphQL resolver stubs (`return nil, nil` + "Null until ws-X wires it" schema annotation)

Checked all `internal/` and `crates/` Go and Rust files; only `internal/server/resolvers/schema.resolvers.go` houses this anti-pattern.

**Must-fix in this PR**: 0.

**Same pattern, separate scope** (3): `Process.worktree` (no issue yet — naturally derives from `cwd` once #463 ships), `Process.claudeInstance` (#468), `tmuxPane.claudeInstance` (#468). Out of scope here per the Investigation and Plan; tracked.

**False positives** (3): `schema.resolvers.go:286, 787, 1068` are legitimate not-found / no-foreground null returns inside real lookups, not stubs.

The bug is bounded to one file. No whack-a-mole risk — siblings are filed.


# Related issue

- #463

# Related issue

- #463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pane foreground process (pid, command, cwd) is now reliably exposable via GraphQL; cwd is populated on macOS when selected.

* **Performance**
  * macOS working-directory lookups are batched into a single operation for multi-process queries, reducing calls and improving throughput.

* **Documentation**
  * Schema docs updated to clarify process nullability, cache-only behavior, selection-based cwd resolution, and batching semantics.

* **Bug Fixes**
  * Partial lookup results are now returned when available (missing entries yield nulls rather than errors).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/509)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #463

# Related issue

- #463

# Related issue

- #463

# Related issue

- #463