### PR TITLE
docs(adr): foundational GraphQL/layer/daemon/Houdini/Tailwind ADRs (016-020)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,47 +1,39 @@
-You are an expert Rust engineer. pecialty: async CLI tools, TUI (ratatui), process orchestration (git/tmux/ssh), and cache-driven data pipelines.
+Expert Rust engineer: async CLI, TUI (ratatui), process orchestration (git/tmux/ssh), cache pipelines.
 
 # Git Orchard
 
-Worktree/session dashboard: aggregates git, tmux, GitHub, and SSH into a unified TUI and JSON API.
-
-Release binary symlinked: `~/Library/pnpm/orchard` → `target/release/orchard`.
+Worktree/session dashboard. Aggregates git, tmux, GitHub, SSH into TUI + JSON API. Binary: `~/Library/pnpm/orchard` → `target/release/orchard`.
 
 ## Architecture
 
-See @docs/architecture.md for the full picture. Constraints to enforce:
-
-- **Functional Core, Imperative Shell** — pure `build_state()` joins data, shell modules fetch it
-- **SRP** — files ≤ 300 lines, one responsibility per module/function
-- **`OrchardState`** is the single unified data model for TUI and `--json`
+See @docs/architecture.md. Enforce:
+- Functional core, imperative shell — pure `build_state()` joins, shell fetches
+- SRP, files ≤ 300 lines
+- `OrchardState` = single data model (TUI + `--json`)
 - ADRs in `docs/adr/`
 
-Agent coordination rules and common mistakes: @AGENTS.md
+Coordination: @AGENTS.md
 
-## Project-Specific Rules (learned the hard way)
+## Rules
 
-### Daemon-first joins — don't double-build on the frontend
+### GraphQL is the protocol (ADR-016, 017, 018)
 
-**Rule**: If a join belongs to the daemon (cwd→worktree, sessionUuid→Conversation, lastSeenAt→ClaudeInstance), expose it on the daemon. Do NOT re-implement the join in TS lens projections.
+Clients call daemon GraphQL. No client-side `git`/`gh`/`tmux` exec. No client-side joins or caches — daemon owns state. Subscriptions drive live updates. File a daemon issue for gaps; don't paper over client-side.
 
-- Bad pattern: `const byUuid = new Map(); for (c of conversations) ...` repeated across 5 lens files.
-- Good pattern: query `claudeInstance { worktree { ... } conversation { ... } }` — one daemon trip, no client-side glue.
-- The frontend stays a render layer. GraphQL is "ask for what you need," not "fetch slices and re-join."
-- Title fallback chain (agentName → customTitle → branch → cwd → uuid) is the rare exception that stays client-side — GraphQL doesn't fluent-coalesce.
+Exception: title fallback chain (`agentName → customTitle → branch → cwd → uuid`) stays client-side; GraphQL doesn't fluent-coalesce.
 
 ### Tmux session ≠ Claude session
 
-These are distinct concepts in the schema and must NOT be conflated in field names:
-
 | Concept | Type | Identity | Lifetime |
 |---|---|---|---|
-| Tmux session | `TmuxSession` | `<host>:<name>` | Until tmux server kills it |
-| Claude session | `ClaudeInstance` | `<host>:<claudePid>` (live) + `sessionUuid` (transcript) | Until Claude REPL exits |
+| Tmux | `TmuxSession` | `<host>:<name>` | tmux server kill |
+| Claude | `ClaudeInstance` | `<host>:<claudePid>` live, `sessionUuid` transcript | REPL exit |
 
-A worktree can carry both, neither, or several of each. Don't add `Worktree.sessions` — use `Worktree.tmuxPanes` / `Worktree.tmuxSession` (already exists, #511) and `Worktree.claudeInstances` (when added).
+Use `Worktree.tmuxPanes` / `Worktree.tmuxSession` / `Worktree.claudeInstances`. Never `Worktree.sessions`.
 
-### Verify the live daemon schema before writing client queries
+### Verify live daemon schema before client queries
 
-Don't assume a field exists because it's in `schema.graphql` — the daemon may not have been regenerated/restarted. Verify with introspection:
+Don't assume a field exists in the running daemon. Introspect:
 
 ```bash
 curl -s -X POST http://127.0.0.1:7777/graphql \
@@ -49,40 +41,39 @@ curl -s -X POST http://127.0.0.1:7777/graphql \
   -d '{"query":"{__type(name:\"<Type>\"){fields{name type{name}}}}"}'
 ```
 
-Daemon-first hook fires on every `gh` call — check `~/.claude/references/orchard-daemon.md` for daemon coverage. File an issue when there's a gap rather than papering over it client-side.
+"Verified live" requires daemon restart after rebuild. Test-pass ≠ deployed.
 
 ### gqlgen traps
 
