### PR TITLE
refactor(heal): accept &HealInput<'_> instead of 6 positional args

### DIFF
--- a/crates/orchard/src/heal.rs
+++ b/crates/orchard/src/heal.rs
@@ -208,6 +208,42 @@ pub struct HealClaudeState {
     pub tmux_session: String,
 }
 
+/// Bundled inputs for `diagnose`.
+///
+/// All fields are borrowed slices/references — `HealInput` is `Copy` and zero-cost
+/// to construct. The `Default` impl produces an all-empty input, which lets test
+/// sites that only need a subset of fields use struct-update syntax:
+///
+/// ```ignore
+/// let report = diagnose(&HealInput {
+///     sessions: &sessions,
+///     worktrees: &worktrees,
+///     ..Default::default()
+/// });
+/// ```
+///
+/// # Invariant
+///
+/// All fields must remain borrowed (`&'a [T]` or `Option<&'a T>`). Adding an
+/// owned `Vec<T>` field would break both the `Copy` derive and the zero-copy
+/// contract — drop the derive and revisit the design instead.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct HealInput<'a> {
+    /// Live tmux sessions from the daemon (or any equivalent source).
+    pub sessions: &'a [TmuxSession],
+    /// Enriched worktrees to check.
+    pub worktrees: &'a [HealWorktree],
+    /// Stale-check candidates from `/tmp/orchard-claude-*.json`.
+    pub claude_states: &'a [HealClaudeState],
+    /// Cache file names from `~/.cache/orchard/`.
+    pub cache_files: &'a [String],
+    /// Repo slugs from global config (e.g. `["owner/repo"]`).
+    pub known_repo_slugs: &'a [String],
+    /// Name of the tmux session invoking heal, if any. `KillSession` findings
+    /// whose target matches this name will have `is_self` set to `true`.
+    pub current_session: Option<&'a str>,
+}
+
 // ---------------------------------------------------------------------------
 // Core diagnostic function (pure)
 // ---------------------------------------------------------------------------
@@ -215,25 +251,21 @@ pub struct HealClaudeState {
 /// Diagnoses the health of the Orchard environment.
 ///
 /// This is a pure function: all I/O is performed by callers who gather the
-/// inputs. The function only analyzes and classifies findings.
+/// inputs via `HealInput`. The function only analyzes and classifies findings.
 ///
-/// # Parameters
-/// - `sessions`: live tmux sessions from the daemon (or any equivalent source)
-/// - `worktrees`: enriched worktrees to check
-/// - `claude_states`: stale-check candidates from `/tmp/orchard-claude-*.json`
-/// - `cache_files`: cache file names from `~/.cache/orchard/`
-/// - `known_repo_slugs`: repo slugs from global config (e.g. `["owner/repo"]`)
-/// - `current_session`: name of the tmux session invoking heal, if any.
-///   `KillSession` findings whose target matches this name will have `is_self`
-///   set to `true`, allowing callers to skip self-destructive kills.
-pub fn diagnose(
-    sessions: &[TmuxSession],
-    worktrees: &[HealWorktree],
-    claude_states: &[HealClaudeState],
-    cache_files: &[String],
-    known_repo_slugs: &[String],
-    current_session: Option<&str>,
-) -> HealReport {
+/// `current_session` (via `HealInput`) names the tmux session invoking heal, if
+/// any. `KillSession` findings whose target matches this name will have `is_self`
+/// set to `true`, allowing callers to skip self-destructive kills.
+pub fn diagnose(input: &HealInput<'_>) -> HealReport {
+    let HealInput {
+        sessions,
+        worktrees,
+        claude_states,
+        cache_files,
+        known_repo_slugs,
+        current_session,
+    } = *input;
+
     let mut findings = Vec::new();
 
     check_sessions(sessions, worktrees, &mut findings, current_session);
@@ -796,7 +828,11 @@ mod tests {
             "/tmp/nonexistent-worktree",
         )];
         let worktrees = vec![make_worktree("/workspace/main", "main")];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            ..Default::default()
+        });
 
         // Path doesn't exist → DeadSessionDirectory, not orphaned
         let finding = &report.findings[0];
