### PR TITLE
fix(loaders): replace HasPrefix with filepath.Rel for cwd→worktree match

### DIFF
--- a/internal/server/loaders/loaders.go
+++ b/internal/server/loaders/loaders.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -61,9 +62,9 @@ type loaderKey struct{}
 // emission). Every dataloader instance holds its own batched promise
 // state.
 type Loaders struct {
-	Host               *dataloader.Loader[string, *graphql1.Host]
-	WorktreeForCwd     *dataloader.Loader[string, *graphql1.Worktree]
-	Process            *dataloader.Loader[ProcessKey, *graphql1.Process]
+	Host                *dataloader.Loader[string, *graphql1.Host]
+	WorktreeForCwd      *dataloader.Loader[string, *graphql1.Worktree]
+	Process             *dataloader.Loader[ProcessKey, *graphql1.Process]
 	PullRequestsForRepo *dataloader.Loader[RepoKey, []*graphql1.PullRequest]
 
 	// metrics — provider call counts, used by the n+1 detector test.
@@ -287,7 +288,7 @@ func WorktreesForCwds(providers *ProvidersBundle, cwds []string) []*graphql1.Wor
 			if rec.worktree.Path == "" {
 				continue
 			}
-			if !strings.HasPrefix(cwd, rec.worktree.Path) {
+			if !cwdInWorktree(cwd, rec.worktree.Path) {
 				continue
 			}
 			if len(rec.worktree.Path) > len(bestPath) {
@@ -308,6 +309,36 @@ func WorktreesForCwds(providers *ProvidersBundle, cwds []string) []*graphql1.Wor
 		}
 	}
 	return out
+}
+
+// cwdInWorktree reports whether cwd is the worktree's path or a descendant.
+//
+// Uses filepath.Rel rather than strings.HasPrefix so that a worktree at
+// `/repo/foo` does not match cwd `/repo/foobar` — the classic prefix-bypass
+// anti-pattern. Mirrors the validatePath idiom in
+// internal/server/conversations_jsonl_handler.go, the codebase's canonical
+// shape for path-descent checks.
+//
+// The match is purely lexical (no symlink resolution): cwd and worktreePath
+// come from tmux/process introspection and provider listings respectively;
+// neither is user-controlled URL input. We Clean both so trailing slashes,
+// `./` segments, and double separators don't perturb the result.
+func cwdInWorktree(cwd, worktreePath string) bool {
+	if cwd == "" || worktreePath == "" {
+		return false
+	}
+	cleanCwd := filepath.Clean(cwd)
+	cleanWT := filepath.Clean(worktreePath)
+	rel, err := filepath.Rel(cleanWT, cleanCwd)
+	if err != nil {
+		return false
+	}
+	// rel == "." → exact match (cwd IS the worktree).
+	// rel starting with ".." → cwd is outside the worktree.
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
 }
 
 // loadProcesses batches (host, pid) keys -> Process via one

--- a/internal/server/loaders/path_descent_test.go
+++ b/internal/server/loaders/path_descent_test.go
@@ -1,0 +1,44 @@
+package loaders
+
+import "testing"
+
+// TestCwdInWorktree_PrefixBypass is the regression test for #515: a worktree
+// at /repo/foo must NOT match a cwd /repo/foobar. Strings.HasPrefix used to
+// return true here; filepath.Rel correctly returns "../foobar" → reject.
+func TestCwdInWorktree_PrefixBypass(t *testing.T) {
+	cases := []struct {
+		name         string
+		cwd          string
+		worktreePath string
+		want         bool
+	}{
+		// Match cases.
+		{"exact match", "/repo/foo", "/repo/foo", true},
+		{"trailing-slash worktree", "/repo/foo", "/repo/foo/", true},
+		{"trailing-slash cwd", "/repo/foo/", "/repo/foo", true},
+		{"direct child", "/repo/foo/src", "/repo/foo", true},
+		{"deep descendant", "/repo/foo/a/b/c", "/repo/foo", true},
+
+		// Reject: classic prefix-bypass — worktree /repo/foo, cwd /repo/foobar.
+		{"prefix-bypass sibling", "/repo/foobar", "/repo/foo", false},
+		{"prefix-bypass deep", "/repo/foobar/deep", "/repo/foo", false},
+
+		// Reject: cwd outside worktree.
+		{"cwd above worktree", "/repo", "/repo/foo", false},
+		{"cwd unrelated", "/elsewhere", "/repo/foo", false},
+
+		// Empty inputs are not matches.
+		{"empty cwd", "", "/repo/foo", false},
+		{"empty worktree path", "/repo/foo", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cwdInWorktree(tc.cwd, tc.worktreePath)
+			if got != tc.want {
+				t.Errorf("cwdInWorktree(%q, %q) = %v, want %v",
+					tc.cwd, tc.worktreePath, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`internal/server/loaders/loaders.go::WorktreesForCwds` used `strings.HasPrefix(cwd, worktree.Path)` to test whether a cwd lives inside a worktree — the classic prefix-bypass anti-pattern. A worktree at `/repo/foo` matches `cwd=/repo/foobar` even though the two are siblings.

Not exploitable today — `cwd` comes from tmux/process introspection, not user-controlled URLs — but structurally wrong, and the codebase's canonical path-descent idiom (`validatePath` in `internal/server/conversations_jsonl_handler.go`, landed in #510) already uses `filepath.Rel`. This aligns the two call sites on one shape.

## Changes

- New helper `cwdInWorktree(cwd, worktreePath) bool` next to `WorktreesForCwds`. Cleans both inputs and uses `filepath.Rel` to test descent — exact match (`rel == \".\"`) accepted, `\"..\"` / `\"..\"+sep` rejected.
- `WorktreesForCwds` calls `cwdInWorktree` instead of inlining `strings.HasPrefix`. The longest-prefix winner logic (max `len(worktree.Path)`) is unchanged — still selects the deepest matching worktree.
- New table test `TestCwdInWorktree_PrefixBypass` covering: exact match, trailing-slash variations, direct child, deep descendant, prefix-bypass sibling (the regression), prefix-bypass deep, cwd-above-worktree, unrelated cwd, empty inputs.

Closes #515

## Test plan

- [x] `go test ./internal/server/loaders/...` — passes (11/11 new sub-tests + existing batch tests)
- [x] `go vet ./internal/server/...` clean
- [x] `gofmt -l internal/server/loaders/` clean
- [x] `go build -o /dev/null ./cmd/orchard-daemon` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved working directory path resolution. Fixed an issue where directories could be incorrectly associated with the wrong worktree due to prefix-based path matching with common directory names. Now uses proper path semantics to ensure accurate directory-to-worktree assignment, eliminating false positive matches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/536)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #515

# Related issue

- #515