### PR TITLE
feat(daemon): Worktree.tmuxPanes / Worktree.tmuxSession server-side join (#511)

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -49,6 +49,10 @@ models:
         resolver: true
       processes:
         resolver: true
+      tmuxPanes:
+        resolver: true
+      tmuxSession:
+        resolver: true
 
   # Host.processes accepts a filter argument, so route it through a custom
   # resolver instead of struct-field auto-binding. The resolver consults the

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -382,16 +382,18 @@ type ComplexityRoot struct {
 	}
 
 	Worktree struct {
-		Bare      func(childComplexity int) int
-		Branch    func(childComplexity int) int
-		Head      func(childComplexity int) int
-		Host      func(childComplexity int) int
-		ID        func(childComplexity int) int
-		Issue     func(childComplexity int) int
-		Path      func(childComplexity int) int
-		Pr        func(childComplexity int) int
-		Processes func(childComplexity int) int
-		Repo      func(childComplexity int) int
+		Bare        func(childComplexity int) int
+		Branch      func(childComplexity int) int
+		Head        func(childComplexity int) int
+		Host        func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Issue       func(childComplexity int) int
+		Path        func(childComplexity int) int
+		Pr          func(childComplexity int) int
+		Processes   func(childComplexity int) int
+		Repo        func(childComplexity int) int
+		TmuxPanes   func(childComplexity int) int
+		TmuxSession func(childComplexity int) int
 	}
 }
 
@@ -514,6 +516,8 @@ type WorktreeResolver interface {
 	Pr(ctx context.Context, obj *Worktree) (*PullRequest, error)
 	Issue(ctx context.Context, obj *Worktree) (*Issue, error)
 	Processes(ctx context.Context, obj *Worktree) ([]*Process, error)
+	TmuxPanes(ctx context.Context, obj *Worktree) ([]*TmuxPane, error)
+	TmuxSession(ctx context.Context, obj *Worktree) (*TmuxSession, error)
 }
 
 type executableSchema struct {
@@ -2421,6 +2425,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Worktree.Repo(childComplexity), true
 
+	case "Worktree.tmuxPanes":
+		if e.complexity.Worktree.TmuxPanes == nil {
+			break
+		}
+
+		return e.complexity.Worktree.TmuxPanes(childComplexity), true
+
+	case "Worktree.tmuxSession":
+		if e.complexity.Worktree.TmuxSession == nil {
+			break
+		}
+
+		return e.complexity.Worktree.TmuxSession(childComplexity), true
+
 	}
 	return 0, false
 }
@@ -3082,6 +3100,21 @@ type Worktree implements Node {
 
   "Processes whose cwd lies under ` + "`" + `path` + "`" + `. Resolved by the ps provider (ws-b-ps); returns ` + "`" + `[]` + "`" + ` until that provider lands."
   processes: [Process!]!
+
+  """
+  Tmux panes whose foreground-process cwd equals ` + "`" + `path` + "`" + ` exactly OR has ` + "`" + `path + '/'` + "`" + ` as a prefix (#511).
+  Returns the matching pane list for every worktree, derived from a server-side join of pane.process.cwd
+  against the worktree path. Ordered deterministically by paneId ascending.
+  Returns ` + "`" + `[]` + "`" + ` when no panes match or when the tmux / ps providers are not wired.
+  """
+  tmuxPanes: [TmuxPane!]!
+
+  """
+  The most-recently-active tmux session among the panes returned by ` + "`" + `tmuxPanes` + "`" + ` (#511).
+  When two sessions tie on lastActivityAt, the session with the lexicographically-first name wins.
+  Null when ` + "`" + `tmuxPanes` + "`" + ` is empty or when the tmux / ps providers are not wired.
+  """
+  tmuxSession: TmuxSession
 }
 
 # ---------------------------------------------------------------------
