### PR TITLE
refactor(orchard-gui): migrate all five panes to Tailwind (ADR-020)

### DIFF
--- a/crates/orchard-gui/src/lib/components/DesktopLayout.svelte
+++ b/crates/orchard-gui/src/lib/components/DesktopLayout.svelte
@@ -102,20 +102,23 @@
 						title="Drag to resize · collapses below 200px"
 					></div>
 				{:else}
-					<div class="rail-collapsed">
-						<div class="rail-list">
+					<div class="flex flex-col h-full py-2">
+						<div class="flex-1 min-h-0 overflow-y-auto flex flex-col gap-0.5 px-1.5">
 							{#each store.tabs as tab (tab.id)}
+								{@const isOn = tab.id === store.activeTabId}
 								<button
-									class="rail-conv"
-									class:on={tab.id === store.activeTabId}
+									class="group/rail relative flex items-center justify-center w-9 h-9 mx-auto border-0 rounded-[9px] cursor-default transition-colors duration-100 bg-transparent hover:bg-fg/[0.06] data-[on=true]:bg-surface-2"
+									data-on={isOn}
 									onclick={() => (store.activeTabId = tab.id)}
 									title={tab.kind === "channel" ? "#" + tab.roomId : (tab.paneId || tab.sessionUuid?.slice(0, 8) || "session")}
 								>
-									<span class="rail-active-bar"></span>
+									<span
+										class="absolute -left-1.5 top-2 bottom-2 w-0.5 rounded-[2px] bg-transparent transition-colors duration-100 group-data-[on=true]/rail:bg-fg"
+									></span>
 									{#if tab.kind === "channel"}
 										<span class="channel-hash">#</span>
 									{:else}
-										<span class="pip ok rail-pip"></span>
+										<span class="pip ok absolute right-1 top-1 w-1.5 h-1.5"></span>
 									{/if}
 								</button>
 							{/each}
@@ -160,61 +163,3 @@
 		</div>
 	</div>
 </div>
-
-<style>
-	.rail-collapsed {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
-		padding: 8px 0;
-	}
-	.rail-list {
-		flex: 1;
-		min-height: 0;
-		overflow-y: auto;
-		display: flex;
-		flex-direction: column;
-		gap: 2px;
-		padding: 0 6px;
-	}
-	.rail-conv {
-		position: relative;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 36px;
-		height: 36px;
-		margin: 0 auto;
-		border: 0;
-		background: transparent;
-		border-radius: 9px;
-		cursor: default;
-		transition: background 0.12s;
-	}
-	.rail-conv:hover {
-		background: color-mix(in oklab, var(--fg) 6%, transparent);
-	}
-	.rail-conv.on {
-		background: var(--surface-2);
-	}
-	.rail-active-bar {
-		position: absolute;
-		left: -6px;
-		top: 8px;
-		bottom: 8px;
-		width: 2px;
-		border-radius: 2px;
-		background: transparent;
-		transition: background 0.12s;
-	}
-	.rail-conv.on .rail-active-bar {
-		background: var(--fg);
-	}
-	.rail-pip {
-		position: absolute;
-		right: 4px;
-		top: 4px;
-		width: 6px;
-		height: 6px;
-	}
-</style>

--- a/crates/orchard-gui/src/lib/components/PanesArea.svelte
+++ b/crates/orchard-gui/src/lib/components/PanesArea.svelte
@@ -117,22 +117,32 @@
 	<div class="panes-empty">
 		<div class="conv-empty">
 			<Icon name="orchard" size={28} />
-			<div style="font-size: 14px; font-weight: 500; color: var(--fg-2);">
+			<div class="text-[14px] font-medium text-fg-2">
 				No conversations open
 			</div>
 			<!-- #540 E1: button row spacing — fixed-width buttons with stable
 			     internal gaps so labels + keyboard glyphs don't collide
 			     into each other regardless of viewport width. -->
-			<div class="empty-actions mono">
-				<button class="btn-tonal empty-action" onclick={onOpenPalette}>
+			<div class="mono flex items-center justify-center flex-wrap gap-3">
+				<button
+					class="btn-tonal inline-flex items-center justify-center gap-2 min-w-[120px] px-3 py-1.5"
+					onclick={onOpenPalette}
+				>
 					<Icon name="command" size={13} />
-					<span class="action-label">Search</span>
-					<span class="action-kbd"><span class="kbd">⌘</span><span class="kbd">K</span></span>
+					<span class="flex-none">Search</span>
+					<span class="inline-flex gap-[3px] ml-1.5 opacity-70">
+						<span class="kbd">⌘</span><span class="kbd">K</span>
+					</span>
 				</button>
-				<button class="btn-tonal empty-action" onclick={onLaunch}>
+				<button
+					class="btn-tonal inline-flex items-center justify-center gap-2 min-w-[120px] px-3 py-1.5"
+					onclick={onLaunch}
+				>
 					<Icon name="plus" size={13} />
-					<span class="action-label">New</span>
-					<span class="action-kbd"><span class="kbd">⌘</span><span class="kbd">N</span></span>
+					<span class="flex-none">New</span>
+					<span class="inline-flex gap-[3px] ml-1.5 opacity-70">
+						<span class="kbd">⌘</span><span class="kbd">N</span>
+					</span>
 				</button>
 			</div>
 		</div>
@@ -149,7 +159,7 @@
 					title="Drag to resize"
 				></div>
 			{/if}
-			<div class="pane-flex" style:flex="{sizes[idx] || 1 / tabs.length} 1 0" style:min-width="0">
+			<div class="flex flex-col h-full" style:flex="{sizes[idx] || 1 / tabs.length} 1 0" style:min-width="0">
 				{#if tab.kind === "session"}
 					<SessionPane
 						paneId={tab.paneId}
@@ -193,36 +203,3 @@
 		{/each}
 	</div>
 {/if}
-
-<style>
-	.pane-flex { display: flex; flex-direction: column; height: 100%; }
-
-	/* #540 E1 — empty-state button row.
-	   Buttons get stable internal layout (icon · label · keyboard glyph)
-	   so the row reads cleanly at every viewport width. The container
-	   gaps spread with `gap: 12px` so the buttons never touch. */
-	.empty-actions {
-		display: flex;
-		gap: 12px;
-		align-items: center;
-		justify-content: center;
-		flex-wrap: wrap;
-	}
-	.empty-action {
-		display: inline-flex;
-		align-items: center;
-		gap: 8px;
-		min-width: 120px;
-		justify-content: center;
-		padding: 6px 12px;
-	}
-	.empty-action .action-label {
-		flex: 0 0 auto;
-	}
-	.empty-action .action-kbd {
-		display: inline-flex;
-		gap: 3px;
-		margin-left: 6px;
-		opacity: 0.7;
-	}
-</style>

--- a/crates/orchard-gui/src/lib/components/SessionComposer.svelte
+++ b/crates/orchard-gui/src/lib/components/SessionComposer.svelte
@@ -58,15 +58,19 @@
 	}
 </script>
 
-<div class="composer">
+<div class="flex flex-col gap-1 px-3 py-2.5 border-t-[0.5px] border-line bg-surface">
 	{#if error}
-		<div class="composer-error mono">
+		<div class="mono flex items-center gap-1.5 px-2 py-1 text-[11.5px] text-bad-fg rounded-md bg-[color-mix(in_oklab,var(--color-bad-fg)_10%,transparent)] border-[0.5px] border-[color-mix(in_oklab,var(--color-bad-fg)_30%,var(--color-line))]">
 			<Icon name="alert" size={11} />
 			<span>{error}</span>
-			<button class="composer-error-close" onclick={() => (error = null)} aria-label="Dismiss">×</button>
+			<button
+				class="ml-auto border-0 bg-transparent text-inherit cursor-pointer text-[13px]"
+				onclick={() => (error = null)}
+				aria-label="Dismiss"
+			>×</button>
 		</div>
 	{/if}
-	<div class="composer-row">
+	<div class="flex items-end gap-2">
 		<textarea
 			bind:this={textarea}
 			bind:value={text}
@@ -75,9 +79,10 @@
 			placeholder={sessionLabel ? `Message ${sessionLabel}…` : "Message session…"}
 			rows="1"
 			disabled={sending}
+			class="flex-1 min-h-[36px] max-h-[200px] resize-none border-[0.5px] border-line bg-surface-2 text-fg rounded-lg px-2.5 py-2 text-[13px] leading-[1.45] outline-none focus:border-[color-mix(in_oklab,var(--color-accent)_60%,var(--color-line))]"
 		></textarea>
 		<button
-			class="composer-send"
+			class="inline-flex items-center justify-center w-9 h-9 border-0 bg-fg text-bg rounded-lg cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed"
 			onclick={send}
 			disabled={sending || !text.trim()}
 			title="Send (Enter) · Shift+Enter for newline"
@@ -89,79 +94,7 @@
 			{/if}
 		</button>
 	</div>
-	<div class="composer-hint mono dimer">
+	<div class="mono dimer text-[10.5px]">
 		Sent via tmux send-keys → {paneId} · Enter to send · Shift+Enter for newline
 	</div>
 </div>
-
-<style>
-	.composer {
-		display: flex;
-		flex-direction: column;
-		gap: 4px;
-		padding: 10px 12px 10px 12px;
-		border-top: 0.5px solid var(--line);
-		background: var(--surface-1);
-	}
-	.composer-error {
-		display: flex;
-		align-items: center;
-		gap: 6px;
-		padding: 5px 8px;
-		font-size: 11.5px;
-		color: var(--bad-fg, #f06);
-		background: color-mix(in oklab, var(--bad-fg, #f06) 10%, transparent);
-		border: 0.5px solid color-mix(in oklab, var(--bad-fg, #f06) 30%, var(--line));
-		border-radius: 6px;
-	}
-	.composer-error-close {
-		margin-left: auto;
-		border: 0;
-		background: transparent;
-		color: inherit;
-		cursor: pointer;
-		font-size: 13px;
-	}
-	.composer-row {
-		display: flex;
-		align-items: flex-end;
-		gap: 8px;
-	}
-	textarea {
-		flex: 1;
-		min-height: 36px;
-		max-height: 200px;
-		resize: none;
-		border: 0.5px solid var(--line);
-		background: var(--surface-2);
-		color: var(--fg);
-		border-radius: 8px;
-		padding: 8px 10px;
-		font: inherit;
-		font-size: 13px;
-		line-height: 1.45;
-	}
-	textarea:focus {
-		outline: none;
-		border-color: color-mix(in oklab, var(--accent, #6cf) 60%, var(--line));
-	}
-	.composer-send {
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		width: 36px;
-		height: 36px;
-		border: 0;
-		background: var(--fg);
-		color: var(--bg);
-		border-radius: 8px;
-		cursor: pointer;
-	}
-	.composer-send:disabled {
-		opacity: 0.4;
-		cursor: not-allowed;
-	}
-	.composer-hint {
-		font-size: 10.5px;
-	}
-</style>

--- a/crates/orchard-gui/src/lib/components/SessionPane.svelte
+++ b/crates/orchard-gui/src/lib/components/SessionPane.svelte
@@ -114,6 +114,11 @@
 			`tmux select-pane -t ${pane.paneId} 2>/dev/null; exec tmux attach-session -t ${sessName}`,
 		];
 	});
+
+	const signalBadgeBase =
+		"text-[10px] px-1.5 py-px rounded-[3px] font-[var(--font-mono)] border-[0.5px]";
+	const signalBadgeRed =
+		"bg-[rgba(255,100,100,0.14)] text-[#ff7272] border-[rgba(255,100,100,0.32)]";
 </script>
 
 <div
@@ -152,7 +157,7 @@
 							<span class="here-badge mono">here</span>
 						{/if}
 						{#if pane || hasTranscript}
-							<span style="margin-left: auto;">
+							<span class="ml-auto">
 								<ViewSwitcher
 									value={view}
 									onChange={(v) => onSetView(v)}
@@ -177,20 +182,29 @@
 									<span>#{worktree.pr.number}</span>
 								</a>
 								{#if isDraft}
-									<span class="signal-badge draft" title="Draft PR">draft</span>
+									<span
+										class="{signalBadgeBase} bg-[rgba(140,140,140,0.18)] text-[#aaa] border-[rgba(140,140,140,0.32)]"
+										title="Draft PR"
+									>draft</span>
 								{:else if prState === "MERGED"}
-									<span class="signal-badge merged" title="PR merged">merged</span>
+									<span
+										class="{signalBadgeBase} bg-[rgba(120,80,200,0.18)] text-[#b990ff] border-[rgba(120,80,200,0.32)]"
+										title="PR merged"
+									>merged</span>
 								{:else if prState === "CLOSED"}
-									<span class="signal-badge closed" title="PR closed">closed</span>
+									<span
+										class="{signalBadgeBase} bg-[rgba(255,100,100,0.18)] text-[#ff7272] border-[rgba(255,100,100,0.32)]"
+										title="PR closed"
+									>closed</span>
 								{/if}
 								{#if ciBad}
-									<span class="signal-badge red" title="CI failing">CI</span>
+									<span class="{signalBadgeBase} {signalBadgeRed}" title="CI failing">CI</span>
 								{/if}
 								{#if reviewBad}
-									<span class="signal-badge red" title="Review changes requested">review</span>
+									<span class="{signalBadgeBase} {signalBadgeRed}" title="Review changes requested">review</span>
 								{/if}
 								{#if conflict}
-									<span class="signal-badge red" title="Merge conflict">conflict</span>
+									<span class="{signalBadgeBase} {signalBadgeRed}" title="Merge conflict">conflict</span>
 								{/if}
 							{/if}
 							{#if worktree.issue}
@@ -210,7 +224,7 @@
 						{/if}
 						{#if session?.sessionUuid}
 							<span class="conv-chip mono" title="Session UUID">
-								<span style:opacity="0.7">id</span>
+								<span class="opacity-70">id</span>
 								<span>{session.sessionUuid.slice(0, 6)}…</span>
 							</span>
 						{/if}
@@ -234,7 +248,10 @@
 						{/if}
 					</div>
 					{#if conversation?.recap}
-						<div class="conv-recap mono dimer" title={conversation.recap}>{conversation.recap}</div>
+						<div
+							class="mono dimer mt-1 text-[11.5px] leading-[1.4] line-clamp-2"
+							title={conversation.recap}
+						>{conversation.recap}</div>
 					{/if}
 				</div>
 			</div>
@@ -243,12 +260,12 @@
 		{#if loading && !data}
 			<div class="conv-empty"><span class="dimer">Loading…</span></div>
 		{:else if view === "chat" && hasTranscript && conversation?.jsonlPath}
-			<div class="chat-stack">
+			<div class="flex-1 min-h-0 flex flex-col">
 				<TranscriptView path={conversation.jsonlPath} sessionUuid={conversation.sessionUuid} />
 				{#if pane?.paneId}
 					<SessionComposer paneId={pane.paneId} sessionLabel={pane.window.session.name} />
 				{:else}
-					<div class="composer-disabled mono dimer">
+					<div class="mono dimer text-center text-[11.5px] px-3.5 py-2.5 border-t-[0.5px] border-line bg-surface">
 						No live tmux pane — open Terminal view to attach a fresh client.
 					</div>
 				{/if}
@@ -271,7 +288,7 @@
 			/>
 		{:else}
 			<div class="conv-empty">
-				<div style="font-size: 13px; font-weight: 500; color: var(--fg-2);">
+				<div class="text-[13px] font-medium text-fg-2">
 					{#if session && !pane}
 						No live tmux pane for this session.
 					{:else}
@@ -279,63 +296,9 @@
 					{/if}
 				</div>
 				{#if conversation?.cwd}
-					<div class="dimer mono" style="font-size: 11.5px; margin-top: 4px;">{conversation.cwd}</div>
+					<div class="dimer mono text-[11.5px] mt-1">{conversation.cwd}</div>
 				{/if}
 			</div>
 		{/if}
 	</div>
 </div>
-
-<style>
-	.signal-badge {
-		font-size: 10px;
-		padding: 1px 6px;
-		border-radius: 3px;
-		font-family: var(--font-mono);
-	}
-	.signal-badge.draft {
-		background: rgba(140, 140, 140, 0.18);
-		color: #aaa;
-		border: 0.5px solid rgba(140, 140, 140, 0.32);
-	}
-	.signal-badge.merged {
-		background: rgba(120, 80, 200, 0.18);
-		color: #b990ff;
-		border: 0.5px solid rgba(120, 80, 200, 0.32);
-	}
-	.signal-badge.closed {
-		background: rgba(255, 100, 100, 0.18);
-		color: #ff7272;
-		border: 0.5px solid rgba(255, 100, 100, 0.32);
-	}
-	.signal-badge.red {
-		background: rgba(255, 100, 100, 0.14);
-		color: #ff7272;
-		border: 0.5px solid rgba(255, 100, 100, 0.32);
-	}
-	.chat-stack {
-		flex: 1;
-		min-height: 0;
-		display: flex;
-		flex-direction: column;
-	}
-	.composer-disabled {
-		padding: 10px 14px;
-		border-top: 0.5px solid var(--line);
-		background: var(--surface-1);
-		font-size: 11.5px;
-		text-align: center;
-	}
-	.conv-recap {
-		margin-top: 4px;
-		font-size: 11.5px;
-		line-height: 1.4;
-		max-height: 2.8em;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		display: -webkit-box;
-		-webkit-line-clamp: 2;
-		line-clamp: 2;
-		-webkit-box-orient: vertical;
-	}
-</style>

--- a/crates/orchard-gui/src/lib/components/TranscriptView.svelte
+++ b/crates/orchard-gui/src/lib/components/TranscriptView.svelte
@@ -158,51 +158,57 @@
 		}
 		return "";
 	}
+
 </script>
 
-<div class="transcript">
+<div class="flex-1 min-h-0 flex flex-col bg-surface">
 	{#if status === "loading"}
-		<div class="transcript-empty"><span class="dimer">Loading transcript…</span></div>
+		<div class="flex-1 flex flex-col items-center justify-center p-8 text-center">
+			<span class="dimer">Loading transcript…</span>
+		</div>
 	{:else if status === "unsupported"}
-		<div class="transcript-empty">
-			<div style="font-size: 13px; font-weight: 500; color: var(--fg-2);">
+		<div class="flex-1 flex flex-col items-center justify-center p-8 text-center">
+			<div class="text-[13px] font-medium text-fg-2">
 				Open in the Orchard desktop app to view this transcript.
 			</div>
 		</div>
 	{:else if status === "error"}
-		<div class="transcript-empty">
-			<div style="font-size: 13px; color: var(--bad-fg);">Transcript failed to load.</div>
-			<div class="dimer mono" style="font-size: 11.5px; margin-top: 4px;">{errMsg}</div>
+		<div class="flex-1 flex flex-col items-center justify-center p-8 text-center">
+			<div class="text-[13px] text-bad-fg">Transcript failed to load.</div>
+			<div class="dimer mono text-[11.5px] mt-1">{errMsg}</div>
 		</div>
 	{:else if status === "empty"}
-		<div class="transcript-empty">
+		<div class="flex-1 flex flex-col items-center justify-center p-8 text-center">
 			<span class="dimer">No conversation turns parsed from {path}</span>
 		</div>
 	{:else}
 		<div
-			class="transcript-scroll"
+			class="flex-1 min-h-0 overflow-y-auto px-3.5 pt-3 pb-6"
 			bind:this={scrollHost}
 			onscroll={onScroll}
 		>
 			{#if truncated}
-				<div class="transcript-trunc mono">
+				<div class="mono text-center text-[11px] text-fg-3 pt-1 pb-2 border-b-[0.5px] border-dashed border-line">
 					… earlier turns omitted ({(totalSize / 1024).toFixed(0)}KB total)
 				</div>
 			{/if}
-			<div class="transcript-virtual" style="height: {$virtualizer.getTotalSize()}px;">
+			<div class="relative w-full" style="height: {$virtualizer.getTotalSize()}px;">
 				{#each $virtualizer.getVirtualItems() as vRow (vRow.key)}
 					{@const turn = turns[vRow.index]}
 					{#if turn}
 					<div
-						class="t-turn"
+						class="flex flex-col gap-1.5 absolute top-0 left-0 right-0 pl-1.5 border-l-2"
+						class:opacity-65={turn.toolFeedback}
+						class:border-l-[color-mix(in_oklab,var(--color-accent)_60%,transparent)]={turn.role === "user"}
+						class:border-l-[color-mix(in_oklab,var(--color-ok-fg)_35%,transparent)]={turn.role === "assistant"}
+						class:border-l-transparent={turn.role !== "user" && turn.role !== "assistant"}
 						data-role={turn.role}
-						class:tool-feedback={turn.toolFeedback}
 						data-index={vRow.index}
 						use:$virtualizer.measureElement
-						style="position: absolute; top: 0; left: 0; right: 0; transform: translateY({vRow.start}px);"
+						style="transform: translateY({vRow.start}px);"
 					>
-						<div class="t-meta mono">
-							<span class="t-role">{turn.role}</span>
+						<div class="flex items-center gap-1.5 mono text-[11px] text-fg-3">
+							<span class="lowercase font-medium text-fg-2">{turn.role}</span>
 							{#if turn.model}
 								<span class="dimest">·</span>
 								<span class="dimer">{turn.model}</span>
@@ -214,40 +220,44 @@
 						</div>
 						{#each turn.blocks as block, i (i)}
 							{#if block.kind === "text"}
-								<div class="t-text">{block.text}</div>
+								<div class="text-[13px] leading-[1.55] whitespace-pre-wrap break-words text-fg">{block.text}</div>
 							{:else if block.kind === "thinking"}
-								<details class="t-thinking">
-									<summary class="dimer mono">thinking</summary>
-									<div class="t-text">{block.text}</div>
+								<details class="text-[12.5px] open:pl-2 open:border-l open:border-dashed open:border-line">
+									<summary class="dimer mono cursor-pointer text-[11px] py-0.5">thinking</summary>
+									<div class="text-[13px] leading-[1.55] whitespace-pre-wrap break-words text-fg">{block.text}</div>
 								</details>
 							{:else if block.kind === "tool_use"}
-								<div class="t-tool">
+								<div class="rounded-md bg-surface-2 border-[0.5px] border-line overflow-hidden">
 									<button
-										class="t-tool-head mono"
+										class="mono flex items-center gap-1.5 w-full px-2 py-1 bg-transparent border-0 text-[11.5px] text-left cursor-pointer text-fg hover:bg-fg/[0.04]"
 										onclick={() => toggleTool(block.toolId || `${turn.uuid}-tu-${i}`)}
 									>
 										<Icon name="terminal" size={11} />
-										<span class="t-tool-name">{block.name}</span>
-										<span class="t-tool-summary dimer">{blockSummary(block)}</span>
-										<span class="t-tool-chev dimer">{expandedTools.has(block.toolId || `${turn.uuid}-tu-${i}`) ? "▾" : "▸"}</span>
+										<span class="font-medium">{block.name}</span>
+										<span class="dimer flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{blockSummary(block)}</span>
+										<span class="dimer text-[10px]">{expandedTools.has(block.toolId || `${turn.uuid}-tu-${i}`) ? "▾" : "▸"}</span>
 									</button>
 									{#if expandedTools.has(block.toolId || `${turn.uuid}-tu-${i}`)}
-										<pre class="t-tool-body mono">{JSON.stringify(block.input, null, 2)}</pre>
+										<pre class="mono m-0 px-2.5 py-2 text-[11.5px] leading-[1.5] max-h-80 overflow-auto bg-surface border-t-[0.5px] border-line whitespace-pre-wrap break-words">{JSON.stringify(block.input, null, 2)}</pre>
 									{/if}
 								</div>
 							{:else if block.kind === "tool_result"}
-								<div class="t-tool" class:err={block.isError}>
+								<div
+									class="rounded-md bg-surface-2 border-[0.5px] overflow-hidden"
+									class:border-line={!block.isError}
+									class:border-[color-mix(in_oklab,var(--color-bad-fg),50%,var(--color-line))]={block.isError}
+								>
 									<button
-										class="t-tool-head mono"
+										class="mono flex items-center gap-1.5 w-full px-2 py-1 bg-transparent border-0 text-[11.5px] text-left cursor-pointer text-fg hover:bg-fg/[0.04]"
 										onclick={() => toggleTool(block.toolId || `${turn.uuid}-tr-${i}`)}
 									>
 										<Icon name={block.isError ? "alert" : "check"} size={11} />
-										<span class="t-tool-name">{block.isError ? "tool error" : "tool result"}</span>
-										<span class="t-tool-summary dimer">{blockSummary(block)}</span>
-										<span class="t-tool-chev dimer">{expandedTools.has(block.toolId || `${turn.uuid}-tr-${i}`) ? "▾" : "▸"}</span>
+										<span class="font-medium">{block.isError ? "tool error" : "tool result"}</span>
+										<span class="dimer flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{blockSummary(block)}</span>
+										<span class="dimer text-[10px]">{expandedTools.has(block.toolId || `${turn.uuid}-tr-${i}`) ? "▾" : "▸"}</span>
 									</button>
 									{#if expandedTools.has(block.toolId || `${turn.uuid}-tr-${i}`)}
-										<pre class="t-tool-body mono">{block.text}</pre>
+										<pre class="mono m-0 px-2.5 py-2 text-[11.5px] leading-[1.5] max-h-80 overflow-auto bg-surface border-t-[0.5px] border-line whitespace-pre-wrap break-words">{block.text}</pre>
 									{/if}
 								</div>
 							{/if}
@@ -260,135 +270,3 @@
 	{/if}
 </div>
 
-<style>
-	.transcript {
-		flex: 1;
-		min-height: 0;
-		display: flex;
-		flex-direction: column;
-		background: var(--surface-1);
-	}
-	.transcript-scroll {
-		flex: 1;
-		min-height: 0;
-		overflow-y: auto;
-		padding: 12px 14px 24px 14px;
-	}
-	.transcript-virtual {
-		position: relative;
-		width: 100%;
-	}
-	.transcript-empty {
-		flex: 1;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-content: center;
-		padding: 32px;
-		text-align: center;
-	}
-	.transcript-trunc {
-		text-align: center;
-		font-size: 11px;
-		color: var(--fg-3);
-		padding: 4px 0 8px 0;
-		border-bottom: 0.5px dashed var(--line);
-	}
-	.t-turn {
-		display: flex;
-		flex-direction: column;
-		gap: 6px;
-	}
-	.t-turn[data-role="user"] {
-		padding-left: 6px;
-		border-left: 2px solid color-mix(in oklab, var(--accent, #6cf) 60%, transparent);
-	}
-	.t-turn[data-role="assistant"] {
-		padding-left: 6px;
-		border-left: 2px solid color-mix(in oklab, var(--ok-fg, #6fd391) 35%, transparent);
-	}
-	.t-turn.tool-feedback {
-		opacity: 0.65;
-	}
-	.t-meta {
-		display: flex;
-		align-items: center;
-		gap: 6px;
-		font-size: 11px;
-		color: var(--fg-3);
-	}
-	.t-role {
-		text-transform: lowercase;
-		font-weight: 500;
-		color: var(--fg-2);
-	}
-	.t-text {
-		font-size: 13px;
-		line-height: 1.55;
-		white-space: pre-wrap;
-		word-break: break-word;
-		color: var(--fg);
-	}
-	.t-thinking {
-		font-size: 12.5px;
-	}
-	.t-thinking summary {
-		cursor: pointer;
-		font-size: 11px;
-		padding: 2px 0;
-	}
-	.t-thinking[open] {
-		padding-left: 8px;
-		border-left: 1px dashed var(--line);
-	}
-	.t-tool {
-		border-radius: 6px;
-		background: var(--surface-2);
-		border: 0.5px solid var(--line);
-		overflow: hidden;
-	}
-	.t-tool.err {
-		border-color: color-mix(in oklab, var(--bad-fg, #f06), 50%, var(--line));
-	}
-	.t-tool-head {
-		display: flex;
-		align-items: center;
-		gap: 6px;
-		width: 100%;
-		padding: 4px 8px;
-		background: transparent;
-		border: 0;
-		font-size: 11.5px;
-		text-align: left;
-		cursor: pointer;
-		color: var(--fg);
-	}
-	.t-tool-head:hover {
-		background: color-mix(in oklab, var(--fg) 4%, transparent);
-	}
-	.t-tool-name {
-		font-weight: 500;
-	}
-	.t-tool-summary {
-		flex: 1;
-		min-width: 0;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-	.t-tool-chev {
-		font-size: 10px;
-	}
-	.t-tool-body {
-		margin: 0;
-		padding: 8px 10px;
-		font-size: 11.5px;
-		line-height: 1.5;
-		max-height: 320px;
-		overflow: auto;
-		background: var(--surface-1);
-		border-top: 0.5px solid var(--line);
-		white-space: pre-wrap;
-		word-break: break-word;
-	}
-</style>


### PR DESCRIPTION
## Summary

Cluster PR per **ADR-020**. Migrates the next 5 components from scoped CSS to Tailwind utilities, following the [ChatMessage.svelte exemplar](https://github.com/drewdrewthis/git-orchard-rs/pull/556).

- DesktopLayout.svelte — closes #558
- PanesArea.svelte — closes #559
- SessionComposer.svelte — closes #560
- SessionPane.svelte — closes #561
- TranscriptView.svelte — closes #562

Five \`<style>\` blocks deleted (304 lines net removed). Layout.css / theme.css globals are untouched — they're still consumed by un-migrated components and removing them is out of scope for this cluster. Per ADR-020 we keep them through the coexistence window.

## Patterns

- **Utility-class markup** replaces every scoped \`<style>\` rule. Spacing, sizing, flex, and colors use first-class Tailwind utilities backed by the \`@theme\` tokens from #556.
- **Dynamic-accent fallback** when an arbitrary value needs to reach \`var(--color-accent)\` at runtime: \`focus:border-[color-mix(in_oklab,var(--color-accent)_60%,var(--color-line))]\` (SessionComposer textarea) and the role-tinted border in TranscriptView. Same pattern as ChatMessage's \`style=\"color:var(--accent)\"\` for inline \`#NNN\` references.
- **Conditional borders without scoped CSS**: TranscriptView's user-vs-assistant border tint uses \`class:border-l-[color-mix(...)]={turn.role === \"user\"}\` so Tailwind's JIT can resolve the arbitrary value at build time without a scoped \`[data-role=...]\` selector.
- **SessionComposer.composer** stops shadowing the global \`.composer\` in layout.css — the global flavor is still owned by the chat \`Composer.svelte\`. The session-tmux composer puts its overrides directly on the elements.

## Verification

- \`pnpm check\`: **0 errors**, 9 pre-existing a11y warnings (same baseline as the foundation PR — all on \`<div>\` elements that pre-date this cluster).
- \`pnpm build\`: clean (18.24s); spot-checks confirm \`data-on\`, \`color-mix\`, \`line-clamp\`, and \`animate-typing\` utilities all land in the emitted bundle.
- \`crates/orchard-gui/scripts/stop-bleed-check.sh origin/main\`: **ok** (no new \`<style>\` blocks on non-allowlisted components).

## Test plan

- [ ] CI green: \`gui-stop-bleed\` check passes for the migrated files.
- [ ] CI green: \`pnpm check\` / build still pass with no new warnings.
- [ ] Visual: dev preview renders DesktopLayout (collapsed-rail + expanded-sidebar), PanesArea (1-pane + 3-pane splits), TranscriptView (user/assistant role borders, tool-call cards), SessionComposer (default + error + sending states), SessionPane (CI/review/merged signal badges, conv-recap line clamp).
- [ ] Dark mode: same as above with \`[data-theme=dark]\` toggled.
- [ ] No accent-hue regression: the runtime \`--accent-hue\` mutation in \`+layout.svelte\` still recolors user-turn borders and the textarea focus ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated sidebar navigation, message composer, session panes, and transcript view components with consistent utility-based styling.
  * Refactored empty-state displays, badge styling, and layout markup across the UI for improved visual coherence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/572)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #3