### PR TITLE
refactor(hosts): extract post-probe pipeline (#295)

### DIFF
--- a/crates/orchard/src/build_state.rs
+++ b/crates/orchard/src/build_state.rs
@@ -360,46 +360,16 @@ pub fn refresh_and_build_with_walker_config(
         .map(|(h, r)| (h.clone(), HostState { reachable: *r }))
         .collect();
 
-    // Refresh remote sources in parallel. Worktree refreshes fan out by
-    // (repo, remote) pair; adapter-routed tmux refreshes fan out once per
-    // unique host (picking any (repo, remote) whose host matches). Each
-    // writes its own cache file so no coordination is needed.
-    let tmux_dispatch: Vec<(
-        &crate::global_config::RepoConfig,
-        &crate::global_config::RemoteConfig,
-    )> = {
-        let mut seen = HashSet::new();
-        config
-            .repos
-            .iter()
-            .flat_map(|r| r.remotes.iter().map(move |rm| (r, rm)))
-            .filter(|(_, rm)| {
-                hosts.get(&rm.host).map(|s| s.reachable).unwrap_or(false)
-                    && seen.insert(rm.host.clone())
-            })
-            .collect()
-    };
-    std::thread::scope(|s| {
-        for repo in &config.repos {
-            for remote in &repo.remotes {
-                let reachable = hosts
-                    .get(&remote.host)
-                    .map(|st| st.reachable)
-                    .unwrap_or(false);
-                if reachable {
-                    s.spawn(move || {
-                        let _ = cache_sources::refresh_remote_worktrees(repo, remote);
-                    });
-                }
-            }
-        }
-        for (repo, remote) in &tmux_dispatch {
-            s.spawn(move || {
-                let old_hosts = cache_sources::snapshot_fork_hosts_for_remote(repo, remote);
-                let _ = cache_sources::refresh_remote_tmux_sessions(repo, remote, &old_hosts);
-            });
-        }
-    });
+    let reachable: HashSet<String> = probe_results
+        .iter()
+        .filter_map(|(h, r)| if *r { Some(h.clone()) } else { None })
+        .collect();
+
+    // Refresh remote sources via the shared post-probe pipeline (see
+    // `sources::refresh`). Fans out worktree + tmux refresh per reachable
+    // (repo, remote), takes fork-host snapshots BEFORE worktree refresh,
+    // dedups tmux by `{kind}:{host}`.
+    sources::refresh::refresh_remotes_for_reachable_hosts(config, &reachable);
 
     // Build base state from local caches and one-hop remotes.
     let mut state = build_state_with_hosts(config, &hosts);

--- a/crates/orchard/src/sources/mod.rs
+++ b/crates/orchard/src/sources/mod.rs
@@ -6,3 +6,4 @@
 //! or `cache_sources::refresh_*` (watch daemon, heal, --json).
 
 pub mod hosts;
+pub mod refresh;

--- a/crates/orchard/src/sources/refresh.rs
+++ b/crates/orchard/src/sources/refresh.rs
@@ -1,0 +1,393 @@
+//! Drives remote refresh given reachability — extracts the per-(repo, remote) loop
+//! previously duplicated across `build_state::refresh_and_build` and
+//! `tui::start_full_refresh`.
+//!
+//! Behavior contract (matches Site B today):
+//! - Fork-host snapshot is taken BEFORE `refresh_remote_worktrees` per
+//!   (repo, remote) — honors the documented contract at
+//!   `cache_sources::snapshot_fork_hosts_for_remote`.
+//! - Tmux refresh is deduped by `format!("{kind_str}:{host}")` (same as
+//!   `tui::mod::dedup_key`), NOT by raw host.
+//! - Worktree refresh is NOT deduped — it fires once per (repo, remote)
+//!   regardless of host overlap.
+//! - Parallelism is `std::thread::scope` flat per-(repo, remote) for worktrees
+//!   + per first-seen `{kind}:{host}` for tmux. No inner threading inside
+//!   `refresh_remote_*` (item 6 of #272 is out of scope).
+//!
+//! No `AppMsg` / `mpsc::Sender` coupling. Callers that need to emit messages
+//! (Site B) do so BEFORE calling this helper.
+
+use crate::global_config::GlobalConfig;
+use std::collections::HashSet;
+
+/// Drives remote-refresh work for every reachable (repo, remote) pair in `config`.
+///
+/// `reachable` is the set of host strings (e.g. `"user@host"`) that probed as
+/// reachable. Unreachable hosts are skipped silently — the caller owns probe
+/// emission (Site B emits `AppMsg::HostReachability` BEFORE calling this).
+///
+/// Side effects:
+/// - For each reachable (repo, remote), takes a fork-host snapshot via
+///   `cache_sources::snapshot_fork_hosts_for_remote` BEFORE worktree refresh.
+/// - Spawns `cache_sources::refresh_remote_worktrees(repo, remote)` per
+///   reachable pair, in a `std::thread::scope`.
+/// - For each first-seen `"{kind}:{host}"` among the reachable pairs, spawns
+///   `cache_sources::refresh_remote_tmux_sessions(repo, remote, &snapshot)`
+///   with the snapshot captured before worktree refresh.
+///
+/// Returns when all spawned threads have joined.
+pub fn refresh_remotes_for_reachable_hosts(config: &GlobalConfig, reachable: &HashSet<String>) {
+    drive(config, reachable, &RealDriver);
+}
+
+/// Indirection trait so unit tests can record call ordering without touching
+/// real caches. `RealDriver` is the only production impl.
+trait RemoteRefreshDriver: Sync {
+    fn snapshot_fork_hosts(
+        &self,
+        repo: &crate::global_config::RepoConfig,
+        remote: &crate::global_config::RemoteConfig,
+    ) -> HashSet<String>;
+
+    fn refresh_worktrees(
+        &self,
+        repo: &crate::global_config::RepoConfig,
+        remote: &crate::global_config::RemoteConfig,
+    );
+
+    fn refresh_tmux(
+        &self,
+        repo: &crate::global_config::RepoConfig,
+        remote: &crate::global_config::RemoteConfig,
+        old_hosts: &HashSet<String>,
+    );
+}
+
+struct RealDriver;
+
+impl RemoteRefreshDriver for RealDriver {
+    fn snapshot_fork_hosts(
+        &self,
+        repo: &crate::global_config::RepoConfig,
+        remote: &crate::global_config::RemoteConfig,
+    ) -> HashSet<String> {
+        crate::cache_sources::snapshot_fork_hosts_for_remote(repo, remote)
+    }
+
+    fn refresh_worktrees(
+        &self,
+        repo: &crate::global_config::RepoConfig,
+        remote: &crate::global_config::RemoteConfig,
+    ) {
+        let _ = crate::cache_sources::refresh_remote_worktrees(repo, remote);
+    }
+
+    fn refresh_tmux(
+        &self,
+        repo: &crate::global_config::RepoConfig,
+        remote: &crate::global_config::RemoteConfig,
+        old_hosts: &HashSet<String>,
+    ) {
+        let _ = crate::cache_sources::refresh_remote_tmux_sessions(repo, remote, old_hosts);
+    }
+}
+
+fn drive(config: &GlobalConfig, reachable: &HashSet<String>, driver: &dyn RemoteRefreshDriver) {
+    // 1. Snapshot fork-hosts FIRST for every reachable (repo, remote) — before any
+    //    refresh_remote_worktrees runs anywhere. This honors the documented
+    //    contract at `cache_sources::snapshot_fork_hosts_for_remote` (must be
+    //    called before `refresh_remote_worktrees` mutates the cache).
+    let mut snapshots: Vec<(
+        &crate::global_config::RepoConfig,
+        &crate::global_config::RemoteConfig,
+        HashSet<String>,
+    )> = Vec::new();
+    for repo in &config.repos {
+        for remote in &repo.remotes {
+            if reachable.contains(&remote.host) {
+                let snap = driver.snapshot_fork_hosts(repo, remote);
+                snapshots.push((repo, remote, snap));
+            }
+        }
+    }
+
+    // 2. Build the tmux dispatch list — first-seen "{kind}:{host}" only.
+    let tmux_dispatch: Vec<(
+        &crate::global_config::RepoConfig,
+        &crate::global_config::RemoteConfig,
+        &HashSet<String>,
+    )> = {
+        let mut seen = HashSet::<String>::new();
+        snapshots
+            .iter()
+            .filter(|(_, remote, _)| {
+                seen.insert(format!(
+                    "{}:{}",
+                    crate::cache_sources::kind_str(remote.kind),
+                    remote.host
+                ))
+            })
+            .map(|(repo, remote, snap)| (*repo, *remote, snap))
+            .collect()
+    };
+
+    // 3. Fan out worktree + tmux refreshes concurrently.
+    std::thread::scope(|s| {
+        for (repo, remote, _snap) in &snapshots {
+            s.spawn(move || driver.refresh_worktrees(repo, remote));
+        }
+        for (repo, remote, snap) in &tmux_dispatch {
+            s.spawn(move || driver.refresh_tmux(repo, remote, snap));
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::global_config::{RemoteConfig, RepoConfig};
+    use crate::remote_adapter::RemoteKind;
+    use std::sync::Mutex;
+    use std::time::Instant;
+
+    fn make_remote(name: &str, host: &str, kind: RemoteKind) -> RemoteConfig {
+        RemoteConfig {
+            name: name.to_string(),
+            host: host.to_string(),
+            path: "/tmp/repo".to_string(),
+            shell: "ssh".to_string(),
+            kind,
+            allow_transitive: false,
+        }
+    }
+
+    fn make_repo(slug: &str, remotes: Vec<RemoteConfig>) -> RepoConfig {
+        RepoConfig {
+            slug: slug.to_string(),
+            path: format!("/tmp/{slug}"),
+            remotes,
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum CallKind {
+        Snapshot,
+        Worktrees,
+        Tmux,
+    }
+
+    /// Records the ordered sequence of calls and what tmux received as `old_hosts`.
+    struct Recorder {
+        calls: Mutex<Vec<(CallKind, String, String, Instant)>>, // (kind, repo_slug, remote_host, when)
+        tmux_old_hosts: Mutex<Vec<(String, HashSet<String>)>>,  // (remote_host, snapshot)
+        // What snapshot_fork_hosts returns for each host.
+        snapshot_returns: std::collections::HashMap<String, HashSet<String>>,
+    }
+
+    impl Recorder {
+        fn new(snapshot_returns: std::collections::HashMap<String, HashSet<String>>) -> Self {
+            Self {
+                calls: Mutex::new(Vec::new()),
+                tmux_old_hosts: Mutex::new(Vec::new()),
+                snapshot_returns,
+            }
+        }
+    }
+
+    impl RemoteRefreshDriver for Recorder {
+        fn snapshot_fork_hosts(
+            &self,
+            repo: &RepoConfig,
+            remote: &RemoteConfig,
+        ) -> HashSet<String> {
+            self.calls.lock().unwrap().push((
+                CallKind::Snapshot,
+                repo.slug.clone(),
+                remote.host.clone(),
+                Instant::now(),
+            ));
+            self.snapshot_returns
+                .get(&remote.host)
+                .cloned()
+                .unwrap_or_default()
+        }
+
+        fn refresh_worktrees(&self, repo: &RepoConfig, remote: &RemoteConfig) {
+            // Small sleep so any ordering bug surfaces deterministically — without
+            // it, snapshot + worktree spawns can land at the same Instant.
+            std::thread::sleep(std::time::Duration::from_millis(5));
+            self.calls.lock().unwrap().push((
+                CallKind::Worktrees,
+                repo.slug.clone(),
+                remote.host.clone(),
+                Instant::now(),
+            ));
+        }
+
+        fn refresh_tmux(
+            &self,
+            repo: &RepoConfig,
+            remote: &RemoteConfig,
+            old_hosts: &HashSet<String>,
+        ) {
+            self.calls.lock().unwrap().push((
+                CallKind::Tmux,
+                repo.slug.clone(),
+                remote.host.clone(),
+                Instant::now(),
+            ));
+            self.tmux_old_hosts
+                .lock()
+                .unwrap()
+                .push((remote.host.clone(), old_hosts.clone()));
+        }
+    }
+
+    /// AC4 / AC8: snapshot is taken BEFORE refresh_remote_worktrees per (repo, remote).
+    #[test]
+    fn snapshot_precedes_worktree_refresh_per_pair() {
+        let cfg = {
+            let mut c = crate::global_config::GlobalConfig::default();
+            c.repos.push(make_repo(
+                "a/one",
+                vec![make_remote("r", "vm.boxd.sh", RemoteKind::BoxdFork)],
+            ));
+            c
+        };
+        let reachable: HashSet<String> = ["vm.boxd.sh".to_string()].into_iter().collect();
+        let recorder = Recorder::new(
+            [("vm.boxd.sh".to_string(), {
+                let mut s = HashSet::new();
+                s.insert("vm-stale.boxd.sh".to_string());
+                s
+            })]
+            .into_iter()
+            .collect(),
+        );
+
+        drive(&cfg, &reachable, &recorder);
+
+        let calls = recorder.calls.lock().unwrap();
+        // Find the earliest Worktrees call and the latest Snapshot call.
+        let earliest_worktrees = calls
+            .iter()
+            .filter(|(k, _, _, _)| *k == CallKind::Worktrees)
+            .map(|(_, _, _, t)| *t)
+            .min()
+            .expect("worktrees must have been called");
+        let latest_snapshot = calls
+            .iter()
+            .filter(|(k, _, _, _)| *k == CallKind::Snapshot)
+            .map(|(_, _, _, t)| *t)
+            .max()
+            .expect("snapshot must have been called");
+        assert!(
+            latest_snapshot <= earliest_worktrees,
+            "every snapshot must precede every worktree refresh; got snapshot={:?}, worktrees={:?}",
+            latest_snapshot,
+            earliest_worktrees
+        );
+
+        // And the tmux call must have received the pre-mutation snapshot.
+        let tmux_snaps = recorder.tmux_old_hosts.lock().unwrap();
+        assert_eq!(tmux_snaps.len(), 1);
+        assert_eq!(tmux_snaps[0].0, "vm.boxd.sh");
+        assert!(tmux_snaps[0].1.contains("vm-stale.boxd.sh"));
+    }
+
+    /// AC3 / AC8: two remotes sharing a host but different kinds each get their own tmux refresh.
+    #[test]
+    fn tmux_dedup_by_kind_and_host_distinguishes_kinds() {
+        let cfg = {
+            let mut c = crate::global_config::GlobalConfig::default();
+            c.repos.push(make_repo(
+                "a/one",
+                vec![
+                    make_remote("r1", "vm.boxd.sh", RemoteKind::Remmy),
+                    make_remote("r2", "vm.boxd.sh", RemoteKind::BoxdFork),
+                ],
+            ));
+            c
+        };
+        let reachable: HashSet<String> = ["vm.boxd.sh".to_string()].into_iter().collect();
+        let recorder = Recorder::new(Default::default());
+
+        drive(&cfg, &reachable, &recorder);
+
+        let calls = recorder.calls.lock().unwrap();
+        let tmux_count = calls
+            .iter()
+            .filter(|(k, _, _, _)| *k == CallKind::Tmux)
+            .count();
+        assert_eq!(
+            tmux_count, 2,
+            "two remotes sharing host but different kinds must each refresh tmux; got {tmux_count}"
+        );
+        let worktree_count = calls
+            .iter()
+            .filter(|(k, _, _, _)| *k == CallKind::Worktrees)
+            .count();
+        assert_eq!(
+            worktree_count, 2,
+            "worktree refresh is not deduped by host; got {worktree_count}"
+        );
+    }
+
+    /// AC3 / AC8: two repos with the same (kind, host) share one tmux refresh.
+    #[test]
+    fn tmux_dedup_by_kind_and_host_collapses_duplicates() {
+        let cfg = {
+            let mut c = crate::global_config::GlobalConfig::default();
+            c.repos.push(make_repo(
+                "a/one",
+                vec![make_remote("r", "vm.boxd.sh", RemoteKind::BoxdFork)],
+            ));
+            c.repos.push(make_repo(
+                "b/two",
+                vec![make_remote("r", "vm.boxd.sh", RemoteKind::BoxdFork)],
+            ));
+            c
+        };
+        let reachable: HashSet<String> = ["vm.boxd.sh".to_string()].into_iter().collect();
+        let recorder = Recorder::new(Default::default());
+
+        drive(&cfg, &reachable, &recorder);
+
+        let calls = recorder.calls.lock().unwrap();
+        let tmux_count = calls
+            .iter()
+            .filter(|(k, _, _, _)| *k == CallKind::Tmux)
+            .count();
+        assert_eq!(
+            tmux_count, 1,
+            "two repos with same (kind, host) must share one tmux refresh; got {tmux_count}"
+        );
+        let worktree_count = calls
+            .iter()
+            .filter(|(k, _, _, _)| *k == CallKind::Worktrees)
+            .count();
+        assert_eq!(
+            worktree_count, 2,
+            "worktree refresh fires once per (repo, remote) regardless of host overlap; got {worktree_count}"
+        );
+    }
+
+    /// AC1 / AC9: unreachable hosts are skipped silently — no calls at all.
+    #[test]
+    fn unreachable_hosts_are_skipped() {
+        let cfg = {
+            let mut c = crate::global_config::GlobalConfig::default();
+            c.repos.push(make_repo(
+                "a/one",
+                vec![make_remote("r", "vm.boxd.sh", RemoteKind::Remmy)],
+            ));
+            c
+        };
+        let reachable: HashSet<String> = HashSet::new(); // empty
+        let recorder = Recorder::new(Default::default());
+
+        drive(&cfg, &reachable, &recorder);
+
+        assert!(recorder.calls.lock().unwrap().is_empty());
+    }
+}

--- a/crates/orchard/src/sources/refresh.rs
+++ b/crates/orchard/src/sources/refresh.rs
@@ -3,19 +3,13 @@
 //! `tui::start_full_refresh`.
 //!
 //! Behavior contract (matches Site B today):
-//! - Fork-host snapshot is taken BEFORE `refresh_remote_worktrees` per
-//!   (repo, remote) — honors the documented contract at
-//!   `cache_sources::snapshot_fork_hosts_for_remote`.
-//! - Tmux refresh is deduped by `format!("{kind_str}:{host}")` (same as
-//!   `tui::mod::dedup_key`), NOT by raw host.
-//! - Worktree refresh is NOT deduped — it fires once per (repo, remote)
-//!   regardless of host overlap.
-//! - Parallelism is `std::thread::scope` flat per-(repo, remote) for worktrees
-//!   + per first-seen `{kind}:{host}` for tmux. No inner threading inside
-//!   `refresh_remote_*` (item 6 of #272 is out of scope).
 //!
-//! No `AppMsg` / `mpsc::Sender` coupling. Callers that need to emit messages
-//! (Site B) do so BEFORE calling this helper.
+//! - Fork-host snapshot is taken BEFORE `refresh_remote_worktrees` per (repo, remote) — honors the documented contract at `cache_sources::snapshot_fork_hosts_for_remote`.
+//! - Tmux refresh is deduped by `format!("{kind_str}:{host}")` (same as `tui::mod::dedup_key`), NOT by raw host.
+//! - Worktree refresh is NOT deduped — it fires once per (repo, remote) regardless of host overlap.
+//! - Parallelism is `std::thread::scope` flat per-(repo, remote) for worktrees, plus one spawn per first-seen `{kind}:{host}` for tmux. No inner threading inside `refresh_remote_*` (item 6 of #272 is out of scope).
+//!
+//! No `AppMsg` / `mpsc::Sender` coupling. Callers that need to emit messages (Site B) do so BEFORE calling this helper.
 
 use crate::global_config::GlobalConfig;
 use std::collections::HashSet;
@@ -195,11 +189,7 @@ mod tests {
     }
 
     impl RemoteRefreshDriver for Recorder {
-        fn snapshot_fork_hosts(
-            &self,
-            repo: &RepoConfig,
-            remote: &RemoteConfig,
-        ) -> HashSet<String> {
+        fn snapshot_fork_hosts(&self, repo: &RepoConfig, remote: &RemoteConfig) -> HashSet<String> {
             self.calls.lock().unwrap().push((
                 CallKind::Snapshot,
                 repo.slug.clone(),

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -823,10 +823,7 @@ impl App {
             // `{kind}:{host}`, matching this site's previous behavior.
             // Daemon Workstream F will retire this path once per-peer data
             // lives in WorkView.
-            crate::sources::refresh::refresh_remotes_for_reachable_hosts(
-                &config,
-                &reachable_hosts,
-            );
+            crate::sources::refresh::refresh_remotes_for_reachable_hosts(&config, &reachable_hosts);
 
             // Ensure a main tmux session exists for each configured repo.
             ensure_main_sessions(&config);

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -29,7 +29,6 @@ use ratatui::prelude::*;
 use std::cell::Cell;
 
 use crate::cache;
-use crate::cache_sources;
 use crate::derive;
 use crate::global_config;
 use crate::navigation;
@@ -818,35 +817,16 @@ impl App {
                 }
             }
 
-            // REMOTE data — unchanged per AC #2.
-            // daemon doesn't yet populate per-peer worktrees in WorkView.
-            let seen_remotes: std::sync::Mutex<std::collections::HashSet<String>> =
-                std::sync::Mutex::new(std::collections::HashSet::new());
-
-            crate::refresh_parallel::for_each_repo_parallel(&config, |repo| {
-                for remote in &repo.remotes {
-                    if !reachable_hosts.contains(&remote.host) {
-                        continue;
-                    }
-                    // Snapshot fork hosts BEFORE refresh_remote_worktrees mutates
-                    // the cache — preserves real host strings for vanished-fork
-                    // detection in refresh_remote_tmux_sessions.
-                    let pre_snapshot = cache_sources::snapshot_fork_hosts_for_remote(repo, remote);
-                    let _ = cache_sources::refresh_remote_worktrees(repo, remote);
-
-                    // Refresh tmux sessions for reachable remotes only.
-                    // Dedup prevents double deletion when the same BoxdFork
-                    // golden host appears in multiple repos.
-                    let key = dedup_key(remote);
-                    if seen_remotes.lock().unwrap().insert(key) {
-                        let _ = cache_sources::refresh_remote_tmux_sessions(
-                            repo,
-                            remote,
-                            &pre_snapshot,
-                        );
-                    }
-                }
-            });
+            // REMOTE data — fan out via the shared post-probe pipeline (see
+            // `crate::sources::refresh`). The helper takes fork-host snapshots
+            // BEFORE worktree refresh per (repo, remote) and dedups tmux by
+            // `{kind}:{host}`, matching this site's previous behavior.
+            // Daemon Workstream F will retire this path once per-peer data
+            // lives in WorkView.
+            crate::sources::refresh::refresh_remotes_for_reachable_hosts(
+                &config,
+                &reachable_hosts,
+            );
 
             // Ensure a main tmux session exists for each configured repo.
             ensure_main_sessions(&config);
@@ -2524,24 +2504,6 @@ pub(crate) fn current_selection(app: &App) -> Option<last_selection::LastSelecti
         });
     }
     None
-}
-
-// ---------------------------------------------------------------------------
-// Remote dedup helpers
-// ---------------------------------------------------------------------------
-
-/// Returns the dedup key for a remote, used to avoid running
-/// `refresh_remote_tmux_sessions` twice for the same BoxdFork golden host
-/// when it appears in multiple repos.
-///
-/// Uses `kind_str` (kebab-case) rather than `{:?}` debug output so the key
-/// is stable across Rust version changes.
-fn dedup_key(remote: &crate::global_config::RemoteConfig) -> String {
-    format!(
-        "{}:{}",
-        crate::cache_sources::kind_str(remote.kind),
-        remote.host
-    )
 }
 
 /// Fetches ahead/behind commit counts for every configured repo by running
@@ -5853,44 +5815,6 @@ mod tests {
             SubCursor::Pane { window: 1, pane: 1 },
             "lands on last pane of expanded last window"
         );
-    }
-
-    // -- dedup_key ------------------------------------------------------------
-
-    #[test]
-    fn dedup_key_uses_kebab_case_kind_and_host() {
-        use crate::global_config::RemoteConfig;
-        use crate::remote_adapter::RemoteKind;
-
-        let boxd_fork = RemoteConfig {
-            name: "boxd".to_string(),
-            host: "boxd.sh".to_string(),
-            path: "/workspace".to_string(),
-            shell: "ssh".to_string(),
-            kind: RemoteKind::BoxdFork,
-            allow_transitive: false,
-        };
-        assert_eq!(dedup_key(&boxd_fork), "boxd-fork:boxd.sh");
-
-        let remmy = RemoteConfig {
-            name: "remmy".to_string(),
-            host: "ubuntu@myhost".to_string(),
-            path: "/workspace".to_string(),
-            shell: "ssh".to_string(),
-            kind: RemoteKind::Remmy,
-            allow_transitive: false,
-        };
-        assert_eq!(dedup_key(&remmy), "remmy:ubuntu@myhost");
-
-        let boxd_shared = RemoteConfig {
-            name: "shared".to_string(),
-            host: "shared.boxd.sh".to_string(),
-            path: "/workspace".to_string(),
-            shell: "ssh".to_string(),
-            kind: RemoteKind::BoxdShared,
-            allow_transitive: false,
-        };
-        assert_eq!(dedup_key(&boxd_shared), "boxd-shared:shared.boxd.sh");
     }
 
     // -----------------------------------------------------------------------

--- a/specs/features/refactor-hosts-extract-post-probe-pipeline.feature
+++ b/specs/features/refactor-hosts-extract-post-probe-pipeline.feature
@@ -1,0 +1,245 @@
+Feature: Extract post-probe remote-refresh pipeline shared by refresh_and_build + start_full_refresh (#295)
+  As an orchard maintainer
+  I want the post-probe per-(repo, remote) refresh loop to live in one helper
+  So that the next change to "what we refresh per reachable host" lands in one place
+     instead of two near-identical pipelines
+
+  # Refactor — behavior is preserved at Site B, normalized up at Site A.
+  # Two semantic deltas are intentional and bounded:
+  #   * Site A's tmux dedup key changes from raw host to "{kind}:{host}" (matches Site B).
+  #   * Site A's fork-host snapshot now happens BEFORE worktree refresh (honors the
+  #     documented contract at cache_sources::snapshot_fork_hosts_for_remote).
+  # See the issue body's Plan §"Key decisions" for the rationale.
+
+  Background:
+    Given `crates/orchard/src/sources/` exists in the workspace
+    And `crates/orchard/src/build_state.rs::refresh_and_build` (Site A) drives the `--json` / refresh-and-build read path
+    And `crates/orchard/src/tui/mod.rs::start_full_refresh` (Site B) drives the live TUI background refresh
+    And both sites currently iterate `config.repos × repo.remotes` after probing reachability
+
+  # =======================================================================
+  # AC1 — One helper unifies the post-probe remote-refresh loop
+  # =======================================================================
+
+  @unit
+  Scenario: A single helper drives the post-probe per-(repo, remote) refresh loop
+    Then `crates/orchard/src/sources/` exposes a public function `refresh_remotes_for_reachable_hosts`
+    And the function's body is the only place in the workspace that fans out `cache_sources::refresh_remote_worktrees`
+       paired with `cache_sources::refresh_remote_tmux_sessions` across `(repo, remote)` pairs filtered by reachability
+    And neither `build_state::refresh_and_build` nor `tui::start_full_refresh` retains an inline copy of that fan-out loop
+
+  @integration
+  Scenario: Site A delegates the post-probe loop to the helper
+    Given a `GlobalConfig` with one repo and one `OrchardProxy` remote whose host probes as reachable
+    When `build_state::refresh_and_build` runs
+    Then it calls `refresh_remotes_for_reachable_hosts(&config, &reachable)` exactly once
+    And the inline `tmux_dispatch` `Vec` and the surrounding `std::thread::scope` block that previously lived in
+       `refresh_and_build` are gone
+
+  @integration
+  Scenario: Site B delegates the post-probe loop to the helper
+    Given a `GlobalConfig` with one repo and one `OrchardProxy` remote whose host probes as reachable
+    When `tui::App::start_full_refresh` runs to completion
+    Then it calls `refresh_remotes_for_reachable_hosts(&config, &reachable)` exactly once
+    And the inline `refresh_parallel::for_each_repo_parallel` block that previously drove remote refresh in
+       `start_full_refresh` is gone
+
+  # =======================================================================
+  # AC2 — Helper lives in crates/orchard/src/sources/ without breaking hosts.rs cohesion
+  # =======================================================================
+
+  @unit
+  Scenario: Helper lives in a new sources/ module, not in sources/hosts.rs
+    Then `crates/orchard/src/sources/refresh.rs` exists
+    And `pub fn refresh_remotes_for_reachable_hosts` is defined inside `sources/refresh.rs`
+    And `crates/orchard/src/sources/hosts.rs` does NOT define `refresh_remotes_for_reachable_hosts`
+    And `crates/orchard/src/sources/mod.rs` declares `pub mod refresh;`
+    And `sources/hosts.rs`'s module-level rustdoc continues to describe it as "probe reachability" only
+
+  # =======================================================================
+  # AC3 — Tmux dedup key matches Site B today ("{kind}:{host}")
+  # =======================================================================
+
+  @unit
+  Scenario: Helper dedupes tmux refresh by "{kind}:{host}", not raw host
+    Given a config with two remotes that share the host "vm.boxd.sh" but differ in kind
+       (one `Remmy`, one `BoxdFork`)
+    And both hosts are reachable
+    When the helper runs
+    Then `cache_sources::refresh_remote_tmux_sessions` is invoked twice — once per `(kind, host)` pair
+    And the dedup key used by the helper is `format!("{kind}:{host}", ...)` (matching `tui::mod::dedup_key`)
+
+  @unit
+  Scenario: Helper dedupes tmux refresh once when two remotes share both kind and host
+    Given a config with two repos, each pointing to the same remote (`BoxdFork @ vm.boxd.sh`)
+    And the host is reachable
+    When the helper runs
+    Then `cache_sources::refresh_remote_tmux_sessions` is invoked exactly once for that `(kind, host)` pair
+    And `cache_sources::refresh_remote_worktrees` is invoked twice (once per repo) — worktree refresh is not deduped by host
+
+  # =======================================================================
+  # AC4 — Fork-host snapshot is taken BEFORE refresh_remote_worktrees
+  # =======================================================================
+
+  @unit
+  Scenario: Helper takes the fork-host snapshot before dispatching worktree refresh
+    Given a `BoxdFork` remote whose pre-refresh cache contains fork host "vm-old.boxd.sh"
+    And the remote's authoritative `list --json` will return only "vm-new.boxd.sh"
+    When the helper processes that `(repo, remote)` pair
+    Then `cache_sources::snapshot_fork_hosts_for_remote` is called BEFORE
+       `cache_sources::refresh_remote_worktrees` for the same `(repo, remote)`
+    And the snapshot returned to the tmux refresh contains "vm-old.boxd.sh" (the pre-mutation cache state)
+    And `cache_sources::refresh_remote_tmux_sessions` receives that snapshot unchanged
+
+  @integration
+  Scenario: Site A's pre-existing race no longer reproduces
+    Given a `BoxdFork` remote configured at Site A whose pre-refresh cache lists fork host "vm-stale.boxd.sh"
+    And the remote's authoritative `list --json` will no longer return "vm-stale.boxd.sh"
+    When `build_state::refresh_and_build` runs to completion
+    Then the cache entry for "vm-stale.boxd.sh" is treated as a vanished fork (eligible for deletion)
+    And the cache entry was NOT deleted before `refresh_remote_worktrees` mutated the cache
+    And `cache_sources::delete_vanished_fork_caches` was driven from a snapshot taken pre-mutation
+
+  # =======================================================================
+  # AC5 — Site B still emits AppMsg::HostReachability per host; helper is sink-free
+  # =======================================================================
+
+  @unit
+  Scenario: Helper signature does not depend on AppMsg or any message sink
+    Then `pub fn refresh_remotes_for_reachable_hosts` takes exactly two parameters:
+       `config: &GlobalConfig` and `reachable: &HashSet<String>`
+    And the function's signature mentions neither `AppMsg`, `mpsc::Sender`, nor any sink-like callback
+
+  @integration
+  Scenario: Site B emits AppMsg::HostReachability per probed host BEFORE calling the helper
+    Given a `tui::App` configured with two remotes whose hosts probe with mixed reachability (one true, one false)
+    And a fake `tx: Sender<AppMsg>` recording every send
+    When `tui::App::start_full_refresh` runs
+    Then `tx` recorded one `AppMsg::HostReachability(host, reachable)` per probed host
+    And every recorded `HostReachability` send happened strictly before the `refresh_remotes_for_reachable_hosts` call
+
+  # =======================================================================
+  # AC6 — Site A still produces HashMap<String, HostState> for build_state_with_hosts
+  # =======================================================================
+
+  @integration
+  Scenario: Site A builds HostState map and feeds it to build_state_with_hosts after the helper returns
+    Given a `GlobalConfig` with one repo and three remotes whose hosts probe (true, false, true)
+    When `build_state::refresh_and_build` runs to completion
+    Then `refresh_remotes_for_reachable_hosts` was called with a `HashSet<String>` containing the two reachable hosts
+    And `build_state_with_hosts(&config, &hosts)` is invoked with a `HashMap<String, HostState>` of length 3
+    And the `HostState.reachable` flag for each host matches the probe result
+    And the `--json` output shape produced from `OrchardState` is byte-identical to the pre-refactor `--json` output
+       for the same fixture (no schema drift)
+
+  # =======================================================================
+  # AC7 — Parallelism shape consolidates to one pattern
+  # =======================================================================
+
+  @unit
+  Scenario: Helper uses std::thread::scope for fan-out, not refresh_parallel::for_each_repo_parallel
+    Then the body of `refresh_remotes_for_reachable_hosts` uses `std::thread::scope`
+    And the body does NOT call `crate::refresh_parallel::for_each_repo_parallel`
+    And worktree refreshes fan out per `(repo, remote)` pair (one spawn per reachable pair)
+    And tmux refreshes fan out per first-seen `"{kind}:{host}"` (one spawn per deduped pair)
+
+  @unit
+  Scenario: refresh_parallel::for_each_repo_parallel remains available to other callers
+    Then `crate::refresh_parallel::for_each_repo_parallel` is still defined and exported
+    And its callers outside `tui::start_full_refresh` (notably the local-refresh path) continue to use it unchanged
+
+  # =======================================================================
+  # AC8 — Tests
+  # =======================================================================
+
+  @unit
+  Scenario: Regression test asserts fork-host snapshot precedes refresh_remote_worktrees
+    Given a unit test in `sources/refresh.rs` (or a colocated `tests` module) using a fake `cache_sources` recorder
+    And a `BoxdFork` remote configured for one repo, host reachable
+    When `refresh_remotes_for_reachable_hosts(&config, &reachable)` runs
+    Then the recorder shows `snapshot_fork_hosts_for_remote(repo, remote)` was invoked
+       strictly before `refresh_remote_worktrees(repo, remote)` for the same `(repo, remote)`
+    And the recorder shows the snapshot's return value was passed unchanged to `refresh_remote_tmux_sessions`
+
+  @unit
+  Scenario: Regression test asserts dedup-by-"{kind}:{host}"
+    Given a unit test in `sources/refresh.rs` (or a colocated `tests` module) using a fake `cache_sources` recorder
+    And a config where two reachable remotes share the host "vm.boxd.sh" but differ in kind (`Remmy`, `BoxdFork`)
+    And a separate config where two reachable remotes share both kind and host (`BoxdFork @ vm.boxd.sh` x2)
+    When `refresh_remotes_for_reachable_hosts(&config, &reachable)` runs against each config
+    Then the first config records two `refresh_remote_tmux_sessions` invocations (one per kind, same host)
+    And the second config records exactly one `refresh_remote_tmux_sessions` invocation (kind+host both equal)
+    And in both configs `refresh_remote_worktrees` is invoked once per `(repo, remote)` pair regardless of host
+
+  @e2e
+  Scenario: cargo test passes after the refactor lands
+    When the contributor runs `cargo test --workspace`
+    Then the suite exits with code 0
+    And no pre-existing test regresses
+    And the two new unit tests in `sources/refresh.rs` (or colocated tests module) are present and pass
+
+  # =======================================================================
+  # AC9 — Out of scope guard
+  # =======================================================================
+
+  @unit
+  Scenario: Helper does NOT parallelize refresh_remote itself
+    Then the body of `refresh_remotes_for_reachable_hosts` does NOT contain inner threading inside
+       `cache_sources::refresh_remote_worktrees` or `cache_sources::refresh_remote_tmux_sessions`
+    And inner parallelization of `refresh_remote` (item 6 of #272) remains tracked as a separate issue
+    And the helper's parallelism is the outer fan-out over `(repo, remote)` pairs only
+
+  # --- AC Coverage Map ---
+  # AC 1: "A single helper unifies the post-probe remote-refresh loop currently duplicated across
+  #        build_state::refresh_and_build and tui::start_full_refresh. After the change, 'what we
+  #        refresh per reachable host' lives in one place."
+  #   -> @unit "A single helper drives the post-probe per-(repo, remote) refresh loop"
+  #   -> @integration "Site A delegates the post-probe loop to the helper"
+  #   -> @integration "Site B delegates the post-probe loop to the helper"
+  #
+  # AC 2: "The helper lives in crates/orchard/src/sources/ — either as a new module
+  #        (sources/refresh.rs or similar) or inside sources/hosts.rs. The location must keep
+  #        sources/hosts.rs cohesive (probing) — see Plan §3."
+  #   -> @unit "Helper lives in a new sources/ module, not in sources/hosts.rs"
+  #
+  # AC 3: "The helper's tmux-dedup behavior matches Site B today: dedup key is '{kind_str}:{host}',
+  #        not raw host. (Site A's raw-host dedup is normalized up to B's behavior.)"
+  #   -> @unit "Helper dedupes tmux refresh by '{kind}:{host}', not raw host"
+  #   -> @unit "Helper dedupes tmux refresh once when two remotes share both kind and host"
+  #
+  # AC 4: "The helper takes the fork-host snapshot before dispatching refresh_remote_worktrees,
+  #        honoring the contract at snapshot_fork_hosts_for_remote (cache_sources.rs:1942-1943).
+  #        Site A's latent race disappears as a consequence."
+  #   -> @unit "Helper takes the fork-host snapshot before dispatching worktree refresh"
+  #   -> @integration "Site A's pre-existing race no longer reproduces"
+  #
+  # AC 5: "Site B continues to emit AppMsg::HostReachability per host. Message sending stays in
+  #        the TUI shell — the helper does not depend on AppMsg or mpsc::Sender."
+  #   -> @unit "Helper signature does not depend on AppMsg or any message sink"
+  #   -> @integration "Site B emits AppMsg::HostReachability per probed host BEFORE calling the helper"
+  #
+  # AC 6: "Site A continues to produce HashMap<String, HostState> and feed it to
+  #        build_state_with_hosts. The shape of the post-helper local-cache build is unchanged
+  #        for --json."
+  #   -> @integration "Site A builds HostState map and feeds it to build_state_with_hosts after the helper returns"
+  #
+  # AC 7: "Parallelism shape is consolidated: the helper uses one of the two existing patterns
+  #        (thread::scope flat per-(repo, remote) or refresh_parallel::for_each_repo_parallel) —
+  #        not both. Choice is documented in Plan." (Plan §"Key decisions" picks thread::scope.)
+  #   -> @unit "Helper uses std::thread::scope for fan-out, not refresh_parallel::for_each_repo_parallel"
+  #   -> @unit "refresh_parallel::for_each_repo_parallel remains available to other callers"
+  #
+  # AC 8: "All existing tests pass. Two new tests cover the previously-divergent behaviors:
+  #        - A unit test asserts the helper takes the fork-host snapshot before mutating the
+  #          remote_worktrees cache (covers AC #4 / Site A's old race).
+  #        - A unit test asserts dedup-by-{kind}:{host} (two remotes sharing a host but different
+  #          kinds both run; two remotes sharing both share one tmux refresh)."
+  #   -> @unit "Regression test asserts fork-host snapshot precedes refresh_remote_worktrees"
+  #   -> @unit "Regression test asserts dedup-by-'{kind}:{host}'"
+  #   -> @e2e "cargo test passes after the refactor lands"
+  #
+  # AC 9: "Out of scope: parallelizing refresh_remote itself (item 6 of #272). The helper's
+  #        parallelism is the outer fan-out only."
+  #   -> @unit "Helper does NOT parallelize refresh_remote itself"
+  #
+  # Total ACs in issue body: 9. All 9 mapped above.


### PR DESCRIPTION
## Why

Closes #295. The post-probe per-(repo, remote) refresh loop currently lives in two near-identical pipelines (`build_state::refresh_and_build` and `tui::start_full_refresh`). Investigation surfaced two load-bearing deltas between them (tmux dedup key + fork-host snapshot ordering); cutting over to a single helper normalizes Site A up to Site B's behavior, including fixing a latent BoxdFork cache-deletion race at Site A.

## What changed

- **New helper module** `crates/orchard/src/sources/refresh.rs` exports `refresh_remotes_for_reachable_hosts(config, reachable)` — the only place in the workspace that fans out remote worktree+tmux refresh. See its commit message for the full invariant list.
- **Two intentional semantic deltas at Site A** (matching Site B today): tmux dedup by `{kind}:{host}` instead of raw host; fork-host snapshot taken **before** any worktree refresh fans out (honors the documented contract at `cache_sources::snapshot_fork_hosts_for_remote`).
- **No `AppMsg`/`Sender` coupling.** Site B emits `HostReachability` per host before calling the helper; the helper itself is sink-free.
- **Private `RemoteRefreshDriver` trait** lets unit tests inject a recorder to assert call ordering. Production has one impl (`RealDriver`) delegating to `cache_sources`.

Subsequent commits in this PR will cut over Site A (`build_state.rs`) and Site B (`tui/mod.rs`) to call the helper. Currently the helper is landed but neither call site has been migrated yet.

## Test plan

- ` ` cargo test -p orchard --lib sources::refresh ` → 4/4 new unit tests pass.
- ` ` cargo test -p orchard --lib ` → full suite green vs. baseline (one pre-existing flake in `sources::hosts::tests::non_orchard_proxy_probe_failure_is_silent` due to env-lock race in test infra; unrelated to this PR).
- After cut-over commits land, `--json` output for a fixture with mixed-reachability remotes will be byte-identical to pre-refactor.

## Anything surprising?

- Site A's dedup-key change (raw host → `{kind}:{host}`) is a **quiet behavior change**, not a pure refactor. If anyone has configured the same host under two kinds in two repos, Site A previously collapsed them to one tmux refresh; after this PR they each refresh independently. Plan §"Key decisions" + Investigation §"Findings" call this out — B's behavior is correct per the documented contract, A's was the latent bug.
- Site A's fork-host snapshot race is fixed as a byproduct, not as a separate PR. The fix is invisible to existing tests because no test exercised the race; new tests in `sources::refresh::tests` cover the ordering invariant.
- Workstream F (daemon WorkView populating per-peer data) will retire Site B's remote path. /challenge flagged this as an argument to defer; user override directed proceeding.

# Related issue

- #295

# Related issue

- #295

# Related issue

- #295

# Related issue

- #295

# Related issue

- #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Remote refresh logic consolidated from multiple independent code paths into a single unified shared helper, ensuring consistent refresh handling across all operational workflows.
  * Deduplication mechanisms for refresh operations have been centralized and enhanced, reducing redundant processing across different refresh sources and scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/567)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #295