### PR TITLE
chore(gui): regenerate Houdini schema snapshot

### DIFF
--- a/crates/orchard-gui/schema.graphql
+++ b/crates/orchard-gui/schema.graphql
@@ -214,6 +214,16 @@ returns null unconditionally.
 """
 type Conversation implements Node {
   """
+  Sub-agent name from the JSONL `type: "agent-name"` record. Null when the session has not yet recorded one.
+  """
+  agentName: String
+
+  """
+  User-set title from the JSONL `type: "custom-title"` record. Null when the session has not yet recorded one.
+  """
+  customTitle: String
+
+  """
   Working directory recorded in the JSONL when the session was created. Null when not yet observed.
   """
   cwd: String
@@ -1114,8 +1124,12 @@ type TmuxServer implements Node {
   """Pid of the tmux daemon process. Null if not currently determinable."""
   pid: Int
 
-  """Sessions hosted on this server."""
-  sessions: [TmuxSession!]!
+  """
+  Sessions hosted on this server. Defaults to LAST_ACTIVITY which orders
+  most-recently-active first (lex name break ties), matching the sidebar's
+  "what should I look at next" intent. Pass NAME for stable lex order.
+  """
+  sessions(sort: TmuxSessionSort = LAST_ACTIVITY): [TmuxSession!]!
 
   """Filesystem path of the tmux socket the daemon is listening on."""
   socketPath: String!
@@ -1173,6 +1187,17 @@ input TmuxSessionFilter {
 
   """Session names to include."""
   nameIn: [String!]
+}
+
+"""Sort key for `TmuxServer.sessions`."""
+enum TmuxSessionSort {
+  """
+  Most-recently-active first (lastActivityAt DESC). Lex-lower name breaks ties; sessions with no activity rank below those with one.
+  """
+  LAST_ACTIVITY
+
+  """Stable lex order by session name."""
+  NAME
 }
 
 """


### PR DESCRIPTION
## Summary
- PR #533 added `Conversation.agentName`, `Conversation.customTitle`, and `TmuxServer.sessions(sort: TmuxSessionSort)` to the daemon schema, but the Houdini snapshot at `crates/orchard-gui/schema.graphql` was not regenerated in that PR.
- Regenerated via `pnpm exec houdini generate` against the live daemon. No code changes — pure snapshot resync.
- `svelte-check` passes (the 2 pre-existing errors in `vite.config.js` and `transcript.ts` are unrelated and predate this PR).

## Test plan
- [x] `pnpm exec houdini generate` produces an unchanged tree
- [x] `pnpm exec svelte-check` reports the same 2 pre-existing errors, no new ones
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversations now display agent names and custom titles for better identification.
  * Added sorting options for tmux sessions, allowing users to sort by last activity or alphabetically by name.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/538)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->