### PR TITLE
refactor(daemon): #511 follow-up — federation correctness + review cleanup

### DIFF
--- a/internal/server/resolvers/node.resolvers.go
+++ b/internal/server/resolvers/node.resolvers.go
@@ -531,16 +531,11 @@ func splitGHNodeID(id, prefix string) (owner, name string, number int, ok bool) 
 	return repo[:slashIdx], repo[slashIdx+1:], n, true
 }
 
-// worktreeNodeValue mirrors `toGraphQLWorktree` in schema.resolvers.go.
-// Kept here so node.resolvers.go is self-contained.
+// worktreeNodeValue delegates to `toGraphQLWorktree` so all Worktree
+// projection happens in one place. Federation work (Workstream F) only
+// needs to update toGraphQLWorktree to populate Host from a real source.
 func worktreeNodeValue(w gitprovider.Worktree) *graphql1.Worktree {
-	return &graphql1.Worktree{
-		ID:     string(w.ID),
-		Path:   w.Path,
-		Branch: w.Branch,
-		Head:   w.Head,
-		Bare:   w.Bare,
-	}
+	return toGraphQLWorktree(w)
 }
 
 // _ keeps imports stable when not all helpers are referenced (build-time

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -1020,10 +1020,14 @@ func (r *tmuxWindowResolver) CurrentPane(ctx context.Context, obj *graphql1.Tmux
 }
 
 // Host is the resolver for the host field.
-// v1 sentinel: all locally-discovered worktrees report "local".
-// Workstream F populates per-peer hostnames in a later iteration.
+// Reads obj.Host — set by toGraphQLWorktree (single source of truth).
+// Falls back to "local" defensively when obj.Host is empty so the
+// v1 sentinel is preserved without encoding it in two places.
 func (r *worktreeResolver) Host(ctx context.Context, obj *graphql1.Worktree) (string, error) {
-	return "local", nil
+	if obj.Host == "" {
+		return "local", nil
+	}
+	return obj.Host, nil
 }
 
 // Repo is the resolver for the repo field.
@@ -1384,12 +1388,11 @@ func stripContractIDPrefix(id string) string {
 	return id
 }
 func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
-	// Host defaults to "local" so that sibling resolvers (TmuxPanes,
-	// TmuxSession) that compare obj.Host against pane.Key.Host see the
-	// correct value when the worktree is locally discovered.
-	// Workstream F will populate this from the remote host id once
-	// federated discovery lands; for now the host resolver also returns
-	// "local" unconditionally. (#511)
+	// Host is the single source of truth for the worktree's host sentinel.
+	// "local" is the v1 sentinel for locally-discovered worktrees.
+	// Workstream F will replace this with the actual remote host id once
+	// federated discovery lands. The worktreeResolver.Host field resolver
+	// reads obj.Host (set here) rather than hardcoding "local". (#511)
 	return &graphql1.Worktree{
 		ID:     string(w.ID),
 		Path:   w.Path,

--- a/internal/server/resolvers/worktree_tmux.go
+++ b/internal/server/resolvers/worktree_tmux.go
@@ -29,17 +29,20 @@ func (r *worktreeResolver) TmuxPanes(ctx context.Context, obj *graphql1.Worktree
 	}
 
 	snap := r.Tmux.Snapshot()
-	matching, err := matchPanesForWorktree(ctx, r, snap, obj)
-	if err != nil {
-		return []*graphql1.TmuxPane{}, nil
+	rawPanes := matchPanesForWorktree(ctx, r, snap, obj)
+
+	// Map raw provider panes to GraphQL projection.
+	out := make([]*graphql1.TmuxPane, len(rawPanes))
+	for i, p := range rawPanes {
+		out[i] = projectPane(p)
 	}
 
 	// Sort by paneId ascending so output is deterministic.
-	sort.Slice(matching, func(i, j int) bool {
-		return matching[i].PaneID < matching[j].PaneID
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].PaneID < out[j].PaneID
 	})
 
-	return matching, nil
+	return out, nil
 }
 
 // TmuxSession resolves Worktree.tmuxSession (#511): returns the
