### PR TITLE
fix(daemon): wire ClaudeInstance.lastActivityAt from jsonl tail

### DIFF
--- a/internal/server/providers/claudeinstance/adapter.go
+++ b/internal/server/providers/claudeinstance/adapter.go
@@ -132,6 +132,9 @@ type rawHeartbeat struct {
 	// script style while camelCase matches the ADR-011 forward-compatible shape.
 	LastActivity      string `json:"last_activity,omitempty"`
 	LastActivityCamel string `json:"lastActivity,omitempty"`
+	// cwd — working directory the Claude process was launched from. Used
+	// together with session_id to locate the session's transcript jsonl.
+	Cwd string `json:"cwd,omitempty"`
 }
 
 // parseFile reads and decodes one heartbeat file. Returns (Heartbeat,
@@ -153,6 +156,7 @@ func parseFile(path string) (Heartbeat, bool) {
 		State:       raw.State,
 		ClaudePid:   firstNonZero(raw.ClaudePid, raw.ClaudePidSnake),
 		RcURL:       firstNonEmpty(raw.RcURL, raw.RcURLSnake),
+		Cwd:         raw.Cwd,
 	}
 	if raw.RcEnabled != nil {
 		hb.RcEnabled = *raw.RcEnabled

--- a/internal/server/providers/claudeinstance/composer.go
+++ b/internal/server/providers/claudeinstance/composer.go
@@ -86,28 +86,35 @@ type Composer struct {
 	procs     ProcessFinder
 	accounts  AccountFinder
 	liveness  LivenessChecker
+	jsonl     JsonlReader
 	clock     func() time.Time
 	staleAfter time.Duration
 }
 
 // NewComposer constructs a Composer with the production
-// LivenessChecker and wall clock. Pass nil for any sibling that has not
-// yet shipped a real provider — v1 leaves those edges null and the
-// composer behaves as if no match was found.
+// LivenessChecker, JsonlReader, and wall clock. Pass nil for any sibling
+// that has not yet shipped a real provider — v1 leaves those edges null
+// and the composer behaves as if no match was found.
 func NewComposer(hostID string, panes PaneFinder, procs ProcessFinder, accounts AccountFinder) *Composer {
-	return NewComposerWith(hostID, panes, procs, accounts, OSLivenessChecker{}, time.Now, HeartbeatStaleAfter)
+	return NewComposerWith(hostID, panes, procs, accounts, OSLivenessChecker{}, NewFsJsonlReader(""), time.Now, HeartbeatStaleAfter)
 }
 
 // NewComposerWith is the test-friendly constructor — accepts injected
-// liveness checker, clock, and stale-after duration. Production wires
-// time.Now and HeartbeatStaleAfter; tests can shrink the window so
-// staleness assertions converge in milliseconds.
+// liveness checker, jsonl reader, clock, and stale-after duration.
+// Production wires OSLivenessChecker, FsJsonlReader, time.Now, and
+// HeartbeatStaleAfter; tests can shrink the window so staleness assertions
+// converge in milliseconds and pass a fixture jsonl reader.
+//
+// The jsonl reader may be nil — the composer falls back to the
+// heartbeat's last_activity field (and from there to the pane's
+// session-level lastActivityAt) when no reader is wired.
 func NewComposerWith(
 	hostID string,
 	panes PaneFinder,
 	procs ProcessFinder,
 	accounts AccountFinder,
 	liveness LivenessChecker,
+	jsonl JsonlReader,
 	clock func() time.Time,
 	staleAfter time.Duration,
 ) *Composer {
@@ -126,6 +133,7 @@ func NewComposerWith(
 		procs:      procs,
 		accounts:   accounts,
 		liveness:   liveness,
+		jsonl:      jsonl,
 		clock:      clock,
 		staleAfter: staleAfter,
 	}
@@ -178,27 +186,34 @@ func (c *Composer) composeOne(ctx context.Context, hb Heartbeat) *graphql.Claude
 		v := hb.Timestamp.UTC().Format(time.RFC3339Nano)
 		inst.StartedAt = &v
 	}
-	if !hb.LastActivity.IsZero() {
-		// Primary source: heartbeat's last_activity field.
-		// Preserve sub-second precision from the original value by using
-		// RFC3339Nano. When the source had no nanoseconds, RFC3339Nano
-		// still produces a valid RFC3339 string (trailing zeros are
-		// stripped by Go's time formatter).
-		v := hb.LastActivity.UTC().Format(time.RFC3339Nano)
-		inst.LastActivityAt = &v
-	} else {
-		// Fallback (option a): read pane.Window.Session.LastActivityAt.
-		// TmuxPane has no lastActivityAt field of its own; the session-level
-		// timestamp is the same conceptual recency for the user's purposes
-		// ("when was this claude instance last touched"). Option (b) — adding
-		// TmuxPane.lastActivityAt as a new schema field — can be layered on
-		// top later when pane-level granularity is needed, without breaking
-		// this fallback.
-		if pane != nil && pane.Window != nil && pane.Window.Session != nil &&
-			pane.Window.Session.LastActivityAt != nil {
-			v := *pane.Window.Session.LastActivityAt
+	// Resolve LastActivityAt in priority order:
+	//
+	//  1. Jsonl tail — the timestamp on the last line of the session's
+	//     transcript. Authoritative because claude appends on every step,
+	//     unlike the hook which only fires on lifecycle events. Used when
+	//     both the cwd and session uuid are known.
+	//  2. Heartbeat last_activity — the hook's recorded activity timestamp.
+	//     Today's hook does not write this field, so this branch only
+	//     fires for forward-compatible heartbeats; preserved as a layer in
+	//     case the hook starts emitting it.
+	//  3. Pane session fallback — the tmux session's lastActivityAt, used
+	//     when nothing more specific is available. Coarse but better than
+	//     null for the GUI's "needs attention" lens.
+	if c.jsonl != nil && hb.Cwd != "" && hb.SessionID != "" {
+		if t, ok := c.jsonl.LastActivityAt(ctx, hb.Cwd, hb.SessionID); ok {
+			v := t.UTC().Format(time.RFC3339Nano)
 			inst.LastActivityAt = &v
 		}
+	}
+	if inst.LastActivityAt == nil && !hb.LastActivity.IsZero() {
+		v := hb.LastActivity.UTC().Format(time.RFC3339Nano)
+		inst.LastActivityAt = &v
+	}
+	if inst.LastActivityAt == nil &&
+		pane != nil && pane.Window != nil && pane.Window.Session != nil &&
+		pane.Window.Session.LastActivityAt != nil {
+		v := *pane.Window.Session.LastActivityAt
+		inst.LastActivityAt = &v
 	}
 	return inst
 }

--- a/internal/server/providers/claudeinstance/composer_jsonl_test.go
+++ b/internal/server/providers/claudeinstance/composer_jsonl_test.go
@@ -1,0 +1,208 @@
+package claudeinstance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+// fakeJsonlReader is the test stub for JsonlReader. Configure either
+// `at` (returned for any matching cwd+sessionID) or `byKey` (per-key
+// override). Returns (zero, false) when neither matches, mirroring the
+// production reader's contract on miss.
+type fakeJsonlReader struct {
+	at    time.Time
+	ok    bool
+	byKey map[string]time.Time
+}
+
+func (f *fakeJsonlReader) LastActivityAt(_ context.Context, cwd, sessionID string) (time.Time, bool) {
+	if f.byKey != nil {
+		if t, ok := f.byKey[cwd+"|"+sessionID]; ok {
+			return t, true
+		}
+		return time.Time{}, false
+	}
+	return f.at, f.ok
+}
+
+// TestComposer_LastActivityAt_PrefersJsonlOverHeartbeat pins the
+// priority order set in composeOne: when both the jsonl reader and the
+// heartbeat have a value, the jsonl wins. The hook's last_activity
+// becomes a fallback layer behind the jsonl.
+//
+// This is the load-bearing assertion for the lastActiveAt field — the
+// jsonl tail is appended to on every assistant/user/system step, so it
+// is more recent and more precise than the hook's lifecycle-only
+// last_activity.
+func TestComposer_LastActivityAt_PrefersJsonlOverHeartbeat(t *testing.T) {
+	now := time.Date(2026, 5, 9, 22, 0, 0, 0, time.UTC)
+	heartbeatActivity := now.Add(-5 * time.Minute) // hook last_activity
+	jsonlActivity := now.Add(-15 * time.Second)    // jsonl tail timestamp
+
+	hb := Heartbeat{
+		TmuxSession:     "alpha",
+		SessionID:       "uuid-alpha",
+		State:           "working",
+		ClaudePid:       42100,
+		Cwd:             "/home/user/workspace/foo",
+		Timestamp:       now.Add(-2 * time.Second),
+		LastHeartbeatAt: now.Add(-2 * time.Second),
+		LastActivity:    heartbeatActivity,
+	}
+
+	c := NewComposerWith(
+		"local",
+		nil,
+		nil,
+		nil,
+		fakeLiveness{alive: map[int]bool{42100: true}},
+		&fakeJsonlReader{at: jsonlActivity, ok: true},
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if len(out) != 1 {
+		t.Fatalf("got %d, want 1", len(out))
+	}
+	if out[0].LastActivityAt == nil {
+		t.Fatal("LastActivityAt is nil; want jsonl timestamp")
+	}
+	got, err := time.Parse(time.RFC3339Nano, *out[0].LastActivityAt)
+	if err != nil {
+		t.Fatalf("parse %q: %v", *out[0].LastActivityAt, err)
+	}
+	if !got.Equal(jsonlActivity) {
+		t.Errorf("LastActivityAt = %v, want jsonlActivity %v (heartbeat was %v)",
+			got, jsonlActivity, heartbeatActivity)
+	}
+}
+
+// TestComposer_LastActivityAt_FallsBackToHeartbeatWhenJsonlMisses
+// covers the second tier of the priority chain: jsonl reader returned
+// (zero, false) (file missing, no timestamp on last line, etc.); the
+// composer must fall back to the hook's last_activity rather than
+// jumping all the way to the pane fallback.
+func TestComposer_LastActivityAt_FallsBackToHeartbeatWhenJsonlMisses(t *testing.T) {
+	now := time.Date(2026, 5, 9, 22, 0, 0, 0, time.UTC)
+	heartbeatActivity := now.Add(-30 * time.Second)
+
+	hb := Heartbeat{
+		TmuxSession:     "alpha",
+		SessionID:       "uuid-alpha",
+		State:           "working",
+		ClaudePid:       42100,
+		Cwd:             "/home/user/workspace/foo",
+		Timestamp:       now.Add(-2 * time.Second),
+		LastHeartbeatAt: now.Add(-2 * time.Second),
+		LastActivity:    heartbeatActivity,
+	}
+
+	c := NewComposerWith(
+		"local",
+		nil,
+		nil,
+		nil,
+		fakeLiveness{alive: map[int]bool{42100: true}},
+		&fakeJsonlReader{ok: false}, // jsonl miss
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if out[0].LastActivityAt == nil {
+		t.Fatal("LastActivityAt is nil; want heartbeat fallback")
+	}
+	got, _ := time.Parse(time.RFC3339Nano, *out[0].LastActivityAt)
+	if !got.Equal(heartbeatActivity) {
+		t.Errorf("LastActivityAt = %v, want heartbeatActivity %v", got, heartbeatActivity)
+	}
+}
+
+// TestComposer_LastActivityAt_SkipsJsonlWhenCwdMissing pins the
+// composer's "if hb.Cwd != ''" guard. When the heartbeat predates cwd
+// recording (legacy hook), the jsonl reader is bypassed entirely — its
+// LastActivityAt method is never called. We verify this by configuring
+// the fake to return a value that would be wrong if used.
+func TestComposer_LastActivityAt_SkipsJsonlWhenCwdMissing(t *testing.T) {
+	now := time.Date(2026, 5, 9, 22, 0, 0, 0, time.UTC)
+	heartbeatActivity := now.Add(-30 * time.Second)
+
+	hb := Heartbeat{
+		TmuxSession:     "alpha",
+		SessionID:       "uuid-alpha",
+		State:           "working",
+		ClaudePid:       42100,
+		// Cwd intentionally absent
+		Timestamp:       now.Add(-2 * time.Second),
+		LastHeartbeatAt: now.Add(-2 * time.Second),
+		LastActivity:    heartbeatActivity,
+	}
+
+	wrongTime := now.Add(1 * time.Hour) // would be obviously wrong if surfaced
+	c := NewComposerWith(
+		"local",
+		nil,
+		nil,
+		nil,
+		fakeLiveness{alive: map[int]bool{42100: true}},
+		&fakeJsonlReader{at: wrongTime, ok: true},
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	got, _ := time.Parse(time.RFC3339Nano, *out[0].LastActivityAt)
+	if got.Equal(wrongTime) {
+		t.Error("composer called jsonl reader despite missing Cwd; want skip")
+	}
+	if !got.Equal(heartbeatActivity) {
+		t.Errorf("LastActivityAt = %v, want heartbeat %v", got, heartbeatActivity)
+	}
+}
+
+// TestComposer_LastActivityAt_FallsBackToPaneSession verifies the third
+// tier: with no heartbeat last_activity AND no jsonl hit, the pane's
+// session-level lastActivityAt is the last resort. Coarse but better
+// than null for the GUI.
+func TestComposer_LastActivityAt_FallsBackToPaneSession(t *testing.T) {
+	now := time.Date(2026, 5, 9, 22, 0, 0, 0, time.UTC)
+	hb := Heartbeat{
+		TmuxSession:     "alpha",
+		SessionID:       "uuid-alpha",
+		State:           "working",
+		ClaudePid:       42100,
+		Cwd:             "/home/user/workspace/foo",
+		Timestamp:       now.Add(-2 * time.Second),
+		LastHeartbeatAt: now.Add(-2 * time.Second),
+		// LastActivity intentionally zero
+	}
+
+	const sessionTS = "2026-05-09T21:30:00Z"
+	v := sessionTS
+	pane := &graphql.TmuxPane{
+		ID: "TmuxPane:local:%26",
+		Window: &graphql.TmuxWindow{
+			Session: &graphql.TmuxSession{LastActivityAt: &v},
+		},
+	}
+
+	c := NewComposerWith(
+		"local",
+		&fakePaneFinder{byPid: map[int]*graphql.TmuxPane{42100: pane}},
+		nil,
+		nil,
+		fakeLiveness{alive: map[int]bool{42100: true}},
+		&fakeJsonlReader{ok: false},
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if out[0].LastActivityAt == nil || *out[0].LastActivityAt != sessionTS {
+		t.Errorf("LastActivityAt = %v, want pane session %q", out[0].LastActivityAt, sessionTS)
+	}
+}

--- a/internal/server/providers/claudeinstance/composer_test.go
+++ b/internal/server/providers/claudeinstance/composer_test.go
@@ -88,6 +88,7 @@ func TestComposer_Compose_Working(t *testing.T) {
 		&fakeProcessFinder{byPid: map[int]*graphql.Process{42100: proc}},
 		&fakeAccountFinder{account: acct},
 		fakeLiveness{alive: map[int]bool{42100: true}},
+		nil,
 		func() time.Time { return now },
 		HeartbeatStaleAfter,
 	)
@@ -143,6 +144,7 @@ func TestComposer_Compose_StaleHeartbeat(t *testing.T) {
 		nil,
 		nil,
 		fakeLiveness{alive: map[int]bool{11: true}},
+		nil,
 		func() time.Time { return now },
 		30*time.Second,
 	)
@@ -172,6 +174,7 @@ func TestComposer_Compose_DeadPid(t *testing.T) {
 		nil,
 		nil,
 		fakeLiveness{alive: map[int]bool{99: false}},
+		nil,
 		func() time.Time { return now },
 		30*time.Second,
 	)
@@ -200,6 +203,7 @@ func TestComposer_Compose_NoPaneStillEmits(t *testing.T) {
 		&fakeProcessFinder{},
 		&fakeAccountFinder{},
 		fakeLiveness{alive: map[int]bool{55: true}},
+		nil,
 		func() time.Time { return now },
 		HeartbeatStaleAfter,
 	)
@@ -234,6 +238,7 @@ func TestComposer_Compose_FallbackToSession(t *testing.T) {
 		nil,
 		nil,
 		fakeLiveness{},
+		nil,
 		func() time.Time { return now },
 		HeartbeatStaleAfter,
 	)
@@ -259,7 +264,7 @@ func TestComposer_Compose_UnknownStateStaysNoClaude(t *testing.T) {
 		Timestamp:       now,
 		LastHeartbeatAt: now,
 	}
-	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{7: true}}, func() time.Time { return now }, HeartbeatStaleAfter)
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{7: true}}, nil, func() time.Time { return now }, HeartbeatStaleAfter)
 	out := c.Compose(context.Background(), []Heartbeat{hb})
 	if out[0].State != graphql.InstanceStateNoClaude {
 		t.Errorf("state = %s, want no_claude for unknown state string", out[0].State)

--- a/internal/server/providers/claudeinstance/e2e_test.go
+++ b/internal/server/providers/claudeinstance/e2e_test.go
@@ -115,7 +115,7 @@ func TestClaudeInstance_E2E_TwoFreshInstances(t *testing.T) {
 	}
 	liveness := fakeLiveness{alive: map[int]bool{10042: true, 10099: true}}
 
-	composer := claudeinstance.NewComposerWith("local", panes, procs, accts, liveness, clock, claudeinstance.HeartbeatStaleAfter)
+	composer := claudeinstance.NewComposerWith("local", panes, procs, accts, liveness, nil, clock, claudeinstance.HeartbeatStaleAfter)
 	reader := claudeinstance.NewFileReader(heartbeatDir)
 	provider := claudeinstance.NewWith("local", reader, composer, clock)
 

--- a/internal/server/providers/claudeinstance/jsonl.go
+++ b/internal/server/providers/claudeinstance/jsonl.go
@@ -1,0 +1,158 @@
+package claudeinstance
+
+// jsonl.go — read the last `timestamp` from a Claude session's transcript
+// jsonl. Used as the authoritative source for ClaudeInstance.lastActivityAt
+// when the hook script's `last_activity` field is absent (today's hook does
+// not write it).
+//
+// Why the jsonl: every line claude writes carries an RFC3339 `timestamp`
+// field, and unlike the hook (which fires on lifecycle events only), the
+// jsonl is appended to on every assistant/user/system step. This keeps
+// lastActivityAt precise even for long-lived sessions sitting in `input` or
+// `idle` state where the hook would otherwise go stale.
+//
+// Layout: ~/.claude/projects/<encoded-cwd>/<session_uuid>.jsonl, where
+// encoded-cwd swaps every '/' for '-'. encodeCwd here mirrors that exact
+// transform; nothing else canonicalises the path so the function stays a
+// pure string operation.
+//
+// I/O profile: one os.Open + one bounded reverse-scan per call. We read the
+// last 64 KiB at most so a multi-GB transcript stays cheap; the most recent
+// line is invariably within that tail. No locking is needed — claude opens,
+// appends, closes per write, so any read sees a consistent line boundary.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// JsonlReader reads the most recent activity timestamp from a Claude
+// session's transcript jsonl. The narrow interface lets the composer fall
+// back gracefully when the reader is nil (tests, missing claude home) and
+// keeps test stubs trivial.
+type JsonlReader interface {
+	// LastActivityAt returns the timestamp of the last line in the session's
+	// transcript jsonl. (zero, false) when the file is missing, empty,
+	// unreadable, or the last line has no parseable timestamp. Errors are
+	// silently swallowed — this is a fallback path, not a critical one.
+	LastActivityAt(ctx context.Context, cwd, sessionUUID string) (time.Time, bool)
+}
+
+// FsJsonlReader is the production JsonlReader. Resolves the project root
+// once at construction time (~/.claude/projects by default) and reads tail
+// bytes from each transcript on demand. No caching — the composer caches
+// at the ClaudeInstance level, and a stale tail timestamp is no worse than
+// a stale heartbeat.
+type FsJsonlReader struct {
+	projectsDir string
+}
+
+// NewFsJsonlReader constructs a reader rooted at projectsDir. When empty,
+// it resolves to ~/.claude/projects via os.UserHomeDir. Returns nil when
+// the home directory is unresolvable so the composer's "if reader == nil"
+// guards remain reliable.
+func NewFsJsonlReader(projectsDir string) *FsJsonlReader {
+	if projectsDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		projectsDir = filepath.Join(home, ".claude", "projects")
+	}
+	return &FsJsonlReader{projectsDir: projectsDir}
+}
+
+// LastActivityAt resolves the transcript path from cwd+sessionUUID and
+// returns its last line's timestamp. (zero, false) on any failure.
+func (r *FsJsonlReader) LastActivityAt(ctx context.Context, cwd, sessionUUID string) (time.Time, bool) {
+	if r == nil || cwd == "" || sessionUUID == "" {
+		return time.Time{}, false
+	}
+	if err := ctx.Err(); err != nil {
+		return time.Time{}, false
+	}
+	path := filepath.Join(r.projectsDir, encodeCwd(cwd), sessionUUID+".jsonl")
+	return readLastTimestamp(path)
+}
+
+// encodeCwd applies claude's project-directory naming convention: every
+// '/' in the absolute cwd becomes '-'. Pure string operation; we do NOT
+// resolve symlinks or normalise the path because claude itself does not.
+func encodeCwd(cwd string) string {
+	return strings.ReplaceAll(cwd, "/", "-")
+}
+
+// tailWindow is the maximum number of trailing bytes we read from the
+// jsonl. Claude lines are dominated by tool snapshots that can run into
+// the hundreds of KiB; 64 KiB comfortably covers the most recent line on
+// any sane transcript while keeping per-call I/O O(1).
+const tailWindow = 64 * 1024
+
+// readLastTimestamp opens path, reads up to tailWindow bytes from the end,
+// finds the last newline-delimited line, parses it as JSON, and extracts
+// the `timestamp` field. Returns (zero, false) on any failure path.
+func readLastTimestamp(path string) (time.Time, bool) {
+	f, err := os.Open(path) // #nosec G304 — path is composed from inputs we already trust.
+	if err != nil {
+		return time.Time{}, false
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return time.Time{}, false
+	}
+	size := info.Size()
+	if size == 0 {
+		return time.Time{}, false
+	}
+
+	readFrom := int64(0)
+	if size > tailWindow {
+		readFrom = size - tailWindow
+	}
+	if _, err := f.Seek(readFrom, io.SeekStart); err != nil {
+		return time.Time{}, false
+	}
+
+	buf, err := io.ReadAll(f)
+	if err != nil && !errors.Is(err, fs.ErrClosed) {
+		return time.Time{}, false
+	}
+
+	// Trim a trailing newline if present so LastIndexByte finds the
+	// separator BEFORE the final line, not the one after it.
+	buf = bytes.TrimRight(buf, "\n")
+	if len(buf) == 0 {
+		return time.Time{}, false
+	}
+
+	if idx := bytes.LastIndexByte(buf, '\n'); idx >= 0 {
+		buf = buf[idx+1:]
+	}
+
+	var line struct {
+		Timestamp string `json:"timestamp"`
+	}
+	if err := json.Unmarshal(buf, &line); err != nil {
+		return time.Time{}, false
+	}
+	if line.Timestamp == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339Nano, line.Timestamp); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.RFC3339, line.Timestamp); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}

