### PR TITLE
feat(daemon): tmuxServer.sessions(sort:) + Conversation.customTitle/agentName

### DIFF
--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -107,6 +107,8 @@ type ComplexityRoot struct {
 	}
 
 	Conversation struct {
+		AgentName    func(childComplexity int) int
+		CustomTitle  func(childComplexity int) int
 		Cwd          func(childComplexity int) int
 		FirstSeenAt  func(childComplexity int) int
 		ID           func(childComplexity int) int
@@ -333,7 +335,7 @@ type ComplexityRoot struct {
 		Clients    func(childComplexity int) int
 		ID         func(childComplexity int) int
 		Pid        func(childComplexity int) int
-		Sessions   func(childComplexity int) int
+		Sessions   func(childComplexity int, sort *TmuxSessionSort) int
 		SocketPath func(childComplexity int) int
 	}
 
@@ -491,7 +493,7 @@ type TmuxPaneResolver interface {
 type TmuxServerResolver interface {
 	Pid(ctx context.Context, obj *TmuxServer) (*int64, error)
 	Alive(ctx context.Context, obj *TmuxServer) (bool, error)
-	Sessions(ctx context.Context, obj *TmuxServer) ([]*TmuxSession, error)
+	Sessions(ctx context.Context, obj *TmuxServer, sort *TmuxSessionSort) ([]*TmuxSession, error)
 	Clients(ctx context.Context, obj *TmuxServer) ([]*TmuxClient, error)
 }
 type TmuxSessionResolver interface {
@@ -800,6 +802,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ContractQuestion.Text(childComplexity), true
+
+	case "Conversation.agentName":
+		if e.complexity.Conversation.AgentName == nil {
+			break
+		}
+
+		return e.complexity.Conversation.AgentName(childComplexity), true
+
+	case "Conversation.customTitle":
+		if e.complexity.Conversation.CustomTitle == nil {
+			break
+		}
+
+		return e.complexity.Conversation.CustomTitle(childComplexity), true
 
 	case "Conversation.cwd":
 		if e.complexity.Conversation.Cwd == nil {
@@ -2130,7 +2146,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		return e.complexity.TmuxServer.Sessions(childComplexity), true
+		args, err := ec.field_TmuxServer_sessions_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.TmuxServer.Sessions(childComplexity, args["sort"].(*TmuxSessionSort)), true
 
 	case "TmuxServer.socketPath":
 		if e.complexity.TmuxServer.SocketPath == nil {
@@ -3186,8 +3207,12 @@ type TmuxServer implements Node {
   "True while the tmux daemon answers a heartbeat command."
   alive: Boolean!
 
-  "Sessions hosted on this server."
-  sessions: [TmuxSession!]!
+  """
+  Sessions hosted on this server. Defaults to LAST_ACTIVITY which orders
+  most-recently-active first (lex name break ties), matching the sidebar's
+  "what should I look at next" intent. Pass NAME for stable lex order.
+  """
+  sessions(sort: TmuxSessionSort = LAST_ACTIVITY): [TmuxSession!]!
 
   "Clients currently connected to this server."
   clients: [TmuxClient!]!
@@ -3394,6 +3419,14 @@ input TmuxSessionFilter {
   activeAttachedOnly: Boolean
 }
 
+"Sort key for ` + "`" + `TmuxServer.sessions` + "`" + `."
+enum TmuxSessionSort {
+  "Most-recently-active first (lastActivityAt DESC). Lex-lower name breaks ties; sessions with no activity rank below those with one."
+  LAST_ACTIVITY
+  "Stable lex order by session name."
+  NAME
+}
+
 """
 Filter for ` + "`" + `Query.hostServices` + "`" + `. AND-combined when multiple are set.
 
@@ -3483,6 +3516,12 @@ type Conversation implements Node {
   Use ` + "`" + `GET /v1/conversations/<sessionUuid>/jsonl` + "`" + ` (hosted on the same listener as ` + "`" + `/graphql` + "`" + `) to read transcript bodies.
   """
   jsonlPath: String!
+
+  "User-set title from the JSONL ` + "`" + `type: \"custom-title\"` + "`" + ` record. Null when the session has not yet recorded one."
+  customTitle: String
+
+  "Sub-agent name from the JSONL ` + "`" + `type: \"agent-name\"` + "`" + ` record. Null when the session has not yet recorded one."
+  agentName: String
 }
 
 """
@@ -4269,6 +4308,21 @@ func (ec *executionContext) field_TmuxPane_content_args(ctx context.Context, raw
 		}
 	}
 	args["stripAnsi"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_TmuxServer_sessions_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 *TmuxSessionSort
+	if tmp, ok := rawArgs["sort"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sort"))
+		arg0, err = ec.unmarshalOTmuxSessionSort2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSessionSort(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["sort"] = arg0
 	return args, nil
 }
 
@@ -6411,6 +6465,88 @@ func (ec *executionContext) _Conversation_jsonlPath(ctx context.Context, field g
 }
 
 func (ec *executionContext) fieldContext_Conversation_jsonlPath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Conversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Conversation_customTitle(ctx context.Context, field graphql.CollectedField, obj *Conversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Conversation_customTitle(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.CustomTitle, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Conversation_customTitle(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Conversation",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Conversation_agentName(ctx context.Context, field graphql.CollectedField, obj *Conversation) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Conversation_agentName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AgentName, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Conversation_agentName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Conversation",
 		Field:      field,
@@ -11249,6 +11385,10 @@ func (ec *executionContext) fieldContext_Query_conversations(ctx context.Context
 				return ec.fieldContext_Conversation_recap(ctx, field)
 			case "jsonlPath":
 				return ec.fieldContext_Conversation_jsonlPath(ctx, field)
+			case "customTitle":
+				return ec.fieldContext_Conversation_customTitle(ctx, field)
+			case "agentName":
+				return ec.fieldContext_Conversation_agentName(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Conversation", field.Name)
 		},
@@ -11310,6 +11450,10 @@ func (ec *executionContext) fieldContext_Query_conversation(ctx context.Context,
 				return ec.fieldContext_Conversation_recap(ctx, field)
 			case "jsonlPath":
 				return ec.fieldContext_Conversation_jsonlPath(ctx, field)
+			case "customTitle":
+				return ec.fieldContext_Conversation_customTitle(ctx, field)
+			case "agentName":
+				return ec.fieldContext_Conversation_agentName(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Conversation", field.Name)
 		},
@@ -13614,6 +13758,10 @@ func (ec *executionContext) fieldContext_Subscription_conversationChanged(ctx co
 				return ec.fieldContext_Conversation_recap(ctx, field)
 			case "jsonlPath":
 				return ec.fieldContext_Conversation_jsonlPath(ctx, field)
+			case "customTitle":
+				return ec.fieldContext_Conversation_customTitle(ctx, field)
+			case "agentName":
+				return ec.fieldContext_Conversation_agentName(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Conversation", field.Name)
 		},
@@ -15152,7 +15300,7 @@ func (ec *executionContext) _TmuxServer_sessions(ctx context.Context, field grap
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.TmuxServer().Sessions(rctx, obj)
+		return ec.resolvers.TmuxServer().Sessions(rctx, obj, fc.Args["sort"].(*TmuxSessionSort))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -15200,6 +15348,17 @@ func (ec *executionContext) fieldContext_TmuxServer_sessions(ctx context.Context
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TmuxSession", field.Name)
 		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_TmuxServer_sessions_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -20106,6 +20265,10 @@ func (ec *executionContext) _Conversation(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "customTitle":
+			out.Values[i] = ec._Conversation_customTitle(ctx, field, obj)
+		case "agentName":
+			out.Values[i] = ec._Conversation_agentName(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -26510,6 +26673,22 @@ func (ec *executionContext) unmarshalOTmuxSessionFilter2ᚖgithubᚗcomᚋdrewdr
 	}
 	res, err := ec.unmarshalInputTmuxSessionFilter(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOTmuxSessionSort2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSessionSort(ctx context.Context, v interface{}) (*TmuxSessionSort, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(TmuxSessionSort)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTmuxSessionSort2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxSessionSort(ctx context.Context, sel ast.SelectionSet, v *TmuxSessionSort) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) marshalOTmuxWindow2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐTmuxWindow(ctx context.Context, sel ast.SelectionSet, v *TmuxWindow) graphql.Marshaler {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -182,6 +182,10 @@ type Conversation struct {
 	// Absolute path to the JSONL transcript on the daemon's host.
 	// Use `GET /v1/conversations/<sessionUuid>/jsonl` (hosted on the same listener as `/graphql`) to read transcript bodies.
 	JsonlPath string `json:"jsonlPath"`
+	// User-set title from the JSONL `type: "custom-title"` record. Null when the session has not yet recorded one.
+	CustomTitle *string `json:"customTitle,omitempty"`
+	// Sub-agent name from the JSONL `type: "agent-name"` record. Null when the session has not yet recorded one.
+	AgentName *string `json:"agentName,omitempty"`
 }
 
 func (Conversation) IsNode() {}
@@ -617,7 +621,9 @@ type TmuxServer struct {
 	Pid *int64 `json:"pid,omitempty"`
 	// True while the tmux daemon answers a heartbeat command.
 	Alive bool `json:"alive"`
-	// Sessions hosted on this server.
+	// Sessions hosted on this server. Defaults to LAST_ACTIVITY which orders
+	// most-recently-active first (lex name break ties), matching the sidebar's
+	// "what should I look at next" intent. Pass NAME for stable lex order.
 	Sessions []*TmuxSession `json:"sessions"`
 	// Clients currently connected to this server.
 	Clients []*TmuxClient `json:"clients"`
@@ -1158,5 +1164,49 @@ func (e *ReviewDecisionEnum) UnmarshalGQL(v interface{}) error {
 }
 
 func (e ReviewDecisionEnum) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Sort key for `TmuxServer.sessions`.
+type TmuxSessionSort string
+
+const (
+	// Most-recently-active first (lastActivityAt DESC). Lex-lower name breaks ties; sessions with no activity rank below those with one.
+	TmuxSessionSortLastActivity TmuxSessionSort = "LAST_ACTIVITY"
+	// Stable lex order by session name.
+	TmuxSessionSortName TmuxSessionSort = "NAME"
+)
+
+var AllTmuxSessionSort = []TmuxSessionSort{
+	TmuxSessionSortLastActivity,
+	TmuxSessionSortName,
+}
+
+func (e TmuxSessionSort) IsValid() bool {
+	switch e {
+	case TmuxSessionSortLastActivity, TmuxSessionSortName:
+		return true
+	}
+	return false
+}
+
+func (e TmuxSessionSort) String() string {
+	return string(e)
+}
+
+func (e *TmuxSessionSort) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = TmuxSessionSort(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid TmuxSessionSort", str)
+	}
+	return nil
+}
+
+func (e TmuxSessionSort) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/internal/server/providers/claudeprojects/adapter.go
+++ b/internal/server/providers/claudeprojects/adapter.go
@@ -184,5 +184,7 @@ func (a *FSAdapter) fromFile(path string) (Conversation, error) {
 		FirstSeenAt:  meta.FirstSeenAt,
 		LastSeenAt:   meta.LastSeenAt,
 		MessageCount: meta.MessageCount,
+		CustomTitle:  meta.CustomTitle,
+		AgentName:    meta.AgentName,
 	}, nil
 }

--- a/internal/server/providers/claudeprojects/jsonl.go
+++ b/internal/server/providers/claudeprojects/jsonl.go
@@ -24,6 +24,8 @@ type jsonlMeta struct {
 	Cwd          *string
 	MessageCount int64
 	ModTime      time.Time
+	CustomTitle  *string
+	AgentName    *string
 }
 
 // jsonlRecord is the parsed shape of a single JSONL line. Fields are
@@ -35,8 +37,11 @@ type jsonlMeta struct {
 // parses it for us. CWD is the only string we need from the body, and
 // only on the latest record we have it on (newer records carry it).
 type jsonlRecord struct {
-	Timestamp *time.Time `json:"timestamp,omitempty"`
-	Cwd       *string    `json:"cwd,omitempty"`
+	Timestamp   *time.Time `json:"timestamp,omitempty"`
+	Cwd         *string    `json:"cwd,omitempty"`
+	Type        string     `json:"type,omitempty"`
+	CustomTitle *string    `json:"customTitle,omitempty"`
+	AgentName   *string    `json:"agentName,omitempty"`
 }
 
 // readJSONLMeta returns the metadata summary of the JSONL at path
@@ -102,6 +107,13 @@ func readJSONLMeta(path string) (jsonlMeta, error) {
 			meta.Cwd = last.Cwd
 		}
 	}
+
+	customTitle, agentName, err := readHeadMarkers(path)
+	if err != nil {
+		return jsonlMeta{}, fmt.Errorf("read head markers of %s: %w", path, err)
+	}
+	meta.CustomTitle = customTitle
+	meta.AgentName = agentName
 
 	return meta, nil
 }
@@ -169,6 +181,51 @@ func readFirstRecord(path string) (*jsonlRecord, error) {
 		return nil, err
 	}
 	return decodeRecord(line)
+}
+
+// readHeadMarkers scans the first N records of path for the JSONL marker types `custom-title` and `agent-name`. Both are written by Claude Code at session start (typically lines 2-3) and stay stable for the life of the session, so a small bounded scan is sufficient — we never load the whole file.
+//
+// Returns nil pointers when the markers are absent, malformed, or carry empty strings. Bounded by `maxHeadRecords`; once both markers are seen the scan returns early.
+func readHeadMarkers(path string) (customTitle, agentName *string, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	r := bufio.NewReaderSize(f, 64*1024)
+	for i := 0; i < maxHeadRecords; i++ {
+		line, lineErr := readBoundedLine(r, maxLineBytes)
+		if lineErr != nil {
+			if errors.Is(lineErr, io.EOF) {
+				// Partial trailing line is fine — let the loop exit; it's
+				// not a head marker we expect to be unterminated anyway.
+				break
+			}
+			if errors.Is(lineErr, errLineTooLong) {
+				continue
+			}
+			return customTitle, agentName, lineErr
+		}
+		rec, decErr := decodeRecord(line)
+		if decErr != nil || rec == nil {
+			continue
+		}
+		switch rec.Type {
+		case "custom-title":
+			if customTitle == nil && rec.CustomTitle != nil && *rec.CustomTitle != "" {
+				customTitle = rec.CustomTitle
+			}
+		case "agent-name":
+			if agentName == nil && rec.AgentName != nil && *rec.AgentName != "" {
+				agentName = rec.AgentName
+			}
+		}
+		if customTitle != nil && agentName != nil {
+			break
+		}
+	}
+	return customTitle, agentName, nil
 }
 
 // readLastRecord parses the last newline-terminated JSON record in
@@ -283,6 +340,12 @@ const (
 	// are skipped — we surface (nil, nil) to the caller, which
 	// degrades to "unknown firstSeenAt/lastSeenAt" on the node.
 	maxLineBytes = 1024 * 1024
+
+	// maxHeadRecords bounds readHeadMarkers. Claude Code writes the
+	// custom-title and agent-name markers at the very top of the JSONL
+	// (typically lines 2-3); 16 records is generous and never reads
+	// past the prologue.
+	maxHeadRecords = 16
 )
 
 // errLineTooLong is the sentinel error returned by readBoundedLine

--- a/internal/server/providers/claudeprojects/jsonl_test.go
+++ b/internal/server/providers/claudeprojects/jsonl_test.go
@@ -153,6 +153,71 @@ func TestReadJSONLMeta_LongLineSkipped(t *testing.T) {
 	}
 }
 
+// TestReadJSONLMeta_HeadMarkers parses a transcript whose first three
+// records are the canonical Claude Code prologue: last-prompt,
+// custom-title, agent-name. We expect the latter two to be surfaced.
+func TestReadJSONLMeta_HeadMarkers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "markers.jsonl")
+	body := `{"type":"last-prompt","leafUuid":"u1","sessionId":"s1"}` + "\n" +
+		`{"type":"custom-title","customTitle":"local:my-session","sessionId":"s1"}` + "\n" +
+		`{"type":"agent-name","agentName":"my-agent","sessionId":"s1"}` + "\n" +
+		`{"timestamp":"2026-05-04T12:00:00Z","type":"user"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	meta, err := readJSONLMeta(path)
+	if err != nil {
+		t.Fatalf("readJSONLMeta: %v", err)
+	}
+	if meta.CustomTitle == nil || *meta.CustomTitle != "local:my-session" {
+		t.Errorf("customTitle = %v, want %q", meta.CustomTitle, "local:my-session")
+	}
+	if meta.AgentName == nil || *meta.AgentName != "my-agent" {
+		t.Errorf("agentName = %v, want %q", meta.AgentName, "my-agent")
+	}
+}
+
+// TestReadJSONLMeta_HeadMarkers_Missing degrades cleanly when neither
+// marker is present — both fields should be nil, not the empty string.
+func TestReadJSONLMeta_HeadMarkers_Missing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nomarkers.jsonl")
+	body := `{"timestamp":"2026-05-04T12:00:00Z","type":"user"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	meta, err := readJSONLMeta(path)
+	if err != nil {
+		t.Fatalf("readJSONLMeta: %v", err)
+	}
+	if meta.CustomTitle != nil {
+		t.Errorf("customTitle = %v, want nil", *meta.CustomTitle)
+	}
+	if meta.AgentName != nil {
+		t.Errorf("agentName = %v, want nil", *meta.AgentName)
+	}
+}
+
+// TestReadJSONLMeta_HeadMarkers_EmptyStringDropped treats an empty
+// customTitle as absent — no point surfacing "" to clients.
+func TestReadJSONLMeta_HeadMarkers_EmptyStringDropped(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "emptymarkers.jsonl")
+	body := `{"type":"custom-title","customTitle":"","sessionId":"s1"}` + "\n" +
+		`{"type":"agent-name","agentName":"","sessionId":"s1"}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	meta, err := readJSONLMeta(path)
+	if err != nil {
+		t.Fatalf("readJSONLMeta: %v", err)
+	}
+	if meta.CustomTitle != nil {
+		t.Errorf("customTitle = %v, want nil (empty string dropped)", *meta.CustomTitle)
+	}
+	if meta.AgentName != nil {
+		t.Errorf("agentName = %v, want nil (empty string dropped)", *meta.AgentName)
+	}
+}
+
 // TestSessionUUIDFromPath asserts the filename → uuid extraction
 // peels only the .jsonl suffix and respects directory components.
 func TestSessionUUIDFromPath(t *testing.T) {

--- a/internal/server/providers/claudeprojects/provider.go
+++ b/internal/server/providers/claudeprojects/provider.go
@@ -281,6 +281,8 @@ func (p *Provider) ToGraphQL(c Conversation) *graphql.Conversation {
 		Open:         p.IsOpen(c),
 		Recap:        nil,
 		JsonlPath:    c.Path,
+		CustomTitle:  c.CustomTitle,
+		AgentName:    c.AgentName,
 	}
 }
 

--- a/internal/server/providers/claudeprojects/types.go
+++ b/internal/server/providers/claudeprojects/types.go
@@ -62,6 +62,10 @@ type Conversation struct {
 	FirstSeenAt  *time.Time
 	LastSeenAt   *time.Time
 	MessageCount int64
+	// CustomTitle is the user-set title from the JSONL `type: "custom-title"` record. Nil when not yet recorded.
+	CustomTitle *string
+	// AgentName is the sub-agent name from the JSONL `type: "agent-name"` record. Nil when not yet recorded.
+	AgentName *string
 }
 
 // GraphQLID returns the stable orchard id for a Conversation node. The

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -611,8 +611,12 @@ type TmuxServer implements Node {
   "True while the tmux daemon answers a heartbeat command."
   alive: Boolean!
 
-  "Sessions hosted on this server."
-  sessions: [TmuxSession!]!
+  """
+  Sessions hosted on this server. Defaults to LAST_ACTIVITY which orders
+  most-recently-active first (lex name break ties), matching the sidebar's
+  "what should I look at next" intent. Pass NAME for stable lex order.
+  """
+  sessions(sort: TmuxSessionSort = LAST_ACTIVITY): [TmuxSession!]!
 
   "Clients currently connected to this server."
   clients: [TmuxClient!]!
@@ -819,6 +823,14 @@ input TmuxSessionFilter {
   activeAttachedOnly: Boolean
 }
 
+"Sort key for `TmuxServer.sessions`."
+enum TmuxSessionSort {
+  "Most-recently-active first (lastActivityAt DESC). Lex-lower name breaks ties; sessions with no activity rank below those with one."
+  LAST_ACTIVITY
+  "Stable lex order by session name."
+  NAME
+}
+
 """
 Filter for `Query.hostServices`. AND-combined when multiple are set.
 
@@ -908,6 +920,12 @@ type Conversation implements Node {
   Use `GET /v1/conversations/<sessionUuid>/jsonl` (hosted on the same listener as `/graphql`) to read transcript bodies.
   """
   jsonlPath: String!
+
+  "User-set title from the JSONL `type: \"custom-title\"` record. Null when the session has not yet recorded one."
+  customTitle: String
+
+  "Sub-agent name from the JSONL `type: \"agent-name\"` record. Null when the session has not yet recorded one."
+  agentName: String
 }
 
 """

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -1151,14 +1151,43 @@ func (r *tmuxServerResolver) Alive(ctx context.Context, obj *graphql1.TmuxServer
 	return r.Tmux.Server().Alive, nil
 }
 
-// Sessions is the resolver for tmuxServer.sessions.
-func (r *tmuxServerResolver) Sessions(ctx context.Context, obj *graphql1.TmuxServer) ([]*graphql1.TmuxSession, error) {
+// Sessions is the resolver for tmuxServer.sessions. Sort key defaults to LAST_ACTIVITY (most-recently-active first; lex name break ties; sessions with zero activity rank below those with one).
+func (r *tmuxServerResolver) Sessions(ctx context.Context, obj *graphql1.TmuxServer, sortKey *graphql1.TmuxSessionSort) ([]*graphql1.TmuxSession, error) {
 	if r.Tmux == nil {
 		return nil, nil
 	}
 	snap := r.Tmux.Snapshot()
-	out := make([]*graphql1.TmuxSession, 0, len(snap.Sessions))
+	sessions := make([]tmux.Session, 0, len(snap.Sessions))
 	for _, s := range snap.Sessions {
+		sessions = append(sessions, s)
+	}
+
+	key := graphql1.TmuxSessionSortLastActivity
+	if sortKey != nil {
+		key = *sortKey
+	}
+	switch key {
+	case graphql1.TmuxSessionSortName:
+		sort.Slice(sessions, func(i, j int) bool {
+			return sessions[i].Key.Name < sessions[j].Key.Name
+		})
+	default: // LAST_ACTIVITY
+		sort.Slice(sessions, func(i, j int) bool {
+			a, b := sessions[i], sessions[j]
+			aZero := a.LastActivityAt.IsZero()
+			bZero := b.LastActivityAt.IsZero()
+			if aZero != bZero {
+				return !aZero
+			}
+			if !a.LastActivityAt.Equal(b.LastActivityAt) {
+				return a.LastActivityAt.After(b.LastActivityAt)
+			}
+			return a.Key.Name < b.Key.Name
+		})
+	}
+
+	out := make([]*graphql1.TmuxSession, 0, len(sessions))
+	for _, s := range sessions {
 		out = append(out, projectSession(s))
 	}
 	return out, nil

--- a/internal/server/resolvers/tmux_server_sessions_test.go
+++ b/internal/server/resolvers/tmux_server_sessions_test.go
@@ -1,0 +1,159 @@
+// Tests for tmuxServerResolver.Sessions sort behaviour.
+
+package resolvers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	tmuxprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
+)
+
+// listAllRow builds a single 18-field list-panes -a -F line as expected by
+// the tmux adapter's listAll parser. We only care about the session-level
+// fields here; window/pane fields get safe defaults.
+func listAllRow(sessionName string, lastActivityUnix int64, paneID string, pid int) string {
+	const fs = "\x01"
+	return strings.Join([]string{
+		sessionName,                          // 0  session_name
+		"1700000000",                         // 1  session_created
+		"0",                                  // 2  session_attached
+		fmt.Sprintf("%d", lastActivityUnix),  // 3  session_activity
+		"1",                                  // 4  session_windows
+		"0",                                  // 5  session_window_index
+		"0",                                  // 6  window_index
+		"main",                               // 7  window_name
+		"1",                                  // 8  window_active
+		"1",                                  // 9  window_panes
+		paneID,                               // 10 window_active_pane
+		paneID,                               // 11 pane_id
+		"",                                   // 12 pane_title
+		"zsh",                                // 13 pane_current_command
+		fmt.Sprintf("%d", pid),               // 14 pane_pid
+		"200",                                // 15 pane_width
+		"50",                                 // 16 pane_height
+		"0",                                  // 17 pane_dead
+	}, fs)
+}
+
+// sessionsRunner serves only the three commands the adapter calls: info,
+// list-panes -a, list-clients. The runner returns one fixed list-panes block
+// for every call.
+type sessionsRunner struct {
+	listAllOutput string
+}
+
+func (r *sessionsRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	if name != "tmux" {
+		return nil, fmt.Errorf("unexpected command: %s", name)
+	}
+	sub := firstNonFlagTmuxArg(args)
+	switch sub {
+	case "info":
+		return []byte("ok\n"), nil
+	case "list-panes":
+		return []byte(r.listAllOutput), nil
+	case "list-clients":
+		return []byte(""), nil
+	default:
+		return []byte(""), nil
+	}
+}
+
+func buildSessionsResolver(t *testing.T, rows []string) *tmuxServerResolver {
+	t.Helper()
+	out := strings.Join(rows, "\n") + "\n"
+	tr := &sessionsRunner{listAllOutput: out}
+	adapter := tmuxprovider.NewAdapter(tmuxprovider.HostID("local")).
+		WithRunner(tr).
+		WithSocket("/tmp/orchard-test-tmuxserver.sock")
+	prov := tmuxprovider.New(adapter, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := prov.Refresh(ctx); err != nil {
+		t.Fatalf("tmux Refresh: %v", err)
+	}
+	return &tmuxServerResolver{&Resolver{Tmux: prov}}
+}
+
+// TestTmuxServerSessions_DefaultSortLastActivity asserts that with no sort
+// arg, sessions come back ordered by lastActivityAt DESC.
+func TestTmuxServerSessions_DefaultSortLastActivity(t *testing.T) {
+	r := buildSessionsResolver(t, []string{
+		listAllRow("oldest", 1700000000, "%1", 100),
+		listAllRow("newest", 1700001000, "%2", 200),
+		listAllRow("middle", 1700000500, "%3", 300),
+	})
+
+	got, err := r.Sessions(context.Background(), nil, nil)
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	want := []string{"newest", "middle", "oldest"}
+	if names := sessionNames(got); !equalNames(names, want) {
+		t.Errorf("Sessions order = %v, want %v", names, want)
+	}
+}
+
+// TestTmuxServerSessions_SortByName asserts NAME forces stable lex order.
+func TestTmuxServerSessions_SortByName(t *testing.T) {
+	r := buildSessionsResolver(t, []string{
+		listAllRow("charlie", 1700001000, "%1", 100),
+		listAllRow("alpha", 1700000000, "%2", 200),
+		listAllRow("bravo", 1700000500, "%3", 300),
+	})
+
+	key := graphql1.TmuxSessionSortName
+	got, err := r.Sessions(context.Background(), nil, &key)
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	want := []string{"alpha", "bravo", "charlie"}
+	if names := sessionNames(got); !equalNames(names, want) {
+		t.Errorf("Sessions order = %v, want %v", names, want)
+	}
+}
+
+// TestTmuxServerSessions_LastActivityTiebreakByName asserts that two sessions
+// with identical lastActivityAt fall back to lex-lower name first.
+func TestTmuxServerSessions_LastActivityTiebreakByName(t *testing.T) {
+	r := buildSessionsResolver(t, []string{
+		listAllRow("zebra", 1700001000, "%1", 100),
+		listAllRow("alpha", 1700001000, "%2", 200),
+		listAllRow("middle", 1700001000, "%3", 300),
+	})
+
+	key := graphql1.TmuxSessionSortLastActivity
+	got, err := r.Sessions(context.Background(), nil, &key)
+	if err != nil {
+		t.Fatalf("Sessions: %v", err)
+	}
+	want := []string{"alpha", "middle", "zebra"}
+	if names := sessionNames(got); !equalNames(names, want) {
+		t.Errorf("Sessions order = %v, want %v", names, want)
+	}
+}
+
+func sessionNames(sessions []*graphql1.TmuxSession) []string {
+	out := make([]string, len(sessions))
+	for i, s := range sessions {
+		out[i] = s.Name
+	}
+	return out
+}
+
+func equalNames(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -611,8 +611,12 @@ type TmuxServer implements Node {
   "True while the tmux daemon answers a heartbeat command."
   alive: Boolean!
 
-  "Sessions hosted on this server."
-  sessions: [TmuxSession!]!
+  """
+  Sessions hosted on this server. Defaults to LAST_ACTIVITY which orders
+  most-recently-active first (lex name break ties), matching the sidebar's
+  "what should I look at next" intent. Pass NAME for stable lex order.
+  """
+  sessions(sort: TmuxSessionSort = LAST_ACTIVITY): [TmuxSession!]!
 
   "Clients currently connected to this server."
   clients: [TmuxClient!]!
@@ -819,6 +823,14 @@ input TmuxSessionFilter {
   activeAttachedOnly: Boolean
 }
 
+"Sort key for `TmuxServer.sessions`."
+enum TmuxSessionSort {
+  "Most-recently-active first (lastActivityAt DESC). Lex-lower name breaks ties; sessions with no activity rank below those with one."
+  LAST_ACTIVITY
+  "Stable lex order by session name."
+  NAME
+}
+
 """
 Filter for `Query.hostServices`. AND-combined when multiple are set.
 
@@ -908,6 +920,12 @@ type Conversation implements Node {
   Use `GET /v1/conversations/<sessionUuid>/jsonl` (hosted on the same listener as `/graphql`) to read transcript bodies.
   """
   jsonlPath: String!
+
+  "User-set title from the JSONL `type: \"custom-title\"` record. Null when the session has not yet recorded one."
+  customTitle: String
+
+  "Sub-agent name from the JSONL `type: \"agent-name\"` record. Null when the session has not yet recorded one."
+  agentName: String
 }
 
 """


### PR DESCRIPTION
## Summary

Two related schema additions for the orchard-gui sidebar:

1. **`tmuxServer.sessions(sort: TmuxSessionSort = LAST_ACTIVITY)`** — fixes sidebar reshuffling on every refresh. New `TmuxSessionSort` enum with `LAST_ACTIVITY` (default; most-recently-active first, lex name break ties, zero-activity sessions rank last) and `NAME` (stable lex order).

2. **`Conversation.customTitle`** and **`Conversation.agentName`** — parsed from the JSONL prologue records `type: \"custom-title\"` and `type: \"agent-name\"` that Claude Code writes at session start. Sidebar can now render \"git-orchard-rs-spawn3\" instead of a session-uuid prefix. New `readHeadMarkers` helper does a bounded (16-record) head scan; empty strings are treated as absent.

## Verified live on running daemon

```
$ curl ... '{ tmuxServer { sessions(sort: LAST_ACTIVITY) { name lastActivityAt } } }'
→ orchard-gui-convo / 2026-05-10T00:02:13Z (most recent first)

$ curl ... '{ conversations { sessionUuid customTitle agentName } }'
→ 70baaae1-... / git-orchard-rs-spawn3 / git-orchard-rs-spawn3
```

## Test plan

- [x] `make generate` clean (idempotent)
- [x] `go build ./...` succeeds
- [x] New unit tests pass:
  - `TestTmuxServerSessions_DefaultSortLastActivity`
  - `TestTmuxServerSessions_SortByName`
  - `TestTmuxServerSessions_LastActivityTiebreakByName`
  - `TestReadJSONLMeta_HeadMarkers`
  - `TestReadJSONLMeta_HeadMarkers_Missing`
  - `TestReadJSONLMeta_HeadMarkers_EmptyStringDropped`
- [x] Pre-existing test failures unchanged (no new regressions)
- [x] Live deploy: built, codesigned, restarted local daemon
- [x] Schema introspection confirms `TmuxSessionSort` enum, `sessions(sort:)` arg, `Conversation.customTitle`, `Conversation.agentName`
- [x] Live data populates `customTitle` and `agentName` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sessions can now be sorted by last activity (default) or alphabetically by name for flexible workspace organization
  * Conversations now display custom titles and agent names when available for improved context

* **Tests**
  * Added comprehensive test coverage for session sorting behavior and edge cases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/533)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->