-1. **Resolver-method/provider-field collision**: Adding a type to `gqlgen.yml` under `models:` makes gqlgen generate a `func (r *Resolver) <TypeName>() <TypeName>Resolver` method. If `Resolver` already has a *field* of the same name (e.g. `ClaudeInstance *claudeinstance.Provider`), build breaks with "field and method with the same name." Fix: rename the provider field (`r.ClaudeInstance` → `r.ClaudeInstanceProvider`) before adding the type to gqlgen.yml, OR avoid the resolver-method codegen by binding the field directly.
+1. **Resolver/field name collision**: type in `gqlgen.yml` `models:` generates `Resolver.<TypeName>()` method. Rename clashing provider fields (e.g. `r.ClaudeInstance` → `r.ClaudeInstanceProvider`) before adding.
+2. **Stale code rescue**: snapshot `schema.resolvers.go` to `/tmp/` before every `make generate`; revert on explosion.
+3. **`sortKey` rewrite**: regen overwrites our `sortKey` rename. Re-rename `sort` → `sortKey` in `internal/server/resolvers/schema.resolvers.go` after every regen.
 
-2. **Stale-code "rescue"** — when you delete a resolver function before regen, gqlgen may dump its body as raw text into `schema.resolvers.go` outside any function, breaking the build. Mitigation: snapshot `schema.resolvers.go` to `/tmp/` before every `make generate`. If the regen explodes, revert.
+### Heavy fields excluded from Conversation (ADR-016)
 
-3. **`sortKey` arg rewrite**: gqlgen regenerates the parameter named `sort` (matching schema) on every run. Our resolver renames it to `sortKey` to avoid shadowing the imported `sort` package. After every regen, re-rename `sort` → `sortKey` in the generated resolver signature. Search `internal/server/resolvers/schema.resolvers.go` for `sort *graphql1.TmuxSessionSort` after regen.
+`Conversation` excludes transcripts/message bodies. Heavy reads: `GET /v1/conversations/<uuid>/jsonl`. Don't add `Conversation.transcript`.
 
-### Heavy fields excluded from Conversation by design
+### Config writers — CLI only
 
-Per schema docs (lines 882–887): `Conversation` deliberately excludes full transcripts and message bodies. Heavy reads go through `GET /v1/conversations/<sessionUuid>/jsonl` (HTTP, last-N bytes from end of file). Don't add a `Conversation.transcript` GraphQL field — it would violate the v1 contract. Virtualize the existing reader instead.
+`~/.orchard/config.json` mutated only by `orchard config init|write` and `orchard init` wizard. Never written from TUI startup. New silent writer = file issue.
 
-### Config writers must be explicit CLI/manual ONLY
+### Houdini cache, no client layers (ADR-019)
 
-`~/.orchard/config.json` may only be mutated by:
-1. `orchard config init` / `orchard config write` (CLI in `internal/cli/config/config.go`)
-2. `orchard init` wizard (CLI in `crates/orchard/src/shell.rs`)
+Use Houdini's normalized cache + `defaultCachePolicy`. No module-level Maps. No custom invalidation. Subscriptions update the cache.
 