@@ -809,7 +845,11 @@ mod tests {
         // Use a real path that exists but is not a worktree.
         let sessions = vec![make_session("myrepo_old-feature", "/tmp")];
         let worktrees = vec![make_worktree("/workspace/main", "main")];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -830,7 +870,11 @@ mod tests {
     fn detect_dead_session_directory() {
         let sessions = vec![make_session("myrepo_gone", "/tmp/nonexistent-path-xyz")];
         let worktrees = vec![];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -853,7 +897,11 @@ mod tests {
             path: "/tmp/orchard-claude-abc123.json".to_string(),
             tmux_session: "myrepo_dead".to_string(),
         }];
-        let report = diagnose(&sessions, &[], &claude_states, &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            claude_states: &claude_states,
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -872,7 +920,11 @@ mod tests {
             path: "/tmp/orchard-claude-abc123.json".to_string(),
             tmux_session: "myrepo_live".to_string(),
         }];
-        let report = diagnose(&sessions, &[], &claude_states, &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            claude_states: &claude_states,
+            ..Default::default()
+        });
 
         let stale = report
             .findings
@@ -892,7 +944,11 @@ mod tests {
     fn detect_stale_cache_file_for_unknown_repo() {
         let cache_files = vec!["ghost_repo_issues.json".to_string()];
         let known_slugs = vec!["owner/my-project".to_string()];
-        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs, None);
+        let report = diagnose(&HealInput {
+            cache_files: &cache_files,
+            known_repo_slugs: &known_slugs,
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -906,7 +962,11 @@ mod tests {
     fn no_stale_cache_finding_for_known_repo() {
         let cache_files = vec!["owner_myproject_issues.json".to_string()];
         let known_slugs = vec!["owner/myproject".to_string()];
-        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs, None);
+        let report = diagnose(&HealInput {
+            cache_files: &cache_files,
+            known_repo_slugs: &known_slugs,
+            ..Default::default()
+        });
 
         let stale = report
             .findings
@@ -919,7 +979,11 @@ mod tests {
     fn tmux_sessions_cache_file_ignored() {
         let cache_files = vec!["tmux_sessions.json".to_string()];
         let known_slugs: Vec<String> = vec![];
-        let report = diagnose(&[], &[], &[], &cache_files, &known_slugs, None);
+        let report = diagnose(&HealInput {
+            cache_files: &cache_files,
+            known_repo_slugs: &known_slugs,
+            ..Default::default()
+        });
 
         let stale = report
             .findings
@@ -937,7 +1001,10 @@ mod tests {
         let mut wt = make_worktree(".worktrees/issue3-tests", "issue3/tests");
         wt.pr_state = Some("merged".to_string());
         wt.pr_number = Some(12);
-        let report = diagnose(&[], &[wt], &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            worktrees: &[wt],
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -957,7 +1024,10 @@ mod tests {
         let mut wt = make_worktree(".worktrees/issue5-fix", "issue5/fix");
         wt.pr_state = Some("closed".to_string());
         wt.pr_number = Some(15);
-        let report = diagnose(&[], &[wt], &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            worktrees: &[wt],
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -971,7 +1041,10 @@ mod tests {
         let mut wt = make_worktree(".worktrees/issue3-tests", "issue3/tests");
         wt.pr_state = Some("merged".to_string());
         wt.pr_number = Some(12);
-        let report = diagnose(&[], &[wt], &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            worktrees: &[wt],
+            ..Default::default()
+        });
 
         let results = apply_fixes(&report.findings);
         // FlagForCleanup produces a result but does not kill/delete anything.
@@ -988,7 +1061,10 @@ mod tests {
     fn flag_worktree_with_closed_issue_no_pr() {
         let mut wt = make_worktree(".worktrees/issue8-refactor", "issue8/refactor");
         wt.issue_state = Some("closed".to_string());
-        let report = diagnose(&[], &[wt], &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            worktrees: &[wt],
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -1003,7 +1079,10 @@ mod tests {
         let mut wt = make_worktree(".worktrees/issue8-refactor", "issue8/refactor");
         wt.issue_state = Some("closed".to_string());
         wt.pr_state = Some("open".to_string());
-        let report = diagnose(&[], &[wt], &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            worktrees: &[wt],
+            ..Default::default()
+        });
 
         let issue_finding = report
             .findings
@@ -1024,7 +1103,11 @@ mod tests {
         let sessions = vec![make_session("wrong-name", "/workspace/feature-login")];
         let mut wt = make_worktree("/workspace/feature-login", "feature/login");
         wt.expected_session_name = Some("myrepo_feature-login".to_string());
-        let report = diagnose(&sessions, &[wt], &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &[wt],
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -1043,7 +1126,11 @@ mod tests {
         )];
         let mut wt = make_worktree("/workspace/feature-login", "feature/login");
         wt.expected_session_name = Some("myrepo_feature-login".to_string());
-        let report = diagnose(&sessions, &[wt], &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &[wt],
+            ..Default::default()
+        });
 
         let mismatch = report
             .findings
@@ -1063,7 +1150,11 @@ mod tests {
             make_session("extra-session", "/workspace/issue10-api"),
         ];
         let wt = make_worktree("/workspace/issue10-api", "issue10/api");
-        let report = diagnose(&sessions, &[wt], &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &[wt],
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -1085,7 +1176,11 @@ mod tests {
         let path = tmp.to_string_lossy().to_string();
         let sessions = vec![make_session("myrepo_main", &path)];
         let worktrees = vec![make_worktree(&path, "main")];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            ..Default::default()
+        });
 
         assert!(report.is_all_ok(), "should report all-ok");
         assert_eq!(report.findings.len(), 0);
@@ -1099,7 +1194,11 @@ mod tests {
     fn format_report_suggests_fix_when_actionable() {
         let sessions = vec![make_session("orphan", "/tmp")];
         let worktrees = vec![];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            ..Default::default()
+        });
         let text = format_report(&report, None);
 
         assert!(
@@ -1115,7 +1214,11 @@ mod tests {
         let path = tmp.to_string_lossy().to_string();
         let sessions = vec![make_session("myrepo_main", &path)];
         let worktrees = vec![make_worktree(&path, "main")];
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            ..Default::default()
+        });
         let text = format_report(&report, None);
 
         assert!(
@@ -1196,7 +1299,11 @@ mod tests {
         };
 
         let worktrees = vec![make_worktree(&worktree_path, "issue297/fix")];
-        let report = diagnose(&[session], &worktrees, &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &[session],
+            worktrees: &worktrees,
+            ..Default::default()
+        });
 
         let bad = report.findings.iter().find(|f| {
             matches!(
@@ -1247,7 +1354,12 @@ mod tests {
         let sessions = vec![make_session("orchardist", "/tmp")];
         let worktrees: Vec<HealWorktree> = vec![];
 
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            current_session: Some("orchardist"),
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -1272,7 +1384,12 @@ mod tests {
         ];
         let worktrees: Vec<HealWorktree> = vec![];
 
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            current_session: Some("orchardist"),
+            ..Default::default()
+        });
 
         let orchardist_finding = report
             .findings
@@ -1305,7 +1422,11 @@ mod tests {
         let sessions = vec![make_session("orchardist", "/tmp")];
         let worktrees: Vec<HealWorktree> = vec![];
 
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            ..Default::default()
+        });
 
         for finding in &report.findings {
             assert!(
@@ -1326,7 +1447,12 @@ mod tests {
             tmux_session: "anything".to_string(),
         }];
 
-        let report = diagnose(&sessions, &[], &claude_states, &[], &[], Some("anything"));
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            claude_states: &claude_states,
+            current_session: Some("anything"),
+            ..Default::default()
+        });
 
         for finding in &report.findings {
             if !matches!(finding.action, HealAction::KillSession(_)) {

--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -247,14 +247,14 @@ fn handle_heal(fix: bool, json: bool) {
     // Build HealWorktree entries from all configured repo caches.
     let worktrees = build_heal_worktrees_for_cli(&config);
 
-    let report = heal::diagnose(
-        &sessions,
-        &worktrees,
-        &claude_states,
-        &cache_files,
-        &known_slugs,
-        current_session.as_deref(),
-    );
+    let report = heal::diagnose(&heal::HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        claude_states: &claude_states,
+        cache_files: &cache_files,
+        known_repo_slugs: &known_slugs,
+        current_session: current_session.as_deref(),
+    });
 
     // Abort before applying any destructive fixes when the invoking session
     // has an Error-severity self-classification. A session in an unknown-bad

--- a/crates/orchard/tests/heal_test.rs
+++ b/crates/orchard/tests/heal_test.rs
@@ -3,7 +3,7 @@
 /// These tests exercise the `heal::diagnose` pure function with realistic inputs,
 /// corresponding to acceptance criteria from `specs/features/orchard-heal.feature`.
 use orchard::heal::{
-    HealAction, HealCategory, HealClaudeState, HealWorktree, Severity, apply_fixes,
+    HealAction, HealCategory, HealClaudeState, HealInput, HealWorktree, Severity, apply_fixes,
     detect_self_error, diagnose, format_report,
 };
 use orchard::types::TmuxSession;
@@ -48,7 +48,12 @@ fn dry_run_reports_findings_without_applying_fixes() {
         tmux_session: "myrepo_dead".to_string(),
     }];
 
-    let report = diagnose(&sessions, &worktrees, &claude_states, &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        claude_states: &claude_states,
+        ..Default::default()
+    });
 
     // Orphaned session finding.
     let orphan = report
@@ -86,7 +91,11 @@ fn all_healthy_when_sessions_match_worktrees() {
     let sessions = vec![session("myrepo_main", &tmp)];
     let worktrees = vec![worktree(&tmp, "main")];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        ..Default::default()
+    });
 
     assert_eq!(report.findings.len(), 0, "should have no findings");
     assert!(report.is_all_ok());
@@ -109,7 +118,11 @@ fn orphaned_session_detected_when_path_exists_but_no_worktree_matches() {
     let sessions = vec![session("myrepo_old-feature", "/tmp")];
     let worktrees = vec![worktree("/workspace/other", "main")];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        ..Default::default()
+    });
 
     let finding = report
         .findings
@@ -139,7 +152,11 @@ fn dead_session_directory_detected_for_nonexistent_path() {
     )];
     let worktrees = vec![];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        ..Default::default()
+    });
 
     let finding = report
         .findings
@@ -163,7 +180,11 @@ fn stale_claude_state_detected_for_dead_session() {
         tmux_session: "myrepo_dead".to_string(),
     }];
 
-    let report = diagnose(&sessions, &[], &claude_states, &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        claude_states: &claude_states,
+        ..Default::default()
+    });
 
     let finding = report
         .findings
@@ -187,7 +208,11 @@ fn no_stale_claude_state_when_session_is_alive() {
         tmux_session: "myrepo_live".to_string(),
     }];
 
-    let report = diagnose(&sessions, &[], &claude_states, &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        claude_states: &claude_states,
+        ..Default::default()
+    });
 
     let stale = report
         .findings
@@ -209,7 +234,11 @@ fn stale_cache_file_flagged_for_unknown_repo() {
     let cache_files = vec!["ghost_repo_issues.json".to_string()];
     let known_slugs = vec!["owner/known-project".to_string()];
 
-    let report = diagnose(&[], &[], &[], &cache_files, &known_slugs, None);
+    let report = diagnose(&HealInput {
+        cache_files: &cache_files,
+        known_repo_slugs: &known_slugs,
+        ..Default::default()
+    });
 
     let finding = report
         .findings
@@ -226,7 +255,11 @@ fn no_stale_cache_for_known_repo() {
     let cache_files = vec!["owner_myrepo_issues.json".to_string()];
     let known_slugs = vec!["owner/myrepo".to_string()];
 
-    let report = diagnose(&[], &[], &[], &cache_files, &known_slugs, None);
+    let report = diagnose(&HealInput {
+        cache_files: &cache_files,
+        known_repo_slugs: &known_slugs,
+        ..Default::default()
+    });
 
     let stale = report
         .findings
@@ -246,7 +279,10 @@ fn merged_pr_worktree_flagged_for_manual_cleanup() {
     wt.pr_state = Some("merged".to_string());
     wt.pr_number = Some(12);
 
-    let report = diagnose(&[], &[wt], &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        worktrees: &[wt],
+        ..Default::default()
+    });
 
     let finding = report
         .findings
@@ -267,7 +303,10 @@ fn closed_pr_worktree_flagged() {
     wt.pr_state = Some("closed".to_string());
     wt.pr_number = Some(15);
 
-    let report = diagnose(&[], &[wt], &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        worktrees: &[wt],
+        ..Default::default()
+    });
 
     let finding = report
         .findings
@@ -283,7 +322,10 @@ fn fix_does_not_auto_delete_merged_pr_worktrees() {
     wt.pr_state = Some("merged".to_string());
     wt.pr_number = Some(12);
 
-    let report = diagnose(&[], &[wt], &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        worktrees: &[wt],
+        ..Default::default()
+    });
     let fix_results = orchard::heal::apply_fixes(&report.findings);
 
     // All results should be FlagForCleanup (not KillSession or DeleteFile).
@@ -306,7 +348,10 @@ fn closed_issue_worktree_flagged_when_no_pr() {
     let mut wt = worktree(".worktrees/issue8-refactor", "issue8/refactor");
     wt.issue_state = Some("closed".to_string());
 
-    let report = diagnose(&[], &[wt], &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        worktrees: &[wt],
+        ..Default::default()
+    });
 
     let finding = report
         .findings
@@ -330,7 +375,11 @@ fn session_naming_mismatch_detected() {
     let mut wt = worktree("/workspace/feature-login", "feature/login");
     wt.expected_session_name = Some("myrepo_feature-login".to_string());
 
-    let report = diagnose(&sessions, &[wt], &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &[wt],
+        ..Default::default()
+    });
 
     let finding = report
         .findings
@@ -354,7 +403,11 @@ fn multiple_sessions_per_worktree_detected() {
     ];
     let wt = worktree("/workspace/issue10-api", "issue10/api");
 
-    let report = diagnose(&sessions, &[wt], &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &[wt],
+        ..Default::default()
+    });
 
     let finding = report
         .findings
@@ -375,7 +428,11 @@ fn report_format_includes_icons() {
     let sessions = vec![session("orphan", "/tmp")]; // /tmp is a real path but not a worktree
     let worktrees = vec![];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        ..Default::default()
+    });
     let text = format_report(&report, None);
 
     // Should contain at least one icon character.
@@ -390,7 +447,11 @@ fn json_output_contains_findings_array() {
     let sessions = vec![session("orphan", "/tmp")];
     let worktrees = vec![];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        ..Default::default()
+    });
     let json_str = serde_json::to_string(&report).expect("serialize report");
     let json: serde_json::Value = serde_json::from_str(&json_str).expect("parse json");
 
@@ -440,7 +501,11 @@ fn outside_tmux_no_self_protection_applied() {
     let worktrees: Vec<HealWorktree> = vec![];
 
     // current_session = None simulates running outside tmux.
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], None);
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        ..Default::default()
+    });
 
     let finding = report
         .findings
@@ -482,7 +547,12 @@ fn regression_heal_must_never_kill_invoking_session() {
     // TODAY diagnose() only accepts 5 positional args — this 6th arg is the one
     // the fix will add. Passing it here causes a compile error, which is the
     // expected failing-first signal for Phase 1 of TDD.
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        current_session: Some("orchardist"),
+        ..Default::default()
+    });
 
     let fix_results = orchard::heal::apply_fixes(&report.findings);
 
