### PR TITLE
refactor(worktree): consolidate worktree-path slug rule in worktree-core

### DIFF
--- a/crates/orchard-worktree/src/cmd/mod.rs
+++ b/crates/orchard-worktree/src/cmd/mod.rs
@@ -10,19 +10,7 @@ pub mod path;
 pub mod prune;
 pub mod rm;
 
-use std::path::PathBuf;
-
 use anyhow::{Result, anyhow};
-
-/// Resolve the path that a new worktree for `branch` should live at.
-///
-/// Convention: `<repo_root>/.worktrees/<branch-with-slashes-replaced>`.
-/// Slashes become hyphens because `.worktrees/foo/bar` would imply a
-/// directory hierarchy that doesn't exist.
-pub fn worktree_path_for(repo_root: &str, branch: &str) -> PathBuf {
-    let slug = branch.replace('/', "-");
-    PathBuf::from(repo_root).join(".worktrees").join(slug)
-}
 
 /// Resolve a worktree by branch name to its absolute path.
 ///
@@ -34,33 +22,4 @@ pub fn resolve_worktree_path(branch: &str) -> Result<String> {
         .find(|t| t.branch.as_deref() == Some(branch))
         .map(|t| t.path.clone())
         .ok_or_else(|| anyhow!("no worktree found for branch '{branch}'"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn worktree_path_for_simple_branch() {
-        assert_eq!(
-            worktree_path_for("/repo", "feature").to_string_lossy(),
-            "/repo/.worktrees/feature"
-        );
-    }
-
-    #[test]
-    fn worktree_path_for_slashed_branch_replaces_with_hyphen() {
-        assert_eq!(
-            worktree_path_for("/repo", "feature/foo").to_string_lossy(),
-            "/repo/.worktrees/feature-foo"
-        );
-    }
-
-    #[test]
-    fn worktree_path_for_double_slash_branch() {
-        assert_eq!(
-            worktree_path_for("/repo", "issue123/feature/sub").to_string_lossy(),
-            "/repo/.worktrees/issue123-feature-sub"
-        );
-    }
 }

--- a/crates/orchard-worktree/src/cmd/new.rs
+++ b/crates/orchard-worktree/src/cmd/new.rs
@@ -7,8 +7,7 @@
 
 use anyhow::{Result, anyhow};
 use clap::Args as ClapArgs;
-
-use crate::cmd::worktree_path_for;
+use worktree_core::worktree_path_for;
 
 #[derive(ClapArgs, Debug)]
 pub struct Args {

--- a/crates/orchard/src/paths.rs
+++ b/crates/orchard/src/paths.rs
@@ -2,8 +2,10 @@
 //!
 //! `tildify` shortens absolute paths by replacing the home directory prefix
 //! with `~`; `truncate_left` caps display width by eliding from the left with
-//! a `…` character. `sanitize_branch_slug` and `derive_local_worktree_path`
-//! produce filesystem-safe paths for worktree directories.
+//! a `…` character. `sanitize_branch_slug` produces a filesystem-safe slug
+//! for the remote-registry-entry naming. New-worktree path computation lives
+//! in `worktree-core` (`worktree_core::worktree_path_for`) — the single
+//! source of truth shared with the `orchard-worktree` CLI.
 /// Replaces the user's home directory prefix in `path` with `~`.
 /// Returns the path unchanged if it does not start with `$HOME`.
 pub fn tildify(path: &str) -> String {
@@ -108,36 +110,6 @@ pub fn session_belongs_to_worktree(session_path: &str, worktree_path: &str) -> b
     session_path == wt || session_path.starts_with(&format!("{}/", wt))
 }
 
-/// Returns the absolute conventional path for a local worktree:
-/// `parent(repo_root)/worktrees/worktree-SLUG`.
-pub(crate) fn derive_local_worktree_path(repo_root: &str, branch: &str) -> String {
-    use std::path::Path;
-
-    let slug = sanitize_branch_slug(branch);
-    let parent = Path::new(repo_root)
-        .parent()
-        .unwrap_or_else(|| Path::new("."));
-    let joined = parent.join("worktrees").join(format!("worktree-{}", slug));
-    // Try canonicalize to resolve symlinks and get an absolute path when the
-    // directory already exists. For new worktrees (the common case), the path
-    // doesn't exist yet and canonicalize fails — we fall through to building
-    // an absolute path manually instead.
-    match joined.canonicalize() {
-        Ok(abs) => abs.to_string_lossy().into_owned(),
-        Err(_) => {
-            if joined.is_absolute() {
-                joined.to_string_lossy().into_owned()
-            } else {
-                std::env::current_dir()
-                    .map(|cwd| cwd.join(&joined))
-                    .unwrap_or(joined)
-                    .to_string_lossy()
-                    .into_owned()
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,7 +192,7 @@ mod tests {
         assert_eq!(sanitize_branch_slug("main"), "main");
     }
 
-    // --- derive_local_worktree_path ---
+    // --- resolve_git_dir ---
 
     #[test]
     fn resolve_git_dir_finds_dir_form() {
@@ -254,26 +226,6 @@ mod tests {
     fn resolve_git_dir_returns_none_outside_repo() {
         let tmp = tempfile::TempDir::new().unwrap();
         assert!(resolve_git_dir(tmp.path()).is_none());
-    }
-
-    #[test]
-    fn local_path_uses_parent_and_slug() {
-        let result = derive_local_worktree_path("/home/user/repo", "feat/my-feature");
-        assert!(
-            result.ends_with("worktrees/worktree-feat-my-feature"),
-            "got: {}",
-            result
-        );
-    }
-
-    #[test]
-    fn local_path_parent_segment_correct() {
-        let result = derive_local_worktree_path("/srv/repos/myrepo", "fix/bug-101");
-        assert!(
-            result.contains("worktrees/worktree-fix-bug-101"),
-            "got: {}",
-            result
-        );
     }
 
     #[test]

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -2204,7 +2204,11 @@ impl App {
         let setup_script = crate::config::load_config().setup_script;
 
         std::thread::spawn(move || {
-            let worktree_path = crate::paths::derive_local_worktree_path(&repo_root, &branch);
+            // Single source of truth for the worktree-path slug rule lives in
+            // `worktree-core` so the TUI dialog and `orchard new` agree on
+            // where to put a new worktree.
+            let worktree_path = worktree_core::worktree_path_for(&repo_root, &branch);
+            let worktree_path = worktree_path.to_string_lossy().into_owned();
 
             // Delegate the new-branch-then-fallback dance to worktree-core.
             // The shared library is the single source of truth for git worktree

--- a/crates/worktree-core/src/lib.rs
+++ b/crates/worktree-core/src/lib.rs
@@ -31,11 +31,13 @@
 pub mod create;
 pub mod destroy;
 pub mod list;
+pub mod path;
 pub mod prune;
 pub mod repo;
 
 pub use create::{CreateOutcome, create_worktree};
 pub use destroy::remove_worktree;
 pub use list::{WorktreeEntry, list_worktrees, parse_porcelain, worktree_has_conflicts};
+pub use path::worktree_path_for;
 pub use prune::prune;
 pub use repo::{find_repo_root, get_repo_name};

--- a/crates/worktree-core/src/path.rs
+++ b/crates/worktree-core/src/path.rs
@@ -1,0 +1,56 @@
+//! Path helpers for worktree mutations.
+//!
+//! These exist in `worktree-core` so callers — `orchard-worktree` CLI,
+//! `orchard-tui` dialogs, future automation — agree on where a worktree for
+//! a given branch lives. Divergence between callers means worktrees created
+//! by one tool aren't found by the other.
+
+use std::path::{Path, PathBuf};
+
+/// Resolve the path that a new worktree for `branch` should live at.
+///
+/// Convention: `<repo_root>/.worktrees/<branch-with-slashes-replaced>`.
+/// Slashes become hyphens because `.worktrees/foo/bar` would imply a
+/// directory hierarchy that doesn't exist.
+pub fn worktree_path_for(repo_root: impl AsRef<Path>, branch: &str) -> PathBuf {
+    let slug = branch.replace('/', "-");
+    repo_root.as_ref().join(".worktrees").join(slug)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_branch() {
+        assert_eq!(
+            worktree_path_for("/repo", "feature").to_string_lossy(),
+            "/repo/.worktrees/feature"
+        );
+    }
+
+    #[test]
+    fn slashed_branch_replaces_with_hyphen() {
+        assert_eq!(
+            worktree_path_for("/repo", "feature/foo").to_string_lossy(),
+            "/repo/.worktrees/feature-foo"
+        );
+    }
+
+    #[test]
+    fn double_slash_branch() {
+        assert_eq!(
+            worktree_path_for("/repo", "issue123/feature/sub").to_string_lossy(),
+            "/repo/.worktrees/issue123-feature-sub"
+        );
+    }
+
+    #[test]
+    fn accepts_pathbuf_repo_root() {
+        let root = PathBuf::from("/repo");
+        assert_eq!(
+            worktree_path_for(&root, "main").to_string_lossy(),
+            "/repo/.worktrees/main"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Two implementations of the worktree-path slug rule had diverged:

- `orchard-worktree::cmd::worktree_path_for` → `<repo_root>/.worktrees/<branch.replace('/', '-')>`
- `orchard::paths::derive_local_worktree_path` → `<parent(repo_root)>/worktrees/worktree-<sanitized-slug>`

`orchard new feat/foo` produced one path; the TUI dialog produced a different one for the same branch — so worktrees created via the CLI weren't where the TUI's `start_create_worktree` would compute. ADR-013 step 4 already moved worktree mutation primitives into `worktree-core` as the single source of truth; this lands the slug helper there too.

## Changes

- New `crates/worktree-core/src/path.rs` exposing `worktree_path_for(repo_root, branch) -> PathBuf` (the `<repo_root>/.worktrees/<branch-with-slashes>` form). Re-exported from `worktree-core::worktree_path_for`.
- `orchard-worktree::cmd::new` calls `worktree_core::worktree_path_for`.
- `orchard::tui::start_create_worktree` calls `worktree_core::worktree_path_for` instead of `paths::derive_local_worktree_path`.
- `derive_local_worktree_path` and the duplicate local `worktree_path_for` in `orchard-worktree::cmd::mod.rs` are removed. `paths::sanitize_branch_slug` stays — still used by remote-registry-entry naming, a different concern.

## Behavioural change

The TUI 'new worktree' dialog now creates at `<repo_root>/.worktrees/<branch-with-slashes>` instead of `<parent(repo_root)>/worktrees/worktree-<slug>`. The repo's de-facto layout already uses the former convention (`.worktrees/issue-triage`, `.worktrees/chat-final`, etc.); no `worktrees/worktree-*` directories exist alongside.

Closes #446

## Test plan

- [x] `cargo test -p worktree-core --lib` — 21/21 pass (4 new path tests)
- [x] `cargo test -p orchard --lib paths::` — 21/21 pass (old `local_path_*` tests removed; sanitize tests retained)
- [x] `cargo test -p orchard-worktree` — 13/13 pass
- [x] `cargo build --workspace` clean
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` clean across the touched crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated worktree path handling into a shared library for improved code reusability.
  * Cleaned up redundant path-computation helpers across modules.

* **Tests**
  * Enhanced test coverage for Git directory resolution and worktree path formatting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/534)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #446

# Related issue

- #446