@@ -52,38 +55,29 @@ func (r *worktreeResolver) TmuxSession(ctx context.Context, obj *graphql1.Worktr
 	}
 
 	snap := r.Tmux.Snapshot()
-	matching, err := matchPanesForWorktree(ctx, r, snap, obj)
-	if err != nil || len(matching) == 0 {
+	matching := matchPanesForWorktree(ctx, r, snap, obj)
+	if len(matching) == 0 {
 		return nil, nil
 	}
 
 	// Collect the unique sessions that the matching panes belong to.
-	// Use SessionKey (host+name) for dedup; store the raw Session value
-	// so we can order by LastActivityAt.
+	// Raw panes carry WindowKey.Session directly — no need to re-key
+	// into snap.Panes, eliminating snapshot-drift and silent-drop risk.
 	seen := make(map[tmux.SessionKey]tmux.Session)
 	for _, pane := range matching {
-		// Reconstruct the raw Pane to access WindowKey.Session — we need
-		// the provider's internal Session value (which carries LastActivityAt
-		// as a time.Time). The matching []*graphql1.TmuxPane only has the
-		// projected PaneID; we look the full Pane back up from the snapshot.
-		paneKey := tmux.PaneKey{Host: tmux.HostID(obj.Host), PaneID: pane.PaneID}
-		rawPane, ok := snap.Panes[paneKey]
-		if !ok {
-			continue
-		}
-		sessionKey := tmux.SessionKey{Host: rawPane.Key.Host, Name: rawPane.WindowKey.Session}
+		sessionKey := tmux.SessionKey{Host: pane.Key.Host, Name: pane.WindowKey.Session}
 		if _, already := seen[sessionKey]; already {
 			continue
 		}
 		// Look up the Session to get its LastActivityAt.
-		if s, ok := snap.Sessions[sessionKey]; ok {
-			seen[sessionKey] = s
-		} else {
-			// Session row missing from snapshot — still include it so we
-			// don't silently drop a pane that genuinely sits in this session;
-			// synthesise a zero-activity Session.
-			seen[sessionKey] = tmux.Session{Key: sessionKey}
+		s, ok := snap.Sessions[sessionKey]
+		if !ok {
+			// Snapshot inconsistency: pane references a session that is absent
+			// from snap.Sessions. Skip rather than synthesise a zero-activity
+			// placeholder — the missing session is not a valid candidate.
+			continue
 		}
+		seen[sessionKey] = s
 	}
 
 	if len(seen) == 0 {
@@ -121,10 +115,12 @@ func (r *worktreeResolver) TmuxSession(ctx context.Context, obj *graphql1.Worktr
 //  2. Has a CurrentPid that the ps provider can resolve to a cwd.
 //  3. Has a cwd that equals obj.Path exactly OR starts with obj.Path+"/".
 //
-// Panes whose cwd cannot be resolved are silently skipped. The returned
-// slice is unsorted; callers sort by paneId.
-func matchPanesForWorktree(ctx context.Context, r *worktreeResolver, snap tmux.RuntimeSnapshot, obj *graphql1.Worktree) ([]*graphql1.TmuxPane, error) {
-	var matching []*graphql1.TmuxPane
+// Returns raw tmux.Pane values so callers can read provider-level fields
+// (e.g. WindowKey.Session for session lookup) without re-keying into the
+// snapshot. Panes whose cwd cannot be resolved are silently skipped. The
+// returned slice is unsorted; callers sort by paneId. Never returns nil.
+func matchPanesForWorktree(ctx context.Context, r *worktreeResolver, snap tmux.RuntimeSnapshot, obj *graphql1.Worktree) []tmux.Pane {
+	var matching []tmux.Pane
 
 	for _, pane := range snap.Panes {
 		// Federation attribution: use pane.Key.Host (which tracks through
@@ -156,13 +152,13 @@ func matchPanesForWorktree(ctx context.Context, r *worktreeResolver, snap tmux.R
 			continue
 		}
 
-		matching = append(matching, projectPane(pane))
+		matching = append(matching, pane)
 	}
 
 	if matching == nil {
-		return []*graphql1.TmuxPane{}, nil
+		return []tmux.Pane{}
 	}
-	return matching, nil
+	return matching
 }
 
 // cwdMatchesWorktree returns true when cwd equals path exactly or is


### PR DESCRIPTION
## Why

PR #516 (closes #511) was squash-merged at branch SHA `0317d3b`, which landed the feature ACs but left two review-feedback commits stranded on the branch. This follow-up PR brings those commits onto main.

Both fixes were caught during the post-merge review pass on #516. Neither was strictly load-bearing for the v1 schema sentinel (`host: "local"`), but both are real improvements that federation work (Workstream F) will rely on:

1. The first commit eliminates a snapshot-drift class between `Worktree.tmuxPanes` and `Worktree.tmuxSession`, drops a silent error swallow, and stops synthesising zero-activity Sessions to mask snapshot inconsistencies.
2. The second commit makes `worktreeNodeValue` delegate to `toGraphQLWorktree` so federation has one site to update instead of two.

## What changed

### Commit 1 — `refactor(daemon): address review concerns on Worktree.tmux* resolvers`

Four targeted fixes from the PR #516 review:

- **`matchPanesForWorktree` now returns `[]tmux.Pane`** (raw provider type) instead of projected `[]*graphql1.TmuxPane`. `TmuxPanes` maps once at the call site; `TmuxSession` reads `pane.WindowKey.Session` directly without re-keying into `snap.Panes`. Eliminates the snapshot-drift risk (two `Snapshot()` calls deriving inconsistent results) and the silent-drop branch.
- **Helper no longer returns `error`.** Had no error path, so the call sites' silent error swallow was a landmine. Signature simplified.
- **`TmuxSession` no longer synthesises a zero-activity Session** when `snap.Sessions[sessionKey]` is missing. That state is a snapshot inconsistency, not a normal case — skip the pane rather than paper over the bug.
- **`worktreeResolver.Host` now reads `obj.Host`** (with a `"local"` fallback for safety) instead of hardcoding `"local"`. `toGraphQLWorktree` is now the single source of truth for the v1 sentinel.

### Commit 2 — `refactor(daemon): worktreeNodeValue delegates to toGraphQLWorktree`

Reviewer caught that the prior commit's "single source of truth" claim was incomplete: `worktreeNodeValue` (the Node-interface projection in `node.resolvers.go`) was a parallel construction site that did not set `Host`. It worked today thanks to the resolver's defensive `"" → "local"` fallback, but Workstream F populating `Host: <real-host>` in `toGraphQLWorktree` only would have left Node-resolved worktrees mis-attributed to `"local"`.

Fix: `worktreeNodeValue` now delegates to `toGraphQLWorktree`. Federation has one site to update.

## Test plan

- `go build ./...` — clean
- `go test ./internal/server/resolvers/...` — green on Linux CI
- The resolver behaviour is unchanged for the v1 sentinel case (verified by the existing test suite in #516 / #522)
- The 17 #511 tests still pass on darwin where the `lsof` cwd path is wired

## Anything surprising?

- One review concern from #516 was **not** addressed in this PR: adding a test for "pane references absent session → skipped, not synthesised." Exercising that path requires constructing a tmux adapter snapshot with asymmetric session/pane parsing, which isn't directly buildable through the existing test fixtures. The contract is documented in the resolver code; a contract test belongs in the `providers/tmux` package alongside the snapshot construction logic.
- These commits originally lived on a branch that was rebased after #522 (the paneRow rename) merged. The rebase was clean — only `worktree_tmux.go`, `schema.resolvers.go`, and `node.resolvers.go` are touched.

## Links

- Closes the post-merge feedback loop on #516
- Related: #521 / #522 (paneRow rename — already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worktree host field now returns the actual host value instead of always displaying "local"
  
* **Improvements**
  * Enhanced tmux pane and session matching logic
  * Worktree-to-tmux session selection now prioritizes most-recently-active sessions
  * Improved handling for missing or invalid tmux session references

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/523)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #511

# Related issue

- #511