-`orchard-tui` startup must NOT write the config. The earlier `register_cwd_repo_if_new` call from `App::new` was removed (#545). If you find a new silent writer, file an issue.
+### Tailwind-first (ADR-020, #544)
 
-### No-handrolling rule (Drew, 2026-05-10)
+No new scoped CSS in orchard-gui. Tailwind classes only. Opportunistic migration on touched components.
 
-If a tool/library does the job, use it. Don't hand-roll:
-- gqlgen has `resolver: true` per field — use it instead of writing your own dispatch.
-- Houdini has `defaultCachePolicy` — use it instead of caching layers.
-- CSS gap/flex — use it instead of margin math.
-- Rust `#[serde(rename_all)]` — use it instead of bespoke `Deserialize`.
-- Go stdlib utilities (`gofmt`, `errors.Is`, `slices`, `cmp`) — use them.
-- Virtualization (`@tanstack/svelte-virtual`) — use it instead of manual visible-window math.
-- Tailwind (when adopted, #544) over hand-rolled scoped CSS.
+### No hand-rolling
 
-When the tool fights you, slow down — likely you're using it wrong, not the tool being broken. (cf. the gqlgen schema-drift fight that wasted a session.)
+Use the tool. Examples: gqlgen `resolver: true`, Houdini cache, CSS flex/grid (no margin math), `#[serde(rename_all)]`, Go stdlib (`errors.Is`, `slices`, `cmp`), `@tanstack/svelte-virtual`, Tailwind.
+
+Tool fighting you = you're using it wrong.
+
+### GUI work requires rendering
+
+UI changes verified by rendering, not diff inspection. Playwright snapshot or browser check before claiming done.
 
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence

--- a/docs/adr/016-graphql-as-wire-protocol.md
+++ b/docs/adr/016-graphql-as-wire-protocol.md
@@ -1,0 +1,29 @@
+# ADR-016: GraphQL Is the Wire Protocol
+
+## Status
+Accepted.
+
+## Decision
+GraphQL (served by the daemon at `127.0.0.1:7777/graphql`) is the wire protocol for all client-daemon communication. Clients do not exec local processes (`git`, `gh`, `tmux`) for state queries or mutations. JSON dumps over HTTP and SSH-piped CLI output (the `--json` legacy path) remain only for cross-daemon federation, not for client→daemon.
+
+## Why
+- Clients are heterogeneous: orchard-tui (Rust), orchard-gui (Svelte+Tauri), orchard-worktree CLI, mobile, future web. A single typed protocol prevents N×M adapters.
+- Schema-first contracts catch breakage at codegen, not at runtime.
+- Subscriptions enable real-time UX (transcript live-refresh, session activity) without polling.
+- The daemon is already the join authority (ADR-008); it should be the only API surface.
+
+## How
+- Schema lives in `internal/server/graphql/schema.graphql`; codegen via gqlgen.
+- All queries, mutations, and subscriptions are defined here.
+- Federation between daemons uses the same schema (one daemon proxies to another).
+- Heavy reads (full transcripts) flow through HTTP REST endpoints documented in the schema; not GraphQL fields.
+
+## What is NOT GraphQL
+- Heavy file streams (jsonl tail reads): HTTP `GET /v1/conversations/<uuid>/jsonl`.
+- PTY data: WebSocket per-pane.
+- Cross-daemon federation: `--json` snapshot over SSH (legacy ADR-008/009).
+
+## Consequences
+- New client features: schema first, then resolver, then UI. No shortcut paths.
+- gqlgen and Houdini codegen are part of the build.
+- Schema drift is caught by codegen failures, not runtime errors.

--- a/docs/adr/017-layer-responsibilities.md
+++ b/docs/adr/017-layer-responsibilities.md
@@ -1,0 +1,35 @@
+# ADR-017: Layer Responsibilities
+
+## Status
+Accepted.
+
+## Decision
+Three layers, single responsibility each:
+
+| Layer | Owns | Does NOT do |
+|-------|------|-------------|
+| **Daemon** (Go) | State, joins, subscriptions, mutations, federation | Render, no opinions on display |
+| **Client** (orchard-tui, orchard-gui, mobile) | Render, input → mutation, view state | Joins, business logic, caching |
+| **Tools** (git, gh, tmux, ssh) | Primitives invoked by daemon only | Invoked directly by clients |
+
+## Why
+- Joins re-implemented in N clients = N drift sources. Done once in the daemon = one truth.
+- Caching done by client = competes with daemon's view of fresh data. Daemon owns invalidation.
+- Tools invoked from clients = mobile and remote clients excluded by construction.
+
+## Anti-patterns
+- Lens projections that re-join data the daemon could serve in one query.
+- Client-side `Map` keyed by id rebuilding daemon-known relationships.
+- Frontend code that reads two daemon fields and combines them when a single field would do — file a daemon issue instead.
+- Clients that exec `gh`, `git`, `tmux` directly. Always go through the daemon.
+
+## Exceptions
+- Title fallback chain (`agentName → customTitle → branch → cwd → uuid`): GraphQL doesn't fluent-coalesce; this stays client-side.
+- Pure presentation derived state (sort order, filter results, hover state).
+
+## Consequences
+- New behavior starts with: "what daemon field/mutation/subscription do I need?"
+- Frontend complexity stays at render + input mapping.
+- Daemon complexity grows; mitigated by gqlgen codegen and schema-first design.
+
+See ADR-016 (GraphQL as protocol), ADR-008 (federated discovery via daemon).

--- a/docs/adr/018-daemon-owns-mutations.md
+++ b/docs/adr/018-daemon-owns-mutations.md
@@ -1,0 +1,30 @@
+# ADR-018: Daemon Owns Mutations
+
+## Status
+Accepted.
+
+## Decision
+All worktree, tmux, Claude session, and config mutations flow through daemon GraphQL mutations. Clients (orchard-tui, orchard-gui, orchard-worktree CLI, mobile) call mutations; they do not exec local processes for state changes.
+
+## Why
+- Mobile and remote clients cannot exec local processes. Mutation-via-exec excludes them by construction.
+- Multiple clients hitting the same worktree race without a coordinating authority.
+- Follows ADR-017 layer responsibilities: daemon owns state changes.
+
+## Scope
+| Action | Owner |
+|--------|-------|
+| Create/destroy worktree | daemon mutation |
+| Kill tmux session | daemon mutation |
+| Switch tmux session | daemon mutation |
+| Transfer worktree | daemon mutation |
+| Write `~/.orchard/config.json` | daemon mutation |
+| Read-path joins | daemon (ADR-008) |
+
+## Consequences
+- gqlgen schema grows mutation surface; resolvers thin-wrap existing CLI primitives.
+- `orchard-worktree` CLI becomes a daemon client, not a direct git wrapper.
+- Mobile and boxd clients unblock for write operations.
+- `worktree-core` keeps the primitive functions; daemon resolvers call them; CLI becomes a thin daemon client.
+
+See ADR-016 (GraphQL protocol), ADR-017 (layer responsibilities).

--- a/docs/adr/018-daemon-owns-mutations.md
+++ b/docs/adr/018-daemon-owns-mutations.md
@@ -12,6 +12,7 @@ All worktree, tmux, Claude session, and config mutations flow through daemon Gra
 - Follows ADR-017 layer responsibilities: daemon owns state changes.
 
 ## Scope
+
 | Action | Owner |
 |--------|-------|
 | Create/destroy worktree | daemon mutation |

--- a/docs/adr/019-houdini-cache-no-client-layer.md
+++ b/docs/adr/019-houdini-cache-no-client-layer.md
@@ -1,0 +1,24 @@
+# ADR-019: Houdini Cache, No Client-Side Cache Layer
+
+## Status
+Accepted.
+
+## Decision
+The orchard-gui frontend uses Houdini's normalized cache and `defaultCachePolicy`. No hand-rolled caching layers, no module-level Maps keyed by id, no custom invalidation logic.
+
+## Why
+- Houdini already does cache normalization, fragment reuse, and subscription-driven invalidation.
+- Hand-rolled cache layers compete with Houdini's; produces stale reads and update storms.
+- Subscription flows (`Subscription.conversationChanged`, etc.) update Houdini's store automatically; bypassed by custom layers.
+
+## How
+- Default cache policy `CacheOrNetwork` unless explicitly overridden per query.
+- Lens projections read from Houdini stores; no parallel state.
+- Server-driven invalidation: mutations and subscriptions drive cache updates, not client polling.
+
+## Consequences
+- Schema requires stable IDs on every type for normalization.
+- Cache bugs become Houdini bugs (well-tested), not ours.
+- Frontend complexity drops.
+
+See ADR-016 (GraphQL protocol), ADR-017 (layer responsibilities).

--- a/docs/adr/020-tailwind-first-styling.md
+++ b/docs/adr/020-tailwind-first-styling.md
@@ -1,0 +1,29 @@
+# ADR-020: Tailwind-First Styling
+
+## Status
+Accepted. Migration tracked in #544.
+
+## Decision
+orchard-gui uses Tailwind for styling. No hand-rolled scoped CSS for new components. Existing scoped CSS migrates to Tailwind opportunistically when a component is touched.
+
+## Why
+- Scoped CSS in Svelte components hides shared design tokens; theme drift across components is invisible.
+- Margin math, manual flex calculations, and bespoke color variables are tool-rejection: Tailwind already provides these.
+- Per-component CSS makes it harder to enforce visual consistency at review time.
+
+## How
+- New components: Tailwind classes only.
+- Touched components: opportunistic migration of the touched section.
+- Design tokens: Tailwind config, not per-component variables.
+- Conditional styling: Tailwind variants (`hover:`, `dark:`, etc.) over JS-driven class swaps.
+
+## Anti-patterns
+- Adding `<style>` blocks for new components.
+- Using `style="..."` attributes for layout/spacing.
+- Margin math (`margin-left: calc(...)`) where flex/grid would solve it.
+- Bespoke color variables shadowing Tailwind theme tokens.
+
+## Consequences
+- Tailwind config becomes the design system.
+- Visual review at PR time is easier (class names tell the story).
+- Existing scoped CSS migrates incrementally; no big-bang refactor.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -425,3 +425,15 @@ discovery only. See ADR-008 for the decision rationale.
 - **ADR-019**: Houdini cache — no client-side cache layers; rely on Houdini's normalized cache and subscription invalidation.
 - **ADR-020**: Tailwind-first styling — no new scoped CSS in orchard-gui; opportunistic migration on touched components.
 - **ADR-021**: Federation peers hot-reload — fsnotify watcher + `Provider.ApplyPeers` diff applier lets operators add/remove `peers[]` entries without restarting the daemon; prerequisite: each peer VM must run `boxd proxy new graphql --vm=<name> --port=7777` and have `orchard-daemon` listening on `127.0.0.1:7777`.
+
+### Legacy vs target state
+
+The sections above this ADR list describe **legacy** orchard-tui shape: cache
+files joined client-side, source modules that shell out to `git`/`gh`/`tmux`,
+`--json` as a per-invocation refresh. ADRs 016–020 define the **target** shape:
+daemon owns state, joins, and mutations; clients call `/graphql`; Houdini's
+normalized cache holds query results; no module-level Maps or scoped CSS in
+new code. Migration is incremental and lives across many PRs — when both
+sections describe the same behaviour, the ADR (target) wins. Build new
+features against the target; only touch the legacy path when fixing bugs in
+it or when a target equivalent does not yet exist.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -418,4 +418,10 @@ discovery only. See ADR-008 for the decision rationale.
 - **ADR-010**: `orchard-tui --json` (and `orchard-tui sessions --json`) is the live read; the TUI keeps the cached fast path. Reverses ADR-008's cache-only `--json` clause.
 - **ADR-013**: Orchard CLI ecosystem — one user-facing `orchard` binary as a thin dispatcher; `orchard-tui`, `orchard-daemon`, `orchard-worktree` as helper binaries; `crates/worktree-core/` is the shared library backing worktree mutation in TUI + CLI. Hybrid grammar (namespaced verbs + bare-verb shortcuts for the worktree primary unit).
 - **ADR-014**: Global config location — `~/.orchard/config.json` (dotdir) instead of `~/.config/orchard/config.json` (XDG). Matches every other dotdir tool in the stack (`~/.aws`, `~/.kube`, `~/.ssh`, `~/.cargo`, `~/.claude`). Clean break — daemon and CLI emit a migration hint when the legacy path is detected.
+- **ADR-015**: Minimal config schema.
+- **ADR-016**: GraphQL is the wire protocol — daemon serves `/graphql`; clients (TUI, GUI, CLI, mobile) call it; no client-side `git`/`gh`/`tmux` exec.
+- **ADR-017**: Layer responsibilities — daemon owns state/joins/mutations; clients render only; no client-side joins or caching layers.
+- **ADR-018**: Daemon owns mutations — worktree, tmux, config writes flow through GraphQL mutations; mobile and remote clients unblock.
+- **ADR-019**: Houdini cache — no client-side cache layers; rely on Houdini's normalized cache and subscription invalidation.
+- **ADR-020**: Tailwind-first styling — no new scoped CSS in orchard-gui; opportunistic migration on touched components.
 - **ADR-021**: Federation peers hot-reload — fsnotify watcher + `Provider.ApplyPeers` diff applier lets operators add/remove `peers[]` entries without restarting the daemon; prerequisite: each peer VM must run `boxd proxy new graphql --vm=<name> --port=7777` and have `orchard-daemon` listening on `127.0.0.1:7777`.


### PR DESCRIPTION
## Summary

Codifies architectural decisions made during recent orchard-gui sessions. Foundational ADRs cite each other; downstream ADRs cite the foundations.

- **ADR-016**: GraphQL is the wire protocol. Clients call daemon GraphQL; no client-side `git`/`gh`/`tmux` exec.
- **ADR-017**: Layer responsibilities. Daemon owns state/joins/mutations; clients render only.
- **ADR-018**: Daemon owns mutations. Unblocks mobile and remote clients (#546-adjacent).
- **ADR-019**: Houdini cache. No hand-rolled client cache layers.
- **ADR-020**: Tailwind-first styling. No new scoped CSS in orchard-gui (#544).

`CLAUDE.md` compressed under minimal-info rule; new sections cite the ADRs. `architecture.md` ADR list updated.

## Test plan

- [ ] ADRs read coherent in order 016 → 017 → 018 → 019 → 020
- [ ] CLAUDE.md still actionable (no behavioral guidance lost in compression)
- [ ] No tooling broken (docs-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revamped engineering guidelines and updated ADR index with six new architecture decisions.
  * Formalized GraphQL as the primary client↔daemon protocol with subscription/live-update guidance.
  * Declared daemon-owned mutations, clarified layer responsibilities and session/worktree identities.
  * Standardized client caching on normalized cache policies and introduced a Tailwind-first UI policy.
  * Tightened config-write ownership, cache-layer rules, and UX verification guidance; condensed legacy frontend/CLI guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/547)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->