### PR TITLE
fix(tmux): adapter populates Client.CurrentWindow / CurrentPane

### DIFF
--- a/internal/server/providers/tmux/adapter.go
+++ b/internal/server/providers/tmux/adapter.go
@@ -524,6 +524,14 @@ func (a *Adapter) listAll(ctx context.Context) (
 	return sessions, windows, panes, nil
 }
 
+// In `list-clients -F` context, the per-client format vars
+// `#{client_window_index}` and `#{client_active_pane}` are silently
+// empty in current tmux releases. The format engine instead resolves
+// the *unprefixed* `#{window_index}` and `#{pane_id}` against the
+// client's currently-attached pane — which is exactly what we want.
+// Verified empirically against tmux 3.5+ on macOS: a client attached
+// to a different window/pane shows that window/pane via the
+// unprefixed vars, while the client_* vars stay empty.
 const clientFormat = "" +
 	"#{client_name}" + fieldSep +
 	"#{client_session}" + fieldSep +
@@ -532,8 +540,8 @@ const clientFormat = "" +
 	"#{client_created}" + fieldSep +
 	"#{client_activity}" + fieldSep +
 	"#{client_readonly}" + fieldSep +
-	"#{client_window_index}" + fieldSep +
-	"#{client_active_pane}"
+	"#{window_index}" + fieldSep +
+	"#{pane_id}"
 
 func (a *Adapter) listClients(ctx context.Context) (map[ClientKey]Client, error) {
 	out, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("list-clients", "-F", clientFormat)...)


### PR DESCRIPTION
## Summary

`TmuxClient.currentPane` and `TmuxClient.currentWindow` were exposed in the schema but resolved to `null` for every client. Root cause: in `tmux list-clients -F` context, the per-client format vars `#{client_window_index}` and `#{client_active_pane}` are silently empty in current tmux releases. Switching to the unprefixed `#{window_index}` and `#{pane_id}` resolves them against the client's currently-attached pane.

Repro before:
```
curl -s -X POST http://127.0.0.1:7777/graphql -H 'Content-Type: application/json' \
  --data '{"query":"{ tmuxServer { clients { tty currentPane { paneId } } } }"}'
```
→ all entries `currentPane: null`.

After this fix the same query returns the actual pane each client is attached to.

## Why we want it

Unblocks the orchard-gui sidebar's "you are here" tracking — the GUI can now flag the worktree whose pane the user is currently watching, and react when the user switches windows in tmux directly. Without it, the GUI has no signal of where the user actually is.

## Verification

Manual: `tmux list-clients -F "tty=#{client_tty} pane=#{pane_id}"` shows different panes per client (e.g. one on `%57` in `git-orchard-rs`, one on `%16` in `voice`); the daemon now reports the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tmux window and pane detection to work correctly with current tmux releases (3.5+). The adapter now properly identifies the attached window and pane, resolving issues with inaccurate tracking.

* **Documentation**
  * Added clarifying comments documenting observed tmux behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/520)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->