@@ -517,7 +587,12 @@ fn format_report_marks_invoking_session_as_skipped() {
     let sessions = vec![session("orchardist", "/tmp")];
     let worktrees: Vec<orchard::heal::HealWorktree> = vec![];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        current_session: Some("orchardist"),
+        ..Default::default()
+    });
     let text = format_report(&report, None);
 
     assert!(
@@ -536,7 +611,12 @@ fn json_output_exposes_is_self_field() {
     let sessions = vec![session("orchardist", "/tmp")];
     let worktrees: Vec<orchard::heal::HealWorktree> = vec![];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        current_session: Some("orchardist"),
+        ..Default::default()
+    });
     let json_str = serde_json::to_string(&report).expect("serialize report");
     let json: serde_json::Value = serde_json::from_str(&json_str).expect("parse json");
 
@@ -581,7 +661,12 @@ fn regression_full_pipeline_from_inside_named_tmux_session_never_kills_self() {
     let sessions = vec![session("orchardist", "/tmp"), session(orphan_name, "/tmp")];
     let worktrees: Vec<HealWorktree> = vec![];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        current_session: Some("orchardist"),
+        ..Default::default()
+    });
     let fix_results = apply_fixes(&report.findings);
 
     // Self must be skipped, not killed.
@@ -633,7 +718,12 @@ fn regression_sister_window_of_invoking_session_is_still_treated_as_self() {
         }];
         let worktrees: Vec<HealWorktree> = vec![];
 
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            current_session: Some("orchardist"),
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -664,7 +754,12 @@ fn regression_sister_window_of_invoking_session_is_still_treated_as_self() {
         }];
         let worktrees: Vec<HealWorktree> = vec![];
 