@@ -8886,6 +8919,10 @@ func (ec *executionContext) fieldContext_Process_worktree(ctx context.Context, f
 				return ec.fieldContext_Worktree_issue(ctx, field)
 			case "processes":
 				return ec.fieldContext_Worktree_processes(ctx, field)
+			case "tmuxPanes":
+				return ec.fieldContext_Worktree_tmuxPanes(ctx, field)
+			case "tmuxSession":
+				return ec.fieldContext_Worktree_tmuxSession(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Worktree", field.Name)
 		},
@@ -9147,6 +9184,10 @@ func (ec *executionContext) fieldContext_Project_worktrees(ctx context.Context, 
 				return ec.fieldContext_Worktree_issue(ctx, field)
 			case "processes":
 				return ec.fieldContext_Worktree_processes(ctx, field)
+			case "tmuxPanes":
+				return ec.fieldContext_Worktree_tmuxPanes(ctx, field)
+			case "tmuxSession":
+				return ec.fieldContext_Worktree_tmuxSession(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Worktree", field.Name)
 		},
@@ -13362,6 +13403,10 @@ func (ec *executionContext) fieldContext_Subscription_worktreeChanged(ctx contex
 				return ec.fieldContext_Worktree_issue(ctx, field)
 			case "processes":
 				return ec.fieldContext_Worktree_processes(ctx, field)
+			case "tmuxPanes":
+				return ec.fieldContext_Worktree_tmuxPanes(ctx, field)
+			case "tmuxSession":
+				return ec.fieldContext_Worktree_tmuxSession(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Worktree", field.Name)
 		},
@@ -17249,6 +17294,145 @@ func (ec *executionContext) fieldContext_Worktree_processes(ctx context.Context,
 				return ec.fieldContext_Process_claudeInstance(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Process", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_tmuxPanes(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_tmuxPanes(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Worktree().TmuxPanes(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*TmuxPane)
+	fc.Result = res
+	return ec.marshalNTmuxPane2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxPaneᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_tmuxPanes(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxPane_id(ctx, field)
+			case "window":
+				return ec.fieldContext_TmuxPane_window(ctx, field)
+			case "paneId":
+				return ec.fieldContext_TmuxPane_paneId(ctx, field)
+			case "title":
+				return ec.fieldContext_TmuxPane_title(ctx, field)
+			case "currentCommand":
+				return ec.fieldContext_TmuxPane_currentCommand(ctx, field)
+			case "currentPid":
+				return ec.fieldContext_TmuxPane_currentPid(ctx, field)
+			case "width":
+				return ec.fieldContext_TmuxPane_width(ctx, field)
+			case "height":
+				return ec.fieldContext_TmuxPane_height(ctx, field)
+			case "dead":
+				return ec.fieldContext_TmuxPane_dead(ctx, field)
+			case "watchingClients":
+				return ec.fieldContext_TmuxPane_watchingClients(ctx, field)
+			case "process":
+				return ec.fieldContext_TmuxPane_process(ctx, field)
+			case "claudeInstance":
+				return ec.fieldContext_TmuxPane_claudeInstance(ctx, field)
+			case "content":
+				return ec.fieldContext_TmuxPane_content(ctx, field)
+			case "contentRange":
+				return ec.fieldContext_TmuxPane_contentRange(ctx, field)
+			case "contentFull":
+				return ec.fieldContext_TmuxPane_contentFull(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxPane", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_tmuxSession(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_tmuxSession(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Worktree().TmuxSession(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*TmuxSession)
+	fc.Result = res
+	return ec.marshalOTmuxSession2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSession(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_tmuxSession(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TmuxSession_id(ctx, field)
+			case "server":
+				return ec.fieldContext_TmuxSession_server(ctx, field)
+			case "name":
+				return ec.fieldContext_TmuxSession_name(ctx, field)
+			case "createdAt":
+				return ec.fieldContext_TmuxSession_createdAt(ctx, field)
+			case "attached":
+				return ec.fieldContext_TmuxSession_attached(ctx, field)
+			case "activeAttached":
+				return ec.fieldContext_TmuxSession_activeAttached(ctx, field)
+			case "attachedClients":
+				return ec.fieldContext_TmuxSession_attachedClients(ctx, field)
+			case "lastActivityAt":
+				return ec.fieldContext_TmuxSession_lastActivityAt(ctx, field)
+			case "windows":
+				return ec.fieldContext_TmuxSession_windows(ctx, field)
+			case "currentWindow":
+				return ec.fieldContext_TmuxSession_currentWindow(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TmuxSession", field.Name)
 		},
 	}
 	return fc, nil
@@ -23625,6 +23809,75 @@ func (ec *executionContext) _Worktree(ctx context.Context, sel ast.SelectionSet,
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "tmuxPanes":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Worktree_tmuxPanes(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "tmuxSession":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Worktree_tmuxSession(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -26028,6 +26281,13 @@ func (ec *executionContext) marshalOTmuxServer2ᚖgithubᚗcomᚋdrewdrewthisᚋ
 		return graphql.Null
 	}
 	return ec._TmuxServer(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOTmuxSession2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSession(ctx context.Context, sel ast.SelectionSet, v *TmuxSession) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TmuxSession(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOTmuxSessionFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSessionFilter(ctx context.Context, v interface{}) (*TmuxSessionFilter, error) {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -730,6 +730,15 @@ type Worktree struct {
 	Issue *Issue `json:"issue,omitempty"`
 	// Processes whose cwd lies under `path`. Resolved by the ps provider (ws-b-ps); returns `[]` until that provider lands.
 	Processes []*Process `json:"processes"`
+	// Tmux panes whose foreground-process cwd equals `path` exactly OR has `path + '/'` as a prefix (#511).
+	// Returns the matching pane list for every worktree, derived from a server-side join of pane.process.cwd
+	// against the worktree path. Ordered deterministically by paneId ascending.
+	// Returns `[]` when no panes match or when the tmux / ps providers are not wired.
+	TmuxPanes []*TmuxPane `json:"tmuxPanes"`
+	// The most-recently-active tmux session among the panes returned by `tmuxPanes` (#511).
+	// When two sessions tie on lastActivityAt, the session with the lexicographically-first name wins.
+	// Null when `tmuxPanes` is empty or when the tmux / ps providers are not wired.
+	TmuxSession *TmuxSession `json:"tmuxSession,omitempty"`
 }
 
 func (Worktree) IsNode() {}

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -547,6 +547,21 @@ type Worktree implements Node {
 
   "Processes whose cwd lies under `path`. Resolved by the ps provider (ws-b-ps); returns `[]` until that provider lands."
   processes: [Process!]!
+
+  """
+  Tmux panes whose foreground-process cwd equals `path` exactly OR has `path + '/'` as a prefix (#511).
+  Returns the matching pane list for every worktree, derived from a server-side join of pane.process.cwd
+  against the worktree path. Ordered deterministically by paneId ascending.
+  Returns `[]` when no panes match or when the tmux / ps providers are not wired.
+  """
+  tmuxPanes: [TmuxPane!]!
+
+  """
+  The most-recently-active tmux session among the panes returned by `tmuxPanes` (#511).
+  When two sessions tie on lastActivityAt, the session with the lexicographically-first name wins.
+  Null when `tmuxPanes` is empty or when the tmux / ps providers are not wired.
+  """
+  tmuxSession: TmuxSession
 }
 
 # ---------------------------------------------------------------------

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -1332,12 +1332,19 @@ func stripContractIDPrefix(id string) string {
 	return id
 }
 func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
+	// Host defaults to "local" so that sibling resolvers (TmuxPanes,
+	// TmuxSession) that compare obj.Host against pane.Key.Host see the
+	// correct value when the worktree is locally discovered.
+	// Workstream F will populate this from the remote host id once
+	// federated discovery lands; for now the host resolver also returns
+	// "local" unconditionally. (#511)
 	return &graphql1.Worktree{
 		ID:     string(w.ID),
 		Path:   w.Path,
 		Branch: w.Branch,
 		Head:   w.Head,
 		Bare:   w.Bare,
+		Host:   "local",
 	}
 }
 func projectProcess(p *ps.Process, hostID string) *graphql1.Process {

--- a/internal/server/resolvers/worktree_tmux.go
+++ b/internal/server/resolvers/worktree_tmux.go
@@ -47,8 +47,73 @@ func (r *worktreeResolver) TmuxPanes(ctx context.Context, obj *graphql1.Worktree
 // sessions tie on lastActivityAt the one with the lexicographically-first
 // name wins.  Returns nil when tmuxPanes is empty.
 func (r *worktreeResolver) TmuxSession(ctx context.Context, obj *graphql1.Worktree) (*graphql1.TmuxSession, error) {
-	// Implemented in a later commit — wired once tmuxPanes is validated.
-	return nil, nil
+	if r.Tmux == nil {
+		return nil, nil
+	}
+
+	snap := r.Tmux.Snapshot()
+	matching, err := matchPanesForWorktree(ctx, r, snap, obj)
+	if err != nil || len(matching) == 0 {
+		return nil, nil
+	}
+
+	// Collect the unique sessions that the matching panes belong to.
+	// Use SessionKey (host+name) for dedup; store the raw Session value
+	// so we can order by LastActivityAt.
+	seen := make(map[tmux.SessionKey]tmux.Session)
+	for _, pane := range matching {
+		// Reconstruct the raw Pane to access WindowKey.Session — we need
+		// the provider's internal Session value (which carries LastActivityAt
+		// as a time.Time). The matching []*graphql1.TmuxPane only has the
+		// projected PaneID; we look the full Pane back up from the snapshot.
+		paneKey := tmux.PaneKey{Host: tmux.HostID(obj.Host), PaneID: pane.PaneID}
+		rawPane, ok := snap.Panes[paneKey]
+		if !ok {
+			continue
+		}
+		sessionKey := tmux.SessionKey{Host: rawPane.Key.Host, Name: rawPane.WindowKey.Session}
+		if _, already := seen[sessionKey]; already {
+			continue
+		}
+		// Look up the Session to get its LastActivityAt.
+		if s, ok := snap.Sessions[sessionKey]; ok {
+			seen[sessionKey] = s
+		} else {
+			// Session row missing from snapshot — still include it so we
+			// don't silently drop a pane that genuinely sits in this session;
+			// synthesise a zero-activity Session.
+			seen[sessionKey] = tmux.Session{Key: sessionKey}
+		}
+	}
+
+	if len(seen) == 0 {
+		return nil, nil
+	}
+
+	// Flatten and sort: most-recently-active first; lex-lower name breaks ties.
+	sessions := make([]tmux.Session, 0, len(seen))
+	for _, s := range seen {
+		sessions = append(sessions, s)
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		a, b := sessions[i], sessions[j]
+		// Zero LastActivityAt is treated as the lowest possible time, so
+		// sessions with a real activity time always rank before those without.
+		aZero := a.LastActivityAt.IsZero()
+		bZero := b.LastActivityAt.IsZero()
+		if aZero != bZero {
+			// whichever has a real time goes first (i is "less" in sort order
+			// = appears earlier = "wins").
+			return !aZero // a has real time, b does not → a wins
+		}
+		if !a.LastActivityAt.Equal(b.LastActivityAt) {
+			return a.LastActivityAt.After(b.LastActivityAt) // later = higher priority
+		}
+		// Deterministic tie-break: lex-lower name wins.
+		return a.Key.Name < b.Key.Name
+	})
+
+	return projectSession(sessions[0]), nil
 }
 
 // matchPanesForWorktree enumerates every pane in snap that:

--- a/internal/server/resolvers/worktree_tmux.go
+++ b/internal/server/resolvers/worktree_tmux.go
@@ -1,0 +1,110 @@
+// worktree_tmux.go implements Worktree.tmuxPanes and Worktree.tmuxSession (#511).
+//
+// The two fields derive a server-side join of pane.process.cwd against the
+// worktree path — exact-equality or path-prefix (path + "/") — so no
+// client-side heuristics are required to attach a terminal to a worktree.
+//
+// Both fields are in their own file to keep schema.resolvers.go lean
+// (per project convention: SRP, one concern per file).
+
+package resolvers
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	tmux "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
+)
+
+// TmuxPanes resolves Worktree.tmuxPanes (#511): returns every tmux pane on
+// the worktree's host whose foreground-process cwd equals obj.Path exactly
+// OR has obj.Path+"/" as a prefix. Panes are returned sorted by paneId
+// ascending (lex sort — "%2" < "%5" < "%9"). Returns [] (never nil) when
+// no panes match or when either the tmux or ps provider is not wired.
+func (r *worktreeResolver) TmuxPanes(ctx context.Context, obj *graphql1.Worktree) ([]*graphql1.TmuxPane, error) {
+	if r.Tmux == nil {
+		return []*graphql1.TmuxPane{}, nil
+	}
+
+	snap := r.Tmux.Snapshot()
+	matching, err := matchPanesForWorktree(ctx, r, snap, obj)
+	if err != nil {
+		return []*graphql1.TmuxPane{}, nil
+	}
+
+	// Sort by paneId ascending so output is deterministic.
+	sort.Slice(matching, func(i, j int) bool {
+		return matching[i].PaneID < matching[j].PaneID
+	})
+
+	return matching, nil
+}
+
+// TmuxSession resolves Worktree.tmuxSession (#511): returns the
+// most-recently-active TmuxSession among the matching panes.  When two
+// sessions tie on lastActivityAt the one with the lexicographically-first
+// name wins.  Returns nil when tmuxPanes is empty.
+func (r *worktreeResolver) TmuxSession(ctx context.Context, obj *graphql1.Worktree) (*graphql1.TmuxSession, error) {
+	// Implemented in a later commit — wired once tmuxPanes is validated.
+	return nil, nil
+}
+
+// matchPanesForWorktree enumerates every pane in snap that:
+//  1. Lives on the same host as obj (attribution via pane.Key.Host).
+//  2. Has a CurrentPid that the ps provider can resolve to a cwd.
+//  3. Has a cwd that equals obj.Path exactly OR starts with obj.Path+"/".
+//
+// Panes whose cwd cannot be resolved are silently skipped. The returned
+// slice is unsorted; callers sort by paneId.
+func matchPanesForWorktree(ctx context.Context, r *worktreeResolver, snap tmux.RuntimeSnapshot, obj *graphql1.Worktree) ([]*graphql1.TmuxPane, error) {
+	var matching []*graphql1.TmuxPane
+
+	for _, pane := range snap.Panes {
+		// Federation attribution: use pane.Key.Host (which tracks through
+		// pane.window.session.host). Never synthesise from the local daemon.
+		if string(pane.Key.Host) != obj.Host {
+			continue
+		}
+
+		// Skip panes with no foreground pid.
+		if pane.CurrentPid == 0 {
+			continue
+		}
+
+		// Resolve cwd via the ps provider — same code path as
+		// processResolver.Cwd (#463).
+		if r.PS == nil {
+			continue
+		}
+		cwd, err := r.PS.LoadCwd(ctx, pane.CurrentPid)
+		if err != nil {
+			// Silently skip panes whose cwd cannot be resolved.
+			continue
+		}
+		if cwd == "" {
+			continue
+		}
+
+		if !cwdMatchesWorktree(obj.Path, cwd) {
+			continue
+		}
+
+		matching = append(matching, projectPane(pane))
+	}
+
+	if matching == nil {
+		return []*graphql1.TmuxPane{}, nil
+	}
+	return matching, nil
+}
+
+// cwdMatchesWorktree returns true when cwd equals path exactly or is
+// immediately under path (i.e. starts with path+"/").
+//
+// The trailing "/" guard prevents false positives: given path="/repo/feat-x",
+// the cwd "/repo/feat-xtra" must NOT match even though it shares a prefix.
+func cwdMatchesWorktree(path, cwd string) bool {
+	return cwd == path || strings.HasPrefix(cwd, path+"/")
+}

--- a/internal/server/resolvers/worktree_tmux_e2e_test.go
+++ b/internal/server/resolvers/worktree_tmux_e2e_test.go
@@ -1,0 +1,481 @@
+package resolvers_test
+
+// End-to-end test for Worktree.tmuxPanes + Worktree.tmuxSession — issue #511.
+//
+// What's "E2E" here:
+//   - Two minimal on-disk git layouts are synthesised (no `git` binary).
+//   - A fake tmux runner serves two panes: %201 (cwd = wt-live path) and
+//     %202 (cwd = /tmp/elsewhere — no worktree match).
+//   - A fake PS runner maps each pane's foreground pid to a cwd.
+//   - The resolvers, DataLoader middleware, and gqlgen schema are all live.
+//   - We POST the query over HTTP and assert the JSON response shape.
+//
+// Scenario (feature file line ~196):
+//
+//	Given the daemon has two worktrees: wt-live and wt-empty
+//	And a tmux pane %201 has its cwd == wt-live's path (via fake PS runner)
+//	And pane %202's cwd is /tmp/elsewhere (no match)
+//	When we query { projects { worktrees { id path tmuxPanes { paneId window { session { name } } } tmuxSession { name lastActivityAt } } } }
+//	Then wt-live.tmuxPanes has length ≥ 1 and contains %201
+//	And  wt-live.tmuxSession.name == live session name
+//	And  wt-live.tmuxSession.lastActivityAt is non-null
+//	And  wt-empty.tmuxPanes == []
+//	And  wt-empty.tmuxSession == null
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+
+	gqlgen "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/loaders"
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
+	psprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	tmuxprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+)
+
+// ----------------------------------------------------------------------
+// Fake providers — local to this package (resolvers_test cannot use
+// the unexported fakes in worktree_tmux_test.go).
+// ----------------------------------------------------------------------
+
+// e2eTmuxRunner is a CommandRunner for the tmux adapter. It serves
+// list-sessions, list-windows, list-panes, and the info probe using
+// the 0x01 field separator the tmux adapter expects.
+type e2eTmuxRunner struct {
+	paneRows    []string
+	sessionRows []string
+	windowRows  []string
+}
+
+func (r *e2eTmuxRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	if name != "tmux" {
+		return nil, fmt.Errorf("unexpected command: %s", name)
+	}
+	sub := e2eFirstNonFlagTmuxArg(args)
+	switch sub {
+	case "info":
+		return []byte("ok\n"), nil
+	case "list-sessions":
+		return []byte(strings.Join(r.sessionRows, "\n") + "\n"), nil
+	case "list-windows":
+		return []byte(strings.Join(r.windowRows, "\n") + "\n"), nil
+	case "list-panes":
+		return []byte(strings.Join(r.paneRows, "\n") + "\n"), nil
+	case "list-clients":
+		return []byte(""), nil
+	default:
+		return []byte(""), nil
+	}
+}
+
+// e2eFirstNonFlagTmuxArg returns the first positional arg, skipping -S / -L pairs.
+func e2eFirstNonFlagTmuxArg(args []string) string {
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-S" || args[i] == "-L" {
+			i++ // skip value
+			continue
+		}
+		return args[i]
+	}
+	return ""
+}
+
+// e2ePaneRow builds a list-panes row in the tmux adapter's field format.
+// Fields: session, windowIdx, paneId, title, command, pid, width, height, dead
+func e2ePaneRow(session, paneID string, pid int) string {
+	return strings.Join([]string{
+		session, "0", paneID, "title", "zsh",
+		fmt.Sprintf("%d", pid),
+		"200", "50", "0",
+	}, "\x01")
+}
+
+// e2eSessionRow builds a list-sessions row.
+// Fields: name, created, attached, activity, windows, curwindow
+func e2eSessionRow(name string, activityUnix int64) string {
+	return strings.Join([]string{
+		name,
+		"1700000000",
+		"0",
+		fmt.Sprintf("%d", activityUnix),
+		"1",
+		"0",
+	}, "\x01")
+}
+
+// e2eWindowRow builds a list-windows row.
+// Fields: session, index, name, active, panes, curpane
+func e2eWindowRow(session string) string {
+	return strings.Join([]string{session, "0", "main", "1", "1", "%1"}, "\x01")
+}
+
+// e2ePsRunner is a CommandRunner for the ps and lsof adapters.
+// It maps pid → cwd for lsof calls and returns a minimal ps header.
+type e2ePsRunner struct {
+	cwdByPid map[int]string
+}
+
+const e2ePsHeader = "  PID  PPID USER             TT  %CPU    RSS                 STARTED COMMAND\n"
+
+func (r *e2ePsRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	switch name {
+	case "ps":
+		return []byte(e2ePsHeader), nil
+	case "lsof":
+		pid := e2eParseLsofPid(args)
+		if cwd, ok := r.cwdByPid[pid]; ok {
+			return []byte(fmt.Sprintf("p%d\nn%s\n", pid, cwd)), nil
+		}
+		return nil, fmt.Errorf("lsof: no entry for pid %d", pid)
+	default:
+		return nil, fmt.Errorf("unexpected command: %s", name)
+	}
+}
+
+// e2eParseLsofPid extracts the pid from `lsof -a -d cwd -p <pid> -F n`.
+func e2eParseLsofPid(args []string) int {
+	for i, a := range args {
+		if a == "-p" && i+1 < len(args) {
+			var n int
+			fmt.Sscanf(args[i+1], "%d", &n)
+			return n
+		}
+	}
+	return 0
+}
+
+// ----------------------------------------------------------------------
+// Git layout helpers — minimal on-disk layout the git provider can read.
+// ----------------------------------------------------------------------
+
+// buildMinimalGitLayout writes a minimal bare-enough git dir under dir
+// so that gitprovider.Provider.AddProject succeeds and returns a main
+// worktree whose Path equals dir.
+//
+// Layout produced (under dir):
+//
+//	dir/
+//	  .git/
+//	    HEAD      — "ref: refs/heads/main\n" (unborn OK — bare=true)
+func buildMinimalGitLayout(t *testing.T, dir string) {
+	t.Helper()
+	gitDir := filepath.Join(dir, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir .git in %s: %v", dir, err)
+	}
+	head := "ref: refs/heads/main\n"
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte(head), 0o644); err != nil {
+		t.Fatalf("write HEAD in %s: %v", dir, err)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Static projects lister (re-declared here; resolvers_test cannot share
+// the one in worktree_dashboard_e2e_test.go because both are in the same
+// package — they are the same type, so we reuse staticProjectsListerE2E
+// already declared in that file).
+// ----------------------------------------------------------------------
+// NOTE: staticProjectsListerE2E is already declared in
+// worktree_dashboard_e2e_test.go (same package). We reuse it directly.
+
+// ----------------------------------------------------------------------
+// E2E test — feature file line 196
+// ----------------------------------------------------------------------
+
+// TestWorktreeTmuxJoin_E2E_LiveQuery proves the full schema → resolver →
+// provider wiring end-to-end for Worktree.tmuxPanes and
+// Worktree.tmuxSession (#511).
+//
+// Darwin-only: cwd resolution via lsof is not wired on Linux yet.
+func TestWorktreeTmuxJoin_E2E_LiveQuery(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	// ── 1. Build minimal on-disk git layouts ──────────────────────────────
+	//
+	// livePath  — the worktree where the fake shell sits.
+	// emptyPath — another worktree with no shell.
+	livePath := t.TempDir()
+	emptyPath := t.TempDir()
+
+	buildMinimalGitLayout(t, livePath)
+	buildMinimalGitLayout(t, emptyPath)
+
+	// ── 2. Register both as separate projects in the git provider ─────────
+	gitProv := gitprovider.NewProvider(nil)
+	t.Cleanup(gitProv.Stop)
+
+	const liveProjectID = "proj-live"
+	const emptyProjectID = "proj-empty"
+
+	if err := gitProv.AddProject(gitprovider.Project{ID: liveProjectID, Dir: livePath}); err != nil {
+		t.Fatalf("AddProject live: %v", err)
+	}
+	if err := gitProv.AddProject(gitprovider.Project{ID: emptyProjectID, Dir: emptyPath}); err != nil {
+		t.Fatalf("AddProject empty: %v", err)
+	}
+
+	// ── 3. Static projects lister ─────────────────────────────────────────
+	projects := &staticProjectsListerE2E{
+		records: []configprovider.Project{
+			{ID: configprovider.ProjectID(liveProjectID), Directory: livePath, Name: "wt-live"},
+			{ID: configprovider.ProjectID(emptyProjectID), Directory: emptyPath, Name: "wt-empty"},
+		},
+	}
+
+	// ── 4. Fake tmux harness ──────────────────────────────────────────────
+	//
+	// live-session has pane %201 whose foreground pid resolves to livePath.
+	// other-session has pane %202 whose cwd is /tmp/elsewhere (no match).
+	const liveSession = "live-session"
+	const livePaneID = "%201"
+	const livePID = 201001
+	const otherSession = "other-session"
+	const elsewherePaneID = "%202"
+	const elsewherePID = 202001
+	const liveActivity = int64(1746784800) // fixed timestamp for assertions
+
+	tr := &e2eTmuxRunner{
+		sessionRows: []string{
+			e2eSessionRow(liveSession, liveActivity),
+			e2eSessionRow(otherSession, 1700000000),
+		},
+		windowRows: []string{
+			e2eWindowRow(liveSession),
+			e2eWindowRow(otherSession),
+		},
+		paneRows: []string{
+			e2ePaneRow(liveSession, livePaneID, livePID),
+			e2ePaneRow(otherSession, elsewherePaneID, elsewherePID),
+		},
+	}
+
+	const hostID = "local"
+
+	tmuxAdapter := tmuxprovider.NewAdapter(tmuxprovider.HostID(hostID)).
+		WithRunner(tr).
+		WithSocket("/tmp/orchard-test-tmux-e2e.sock")
+	tmuxProv := tmuxprovider.New(tmuxAdapter, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := tmuxProv.Refresh(ctx); err != nil {
+		t.Fatalf("tmux Refresh: %v", err)
+	}
+
+	// ── 5. Fake PS runner ─────────────────────────────────────────────────
+	//
+	// livePID resolves to livePath (pane %201 sits in the live worktree).
+	// elsewherePID resolves to /tmp/elsewhere (no worktree match).
+	psRunner := &e2ePsRunner{
+		cwdByPid: map[int]string{
+			livePID:       livePath,
+			elsewherePID:  "/tmp/elsewhere",
+		},
+	}
+	psAdapter := psprovider.NewAdapter(hostID).WithRunner(psRunner)
+	psProv := psprovider.New(psAdapter, nil)
+	if err := psProv.Start(ctx); err != nil {
+		t.Fatalf("ps Start: %v", err)
+	}
+
+	// ── 6. Wire resolver ──────────────────────────────────────────────────
+	r := resolvers.New(time.Now()).
+		WithGit(gitProv).
+		WithTmux(tmuxProv).
+		WithPS(psProv).
+		WithProjects(projects)
+
+	gqlSrv := handler.New(gqlgen.NewExecutableSchema(gqlgen.Config{Resolvers: r}))
+	gqlSrv.AddTransport(transport.POST{})
+
+	ts := httptest.NewServer(loaders.Middleware(r.LoaderBundle(), gqlSrv))
+	t.Cleanup(ts.Close)
+
+	// ── 7. Fire the query ─────────────────────────────────────────────────
+	const q = `{
+		projects {
+			worktrees {
+				id
+				path
+				tmuxPanes {
+					paneId
+					window {
+						session {
+							name
+						}
+					}
+				}
+				tmuxSession {
+					name
+					lastActivityAt
+				}
+			}
+		}
+	}`
+
+	body, _ := json.Marshal(map[string]string{"query": q})
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, ts.URL, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("graphql request: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// ── 8. Assert HTTP 200 ────────────────────────────────────────────────
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("http status = %d, want 200", resp.StatusCode)
+	}
+
+	// ── 9. Decode response ────────────────────────────────────────────────
+	type tmuxPaneShape struct {
+		PaneID string `json:"paneId"`
+		Window *struct {
+			Session *struct {
+				Name string `json:"name"`
+			} `json:"session"`
+		} `json:"window"`
+	}
+	type tmuxSessionShape struct {
+		Name           string  `json:"name"`
+		LastActivityAt *string `json:"lastActivityAt"`
+	}
+	type worktreeShape struct {
+		ID          string            `json:"id"`
+		Path        string            `json:"path"`
+		TmuxPanes   []tmuxPaneShape   `json:"tmuxPanes"`
+		TmuxSession *tmuxSessionShape `json:"tmuxSession"`
+	}
+	type projectShape struct {
+		Worktrees []worktreeShape `json:"worktrees"`
+	}
+	var out struct {
+		Data struct {
+			Projects []projectShape `json:"projects"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// ── 10. No GraphQL errors ─────────────────────────────────────────────
+	if len(out.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", out.Errors)
+	}
+
+	// ── 11. Collect all worktrees from both projects ───────────────────────
+	var allWorktrees []worktreeShape
+	for _, proj := range out.Data.Projects {
+		allWorktrees = append(allWorktrees, proj.Worktrees...)
+	}
+
+	if len(allWorktrees) == 0 {
+		t.Fatal("expected at least two worktrees across projects, got none")
+	}
+
+	// ── 12. Find wt-live and wt-empty by path ─────────────────────────────
+	var wtLive, wtEmpty *worktreeShape
+	for i := range allWorktrees {
+		wt := &allWorktrees[i]
+		switch wt.Path {
+		case livePath:
+			wtLive = wt
+		case emptyPath:
+			wtEmpty = wt
+		}
+	}
+
+	if wtLive == nil {
+		paths := make([]string, 0, len(allWorktrees))
+		for _, wt := range allWorktrees {
+			paths = append(paths, fmt.Sprintf("%q", wt.Path))
+		}
+		t.Fatalf("no worktree with path %q; got paths: %v", livePath, paths)
+	}
+	if wtEmpty == nil {
+		paths := make([]string, 0, len(allWorktrees))
+		for _, wt := range allWorktrees {
+			paths = append(paths, fmt.Sprintf("%q", wt.Path))
+		}
+		t.Fatalf("no worktree with path %q; got paths: %v", emptyPath, paths)
+	}
+
+	// ── 13. Assert wt-live: tmuxPanes ≥ 1 and contains %201 ──────────────
+	if len(wtLive.TmuxPanes) == 0 {
+		t.Fatalf("wt-live.tmuxPanes = [], want at least one pane (%%201)")
+	}
+
+	foundLivePane := false
+	var liveSessionNameFromPane string
+	for _, pane := range wtLive.TmuxPanes {
+		if pane.PaneID == livePaneID {
+			foundLivePane = true
+			if pane.Window != nil && pane.Window.Session != nil {
+				liveSessionNameFromPane = pane.Window.Session.Name
+			}
+			break
+		}
+	}
+	if !foundLivePane {
+		paneIDs := make([]string, 0, len(wtLive.TmuxPanes))
+		for _, p := range wtLive.TmuxPanes {
+			paneIDs = append(paneIDs, p.PaneID)
+		}
+		t.Errorf("wt-live.tmuxPanes does not contain %%201; got panes: %v", paneIDs)
+	}
+
+	// ── 14. Assert wt-live: tmuxSession non-null and name matches pane's session ──
+	if wtLive.TmuxSession == nil {
+		t.Fatal("wt-live.tmuxSession = null, want non-null")
+	}
+
+	if liveSessionNameFromPane != "" && wtLive.TmuxSession.Name != liveSessionNameFromPane {
+		t.Errorf("wt-live.tmuxSession.name = %q, want %q (pane's session name)",
+			wtLive.TmuxSession.Name, liveSessionNameFromPane)
+	}
+	if wtLive.TmuxSession.Name != liveSession {
+		t.Errorf("wt-live.tmuxSession.name = %q, want %q", wtLive.TmuxSession.Name, liveSession)
+	}
+
+	// ── 15. Assert wt-live: lastActivityAt is non-null ────────────────────
+	if wtLive.TmuxSession.LastActivityAt == nil {
+		t.Error("wt-live.tmuxSession.lastActivityAt = null, want non-null")
+	}
+
+	// ── 16. Assert wt-empty: tmuxPanes == [] ──────────────────────────────
+	if len(wtEmpty.TmuxPanes) != 0 {
+		paneIDs := make([]string, 0, len(wtEmpty.TmuxPanes))
+		for _, p := range wtEmpty.TmuxPanes {
+			paneIDs = append(paneIDs, p.PaneID)
+		}
+		t.Errorf("wt-empty.tmuxPanes = %v, want [] (no shell sits in the empty worktree)", paneIDs)
+	}
+
+	// ── 17. Assert wt-empty: tmuxSession == null ──────────────────────────
+	if wtEmpty.TmuxSession != nil {
+		t.Errorf("wt-empty.tmuxSession = {name: %q}, want null", wtEmpty.TmuxSession.Name)
+	}
+}

--- a/internal/server/resolvers/worktree_tmux_test.go
+++ b/internal/server/resolvers/worktree_tmux_test.go
@@ -853,6 +853,174 @@ func TestWorktreeTmuxSession_SchemaDoc(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------
+// AC7 — Integration test: 4 worktrees × 6 panes (feature scenario @ line 152)
+// @integration @issue-511
+// ----------------------------------------------------------------------
+
+// TestWorktreeTmuxJoin_Integration_AC7 is the definitive end-to-end join test:
+// 4 worktrees and 6 panes are fed through the real resolver (same fake-provider
+// harness used by other tests), and every assignment is checked.
+//
+// Pane assignments:
+//
+//	p1 (%101) — cwd "/repo/.worktrees/A"        → wt-A (exact match)
+//	p2 (%102) — cwd "/repo/.worktrees/A/sub"    → wt-A (prefix match)
+//	p3 (%103) — cwd "/repo/.worktrees/B"        → wt-B (exact match)
+//	p4 (%104) — cwd "/elsewhere"                → no match
+//	p5 (%105) — cwd "/repo"                     → no match (parent, not prefix)
+//	p6 (%106) — cwd "" (null)                   → silently skipped (AC5)
+//
+// Session assignment (distinct activities so tmuxSession tie-break is exercised):
+//
+//	p1 lives in session "sess-p1" (lastActivityAt = T+100s — earlier)
+//	p2 lives in session "sess-p2" (lastActivityAt = T+200s — later, wins)
+//	p3 lives in session "sess-p3"
+//	p4/p5/p6 live in session "sess-other"
+//
+// Placeholder-resolver failure contract: a stub returning (nil, nil) from both
+// TmuxPanes and TmuxSession would fail the wt-A pane-count assertion,
+// the wt-B pane assertion, and the wt-A tmuxSession non-nil assertion — at
+// least three of the six assertions below.
+//
+// Darwin-only: cwd resolution via lsof is not wired on Linux yet.
+func TestWorktreeTmuxJoin_Integration_AC7(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	// ── paths ────────────────────────────────────────────────────────────
+	const (
+		pathA = "/repo/.worktrees/A"
+		pathB = "/repo/.worktrees/B"
+		pathC = "/repo/.worktrees/C"
+		pathD = "/repo/.worktrees/D"
+
+		// p1 and p2 are in separate sessions with distinct activities so
+		// wt-A.tmuxSession = sess-p2 (the more-recently-active one).
+		activityP1 = int64(1746784800 + 100) // T+100s — earlier
+		activityP2 = int64(1746784800 + 200) // T+200s — later, should win
+
+		// Fake pids — distinct for every pane.
+		pidP1 = 110001
+		pidP2 = 110002
+		pidP3 = 110003
+		pidP4 = 110004
+		pidP5 = 110005
+		pidP6 = 110006
+	)
+
+	// ── fake tmux harness ────────────────────────────────────────────────
+	tr := &tmuxTestRunner{
+		sessionRows: []string{
+			sessionRow("sess-p1", activityP1),
+			sessionRow("sess-p2", activityP2),
+			sessionRow("sess-p3", 1746784800),
+			sessionRow("sess-other", 1700000000),
+		},
+		windowRows: []string{
+			windowRow("sess-p1"),
+			windowRow("sess-p2"),
+			windowRow("sess-p3"),
+			windowRow("sess-other"),
+		},
+		paneRows: []string{
+			paneRow("sess-p1", "%101", pidP1),   // p1
+			paneRow("sess-p2", "%102", pidP2),   // p2
+			paneRow("sess-p3", "%103", pidP3),   // p3
+			paneRow("sess-other", "%104", pidP4), // p4
+			paneRow("sess-other", "%105", pidP5), // p5
+			paneRow("sess-other", "%106", pidP6), // p6
+		},
+	}
+
+	// ── fake cwd map ──────────────────────────────────────────────────────
+	// p6 maps to "" to simulate a null/unresolvable cwd (AC5 contract).
+	r := buildResolver(t, tr, map[int]string{
+		pidP1: pathA,
+		pidP2: pathA + "/sub",
+		pidP3: pathB,
+		pidP4: "/elsewhere",
+		pidP5: "/repo",
+		pidP6: "", // null cwd — silently skipped
+	})
+
+	ctx := context.Background()
+
+	// ── wt-A: expects [%101, %102] sorted by paneId, tmuxSession = sess-p2 ──
+	wtA := &graphql1.Worktree{ID: "proj:wt-A", Path: pathA, Host: "local"}
+
+	panesA, err := r.TmuxPanes(ctx, wtA)
+	if err != nil {
+		t.Fatalf("wt-A TmuxPanes: %v", err)
+	}
+	if len(panesA) != 2 {
+		t.Fatalf("wt-A TmuxPanes = %v (len %d), want [%%101 %%102]", paneIDsOf(panesA), len(panesA))
+	}
+	if panesA[0].PaneID != "%101" {
+		t.Errorf("wt-A TmuxPanes[0].PaneID = %q, want %%101 (sorted by paneId asc)", panesA[0].PaneID)
+	}
+	if panesA[1].PaneID != "%102" {
+		t.Errorf("wt-A TmuxPanes[1].PaneID = %q, want %%102 (sorted by paneId asc)", panesA[1].PaneID)
+	}
+
+	sessA, err := r.TmuxSession(ctx, wtA)
+	if err != nil {
+		t.Fatalf("wt-A TmuxSession: %v", err)
+	}
+	if sessA == nil {
+		t.Fatal("wt-A TmuxSession = nil, want non-nil (p2 in sess-p2 has higher lastActivityAt)")
+	}
+	// sess-p2 has activityP2 > activityP1, so it must win.
+	if sessA.Name != "sess-p2" {
+		t.Errorf("wt-A TmuxSession.Name = %q, want %q (most-recently-active session of p1/p2)", sessA.Name, "sess-p2")
+	}
+
+	// ── wt-B: expects [%103] ────────────────────────────────────────────
+	wtB := &graphql1.Worktree{ID: "proj:wt-B", Path: pathB, Host: "local"}
+
+	panesB, err := r.TmuxPanes(ctx, wtB)
+	if err != nil {
+		t.Fatalf("wt-B TmuxPanes: %v", err)
+	}
+	if len(panesB) != 1 {
+		t.Fatalf("wt-B TmuxPanes = %v (len %d), want [%%103]", paneIDsOf(panesB), len(panesB))
+	}
+	if panesB[0].PaneID != "%103" {
+		t.Errorf("wt-B TmuxPanes[0].PaneID = %q, want %%103", panesB[0].PaneID)
+	}
+
+	// ── wt-C: expects [] and nil session ────────────────────────────────
+	wtC := &graphql1.Worktree{ID: "proj:wt-C", Path: pathC, Host: "local"}
+
+	panesC, err := r.TmuxPanes(ctx, wtC)
+	if err != nil {
+		t.Fatalf("wt-C TmuxPanes: %v", err)
+	}
+	if len(panesC) != 0 {
+		t.Errorf("wt-C TmuxPanes = %v, want [] (no panes match /repo/.worktrees/C)", paneIDsOf(panesC))
+	}
+
+	sessC, err := r.TmuxSession(ctx, wtC)
+	if err != nil {
+		t.Fatalf("wt-C TmuxSession: %v", err)
+	}
+	if sessC != nil {
+		t.Errorf("wt-C TmuxSession = %v, want nil", sessC)
+	}
+
+	// ── wt-D: expects [] (empty, not nil) ───────────────────────────────
+	wtD := &graphql1.Worktree{ID: "proj:wt-D", Path: pathD, Host: "local"}
+
+	panesD, err := r.TmuxPanes(ctx, wtD)
+	if err != nil {
+		t.Fatalf("wt-D TmuxPanes: %v", err)
+	}
+	if len(panesD) != 0 {
+		t.Errorf("wt-D TmuxPanes = %v, want [] (no panes match /repo/.worktrees/D)", paneIDsOf(panesD))
+	}
+}
+
+// ----------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------
 

--- a/internal/server/resolvers/worktree_tmux_test.go
+++ b/internal/server/resolvers/worktree_tmux_test.go
@@ -367,6 +367,492 @@ func TestWorktreeTmuxPanes_SchemaIsNonNullable(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------
+// AC2 — tmuxSession unique session (feature scenario @ line 63)
+// @integration @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxSessionResolver_SinglePane verifies that when exactly one pane
+// matches, TmuxSession returns that pane's session (AC2: single-pane case).
+// Also validates that lastActivityAt is correctly surfaced through the
+// sub-resolver.
+func TestTmuxSessionResolver_SinglePane(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	const worktreePath = "/Users/me/repo/.worktrees/feat-x"
+	const sessionName = "feat-x"
+	const fakePID = 20001
+	// 2026-05-09T10:00:00Z as unix seconds.
+	const activityUnix = int64(1746784800)
+
+	tr := &tmuxTestRunner{
+		sessionRows: []string{sessionRow(sessionName, activityUnix)},
+		windowRows:  []string{windowRow(sessionName)},
+		paneRows:    []string{paneRow(sessionName, "%1", fakePID)},
+	}
+	r := buildResolver(t, tr, map[int]string{
+		fakePID: worktreePath,
+	})
+
+	wt := &graphql1.Worktree{
+		ID:   "proj:feat-x",
+		Path: worktreePath,
+		Host: "local",
+	}
+
+	sess, err := r.TmuxSession(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("TmuxSession: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("TmuxSession = nil, want non-nil")
+	}
+	if sess.Name != sessionName {
+		t.Errorf("TmuxSession.Name = %q, want %q", sess.Name, sessionName)
+	}
+
+	// Verify lastActivityAt via the sub-resolver.
+	sessResolver := &tmuxSessionResolver{r.Resolver}
+	lastAt, err := sessResolver.LastActivityAt(context.Background(), sess)
+	if err != nil {
+		t.Fatalf("LastActivityAt: %v", err)
+	}
+	if lastAt == nil {
+		t.Fatal("LastActivityAt = nil, want non-nil")
+	}
+	// The feature spec says "2026-05-09T10:00:00Z"; round-trip through
+	// RFC3339 parsing so we compare canonical form, not literal bytes.
+	wantUnix := time.Unix(activityUnix, 0).UTC().Format(time.RFC3339)
+	if *lastAt != wantUnix {
+		t.Errorf("LastActivityAt = %q, want %q", *lastAt, wantUnix)
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC2 — tmuxSession is nullable in the schema (feature scenario @ line 71)
+// @integration @issue-511 (cross-platform)
+// ----------------------------------------------------------------------
+
+// TestWorktreeTmuxSession_SchemaIsNullable verifies that the
+// Worktree.tmuxSession field is declared as nullable (TmuxSession, no "!")
+// in the embedded schema SDL.
+func TestWorktreeTmuxSession_SchemaIsNullable(t *testing.T) {
+	sdl := SchemaSDL()
+	// The field must be present without a trailing "!".
+	needle := "tmuxSession: TmuxSession"
+	if !strings.Contains(sdl, needle) {
+		t.Errorf("schema SDL does not contain %q — Worktree.tmuxSession must be nullable", needle)
+	}
+	// Double-check: it must NOT be declared non-nullable.
+	nonNullNeedle := "tmuxSession: TmuxSession!"
+	if strings.Contains(sdl, nonNullNeedle) {
+		t.Errorf("schema SDL contains %q — Worktree.tmuxSession must be nullable (no '!')", nonNullNeedle)
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC3 — higher lastActivityAt wins (feature scenario @ line 81)
+// @unit @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxSessionResolver_HigherActivityWins verifies that when two sessions
+// both have matching panes, TmuxSession returns the one with the higher
+// lastActivityAt (AC3).
+func TestTmuxSessionResolver_HigherActivityWins(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	const worktreePath = "/Users/me/repo/.worktrees/feat-x"
+	const pidAlpha = 30001
+	const pidBeta = 30002
+	// alpha: 2026-05-09T09:00:00Z; beta: 2026-05-09T11:00:00Z
+	const alphaActivity = int64(1746781200)
+	const betaActivity = int64(1746788400)
+
+	tr := &tmuxTestRunner{
+		sessionRows: []string{
+			sessionRow("alpha", alphaActivity),
+			sessionRow("beta", betaActivity),
+		},
+		windowRows: []string{
+			windowRow("alpha"),
+			windowRow("beta"),
+		},
+		paneRows: []string{
+			paneRow("alpha", "%10", pidAlpha),
+			paneRow("beta", "%11", pidBeta),
+		},
+	}
+	r := buildResolver(t, tr, map[int]string{
+		pidAlpha: worktreePath,
+		pidBeta:  worktreePath,
+	})
+
+	wt := &graphql1.Worktree{
+		ID:   "proj:feat-x",
+		Path: worktreePath,
+		Host: "local",
+	}
+
+	sess, err := r.TmuxSession(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("TmuxSession: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("TmuxSession = nil, want non-nil")
+	}
+	if sess.Name != "beta" {
+		t.Errorf("TmuxSession.Name = %q, want %q (higher lastActivityAt should win)", sess.Name, "beta")
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC3 — name tie-break (feature scenario @ line 89)
+// @unit @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxSessionResolver_NameTieBreak verifies that when two sessions have
+// identical lastActivityAt, the session with the lex-lower name wins (AC3).
+func TestTmuxSessionResolver_NameTieBreak(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	const worktreePath = "/Users/me/repo/.worktrees/feat-x"
+	const pidZebra = 40001
+	const pidAlpha = 40002
+	// Both sessions have the same lastActivityAt.
+	const sameActivity = int64(1746788400)
+
+	tr := &tmuxTestRunner{
+		sessionRows: []string{
+			sessionRow("zebra", sameActivity),
+			sessionRow("alpha", sameActivity),
+		},
+		windowRows: []string{
+			windowRow("zebra"),
+			windowRow("alpha"),
+		},
+		paneRows: []string{
+			paneRow("zebra", "%20", pidZebra),
+			paneRow("alpha", "%21", pidAlpha),
+		},
+	}
+	r := buildResolver(t, tr, map[int]string{
+		pidZebra: worktreePath,
+		pidAlpha: worktreePath,
+	})
+
+	wt := &graphql1.Worktree{
+		ID:   "proj:feat-x",
+		Path: worktreePath,
+		Host: "local",
+	}
+
+	sess, err := r.TmuxSession(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("TmuxSession: %v", err)
+	}
+	if sess == nil {
+		t.Fatal("TmuxSession = nil, want non-nil")
+	}
+	if sess.Name != "alpha" {
+		t.Errorf("TmuxSession.Name = %q, want %q (lex-lower name must win on tie)", sess.Name, "alpha")
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC4 — no matches (feature scenario @ line 101)
+// @unit @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxPanesAndSession_NoMatch verifies that a worktree with no matching
+// panes returns tmuxPanes=[] and tmuxSession=nil (AC4).
+func TestTmuxPanesAndSession_NoMatch(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	const worktreePath = "/Users/me/repo/.worktrees/lonely"
+	const fakePID = 50001
+
+	tr := &tmuxTestRunner{
+		sessionRows: []string{sessionRow("other", 1700000000)},
+		windowRows:  []string{windowRow("other")},
+		paneRows:    []string{paneRow("other", "%30", fakePID)},
+	}
+	// The pane's cwd is somewhere else entirely.
+	r := buildResolver(t, tr, map[int]string{
+		fakePID: "/some/other/path",
+	})
+
+	wt := &graphql1.Worktree{
+		ID:   "proj:lonely",
+		Path: worktreePath,
+		Host: "local",
+	}
+
+	panes, err := r.TmuxPanes(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("TmuxPanes: %v", err)
+	}
+	if len(panes) != 0 {
+		t.Errorf("TmuxPanes = %v, want []", paneIDsOf(panes))
+	}
+
+	sess, err := r.TmuxSession(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("TmuxSession: %v", err)
+	}
+	if sess != nil {
+		t.Errorf("TmuxSession = %v, want nil", sess)
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC5 — null cwd silently skipped (feature scenario @ line 113)
+// @unit @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxPanesResolver_NullCwdSkipped verifies that a pane whose lsof
+// returns an empty cwd is NOT treated as matching everything (AC5).
+// The empty-cwd pane must be silently dropped; no error surfaced.
+func TestTmuxPanesResolver_NullCwdSkipped(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	const worktreePath = "/Users/me/repo/.worktrees/feat-x"
+	const fakePID = 60001
+
+	tr := &tmuxTestRunner{
+		sessionRows: []string{sessionRow("main", 1700000000)},
+		windowRows:  []string{windowRow("main")},
+		paneRows:    []string{paneRow("main", "%40", fakePID)},
+	}
+	// Map the pane pid to an empty cwd — simulates null/unresolvable cwd.
+	r := buildResolver(t, tr, map[int]string{
+		fakePID: "", // empty cwd — should NOT match the worktree
+	})
+
+	wt := &graphql1.Worktree{
+		ID:   "proj:feat-x",
+		Path: worktreePath,
+		Host: "local",
+	}
+
+	got, err := r.TmuxPanes(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("TmuxPanes returned error %v, want nil (empty cwd must be silently skipped)", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("TmuxPanes = %v, want [] (pane with empty cwd must NOT match)", paneIDsOf(got))
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC5 — PS error silently skipped (feature scenario @ line 121)
+// @unit @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxPanesResolver_PSErrorSkipped verifies that a pane whose foreground
+// pid is unresolvable by the ps provider is silently skipped (AC5).
+func TestTmuxPanesResolver_PSErrorSkipped(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	const worktreePath = "/Users/me/repo/.worktrees/feat-x"
+	const badPID = 70001  // lsof will return an error for this pid
+	const goodPID = 70002 // this one resolves fine
+
+	tr := &tmuxTestRunner{
+		sessionRows: []string{sessionRow("main", 1700000000)},
+		windowRows:  []string{windowRow("main")},
+		paneRows: []string{
+			paneRow("main", "%50", badPID),
+			paneRow("main", "%51", goodPID),
+		},
+	}
+	// Only map the good pid; bad pid will cause lsof to return an error.
+	r := buildResolver(t, tr, map[int]string{
+		goodPID: worktreePath,
+		// badPID is intentionally absent — psTestRunner.Run returns an error
+	})
+
+	wt := &graphql1.Worktree{
+		ID:   "proj:feat-x",
+		Path: worktreePath,
+		Host: "local",
+	}
+
+	got, err := r.TmuxPanes(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("TmuxPanes returned error %v, want nil (PS errors must be silently skipped)", err)
+	}
+	// Only the good pane should be returned.
+	if len(got) != 1 {
+		t.Fatalf("TmuxPanes = %v (len %d), want [%%51] (only good pane)", paneIDsOf(got), len(got))
+	}
+	if got[0].PaneID != "%51" {
+		t.Errorf("TmuxPanes[0].PaneID = %q, want %%51", got[0].PaneID)
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC6 — host attribution via pane.Key.Host (feature scenario @ line 132)
+// @integration @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxPanesResolver_HostAttribution verifies that pane attribution uses
+// pane.Key.Host (pane.window.session.host), not the local daemon's host id.
+// A pane on host "B" matches a worktree on host "B" even when the local
+// daemon is host "A" (AC6).
+func TestTmuxPanesResolver_HostAttribution(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	// Build a resolver whose tmux adapter is tagged as host "B".
+	const worktreePath = "/home/me/repo"
+	const fakePID = 80001
+
+	tr := &tmuxTestRunner{
+		sessionRows: []string{sessionRow("main", 1700000000)},
+		windowRows:  []string{windowRow("main")},
+		paneRows:    []string{paneRow("main", "%60", fakePID)},
+	}
+
+	// Build the resolver with a non-"local" hostID to simulate host "B".
+	hostID := "B"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tmuxAdapter := tmuxprovider.NewAdapter(tmuxprovider.HostID(hostID)).
+		WithRunner(tr).
+		WithSocket("/tmp/orchard-test-host-b.sock")
+	tmuxProv := tmuxprovider.New(tmuxAdapter, nil)
+	if err := tmuxProv.Refresh(ctx); err != nil {
+		t.Fatalf("tmux Refresh: %v", err)
+	}
+
+	psRunner := &psTestRunner{cwdByPid: map[int]string{fakePID: worktreePath}}
+	psAdapter := psprovider.NewAdapter(hostID).WithRunner(psRunner)
+	psProv := psprovider.New(psAdapter, nil)
+	if err := psProv.Start(ctx); err != nil {
+		t.Fatalf("ps Start: %v", err)
+	}
+
+	r := &worktreeResolver{&Resolver{Tmux: tmuxProv, PS: psProv}}
+
+	// Worktree on host "B" — attribution must use pane.Key.Host.
+	wt := &graphql1.Worktree{
+		ID:   "proj:repo",
+		Path: worktreePath,
+		Host: "B", // AC6: resolver reads pane.Key.Host, not local daemon host
+	}
+
+	got, err := r.TmuxPanes(ctx, wt)
+	if err != nil {
+		t.Fatalf("TmuxPanes: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("TmuxPanes = %v (len %d), want [%%60]", paneIDsOf(got), len(got))
+	}
+	if got[0].PaneID != "%60" {
+		t.Errorf("TmuxPanes[0].PaneID = %q, want %%60 (attribution via pane.Key.Host)", got[0].PaneID)
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC6 — cross-host non-match (feature scenario @ line 141)
+// @integration @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxPanesResolver_CrossHostNoMatch verifies that a pane on host "B"
+// does NOT match a worktree on host "A", even when the path matches (AC6).
+func TestTmuxPanesResolver_CrossHostNoMatch(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	const worktreePath = "/Users/me/repo"
+	const fakePID = 90001
+
+	// Pane is on host "B" (the tmux adapter is tagged as "B").
+	tr := &tmuxTestRunner{
+		sessionRows: []string{sessionRow("main", 1700000000)},
+		windowRows:  []string{windowRow("main")},
+		paneRows:    []string{paneRow("main", "%70", fakePID)},
+	}
+
+	hostB := "B"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	tmuxAdapter := tmuxprovider.NewAdapter(tmuxprovider.HostID(hostB)).
+		WithRunner(tr).
+		WithSocket("/tmp/orchard-test-cross-host.sock")
+	tmuxProv := tmuxprovider.New(tmuxAdapter, nil)
+	if err := tmuxProv.Refresh(ctx); err != nil {
+		t.Fatalf("tmux Refresh: %v", err)
+	}
+
+	psRunner := &psTestRunner{cwdByPid: map[int]string{fakePID: worktreePath}}
+	psAdapter := psprovider.NewAdapter(hostB).WithRunner(psRunner)
+	psProv := psprovider.New(psAdapter, nil)
+	if err := psProv.Start(ctx); err != nil {
+		t.Fatalf("ps Start: %v", err)
+	}
+
+	r := &worktreeResolver{&Resolver{Tmux: tmuxProv, PS: psProv}}
+
+	// Worktree is on host "A" — the pane on host "B" must NOT match.
+	wt := &graphql1.Worktree{
+		ID:   "proj:repo",
+		Path: worktreePath,
+		Host: "A", // different from the pane's host "B"
+	}
+
+	got, err := r.TmuxPanes(ctx, wt)
+	if err != nil {
+		t.Fatalf("TmuxPanes: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("TmuxPanes = %v, want [] (cross-host pane must NOT match a host-A worktree)", paneIDsOf(got))
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC8 — tmuxSession schema doc (feature scenario @ line 185)
+// @unit @issue-511
+// ----------------------------------------------------------------------
+
+// TestWorktreeTmuxSession_SchemaDoc verifies that the Worktree.tmuxSession
+// field doc string describes the most-recently-active selection and
+// references issue #511 (AC8).
+func TestWorktreeTmuxSession_SchemaDoc(t *testing.T) {
+	sdl := SchemaSDL()
+
+	// The field must be present in the SDL.
+	if !strings.Contains(sdl, "tmuxSession: TmuxSession") {
+		t.Errorf("schema SDL does not contain 'tmuxSession: TmuxSession'")
+	}
+
+	// The description must reference issue #511.
+	if !strings.Contains(sdl, "#511") {
+		t.Errorf("schema SDL does not reference '#511' near tmuxSession")
+	}
+
+	// The description must mention the most-recently-active semantics.
+	if !strings.Contains(sdl, "most-recently-active") {
+		t.Errorf("schema SDL does not describe most-recently-active semantics for tmuxSession")
+	}
+}
+
+// ----------------------------------------------------------------------
 // Helpers
 // ----------------------------------------------------------------------
 

--- a/internal/server/resolvers/worktree_tmux_test.go
+++ b/internal/server/resolvers/worktree_tmux_test.go
@@ -1,0 +1,380 @@
+// worktree_tmux_test.go covers Worktree.tmuxPanes AC1 scenarios (#511):
+//
+//   - Exact cwd match (feature scenario @ line 25)
+//   - cwd under path with trailing component (feature scenario @ line 32)
+//   - Sibling path excluded — no false-prefix match (feature scenario @ line 39)
+//   - Panes sorted deterministically by paneId ascending (feature scenario @ line 47)
+//   - tmuxPanes is [TmuxPane!]! (non-nullable) in the schema (feature scenario @ line 53)
+//
+// The @integration scenarios (lines 25, 32, 47) that require cwd resolution
+// via lsof are Darwin-only because the PS adapter's FetchCwds falls back to
+// an empty map on Linux until the /proc path lands (ps.FetchCwds #platform).
+// The @unit scenarios (lines 39, 53) run on all platforms.
+
+package resolvers
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	psprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	tmuxprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
+)
+
+// ----------------------------------------------------------------------
+// Shared fakes
+// ----------------------------------------------------------------------
+
+// tmuxTestRunner is a CommandRunner for the tmux adapter. It handles
+// the four list-* commands and the info probe using a fixed field
+// separator (0x01) matching the adapter's fieldSep constant.
+type tmuxTestRunner struct {
+	// paneRows is the list of raw pane lines in the format:
+	// session\x01windowIdx\x01paneId\x01title\x01command\x01pid\x01width\x01height\x01dead
+	paneRows []string
+	// sessionRows: session\x01created\x01attached\x01activity\x01windows\x01curwindow
+	sessionRows []string
+	// windowRows: session\x01index\x01name\x01active\x01panes\x01curpane
+	windowRows []string
+}
+
+func (r *tmuxTestRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	if name != "tmux" {
+		return nil, fmt.Errorf("unexpected command: %s", name)
+	}
+	// find the subcommand (first non-flag positional arg)
+	sub := firstNonFlagTmuxArg(args)
+	switch sub {
+	case "info":
+		return []byte("ok\n"), nil
+	case "list-sessions":
+		return []byte(strings.Join(r.sessionRows, "\n") + "\n"), nil
+	case "list-windows":
+		return []byte(strings.Join(r.windowRows, "\n") + "\n"), nil
+	case "list-panes":
+		return []byte(strings.Join(r.paneRows, "\n") + "\n"), nil
+	case "list-clients":
+		return []byte(""), nil
+	default:
+		return []byte(""), nil
+	}
+}
+
+// firstNonFlagTmuxArg returns the first positional arg in a tmux command line,
+// skipping -S / -L flag-value pairs.
+func firstNonFlagTmuxArg(args []string) string {
+	for i := 0; i < len(args); i++ {
+		if args[i] == "-S" || args[i] == "-L" {
+			i++ // skip value
+			continue
+		}
+		return args[i]
+	}
+	return ""
+}
+
+// paneRow builds a list-panes row in the adapter's field-separated format.
+// Fields: session, windowIdx, paneId, title, command, pid, width, height, dead
+func paneRow(session, paneID string, pid int) string {
+	return strings.Join([]string{
+		session, "0", paneID, "title", "zsh",
+		fmt.Sprintf("%d", pid),
+		"200", "50", "0",
+	}, "\x01")
+}
+
+// sessionRow builds a list-sessions row.
+func sessionRow(name string, activityUnix int64) string {
+	return strings.Join([]string{
+		name,
+		"1700000000",         // created
+		"0",                  // attached
+		fmt.Sprintf("%d", activityUnix), // last activity
+		"1",                  // window count
+		"0",                  // current window index
+	}, "\x01")
+}
+
+// windowRow builds a list-windows row.
+func windowRow(session string) string {
+	return strings.Join([]string{session, "0", "main", "1", "1", "%1"}, "\x01")
+}
+
+// psTestRunner is a CommandRunner for the ps and lsof adapters.
+// It maps pid → cwd for lsof calls and returns a minimal ps header for FetchAll.
+type psTestRunner struct {
+	// cwdByPid maps pid → cwd for fake lsof responses.
+	cwdByPid map[int]string
+}
+
+const psHeader = "  PID  PPID USER             TT  %CPU    RSS                 STARTED COMMAND\n"
+
+func (r *psTestRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	switch name {
+	case "ps":
+		// Return header-only so FetchAll succeeds with an empty process table.
+		return []byte(psHeader), nil
+	case "lsof":
+		// lsof -a -d cwd -p <pid> -F n
+		pid := parseLsofPid(args)
+		if cwd, ok := r.cwdByPid[pid]; ok {
+			return []byte(fmt.Sprintf("p%d\nn%s\n", pid, cwd)), nil
+		}
+		// Unknown pid: return non-zero exit (lsof convention for gone process)
+		return nil, fmt.Errorf("lsof: no entry for pid %d", pid)
+	default:
+		return nil, fmt.Errorf("unexpected command: %s", name)
+	}
+}
+
+// parseLsofPid extracts the pid argument from `lsof -a -d cwd -p <pid> -F n`.
+func parseLsofPid(args []string) int {
+	for i, a := range args {
+		if a == "-p" && i+1 < len(args) {
+			var n int
+			fmt.Sscanf(args[i+1], "%d", &n)
+			return n
+		}
+	}
+	return 0
+}
+
+// buildResolver wires a worktreeResolver backed by fake tmux and ps providers.
+// The fake tmux runner serves the given pane rows; the fake ps runner maps
+// pid → cwd for lsof calls.
+//
+// On non-Darwin platforms FetchCwds always returns an empty map (no /proc
+// path wired), so callers that need cwd-based assertions must skip on non-Darwin
+// via t.Skip in the test body.
+func buildResolver(t *testing.T, tr *tmuxTestRunner, pidToCwd map[int]string) *worktreeResolver {
+	t.Helper()
+
+	hostID := "local"
+
+	// Tmux provider
+	tmuxAdapter := tmuxprovider.NewAdapter(tmuxprovider.HostID(hostID)).
+		WithRunner(tr).
+		WithSocket("/tmp/orchard-test-worktree-tmux.sock")
+	tmuxProv := tmuxprovider.New(tmuxAdapter, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := tmuxProv.Refresh(ctx); err != nil {
+		t.Fatalf("tmux Refresh: %v", err)
+	}
+
+	// PS provider
+	psRunner := &psTestRunner{cwdByPid: pidToCwd}
+	psAdapter := psprovider.NewAdapter(hostID).WithRunner(psRunner)
+	psProv := psprovider.New(psAdapter, nil)
+	if err := psProv.Start(ctx); err != nil {
+		t.Fatalf("ps Start: %v", err)
+	}
+
+	return &worktreeResolver{&Resolver{
+		Tmux: tmuxProv,
+		PS:   psProv,
+	}}
+}
+
+// ----------------------------------------------------------------------
+// AC1 — cwd exact match (feature scenario @ line 25)
+// @integration @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxPanesResolver_ExactCwdMatch verifies that a pane whose cwd exactly
+// equals the worktree path is included in tmuxPanes.
+func TestTmuxPanesResolver_ExactCwdMatch(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	const worktreePath = "/Users/me/repo/.worktrees/feat-x"
+	const paneID = "%1"
+	const fakePID = 10001
+
+	tr := &tmuxTestRunner{
+		sessionRows: []string{sessionRow("main", 1700000000)},
+		windowRows:  []string{windowRow("main")},
+		paneRows:    []string{paneRow("main", paneID, fakePID)},
+	}
+	r := buildResolver(t, tr, map[int]string{
+		fakePID: worktreePath, // cwd == worktree path exactly
+	})
+
+	wt := &graphql1.Worktree{
+		ID:   "proj:feat-x",
+		Path: worktreePath,
+		Host: "local",
+	}
+
+	got, err := r.TmuxPanes(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("TmuxPanes: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("TmuxPanes = %d panes, want 1; got: %v", len(got), paneIDsOf(got))
+	}
+	if got[0].PaneID != paneID {
+		t.Errorf("TmuxPanes[0].PaneID = %q, want %q", got[0].PaneID, paneID)
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC1 — cwd under path (feature scenario @ line 32)
+// @integration @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxPanesResolver_CwdUnderPath verifies that a pane whose cwd sits
+// under the worktree path (cwd has path + "/" as prefix) is included.
+func TestTmuxPanesResolver_CwdUnderPath(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	const worktreePath = "/Users/me/repo/.worktrees/feat-x"
+	const paneCwd = worktreePath + "/internal/server"
+	const paneID = "%2"
+	const fakePID = 10002
+
+	tr := &tmuxTestRunner{
+		sessionRows: []string{sessionRow("main", 1700000000)},
+		windowRows:  []string{windowRow("main")},
+		paneRows:    []string{paneRow("main", paneID, fakePID)},
+	}
+	r := buildResolver(t, tr, map[int]string{
+		fakePID: paneCwd,
+	})
+
+	wt := &graphql1.Worktree{
+		ID:   "proj:feat-x",
+		Path: worktreePath,
+		Host: "local",
+	}
+
+	got, err := r.TmuxPanes(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("TmuxPanes: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("TmuxPanes = %d panes, want 1; got: %v", len(got), paneIDsOf(got))
+	}
+	if got[0].PaneID != paneID {
+		t.Errorf("TmuxPanes[0].PaneID = %q, want %q", got[0].PaneID, paneID)
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC1 — sibling path excluded (feature scenario @ line 39)
+// @unit @issue-511
+// ----------------------------------------------------------------------
+
+// TestCwdMatchesWorktree_SiblingExcluded verifies the "exact OR path+/"
+// match rule: a cwd that merely shares a prefix string with worktree.path
+// but continues without a "/" separator must NOT match.
+func TestCwdMatchesWorktree_SiblingExcluded(t *testing.T) {
+	const path = "/Users/me/repo/.worktrees/feat-x"
+
+	// Sibling path: shares prefix but no "/".
+	if cwdMatchesWorktree(path, path+"extra") {
+		t.Errorf("cwdMatchesWorktree(%q, %q) = true, want false (sibling path must not match)", path, path+"extra")
+	}
+
+	// Exact match must still pass.
+	if !cwdMatchesWorktree(path, path) {
+		t.Errorf("cwdMatchesWorktree(%q, %q) = false, want true (exact match must pass)", path, path)
+	}
+
+	// Under-path must still pass.
+	if !cwdMatchesWorktree(path, path+"/sub/dir") {
+		t.Errorf("cwdMatchesWorktree(%q, %q) = false, want true (sub-path must pass)", path, path+"/sub/dir")
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC1 — sort order (feature scenario @ line 47)
+// @unit @issue-511
+// ----------------------------------------------------------------------
+
+// TestTmuxPanesResolver_SortedByPaneId verifies that matching panes are
+// returned ordered by paneId ascending (lex order — "%2" < "%5" < "%9").
+func TestTmuxPanesResolver_SortedByPaneId(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("cwd resolution via lsof is darwin-only (Linux /proc path not yet wired)")
+	}
+
+	const worktreePath = "/Users/me/repo/.worktrees/feat-x"
+	const fakePID5 = 10005
+	const fakePID2 = 10002
+	const fakePID9 = 10009
+
+	tr := &tmuxTestRunner{
+		sessionRows: []string{sessionRow("main", 1700000000)},
+		windowRows:  []string{windowRow("main")},
+		paneRows: []string{
+			paneRow("main", "%5", fakePID5),
+			paneRow("main", "%2", fakePID2),
+			paneRow("main", "%9", fakePID9),
+		},
+	}
+	r := buildResolver(t, tr, map[int]string{
+		fakePID5: worktreePath,
+		fakePID2: worktreePath,
+		fakePID9: worktreePath,
+	})
+
+	wt := &graphql1.Worktree{
+		ID:   "proj:feat-x",
+		Path: worktreePath,
+		Host: "local",
+	}
+
+	got, err := r.TmuxPanes(context.Background(), wt)
+	if err != nil {
+		t.Fatalf("TmuxPanes: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("TmuxPanes = %d panes, want 3; got: %v", len(got), paneIDsOf(got))
+	}
+	want := []string{"%2", "%5", "%9"}
+	for i, id := range want {
+		if got[i].PaneID != id {
+			t.Errorf("TmuxPanes[%d].PaneID = %q, want %q (not sorted by paneId)", i, got[i].PaneID, id)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+// AC1 — non-nullable in schema (feature scenario @ line 53)
+// @integration @issue-511
+// ----------------------------------------------------------------------
+
+// TestWorktreeTmuxPanes_SchemaIsNonNullable verifies that the Worktree.tmuxPanes
+// field is declared as [TmuxPane!]! (non-null list of non-null TmuxPane) in
+// the embedded schema SDL.
+func TestWorktreeTmuxPanes_SchemaIsNonNullable(t *testing.T) {
+	sdl := SchemaSDL()
+	// The schema must contain the non-nullable declaration.
+	needle := "tmuxPanes: [TmuxPane!]!"
+	if !strings.Contains(sdl, needle) {
+		t.Errorf("schema SDL does not contain %q — Worktree.tmuxPanes must be non-nullable ([TmuxPane!]!)", needle)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------
+
+// paneIDsOf extracts pane IDs for diagnostic messages.
+func paneIDsOf(panes []*graphql1.TmuxPane) []string {
+	ids := make([]string, len(panes))
+	for i, p := range panes {
+		ids[i] = p.PaneID
+	}
+	return ids
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -547,6 +547,21 @@ type Worktree implements Node {
 
   "Processes whose cwd lies under `path`. Resolved by the ps provider (ws-b-ps); returns `[]` until that provider lands."
   processes: [Process!]!
+
+  """
+  Tmux panes whose foreground-process cwd equals `path` exactly OR has `path + '/'` as a prefix (#511).
+  Returns the matching pane list for every worktree, derived from a server-side join of pane.process.cwd
+  against the worktree path. Ordered deterministically by paneId ascending.
+  Returns `[]` when no panes match or when the tmux / ps providers are not wired.
+  """
+  tmuxPanes: [TmuxPane!]!
+
+  """
+  The most-recently-active tmux session among the panes returned by `tmuxPanes` (#511).
+  When two sessions tie on lastActivityAt, the session with the lexicographically-first name wins.
+  Null when `tmuxPanes` is empty or when the tmux / ps providers are not wired.
+  """
+  tmuxSession: TmuxSession
 }
 
 # ---------------------------------------------------------------------

--- a/specs/features/daemon-worktree-tmuxsession-worktree.feature
+++ b/specs/features/daemon-worktree-tmuxsession-worktree.feature
@@ -1,0 +1,239 @@
+Feature: daemon Worktree.tmuxPanes / Worktree.tmuxSession — server-side cwd join (#511)
+  As a client (Orchard GUI, Rust TUI, scripts) querying the daemon for "which tmux session is attached to this worktree"
+  I want the Worktree GraphQL type to expose tmuxPanes and tmuxSession derived from a server-side join of pane.process.cwd against worktree.path
+  So that no client-side naming heuristics, no commandIn allowlists, and no multi-query JS joins are required to attach a terminal to a worktree
+
+  # Server-side join: for each worktree, enumerate every tmux pane on its host,
+  # resolve pane.process.cwd via the ps provider, and keep panes whose cwd
+  # equals worktree.path or sits under worktree.path + "/". tmuxSession is
+  # sugar for "the most-recently-active session among those panes".
+  #
+  # Blocked by #463 (tmuxPane.process wiring). Independent of #468.
+
+  Background:
+    Given the daemon serves a GraphQL schema at 127.0.0.1:7777
+    And the existing Worktree type already exposes id, path, branch, head, bare, processes
+    And the existing TmuxPane type exposes paneId, window.session, and a process accessor backed by the ps provider
+    And the existing TmuxSession type exposes name, host, and lastActivityAt
+    And the ps provider can resolve a foreground process cwd from a pid (where the platform supports it)
+
+  # =======================================================================
+  # AC1 — tmuxPanes returns the matching pane list for every worktree
+  # =======================================================================
+
+  @integration @issue-511
+  Scenario: tmuxPanes returns panes whose cwd exactly equals the worktree path
+    Given a worktree at path "/Users/me/repo/.worktrees/feat-x"
+    And a tmux pane "%1" whose foreground process cwd is "/Users/me/repo/.worktrees/feat-x"
+    When the GraphQL query "{ projects { worktrees { id path tmuxPanes { paneId } } } }" is executed
+    Then tmuxPanes for that worktree contains the pane "%1"
+
+  @integration @issue-511
+  Scenario: tmuxPanes returns panes whose cwd sits under the worktree path
+    Given a worktree at path "/Users/me/repo/.worktrees/feat-x"
+    And a tmux pane "%2" whose foreground process cwd is "/Users/me/repo/.worktrees/feat-x/internal/server"
+    When tmuxPanes is resolved for that worktree
+    Then tmuxPanes contains the pane "%2"
+
+  @unit @issue-511
+  Scenario: tmuxPanes excludes panes whose cwd is a sibling of the worktree path (no false-prefix match)
+    Given a worktree at path "/Users/me/repo/.worktrees/feat-x"
+    And a tmux pane whose foreground process cwd is "/Users/me/repo/.worktrees/feat-xtra"
+    When tmuxPanes is resolved for that worktree
+    Then the pane is NOT included in tmuxPanes
+    And the cwd-match rule is "exact OR prefix `path + '/'`"
+
+  @unit @issue-511
+  Scenario: tmuxPanes returns panes ordered deterministically by paneId ascending
+    Given three matching panes with paneIds "%5", "%2", "%9"
+    When tmuxPanes is resolved
+    Then the returned slice is ordered "%2", "%5", "%9"
+
+  @integration @issue-511
+  Scenario: tmuxPanes is non-nullable in the schema
+    Given the generated GraphQL schema
+    When the Worktree.tmuxPanes field is inspected
+    Then its type is "[TmuxPane!]!" (non-null list of non-null TmuxPane)
+
+  # =======================================================================
+  # AC2 — tmuxSession returns the most-recently-active matching session
+  # =======================================================================
+
+  @integration @issue-511
+  Scenario: tmuxSession returns the unique session of the single matching pane
+    Given a worktree at path "/Users/me/repo/.worktrees/feat-x"
+    And exactly one tmux pane matches that worktree, attached to session "feat-x" (lastActivityAt 2026-05-09T10:00:00Z)
+    When tmuxSession is resolved
+    Then tmuxSession.name equals "feat-x"
+    And tmuxSession.lastActivityAt equals "2026-05-09T10:00:00Z"
+
+  @integration @issue-511
+  Scenario: tmuxSession field is nullable in the schema
+    Given the generated GraphQL schema
+    When the Worktree.tmuxSession field is inspected
+    Then its type is "TmuxSession" (nullable)
+
+  # =======================================================================
+  # AC3 — Two sessions both matching: most-recently-active wins, deterministic tie-break
+  # =======================================================================
+
+  @unit @issue-511
+  Scenario: tmuxSession picks the session with the higher lastActivityAt when two sessions match
+    Given a worktree at path "/Users/me/repo/.worktrees/feat-x"
+    And session "alpha" has lastActivityAt 2026-05-09T09:00:00Z and a pane matching the worktree
+    And session "beta" has lastActivityAt 2026-05-09T11:00:00Z and a pane matching the worktree
+    When tmuxSession is resolved
+    Then tmuxSession.name equals "beta"
+
+  @unit @issue-511
+  Scenario: tmuxSession ties on lastActivityAt are broken by session name lex order ascending
+    Given a worktree at path "/Users/me/repo/.worktrees/feat-x"
+    And session "zebra" has lastActivityAt 2026-05-09T11:00:00Z and a pane matching the worktree
+    And session "alpha" has lastActivityAt 2026-05-09T11:00:00Z and a pane matching the worktree
+    When tmuxSession is resolved
+    Then tmuxSession.name equals "alpha"
+
+  # =======================================================================
+  # AC4 — No matches: empty list and null session
+  # =======================================================================
+
+  @unit @issue-511
+  Scenario: Worktree with no matching panes returns empty tmuxPanes and null tmuxSession
+    Given a worktree at path "/Users/me/repo/.worktrees/lonely"
+    And no tmux pane has a foreground process cwd at or under that path
+    When tmuxPanes and tmuxSession are resolved
+    Then tmuxPanes equals an empty list "[]"
+    And tmuxSession equals null
+
+  # =======================================================================
+  # AC5 — Panes whose cwd is null (e.g. Linux without /proc/<pid>/cwd) are silently skipped
+  # =======================================================================
+
+  @unit @issue-511
+  Scenario: A pane whose process.cwd is null is not treated as matching everything
+    Given a worktree at path "/Users/me/repo/.worktrees/feat-x"
+    And a tmux pane whose foreground process exists but whose cwd is null
+    When tmuxPanes is resolved for that worktree
+    Then the pane is NOT included in tmuxPanes
+    And the pane is silently skipped (no error surfaced)
+
+  @unit @issue-511
+  Scenario: A pane whose process resolution fails entirely is silently skipped
+    Given a worktree at path "/Users/me/repo/.worktrees/feat-x"
+    And a tmux pane whose foreground pid is unresolvable by the ps provider
+    When tmuxPanes is resolved for that worktree
+    Then the pane is NOT included in tmuxPanes
+
+  # =======================================================================
+  # AC6 — Federation attribution via pane.window.session.host
+  # =======================================================================
+
+  @integration @issue-511
+  Scenario: Pane attribution uses pane.window.session.host, not the local daemon's host id
+    Given a worktree on host "B" at path "/home/me/repo"
+    And a tmux pane whose pane.window.session.host equals "B" and whose foreground cwd is "/home/me/repo"
+    And the local daemon's host id is "A"
+    When tmuxPanes is resolved for the worktree on host "B"
+    Then the matching pane is included
+    And attribution is read from pane.window.session.host (value "B"), not synthesised from the local daemon's host id
+
+  @integration @issue-511
+  Scenario: Panes from a different host do not match a local-host worktree
+    Given a worktree on host "A" at path "/Users/me/repo"
+    And a tmux pane whose pane.window.session.host equals "B" with cwd "/Users/me/repo"
+    When tmuxPanes is resolved for the worktree on host "A"
+    Then the cross-host pane is NOT included in tmuxPanes for the host "A" worktree
+
+  # =======================================================================
+  # AC7 — Integration test: 4 worktrees × 6 panes resolves correctly
+  # =======================================================================
+
+  @integration @issue-511
+  Scenario: Integration test against fake Tmux + fake PS providers — 4 worktrees, 6 panes resolve correctly
+    Given fake Tmux and fake PS providers wired into the resolver harness
+    And worktree "wt-A" at "/repo/.worktrees/A"
+    And worktree "wt-B" at "/repo/.worktrees/B"
+    And worktree "wt-C" at "/repo/.worktrees/C"
+    And worktree "wt-D" at "/repo/.worktrees/D"
+    And pane "p1" with cwd "/repo/.worktrees/A"
+    And pane "p2" with cwd "/repo/.worktrees/A/sub"
+    And pane "p3" with cwd "/repo/.worktrees/B"
+    And pane "p4" with cwd "/elsewhere"
+    And pane "p5" with cwd "/repo"
+    And pane "p6" with cwd null
+    When the GraphQL dashboard query selects { worktrees { id tmuxPanes { paneId } tmuxSession { name } } }
+    Then "wt-A".tmuxPanes equals ["p1", "p2"] (sorted by paneId)
+    And "wt-B".tmuxPanes equals ["p3"]
+    And "wt-C".tmuxPanes equals []
+    And "wt-D".tmuxPanes equals []
+    And "wt-A".tmuxSession equals the session of the most-recently-active of p1/p2
+    And "wt-C".tmuxSession equals null
+    And the test fails against a placeholder resolver that returns []/null and passes against the real one
+
+  # =======================================================================
+  # AC8 — Schema doc strings name this issue and the cwd-match semantics
+  # =======================================================================
+
+  @unit @issue-511
+  Scenario: tmuxPanes schema doc string documents cwd-match semantics and references this issue
+    Given the Worktree.tmuxPanes field in the generated schema
+    When its description is inspected
+    Then the description states the match rule "exact OR `path + '/'` prefix"
+    And the description references issue #511
+
+  @unit @issue-511
+  Scenario: tmuxSession schema doc string documents the most-recently-active selection and references this issue
+    Given the Worktree.tmuxSession field in the generated schema
+    When its description is inspected
+    Then the description states the field is the most-recently-active session among tmuxPanes
+    And the description references issue #511
+
+  # =======================================================================
+  # E2E — full dashboard query against the live daemon
+  # =======================================================================
+
+  @e2e @issue-511
+  Scenario: Live daemon returns tmuxPanes and tmuxSession for a worktree with a real shell sitting in it
+    Given the daemon is running with at least one worktree at path "$WT"
+    And a real tmux session has a pane whose foreground shell cwd is "$WT"
+    When a GraphQL query selects { projects { worktrees { id path tmuxPanes { paneId window { session { name } } } tmuxSession { name lastActivityAt } } } }
+    Then the worktree at "$WT" has a non-empty tmuxPanes list
+    And tmuxSession is non-null and matches the live session's name
+    And a worktree with no shell sitting in it returns "tmuxPanes: []" and "tmuxSession: null"
+
+  # --- AC Coverage Map ---
+  # AC1: "tmuxPanes returns the matching pane list for every worktree, derived from cwd-equality / prefix match against the worktree path"
+  #   -> @integration "tmuxPanes returns panes whose cwd exactly equals the worktree path"
+  #   -> @integration "tmuxPanes returns panes whose cwd sits under the worktree path"
+  #   -> @unit "tmuxPanes excludes panes whose cwd is a sibling of the worktree path (no false-prefix match)"
+  #   -> @unit "tmuxPanes returns panes ordered deterministically by paneId ascending"
+  #   -> @integration "tmuxPanes is non-nullable in the schema"
+  #   -> @e2e  "Live daemon returns tmuxPanes and tmuxSession for a worktree with a real shell sitting in it"
+  #
+  # AC2: "tmuxSession returns the most-recently-active matching session, or null when no panes match"
+  #   -> @integration "tmuxSession returns the unique session of the single matching pane"
+  #   -> @integration "tmuxSession field is nullable in the schema"
+  #   -> @e2e  "Live daemon returns tmuxPanes and tmuxSession for a worktree with a real shell sitting in it"
+  #
+  # AC3: "When two panes from different sessions both sit under a worktree path, tmuxSession returns the session with the higher lastActivityAt; tie-broken deterministically by session name lex order"
+  #   -> @unit "tmuxSession picks the session with the higher lastActivityAt when two sessions match"
+  #   -> @unit "tmuxSession ties on lastActivityAt are broken by session name lex order ascending"
+  #
+  # AC4: "A worktree with no tmux activity returns tmuxPanes: [] and tmuxSession: null"
+  #   -> @unit "Worktree with no matching panes returns empty tmuxPanes and null tmuxSession"
+  #   -> @e2e  "Live daemon returns tmuxPanes and tmuxSession for a worktree with a real shell sitting in it"
+  #
+  # AC5: "A pane whose process.cwd is null is silently skipped, NOT treated as matching everything"
+  #   -> @unit "A pane whose process.cwd is null is not treated as matching everything"
+  #   -> @unit "A pane whose process resolution fails entirely is silently skipped"
+  #
+  # AC6: "Federated case: a worktree on host B with a pane on host B attaches via this field; attribution uses pane.window.session.host, not the local daemon's host id"
+  #   -> @integration "Pane attribution uses pane.window.session.host, not the local daemon's host id"
+  #   -> @integration "Panes from a different host do not match a local-host worktree"
+  #
+  # AC7: "Integration test against fake Tmux + fake PS providers: 4 worktrees, 6 panes — all 4 worktrees resolve correctly; test fails on placeholder, passes on real resolver"
+  #   -> @integration "Integration test against fake Tmux + fake PS providers — 4 worktrees, 6 panes resolve correctly"
+  #
+  # AC8: "Schema doc on both fields names this issue and documents the cwd-match semantics (exact OR `path + '/'` prefix)"
+  #   -> @unit "tmuxPanes schema doc string documents cwd-match semantics and references this issue"
+  #   -> @unit "tmuxSession schema doc string documents the most-recently-active selection and references this issue"


### PR DESCRIPTION
## Why

Closes #511.

The Orchard GUI wants to attach a live xterm.js terminal to whichever tmux pane is currently sitting in a selected worktree. Today the only way to know "which session" is either name-matching against tmux session names (brittle — fails for `feat/chat-final` whose conventional session name is `chat-final` under a parent like `orchard-gui-convo`) or a three-query client-side join of `tmuxPanes { currentPid }` × `Host.processes(filter: { commandIn: [...] })` which depends on maintaining a list of "interesting" foreground commands. Both are wrong: the daemon already has both halves of the join.

This PR puts the join on the server and exposes it as two first-class fields on `Worktree`:

- `tmuxPanes: [TmuxPane!]!` — every pane on the worktree's host whose foreground process cwd equals `worktree.path` or sits under `worktree.path + "/"`.
- `tmuxSession: TmuxSession` — sugar for the dashboard's primary case, returning the most-recently-active session among matching panes.

## What changed

- New GraphQL fields on `Worktree` (in both `schema.graphql` and `internal/server/resolvers/schema.graphql` so the embedded copy and the source-of-truth stay aligned). gqlgen regenerates `models_gen.go` + `generated.go`.
- New resolver file `internal/server/resolvers/worktree_tmux.go` keeps `schema.resolvers.go` lean. Implements `TmuxPanes` with a per-request match helper that:
  - Reads `obj.Host` to scope the pane enumeration.
  - Iterates the tmux snapshot and skips panes whose `pane.Key.Host` differs from the worktree's host (federation attribution: never the local-daemon constant).
  - Resolves cwd via the existing PS provider's `LoadCwd` path that #463 wired up — same code path, no new providers.
  - Skips panes whose cwd resolves null/empty (AC5 — honest empty result, not match-all).
  - Applies the cwd-match rule: `cwd == path || strings.HasPrefix(cwd, path + "/")`. The trailing slash is load-bearing — `/Users/me/repo/.worktrees/feat-x` must NOT match `/Users/me/repo/.worktrees/feat-xtra`.
  - Sorts by paneId ascending for deterministic output.
- `TmuxSession` resolver is stubbed to `nil, nil` for now; field exists so gqlgen wires the method signature once. Resolver body lands in the next commit alongside AC2/AC3/AC4.
- `cwdMatchesWorktree` extracted as a pure helper — easy to unit-test cross-platform (the integration tests are darwin-only because `ps.PsAdapter.FetchCwds` has a `runtime.GOOS != "darwin"` guard until Linux `/proc/<pid>/cwd` reading lands).
- Feature file `specs/features/daemon-worktree-tmuxsession-worktree.feature` documents the 18 scenarios across all 8 ACs. This PR delivers the AC1 + AC8-doc-string scenarios.

## Test plan

`internal/server/resolvers/worktree_tmux_test.go`:

- `TestTmuxPanesResolver_ExactCwdMatch` (line 25 scenario, darwin integration) — pane cwd == worktree.path → included.
- `TestTmuxPanesResolver_CwdUnderPath` (line 32, darwin integration) — pane cwd is `path + "/internal/server"` → included.
- `TestCwdMatchesWorktree_SiblingExcluded` (line 39, pure unit cross-platform) — `path + "extra"` does NOT match. The boundary case the prefix-match rule exists for.
- `TestTmuxPanesResolver_SortedByPaneId` (line 47, darwin integration) — three panes `%5`, `%2`, `%9` → returned slice is `[%2, %5, %9]`.
- `TestWorktreeTmuxPanes_SchemaIsNonNullable` (line 53, schema SDL check, cross-platform) — `tmuxPanes: [TmuxPane!]!` is present in the embedded SDL.

Verified locally:
- `go build ./...` clean.
- `go test ./internal/server/resolvers/...` all green, including the five new tests above.

## Anything surprising?

- This PR is the first slice of #511's 18 scenarios. Subsequent commits (still on this branch, before flipping the PR ready-for-review) will deliver AC2–AC7 and the live-daemon e2e check.
- During codegen we hit a transient gqlgen corruption where the schema doc-string content was emitted as Go source into `schema.resolvers.go`; recovered with `git checkout HEAD -- ...` and the new methods landed cleanly in their own file (`worktree_tmux.go`) so gqlgen never tried to re-touch the resolver file. Worth flagging if anyone else runs `go generate` on a fresh branch — the resolver-file-per-concern split sidesteps the problem.
- AC5's "Linux without `/proc` cwd reader" path isn't covered by an integration test yet because the PS adapter explicitly returns empty cwds on non-darwin; the pure helper test plus the resolver's null-cwd guard cover the logic, but a real Linux integration test should land alongside the eventual `/proc/<pid>/cwd` reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #511

# Related issue

- #511

# Related issue

- #511

# Related issue

- #511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `tmuxPanes` and `tmuxSession` fields to Worktree queries. The `tmuxPanes` field returns a deterministically ordered list of tmux panes, while `tmuxSession` returns the most recently active session among matching panes, with lexicographic ordering as a tie-breaker.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/516)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #511

# Related issue

- #511