--- a/internal/server/providers/claudeinstance/jsonl_test.go
+++ b/internal/server/providers/claudeinstance/jsonl_test.go
@@ -1,0 +1,217 @@
+package claudeinstance
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEncodeCwd_SwapsSlashes locks in claude's project-directory naming
+// transform: every '/' becomes '-'. This is the only canonicalisation —
+// no symlink resolution, no normalization. Pure string replacement.
+func TestEncodeCwd_SwapsSlashes(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/home/user/workspace/git-orchard-rs", "-home-user-workspace-git-orchard-rs"},
+		{"/", "-"},
+		{"", ""},
+		{"/foo", "-foo"},
+		{"/home/user/.claude/projects", "-home-user-.claude-projects"},
+	}
+	for _, c := range cases {
+		if got := encodeCwd(c.in); got != c.want {
+			t.Errorf("encodeCwd(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestFsJsonlReader_LastActivityAt_ReturnsTimestampFromLastLine verifies
+// the happy path: a transcript jsonl with several lines, each carrying a
+// `timestamp` field, returns the last line's timestamp.
+func TestFsJsonlReader_LastActivityAt_ReturnsTimestampFromLastLine(t *testing.T) {
+	const cwd = "/home/user/workspace/foo"
+	const sessionID = "11111111-2222-3333-4444-555555555555"
+	const lastTS = "2026-05-09T22:33:44.567Z"
+
+	dir := makeJsonlFixture(t, cwd, sessionID,
+		`{"type":"user","timestamp":"2026-05-09T22:33:40Z"}`,
+		`{"type":"assistant","timestamp":"2026-05-09T22:33:42Z"}`,
+		`{"type":"assistant","timestamp":"`+lastTS+`"}`,
+	)
+
+	r := NewFsJsonlReader(dir)
+	got, ok := r.LastActivityAt(context.Background(), cwd, sessionID)
+	if !ok {
+		t.Fatal("LastActivityAt returned ok=false; want true")
+	}
+	want, _ := time.Parse(time.RFC3339Nano, lastTS)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestFsJsonlReader_LastActivityAt_HandlesTrailingNewline verifies the
+// reader does not mistake a trailing '\n' for an empty last line.
+func TestFsJsonlReader_LastActivityAt_HandlesTrailingNewline(t *testing.T) {
+	const cwd = "/home/user/workspace/foo"
+	const sessionID = "trailing-newline"
+	const lastTS = "2026-05-09T22:33:44Z"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, encodeCwd(cwd))
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	body := `{"type":"user","timestamp":"2026-05-09T22:33:40Z"}` + "\n" +
+		`{"type":"assistant","timestamp":"` + lastTS + `"}` + "\n"
+	if err := os.WriteFile(filepath.Join(path, sessionID+".jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	r := NewFsJsonlReader(dir)
+	got, ok := r.LastActivityAt(context.Background(), cwd, sessionID)
+	if !ok {
+		t.Fatal("LastActivityAt returned ok=false; want true")
+	}
+	want, _ := time.Parse(time.RFC3339, lastTS)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestFsJsonlReader_LastActivityAt_TailWindowSurvivesGiantTranscript
+// verifies the bounded-tail read works when the transcript is larger
+// than tailWindow. We synthesise a >tailWindow file whose last line
+// carries the answer; the reader must seek-to-end and find it.
+func TestFsJsonlReader_LastActivityAt_TailWindowSurvivesGiantTranscript(t *testing.T) {
+	const cwd = "/home/user/workspace/foo"
+	const sessionID = "giant"
+	const lastTS = "2026-05-09T22:33:44Z"
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, encodeCwd(cwd))
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// Build a transcript whose first line is a 100 KiB blob (well
+	// past tailWindow), followed by the line we actually care about.
+	// readLastTimestamp must not be deceived by the giant prefix — it
+	// only reads the last tailWindow bytes.
+	bigPrefix := strings.Repeat("x", 100*1024)
+	body := `{"type":"junk","blob":"` + bigPrefix + `"}` + "\n" +
+		`{"type":"assistant","timestamp":"` + lastTS + `"}` + "\n"
+	if err := os.WriteFile(filepath.Join(path, sessionID+".jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	r := NewFsJsonlReader(dir)
+	got, ok := r.LastActivityAt(context.Background(), cwd, sessionID)
+	if !ok {
+		t.Fatal("LastActivityAt returned ok=false; want true")
+	}
+	want, _ := time.Parse(time.RFC3339, lastTS)
+	if !got.Equal(want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestFsJsonlReader_LastActivityAt_MissingFileReturnsFalse covers the
+// silent-failure contract: a missing transcript is not an error, the
+// reader simply returns (zero, false) so the composer falls through.
+func TestFsJsonlReader_LastActivityAt_MissingFileReturnsFalse(t *testing.T) {
+	dir := t.TempDir()
+	r := NewFsJsonlReader(dir)
+	if _, ok := r.LastActivityAt(context.Background(), "/no/such/cwd", "no-such-uuid"); ok {
+		t.Error("LastActivityAt on missing file returned ok=true; want false")
+	}
+}
+
+// TestFsJsonlReader_LastActivityAt_EmptyFileReturnsFalse covers the
+// edge where the transcript exists but is empty — same contract.
+func TestFsJsonlReader_LastActivityAt_EmptyFileReturnsFalse(t *testing.T) {
+	const cwd = "/home/user/workspace/foo"
+	const sessionID = "empty"
+	dir := makeJsonlFixture(t, cwd, sessionID)
+
+	r := NewFsJsonlReader(dir)
+	if _, ok := r.LastActivityAt(context.Background(), cwd, sessionID); ok {
+		t.Error("LastActivityAt on empty file returned ok=true; want false")
+	}
+}
+
+// TestFsJsonlReader_LastActivityAt_LastLineWithoutTimestampReturnsFalse
+// covers the case where the last line is well-formed JSON but carries
+// no `timestamp` field (early summary lines do this). The reader must
+// not invent a value.
+func TestFsJsonlReader_LastActivityAt_LastLineWithoutTimestampReturnsFalse(t *testing.T) {
+	const cwd = "/home/user/workspace/foo"
+	const sessionID = "no-ts"
+	dir := makeJsonlFixture(t, cwd, sessionID,
+		`{"type":"user","timestamp":"2026-05-09T22:33:40Z"}`,
+		`{"type":"summary","summary":"some recap text"}`,
+	)
+
+	r := NewFsJsonlReader(dir)
+	if _, ok := r.LastActivityAt(context.Background(), cwd, sessionID); ok {
+		t.Error("LastActivityAt with no timestamp on last line returned ok=true; want false")
+	}
+}
+
+// TestFsJsonlReader_LastActivityAt_NilOrEmptyArgsReturnsFalse pins the
+// nil-safe contract used by composer's "if c.jsonl != nil && hb.Cwd !=
+// '' && hb.SessionID != ''" guard. The reader still defends against
+// empty inputs in case a caller forgets.
+func TestFsJsonlReader_LastActivityAt_NilOrEmptyArgsReturnsFalse(t *testing.T) {
+	r := NewFsJsonlReader(t.TempDir())
+	if _, ok := r.LastActivityAt(context.Background(), "", "uuid"); ok {
+		t.Error("empty cwd returned ok=true; want false")
+	}
+	if _, ok := r.LastActivityAt(context.Background(), "/cwd", ""); ok {
+		t.Error("empty sessionID returned ok=true; want false")
+	}
+	var nilReader *FsJsonlReader
+	if _, ok := nilReader.LastActivityAt(context.Background(), "/cwd", "uuid"); ok {
+		t.Error("nil receiver returned ok=true; want false")
+	}
+}
+
+// TestNewFsJsonlReader_DefaultsToHomeProjects verifies the constructor
+// defaults to ~/.claude/projects when projectsDir is empty. We do not
+// assert the file system state — only that the resolved path matches
+// the home-directory shape so consumers see the expected behaviour.
+func TestNewFsJsonlReader_DefaultsToHomeProjects(t *testing.T) {
+	r := NewFsJsonlReader("")
+	if r == nil {
+		// On a build agent without HOME this can legitimately be nil —
+		// composer guards against that. Skip rather than fail.
+		t.Skip("UserHomeDir unresolvable in this environment")
+	}
+	if !strings.HasSuffix(r.projectsDir, filepath.Join(".claude", "projects")) {
+		t.Errorf("projectsDir = %q, want suffix .claude/projects", r.projectsDir)
+	}
+}
+
+// makeJsonlFixture builds a test directory laid out the way claude's
+// project layout looks: <dir>/<encoded-cwd>/<sessionID>.jsonl. Lines
+// are joined with '\n' and a trailing '\n' is appended.
+func makeJsonlFixture(t *testing.T, cwd, sessionID string, lines ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, encodeCwd(cwd))
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	body := strings.Join(lines, "\n")
+	if body != "" {
+		body += "\n"
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, sessionID+".jsonl"), []byte(body), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return dir
+}

--- a/internal/server/providers/claudeinstance/last_activity_at_ac2_test.go
+++ b/internal/server/providers/claudeinstance/last_activity_at_ac2_test.go
@@ -96,6 +96,7 @@ func newComposerForTest(pane *graphql.TmuxPane) *Composer {
 		&fakeProcessFinder{},
 		&fakeAccountFinder{},
 		fakeLiveness{alive: map[int]bool{}},
+		nil,
 		func() time.Time { return now },
 		HeartbeatStaleAfter,
 	)

--- a/internal/server/providers/claudeinstance/last_activity_at_ac3_e2e_test.go
+++ b/internal/server/providers/claudeinstance/last_activity_at_ac3_e2e_test.go
@@ -163,7 +163,7 @@ func TestClaudeInstance_E2E_QueryLastActivityAt(t *testing.T) {
 	liveness := fakeLiveness{alive: map[int]bool{20042: true, 20099: true}}
 
 	composer := claudeinstance.NewComposerWith(
-		"local", panes, procs, &fakeAccountFinder{}, liveness,
+		"local", panes, procs, &fakeAccountFinder{}, liveness, nil,
 		func() time.Time { return now }, claudeinstance.HeartbeatStaleAfter,
 	)
 	reader := claudeinstance.NewFileReader(heartbeatDir)
@@ -254,6 +254,7 @@ func TestClaudeInstance_E2E_SubscriptionOnLastActivityChange(t *testing.T) {
 		&fakeProcessFinder{},
 		&fakeAccountFinder{},
 		liveness,
+		nil,
 		func() time.Time { return now },
 		claudeinstance.HeartbeatStaleAfter,
 	)

--- a/internal/server/providers/claudeinstance/last_activity_at_ac3_test.go
+++ b/internal/server/providers/claudeinstance/last_activity_at_ac3_test.go
@@ -93,6 +93,7 @@ func TestProvider_Subscribe_FiresOnLastActivityChange(t *testing.T) {
 	}
 	c := NewComposerWith("local", nil, nil, nil,
 		fakeLiveness{alive: map[int]bool{pid: true}},
+		nil,
 		clock,
 		HeartbeatStaleAfter,
 	)
@@ -188,6 +189,7 @@ func TestProvider_Subscribe_SilentOnLastActivityUnchanged(t *testing.T) {
 	r := &staticReader{heartbeats: []Heartbeat{hb}}
 	c := NewComposerWith("local", nil, nil, nil,
 		fakeLiveness{alive: map[int]bool{pid: true}},
+		nil,
 		clock,
 		HeartbeatStaleAfter,
 	)

--- a/internal/server/providers/claudeinstance/last_activity_at_test.go
+++ b/internal/server/providers/claudeinstance/last_activity_at_test.go
@@ -80,6 +80,7 @@ func TestLastActivityAt_RFC3339FromHeartbeat(t *testing.T) {
 		&fakeProcessFinder{},
 		&fakeAccountFinder{},
 		fakeLiveness{alive: map[int]bool{}},
+		nil,
 		func() time.Time { return now },
 		HeartbeatStaleAfter,
 	)
@@ -147,6 +148,7 @@ func TestLastActivityAt_RFC3339NanoSubSecond(t *testing.T) {
 		&fakeProcessFinder{},
 		&fakeAccountFinder{},
 		fakeLiveness{alive: map[int]bool{}},
+		nil,
 		func() time.Time { return now },
 		HeartbeatStaleAfter,
 	)

--- a/internal/server/providers/claudeinstance/provider_test.go
+++ b/internal/server/providers/claudeinstance/provider_test.go
@@ -27,7 +27,7 @@ func (s *staticReader) Dir() string { return s.dir }
 func TestProvider_List_Empty(t *testing.T) {
 	now := time.Now()
 	r := &staticReader{}
-	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{}, func() time.Time { return now }, HeartbeatStaleAfter)
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{}, nil, func() time.Time { return now }, HeartbeatStaleAfter)
 	p := NewWith("local", r, c, func() time.Time { return now })
 
 	got, err := p.List(context.Background())
@@ -52,7 +52,7 @@ func TestProvider_Refresh_PopulatesCache(t *testing.T) {
 		LastHeartbeatAt: now.Add(-2 * time.Second),
 	}}
 	r := &staticReader{heartbeats: hbs}
-	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{42100: true}}, func() time.Time { return now }, HeartbeatStaleAfter)
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{42100: true}}, nil, func() time.Time { return now }, HeartbeatStaleAfter)
 	p := NewWith("local", r, c, func() time.Time { return now })
 
 	if err := p.Refresh(context.Background(), "test"); err != nil {
@@ -87,7 +87,7 @@ func TestProvider_Subscribe_FiresOnChange(t *testing.T) {
 	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 	clock := func() time.Time { return now }
 	r := &staticReader{}
-	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{42100: true}}, clock, HeartbeatStaleAfter)
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{42100: true}}, nil, clock, HeartbeatStaleAfter)
 	p := NewWith("local", r, c, clock)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -140,7 +140,7 @@ func TestProvider_Subscribe_FiresOnChange(t *testing.T) {
 func TestProvider_Get_Unknown(t *testing.T) {
 	r := &staticReader{}
 	now := time.Now()
-	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{}, func() time.Time { return now }, HeartbeatStaleAfter)
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{}, nil, func() time.Time { return now }, HeartbeatStaleAfter)
 	p := NewWith("local", r, c, func() time.Time { return now })
 	_, _, err := p.Get(context.Background(), InstanceID{HostID: "local", ClaudePid: 99999})
 	if err == nil {

--- a/internal/server/providers/claudeinstance/regression_pid_join_test.go
+++ b/internal/server/providers/claudeinstance/regression_pid_join_test.go
@@ -177,6 +177,7 @@ func TestRegression_PidJoin_ProductionAdapters_Issue468(t *testing.T) {
 		processFinder,
 		accountFinder,
 		liveness,
+		nil,
 		clock,
 		claudeinstance.HeartbeatStaleAfter,
 	)

--- a/internal/server/providers/claudeinstance/types.go
+++ b/internal/server/providers/claudeinstance/types.go
@@ -82,8 +82,14 @@ type Heartbeat struct {
 	// Claude activity as recorded by the hook script in the last_activity /
 	// lastActivity field. Zero when the heartbeat file does not include the
 	// field (e.g. older hook versions). Used as the primary source for
-	// ClaudeInstance.lastActivityAt; zero means "fall back to pane".
+	// ClaudeInstance.lastActivityAt; zero means "fall back to jsonl tail".
 	LastActivity time.Time
+	// Cwd is the working directory the Claude process was launched from,
+	// as recorded by the hook script. Used together with SessionID to
+	// resolve the session's transcript jsonl under
+	// ~/.claude/projects/<encoded-cwd>/<session_uuid>.jsonl. Empty when the
+	// heartbeat predates cwd recording.
+	Cwd string
 }
 
 // HostID returns the host id this provider was constructed with. Useful

--- a/internal/server/providers/claudeinstance/watcher_test.go
+++ b/internal/server/providers/claudeinstance/watcher_test.go
@@ -23,7 +23,7 @@ func TestWatcher_FSNotify_TriggersRefresh(t *testing.T) {
 	clock := func() time.Time { return now }
 
 	reader := NewFileReader(dir)
-	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{42100: true}}, clock, HeartbeatStaleAfter)
+	c := NewComposerWith("local", nil, nil, nil, fakeLiveness{alive: map[int]bool{42100: true}}, nil, clock, HeartbeatStaleAfter)
 	p := NewWith("local", reader, c, clock)
 
 	w := NewWatcherWith(p, silentLogger(), 50*time.Millisecond)

--- a/internal/server/resolvers/tmux_pane_claude_instance_test.go
+++ b/internal/server/resolvers/tmux_pane_claude_instance_test.go
@@ -93,6 +93,7 @@ func buildProviderWithPane(t *testing.T, paneID string) *claudeinstance.Provider
 		nil, // no process finder needed for these tests
 		nil, // no account finder needed
 		alwaysAlive{},
+		nil, // no jsonl reader needed
 		clock,
 		claudeinstance.HeartbeatStaleAfter,
 	)


### PR DESCRIPTION
## Summary
- ClaudeInstance.lastActivityAt is currently null on every daemon row because today's hook script does not write `last_activity` (verified across all live hook files).
- The hook is fundamentally lifecycle-only — even when it does record activity, the value goes stale within 30s for sessions sitting in `input` or `idle` states.
- Read the truth from the source: every line of a Claude session's transcript jsonl carries an RFC3339 `timestamp`, and claude appends on every assistant/user/system step. That's the authoritative recency signal.

## How it works
- `Heartbeat` now carries `Cwd` alongside `SessionID` (the hook already writes both — `parseFile` just wasn't reading cwd).
- New `JsonlReader` interface + production `FsJsonlReader` that resolves `~/.claude/projects/<encoded-cwd>/<session_uuid>.jsonl` and reads the last newline-delimited line via a bounded 64 KiB tail (multi-GB transcripts stay cheap).
- Composer's lastActivityAt resolution is now: **jsonl tail → heartbeat last_activity → pane session fallback**. Each tier degrades gracefully so a missing reader, legacy heartbeat, or absent jsonl all stay safe.

## Why this unblocks the GUI
The orchard-gui "needs attention" lens needs to know when each session was last alive. With null `lastActivityAt` on every row it can't sort by recency or surface stale sessions. This PR makes the field carry real data.

## Test plan
- [x] `go test ./internal/server/providers/claudeinstance/...` passes locally
- [x] `jsonl_test.go`: encodeCwd transform, happy path, trailing newline, giant transcript (>tailWindow), missing/empty file, last line without timestamp, nil-safe arg defenses
- [x] `composer_jsonl_test.go`: jsonl wins over heartbeat, jsonl miss falls back to heartbeat, missing Cwd skips jsonl entirely, pane session remains the third-tier fallback
- [x] `internal/server/resolvers` failures pre-exist on `origin/main` (verified by stashing this branch's claudeinstance changes and re-running) — not caused by this PR; they're scoped to the unrelated tmux pane test fixtures (contract C-2026-05-09-5d041bea covers them)
- [x] `codesign --force --sign - <built daemon>` to satisfy macOS Gatekeeper after binary replacement

## Out of scope
- Hook script changes (separate concern; this PR makes the daemon resilient to the hook's current shape rather than requiring a hook update first)
- Staleness-collapse fix for `input`/`idle` states (the 30s heartbeat staleness still collapses those to `no_claude` — separate PR if/when)
- Schema additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Claude instance activity tracking by reading session transcript files to determine the most recent activity time, providing more accurate activity status.

* **Tests**
  * Added comprehensive test coverage for session transcript reading functionality and activity timestamp resolution across multiple scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/524)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->