### PR TITLE
fix(npm): allow release-assets.githubusercontent.com redirect target

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -40,6 +40,7 @@ const ALLOWED_HOSTS = new Set([
   'github.com',
   'objects.githubusercontent.com',
   'github-releases.githubusercontent.com',
+  'release-assets.githubusercontent.com',
 ]);
 
 const MAX_REDIRECTS = 5;


### PR DESCRIPTION
## Summary

GitHub now redirects release-asset downloads to `release-assets.githubusercontent.com`. The npm install script's redirect-host allowlist did not include this host, so every fresh `npm install -g git-orchard` was failing with:

```
Failed to download orchard binary: Redirect to untrusted host: release-assets.githubusercontent.com
```

This adds the host to the allowlist alongside the existing GitHub-owned release hosts (`objects.githubusercontent.com`, `github-releases.githubusercontent.com`). The allowlist is still scoped to GitHub-owned hosts — it doesn't lower the redirect-validation bar.

Closes #324

## Test plan

- [x] `node -c npm/install.js` parses cleanly
- [ ] (post-merge) `npm install -g git-orchard` against the released artifact succeeds (sibling issue #325 tracks the empty-assets release-pipeline bug — when that lands the field test becomes meaningful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability by supporting redirects during the binary download process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/530)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #324

# Related issue

- #324