-        let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+        let report = diagnose(&HealInput {
+            sessions: &sessions,
+            worktrees: &worktrees,
+            current_session: Some("orchardist"),
+            ..Default::default()
+        });
 
         let finding = report
             .findings
@@ -692,7 +787,12 @@ fn regression_warning_severity_self_does_not_trigger_abort_path() {
     let sessions = vec![session("orchardist", "/tmp")];
     let worktrees: Vec<HealWorktree> = vec![];
 
-    let report = diagnose(&sessions, &worktrees, &[], &[], &[], Some("orchardist"));
+    let report = diagnose(&HealInput {
+        sessions: &sessions,
+        worktrees: &worktrees,
+        current_session: Some("orchardist"),
+        ..Default::default()
+    });
 
     // Confirm we actually got a self finding at Warning severity.
     let self_finding = report

--- a/crates/orchard/tests/heal_test.rs
+++ b/crates/orchard/tests/heal_test.rs
@@ -543,10 +543,8 @@ fn regression_heal_must_never_kill_invoking_session() {
     let sessions = vec![session("orchardist", "/tmp")];
     let worktrees: Vec<orchard::heal::HealWorktree> = vec![];
 
-    // Pass `Some("orchardist")` as the `current_session` argument.
-    // TODAY diagnose() only accepts 5 positional args — this 6th arg is the one
-    // the fix will add. Passing it here causes a compile error, which is the
-    // expected failing-first signal for Phase 1 of TDD.
+    // Pass `Some("orchardist")` as the `current_session` field so the diagnose
+    // self-protection branch fires.
     let report = diagnose(&HealInput {
         sessions: &sessions,
         worktrees: &worktrees,

--- a/specs/features/heal-diagnose-healinput-struct.feature
+++ b/specs/features/heal-diagnose-healinput-struct.feature
@@ -1,0 +1,216 @@
+Feature: Refactor heal::diagnose to take a HealInput struct
+  As a developer maintaining the heal subsystem
+  I want diagnose() to take a single &HealInput<'_> instead of 6 positional refs
+  So that adding new inputs is safe and call sites are self-documenting
+
+  Background:
+    Given heal.rs is in crates/orchard/src/heal.rs
+    And diagnose currently takes 6 positional reference arguments
+    And cache_files and known_repo_slugs both have type &[String] (positionally swappable)
+
+  # ===================================================================
+  # HealInput struct — definition
+  # ===================================================================
+
+  @unit
+  Scenario: HealInput struct exists with named fields for all current diagnose inputs
+    Given the HealInput<'a> struct in crates/orchard/src/heal.rs
+    Then it has these public fields:
+      | field            | type                    |
+      | sessions         | &'a [TmuxSession]       |
+      | worktrees        | &'a [HealWorktree]      |
+      | claude_states    | &'a [HealClaudeState]   |
+      | cache_files      | &'a [String]            |
+      | known_repo_slugs | &'a [String]            |
+      | current_session  | Option<&'a str>         |
+
+  @unit
+  Scenario: HealInput derives Debug, Clone, Copy, Default
+    Given the HealInput<'a> struct
+    Then it derives Debug, Clone, Copy, and Default
+
+  @unit
+  Scenario: HealInput::default() yields empty slices and None
+    When HealInput::default() is called
+    Then sessions is an empty slice
+    And worktrees is an empty slice
+    And claude_states is an empty slice
+    And cache_files is an empty slice
+    And known_repo_slugs is an empty slice
+    And current_session is None
+
+  @unit
+  Scenario: HealInput is public from the heal module
+    Given crates/orchard/src/heal.rs
+    Then HealInput is declared with `pub struct HealInput<'a>`
+    And it is reachable as orchard::heal::HealInput from outside the module
+
+  @unit
+  Scenario: HealInput documents the borrowed-only invariant
+    Given the doc comment on HealInput
+    Then it states that all fields are borrowed
+    And it warns that adding an owned field (e.g. Vec<T>) requires dropping the Default derive
+    And it warns that adding an owned field requires revisiting the zero-copy contract
+
+  # ===================================================================
+  # diagnose signature — single &HealInput<'_> argument
+  # ===================================================================
+
+  @unit
+  Scenario: diagnose takes a single &HealInput<'_> argument
+    Given the diagnose function in crates/orchard/src/heal.rs
+    Then its signature is `pub fn diagnose(input: &HealInput<'_>) -> HealReport`
+    And it takes exactly one parameter
+
+  @unit
+  Scenario: diagnose destructures HealInput once at the top
+    Given the body of diagnose
+    Then it destructures *input into the six named fields once
+    And the existing check_* helper signatures are unchanged
+    And the helpers are called with the destructured locals
+
+  # ===================================================================
+  # Behavior preservation — no observable change
+  # ===================================================================
+
+  @integration
+  Scenario: diagnose returns the same HealReport for the same inputs
+    Given a fixed set of sessions, worktrees, claude_states, cache_files, known_repo_slugs, and current_session
+    When the same inputs are passed to the new HealInput-based diagnose
+    Then the returned HealReport.findings is identical to the pre-refactor output
+    And findings order is preserved
+    And every HealFinding field (category, severity, message, action, is_self) is unchanged
+
+  @integration
+  Scenario: Self-kill detection still flips is_self
+    Given a tmux session named "myrepo_branch" with no matching worktree
+    And current_session set to "myrepo_branch"
+    When diagnose is called with a HealInput carrying these values
+    Then the OrphanedSession finding for "myrepo_branch" has is_self = true
+
+  @integration
+  Scenario: Existing heal tests pass without modification of expectations
+    When `cargo test -p orchard` is run
+    Then every test in crates/orchard/src/heal.rs `#[cfg(test)]` block passes
+    And every test in crates/orchard/tests/heal_test.rs passes
+    And only call-site syntax changed; assertions on HealReport contents did not
+
+  # ===================================================================
+  # Call-site migration — production
+  # ===================================================================
+
+  @integration
+  Scenario: Production caller in main.rs uses a full HealInput literal
+    Given crates/orchard/src/main.rs at the heal-dispatch site
+    Then it constructs `HealInput { sessions: …, worktrees: …, claude_states: …, cache_files: …, known_repo_slugs: …, current_session: … }`
+    And it passes `&input` (or equivalent) to `heal::diagnose`
+    And no positional 6-arg call to diagnose remains in the production code
+
+  # ===================================================================
+  # Call-site migration — tests
+  # ===================================================================
+
+  @integration
+  Scenario: Sparse test call sites use `..Default::default()`
+    Given a test that previously passed three or more empty slice arguments to diagnose
+    Then the rewritten test constructs HealInput with only the relevant fields populated
+    And the remaining fields come from `..Default::default()`
+
+  @integration
+  Scenario: Dense test call sites use full struct literals
+    Given a test that previously populated most or all positional arguments
+    Then the rewritten test uses a full HealInput literal with every field named
+    And no test relies on positional argument order
+
+  @integration
+  Scenario: cache_files and known_repo_slugs are never swapped at any call site
+    Given every migrated call site (production + tests)
+    When the fields are inspected
+    Then cache_files always receives the cache-file list
+    And known_repo_slugs always receives the repo-slug list
+    And the named-field syntax makes mis-binding impossible to introduce silently
+
+  @integration
+  Scenario: No positional 6-arg diagnose call survives in the workspace
+    When the workspace is grepped for calls to `diagnose(`
+    Then every call passes a single `&HealInput` (or `&input` binding) argument
+    And no call uses the legacy 6-positional-argument form
+
+  # ===================================================================
+  # Quality gates
+  # ===================================================================
+
+  @integration
+  Scenario: Workspace builds clean after the refactor
+    When `cargo build --workspace` is run
+    Then it succeeds with no errors
+    And `cargo clippy --workspace --all-targets -- -D warnings` succeeds
+    And `cargo fmt --check` succeeds
+
+  @integration
+  Scenario: Full workspace test suite passes
+    When `cargo test --workspace` is run
+    Then all tests pass
+
+  # ===================================================================
+  # Scope guards — what this refactor does NOT do
+  # ===================================================================
+
+  @unit
+  Scenario: check_* helper signatures are NOT modified
+    Given check_sessions, check_claude_states, check_cache_files,
+          check_worktree_pr_states, check_worktree_issue_states,
+          check_session_naming, check_multiple_sessions_per_worktree
+    Then their parameter lists are unchanged from the pre-refactor signatures
+    And they still take individual &[T] slices (not &HealInput)
+
+  @unit
+  Scenario: HealReport, HealFinding, HealAction, HealCategory are NOT modified
+    Given the output types of heal::diagnose
+    Then HealReport is unchanged
+    And HealFinding is unchanged
+    And HealAction is unchanged
+    And HealCategory is unchanged
+
+  @unit
+  Scenario: No new fields are added to HealInput beyond the current six
+    Given the HealInput struct as shipped by this refactor
+    Then it contains exactly six fields matching the pre-refactor diagnose signature
+    And cross-server detection or other new inputs are deferred to a follow-up issue
+
+  @unit
+  Scenario: HealInput is flat, not nested by domain
+    Given the HealInput struct
+    Then it does NOT contain sub-structs like TmuxState, GithubState, or CacheState
+    And all six fields live directly on HealInput
+
+  # ===================================================================
+  # AC Coverage Map
+  # ===================================================================
+  # AC 1: "diagnose takes a single &HealInput<'_> argument."
+  #       → "diagnose takes a single &HealInput<'_> argument"
+  #       → "diagnose destructures HealInput once at the top"
+  #
+  # AC 2: "HealInput is a struct (with lifetimes) carrying current fields plus easy room for additions."
+  #       → "HealInput struct exists with named fields for all current diagnose inputs"
+  #       → "HealInput derives Debug, Clone, Copy, Default"
+  #       → "HealInput::default() yields empty slices and None"
+  #       → "HealInput is public from the heal module"
+  #       → "HealInput documents the borrowed-only invariant"
+  #       → "HealInput is flat, not nested by domain"
+  #
+  # AC 3: "All ~25 call sites (production + tests) migrate to the new signature."
+  #       → "Production caller in main.rs uses a full HealInput literal"
+  #       → "Sparse test call sites use `..Default::default()`"
+  #       → "Dense test call sites use full struct literals"
+  #       → "cache_files and known_repo_slugs are never swapped at any call site"
+  #       → "No positional 6-arg diagnose call survives in the workspace"
+  #
+  # AC 4: "Behavior unchanged; existing tests pass."
+  #       → "diagnose returns the same HealReport for the same inputs"
+  #       → "Self-kill detection still flips is_self"
+  #       → "Existing heal tests pass without modification of expectations"
+  #       → "Workspace builds clean after the refactor"
+  #       → "Full workspace test suite passes"
+  #       → "check_* helper signatures are NOT modified"
+  #       → "HealReport, HealFinding, HealAction, HealCategory are NOT modified"


### PR DESCRIPTION
## Why

Closes #370.

`heal::diagnose` had grown to 6 positional reference args. Two of them (`cache_files` and `known_repo_slugs`) share `&[String]` and were positionally swappable — a real bug risk, not just readability. Issue #361's "if more knobs land later, refactor to `HealInput` then" triggered when PR #368 added the 6th arg.

## What changed

- Introduced `HealInput<'a>` — flat struct of borrowed fields, `Debug + Clone + Copy + Default`. Documented borrowed-only invariant so a future owned field doesn't quietly break the `Copy`/zero-copy contract.
- `diagnose` takes `&HealInput<'_>`, destructures once at the top — internal `check_*` helpers keep their existing signatures, body diff is minimal.
- 50 call sites migrated (1 production + 25 in-file `#[cfg(test)]` + 24 integration). Sparse sites collapse to `..Default::default()`; dense sites and the production caller use full struct literals.
- Shape follows `WebhookRequest<'a>` idiom (`webhook/handler.rs:17`); `Default` on borrowed fields is a new pattern in this repo — call out in review.

See commit `2dd7391` for the rationale on each decision.

## Test plan

- `cargo test -p orchard --test heal_test` → 23/23 ✅ (baseline 23/23)
- `cargo test -p orchard --lib heal::` → 38/38 ✅ (baseline 38/38)
- `cargo build -p orchard` → clean
- `cargo clippy -p orchard --all-targets -- -D warnings` → clean
- `cargo fmt --check` → clean

No new test failures vs baseline. One pre-existing flake (`sources::hosts::tests::non_orchard_proxy_probe_failure_is_silent`) is unrelated to heal and fails identically on `main` when run via the full lib suite — separate issue.

## Anything surprising?

- The `Default` derive on a struct of borrowed slices is sound because `&[]` and `Option::None` are `'static`, but it's new ground for this codebase. The `# Invariant` doc on `HealInput` is the guardrail: any future field must stay borrowed, or the derive must come off.
- Refactor lands as one commit because ACs 1–4 are tightly coupled (the signature change and the 50 call-site updates must move together — splitting would intentionally red-build between commits).


# Related issue

- #370

# Related issue

- #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization of the healing diagnostic system for enhanced maintainability and testing robustness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/565)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #370