### PR TITLE
fix(claudeinstances): heartbeat staleness no longer reports no_claude for live sessions

### DIFF
--- a/internal/cli/daemon/claudeinstance_wiring.go
+++ b/internal/cli/daemon/claudeinstance_wiring.go
@@ -19,6 +19,7 @@ package daemon
 import (
 	"context"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -133,9 +134,10 @@ func (a *tmuxInputAdapter) PaneByPid(ctx context.Context, hostID string, pid int
 	if a.p == nil || pid <= 0 {
 		return nil, false
 	}
-	for _, pn := range a.p.Snapshot().Panes {
+	snap := a.p.Snapshot()
+	for _, pn := range snap.Panes {
 		if string(pn.Key.Host) == hostID && pn.CurrentPid == pid {
-			return projectPane(pn), true
+			return projectPaneWithSession(pn, snap), true
 		}
 	}
 	return nil, false
@@ -155,7 +157,8 @@ func (a *tmuxInputAdapter) PaneBySession(ctx context.Context, hostID, session st
 	if a.p == nil || session == "" {
 		return nil, false
 	}
-	for _, pn := range a.p.Snapshot().Panes {
+	snap := a.p.Snapshot()
+	for _, pn := range snap.Panes {
 		if string(pn.Key.Host) != hostID || pn.WindowKey.Session != session {
 			continue
 		}
@@ -164,7 +167,7 @@ func (a *tmuxInputAdapter) PaneBySession(ctx context.Context, hostID, session st
 		}
 		if a.ps == nil {
 			// No ps provider: return first pane with a non-zero pid (v1 behaviour).
-			return projectPane(pn), true
+			return projectPaneWithSession(pn, snap), true
 		}
 		// ps cross-check: only return the pane if its foreground process Command
 		// basename contains "claude".
@@ -173,7 +176,7 @@ func (a *tmuxInputAdapter) PaneBySession(ctx context.Context, hostID, session st
 			continue
 		}
 		if strings.Contains(strings.ToLower(filepath.Base(cmd)), "claude") {
-			return projectPane(pn), true
+			return projectPaneWithSession(pn, snap), true
 		}
 	}
 	return nil, false
@@ -200,7 +203,10 @@ func (a *psGetterAdapter) CommandForPid(ctx context.Context, hostID string, pid 
 	return proc.Command, true
 }
 
-// projectPane projects a tmuxprovider.Pane onto *gql.TmuxPane.
+// projectPane projects a tmuxprovider.Pane onto *gql.TmuxPane. Window /
+// Session edges are left nil — callers that need session-level data (e.g.
+// lastActivityAt fallback for ClaudeInstance) MUST use projectPaneWithSession
+// instead so the composer can reach Pane.Window.Session.LastActivityAt.
 func projectPane(pn tmuxprovider.Pane) *gql.TmuxPane {
 	out := &gql.TmuxPane{
 		ID:             "TmuxPane:" + string(pn.Key.Host) + ":" + pn.Key.PaneID,
@@ -210,6 +216,42 @@ func projectPane(pn tmuxprovider.Pane) *gql.TmuxPane {
 	if pn.CurrentPid > 0 {
 		pid := int64(pn.CurrentPid)
 		out.CurrentPid = &pid
+	}
+	return out
+}
+
+// projectPaneWithSession extends projectPane with the minimal Window/Session
+// chain the ClaudeInstance composer's third lastActivityAt fallback walks
+// (composer.composeOne: pane.Window.Session.LastActivityAt). Only the fields
+// composer reads are populated — there is no full hydration, since the
+// composer does not need Window.Panes or Session.AttachedClients.
+//
+// The session's LastActivityAt is the coarsest of the three lastActivityAt
+// fallbacks but the only one that survives when the hook stops heartbeating
+// AND the jsonl reader can't resolve the transcript path. It is the reason
+// idle sessions still show a non-null `lastActivityAt` in the dashboard.
+func projectPaneWithSession(pn tmuxprovider.Pane, snap tmuxprovider.RuntimeSnapshot) *gql.TmuxPane {
+	out := projectPane(pn)
+	sess, ok := snap.Sessions[tmuxprovider.SessionKey{
+		Host: pn.Key.Host,
+		Name: pn.WindowKey.Session,
+	}]
+	if !ok {
+		return out
+	}
+	session := &gql.TmuxSession{
+		ID:   "TmuxSession:" + string(sess.Key.Host) + ":" + sess.Key.Name,
+		Name: sess.Key.Name,
+	}
+	if !sess.LastActivityAt.IsZero() {
+		v := sess.LastActivityAt.UTC().Format(time.RFC3339)
+		session.LastActivityAt = &v
+	}
+	out.Window = &gql.TmuxWindow{
+		ID: "TmuxWindow:" + string(pn.WindowKey.Host) + ":" + pn.WindowKey.Session +
+			":" + strconv.Itoa(pn.WindowKey.Index),
+		Index:   int64(pn.WindowKey.Index),
+		Session: session,
 	}
 	return out
 }

--- a/internal/server/providers/claudeinstance/composer.go
+++ b/internal/server/providers/claudeinstance/composer.go
@@ -163,7 +163,7 @@ func (c *Composer) composeOne(ctx context.Context, hb Heartbeat) *graphql.Claude
 	pid := c.resolvePid(hb, pane)
 	proc := c.findProcess(ctx, pid)
 	account := c.findAccount(ctx)
-	state := c.deriveState(hb, pid)
+	state := c.deriveState(hb, pid, pane)
 
 	id := buildID(c.hostID, pid, hb.TmuxSession)
 	inst := &graphql.ClaudeInstance{
@@ -294,27 +294,41 @@ func (c *Composer) findAccount(ctx context.Context) *graphql.ClaudeAccount {
 
 // deriveState collapses the briefing's matrix into one InstanceState.
 //
-//	working   — heartbeat fresh AND state==working AND pid alive (or unknown)
-//	idle      — heartbeat fresh AND state==idle    AND pid alive (or unknown)
-//	input     — heartbeat fresh AND state==input   AND pid alive (or unknown)
-//	no_claude — heartbeat stale OR pid known dead OR state unrecognised
+// The hook is event-driven (PreToolUse / PostToolUse / Notification), NOT
+// periodic — so a long-idle session sitting in `input` legitimately stops
+// emitting heartbeats. We therefore treat heartbeat freshness as a
+// fast-path signal, with pid liveness as the trumping authority:
 //
-// "pid unknown" (heartbeat predates the pid-recording shape) does NOT
-// downgrade to no_claude — we trust the heartbeat in that case because
-// the alternative is a permanent no_claude for every instance until the
-// hook script is updated.
-func (c *Composer) deriveState(hb Heartbeat, pid int) graphql.InstanceState {
+//	pid known alive  → trust the last-known heartbeat state, even if stale.
+//	                   Covers idle/input sessions that sit for minutes/hours
+//	                   between events (#501) and the respawn case where the
+//	                   tracked pid died but pane still hosts a live claude (#421).
+//	pid known dead   → no_claude. The session is genuinely gone.
+//	pid unknown      → trust the heartbeat freshness window. When stale and
+//	                   we have no way to verify liveness, conservative
+//	                   no_claude is the safer call.
+//
+// State string lookup happens last and unrecognised strings collapse to
+// no_claude — the hook MUST write one of working/idle/input or we treat
+// it as garbage.
+func (c *Composer) deriveState(hb Heartbeat, pid int, pane *graphql.TmuxPane) graphql.InstanceState {
 	now := c.clock()
 	stamp := hb.LastHeartbeatAt
 	if stamp.IsZero() {
 		stamp = hb.Timestamp
 	}
-	if stamp.IsZero() || now.Sub(stamp) > c.staleAfter {
+	fresh := !stamp.IsZero() && now.Sub(stamp) <= c.staleAfter
+
+	alive := c.aliveSignal(pid, pane)
+	switch alive {
+	case alivenessDead:
 		return graphql.InstanceStateNoClaude
+	case alivenessUnknown:
+		if !fresh {
+			return graphql.InstanceStateNoClaude
+		}
 	}
-	if pid > 0 && !c.liveness.IsAlive(pid) {
-		return graphql.InstanceStateNoClaude
-	}
+
 	switch strings.ToLower(strings.TrimSpace(hb.State)) {
 	case "working":
 		return graphql.InstanceStateWorking
@@ -325,6 +339,48 @@ func (c *Composer) deriveState(hb Heartbeat, pid int) graphql.InstanceState {
 	default:
 		return graphql.InstanceStateNoClaude
 	}
+}
+
+// aliveness is a three-valued signal — pid liveness can be authoritative
+// (alive or dead) or absent (no pid recorded anywhere).
+type aliveness int
+
+const (
+	alivenessUnknown aliveness = iota
+	alivenessAlive
+	alivenessDead
+)
+
+// aliveSignal answers "is there a live Claude for this heartbeat?" using
+// every pid we have. The pane's CurrentPid is consulted in addition to
+// the resolved pid because the pane may be hosting a respawned claude
+// whose pid differs from the heartbeat (#421). Either pid being alive
+// flips the signal to alivenessAlive.
+//
+// The function returns alivenessUnknown only when no pid is available at
+// all — neither heartbeat nor pane recorded one. The deriveState caller
+// then falls back to heartbeat-freshness alone.
+func (c *Composer) aliveSignal(pid int, pane *graphql.TmuxPane) aliveness {
+	checked := false
+	if pid > 0 {
+		checked = true
+		if c.liveness.IsAlive(pid) {
+			return alivenessAlive
+		}
+	}
+	if pane != nil && pane.CurrentPid != nil && *pane.CurrentPid > 0 {
+		panePid := int(*pane.CurrentPid)
+		if panePid != pid {
+			checked = true
+			if c.liveness.IsAlive(panePid) {
+				return alivenessAlive
+			}
+		}
+	}
+	if checked {
+		return alivenessDead
+	}
+	return alivenessUnknown
 }
 
 // buildID is the canonical id formatter — `ClaudeInstance:<host>:<pid>`

--- a/internal/server/providers/claudeinstance/composer_test.go
+++ b/internal/server/providers/claudeinstance/composer_test.go
@@ -125,14 +125,19 @@ func TestComposer_Compose_Working(t *testing.T) {
 	}
 }
 
-// TestComposer_Compose_StaleHeartbeat asserts a fresh-state heartbeat
-// from > staleAfter ago collapses to no_claude — covers the briefing's
-// "touch a heartbeat backward → state goes to no_claude" assertion.
-func TestComposer_Compose_StaleHeartbeat(t *testing.T) {
+// TestComposer_Compose_StaleHeartbeatAlivePidTrustsState asserts that a
+// stale heartbeat whose tracked pid is still alive does NOT collapse to
+// no_claude — the orchard hook is event-driven, so an idle session
+// legitimately stops heartbeating between events. The last-known state
+// (working/idle/input) survives so long as the pid is verifiably alive.
+//
+// Regression: prior to fix(claudeinstances) this returned no_claude for
+// every idle session past 30s, masking the entire fleet as dead (#421, #501).
+func TestComposer_Compose_StaleHeartbeatAlivePidTrustsState(t *testing.T) {
 	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
 	hb := Heartbeat{
-		TmuxSession:     "stale",
-		State:           "working",
+		TmuxSession:     "stale-but-alive",
+		State:           "input",
 		ClaudePid:       11,
 		Timestamp:       now.Add(-2 * time.Minute),
 		LastHeartbeatAt: now.Add(-2 * time.Minute),
@@ -152,8 +157,105 @@ func TestComposer_Compose_StaleHeartbeat(t *testing.T) {
 	if len(out) != 1 {
 		t.Fatalf("got %d, want 1", len(out))
 	}
+	if out[0].State != graphql.InstanceStateInput {
+		t.Errorf("state = %s, want input (stale heartbeat but pid alive)", out[0].State)
+	}
+}
+
+// TestComposer_Compose_StaleHeartbeatDeadPidNoClaude asserts a stale
+// heartbeat AND a dead tracked pid AND no live pid in the pane collapses
+// to no_claude — the session is genuinely gone.
+func TestComposer_Compose_StaleHeartbeatDeadPidNoClaude(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	hb := Heartbeat{
+		TmuxSession:     "stale-dead",
+		State:           "working",
+		ClaudePid:       11,
+		Timestamp:       now.Add(-2 * time.Minute),
+		LastHeartbeatAt: now.Add(-2 * time.Minute),
+	}
+
+	c := NewComposerWith(
+		"local",
+		nil,
+		nil,
+		nil,
+		fakeLiveness{alive: map[int]bool{11: false}},
+		nil,
+		func() time.Time { return now },
+		30*time.Second,
+	)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
 	if out[0].State != graphql.InstanceStateNoClaude {
-		t.Errorf("state = %s, want no_claude", out[0].State)
+		t.Errorf("state = %s, want no_claude (stale + dead pid)", out[0].State)
+	}
+}
+
+// TestComposer_Compose_StaleHeartbeatNoPidNoClaude asserts that when
+// staleness applies AND no pid is available anywhere (heartbeat pid==0,
+// pane CurrentPid==nil), the state collapses to no_claude — we have no
+// way to verify the session is still alive, so the conservative call
+// stands.
+func TestComposer_Compose_StaleHeartbeatNoPidNoClaude(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	hb := Heartbeat{
+		TmuxSession:     "stale-pidless",
+		State:           "working",
+		ClaudePid:       0,
+		Timestamp:       now.Add(-2 * time.Minute),
+		LastHeartbeatAt: now.Add(-2 * time.Minute),
+	}
+
+	c := NewComposerWith(
+		"local",
+		nil,
+		nil,
+		nil,
+		fakeLiveness{},
+		nil,
+		func() time.Time { return now },
+		30*time.Second,
+	)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if out[0].State != graphql.InstanceStateNoClaude {
+		t.Errorf("state = %s, want no_claude (stale + no pid)", out[0].State)
+	}
+}
+
+// TestComposer_Compose_RespawnedInSamePane asserts that when ralph-loop
+// (or any restart-in-place workflow) replaces the Claude process inside
+// the same tmux pane — old pid dies, new pid takes over — the composer
+// reports the session as alive rather than no_claude. Even though the
+// heartbeat tracks the dead pid, the pane's current foreground pid is
+// alive and belongs to a claude process, so the instance is not dead.
+//
+// Regression for #421: prior to fix, the daemon collapsed to no_claude
+// the moment the tracked pid died, even though `tmux capture-pane`
+// showed a live Claude REPL in the same pane.
+func TestComposer_Compose_RespawnedInSamePane(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 0, 0, 0, time.UTC)
+	hb := Heartbeat{
+		TmuxSession:     "respawned",
+		State:           "working",
+		ClaudePid:       100, // old, dead
+		Timestamp:       now.Add(-3 * time.Second),
+		LastHeartbeatAt: now.Add(-3 * time.Second),
+	}
+	newPid := int64(200) // pane now hosts a new claude
+	pane := &graphql.TmuxPane{ID: "TmuxPane:local:%99", CurrentPid: &newPid}
+	c := NewComposerWith(
+		"local",
+		&fakePaneFinder{byPid: map[int]*graphql.TmuxPane{100: pane}},
+		nil,
+		nil,
+		fakeLiveness{alive: map[int]bool{100: false, 200: true}},
+		nil,
+		func() time.Time { return now },
+		HeartbeatStaleAfter,
+	)
+	out := c.Compose(context.Background(), []Heartbeat{hb})
+	if out[0].State != graphql.InstanceStateWorking {
+		t.Errorf("state = %s, want working (pane respawn: heartbeat pid dead but new pid alive in same pane)", out[0].State)
 	}
 }
 

--- a/internal/server/providers/claudeinstance/e2e_test.go
+++ b/internal/server/providers/claudeinstance/e2e_test.go
@@ -185,8 +185,11 @@ func TestClaudeInstance_E2E_TwoFreshInstances(t *testing.T) {
 		t.Error("bravo rcEnabled = true, want false")
 	}
 
-	// -------- Phase 2: touch alpha heartbeat backward → no_claude.
-	// Rewrite alpha's content with an old timestamp; refresh; re-query.
+	// -------- Phase 2: touch alpha heartbeat backward but keep pid alive.
+	// Hook is event-driven so an idle session legitimately stops
+	// heartbeating; as long as the tracked pid is alive, the dashboard
+	// must keep showing the last-known state (working) — NOT collapse to
+	// no_claude. Cf. #421, #501.
 	staleTimestamp := now.Add(-2 * time.Minute).Format(time.RFC3339)
 	writeHeartbeat(t, heartbeatDir, "alpha", map[string]any{
 		"tmux_session":    "alpha",
@@ -210,11 +213,26 @@ func TestClaudeInstance_E2E_TwoFreshInstances(t *testing.T) {
 	for _, inst := range resp2.Data.ClaudeInstances {
 		staleByID[inst.ID] = inst.State
 	}
-	if got := staleByID["ClaudeInstance:local:10042"]; got != "no_claude" {
-		t.Errorf("alpha state after staling = %q, want no_claude", got)
+	if got := staleByID["ClaudeInstance:local:10042"]; got != "working" {
+		t.Errorf("alpha state after staling (pid still alive) = %q, want working", got)
 	}
 	if got := staleByID["ClaudeInstance:local:10099"]; got != "idle" {
 		t.Errorf("bravo state should still be idle, got %q", got)
+	}
+
+	// -------- Phase 3: alpha pid dies. Now the session is genuinely gone.
+	// Stale heartbeat + dead pid + no other live pid in the pane = no_claude.
+	liveness.alive[10042] = false
+	if err := provider.Refresh(context.Background(), "test-dead"); err != nil {
+		t.Fatalf("refresh after dead pid: %v", err)
+	}
+	resp3 := postQuery(t, srv.URL, `query { claudeInstances { id state } }`)
+	deadByID := map[string]string{}
+	for _, inst := range resp3.Data.ClaudeInstances {
+		deadByID[inst.ID] = inst.State
+	}
+	if got := deadByID["ClaudeInstance:local:10042"]; got != "no_claude" {
+		t.Errorf("alpha state after dead pid = %q, want no_claude", got)
 	}
 }
 

--- a/internal/server/providers/claudeinstance/e2e_test.go
+++ b/internal/server/providers/claudeinstance/e2e_test.go
@@ -227,6 +227,9 @@ func TestClaudeInstance_E2E_TwoFreshInstances(t *testing.T) {
 		t.Fatalf("refresh after dead pid: %v", err)
 	}
 	resp3 := postQuery(t, srv.URL, `query { claudeInstances { id state } }`)
+	if len(resp3.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp3.Errors)
+	}
 	deadByID := map[string]string{}
 	for _, inst := range resp3.Data.ClaudeInstances {
 		deadByID[inst.ID] = inst.State


### PR DESCRIPTION
## Summary

The orchard hook is **event-driven** (PreToolUse / PostToolUse / Notification), not periodic — so an idle session in `input` state legitimately stops emitting heartbeats. The 30s staleness threshold treated every such session as dead, masking the entire fleet as `no_claude` (#501) and missing the ralph-loop respawn case (#421).

The fix flips pid liveness from a no-op fast-fail into the trumping signal:

- **pid known alive** → trust the last-known heartbeat state, even if stale.
- **pid known dead** → `no_claude` (genuine death).
- **pid unknown** → trust the heartbeat freshness window. When stale and we can't verify liveness, conservative `no_claude` stands.

The composer's `pane.CurrentPid` is now consulted alongside the heartbeat's tracked pid so a respawn (old pid dead, new pid alive in same pane) is detected — fixing #421's "ralph-loop replaced the process in-place" case.

Also wires `Pane.Window.Session.LastActivityAt` so the composer's third `lastActivityAt` fallback works (it was dead code before — `projectPane` never populated `Window`). Improves `lastActivityAt: null` symptom from #501 for sessions whose transcript jsonl is unreachable.

## Cluster scope

This PR closes #421 and #501 — both stem from the same root cause (state derivation conflating stale heartbeats with dead processes).

**#367 is a different domain** — `orchard-monitor` flapping `conflicts:True→False` on `mergeStateStatus: UNKNOWN`. That's monitor poll-loop logic, not daemon state derivation. Will leave a comment on #367 noting it's separate from this cluster.

## Changes

| File | Change |
|---|---|
| `internal/server/providers/claudeinstance/composer.go` | `deriveState` now takes `pane` and uses three-valued aliveness (`alive` / `dead` / `unknown`) cross-checked against heartbeat pid AND pane pid |
| `internal/cli/daemon/claudeinstance_wiring.go` | New `projectPaneWithSession` populates Window + Session so composer's third lastActivityAt fallback can resolve |
| `internal/server/providers/claudeinstance/composer_test.go` | Renamed `TestComposer_Compose_StaleHeartbeat` → `TestComposer_Compose_StaleHeartbeatAlivePidTrustsState`. Added: `StaleHeartbeatDeadPidNoClaude`, `StaleHeartbeatNoPidNoClaude`, `RespawnedInSamePane` |
| `internal/server/providers/claudeinstance/e2e_test.go` | E2E now exercises three phases: fresh → stale-alive (working stays working) → stale-dead (collapses to no_claude) |

## Test plan

- [x] `go test ./internal/server/providers/claudeinstance/...` — provider + composer + e2e tests pass
- [x] `go test ./internal/cli/daemon/...` — wiring tests pass
- [x] `go test ./...` — full Go test surface (incl. 31s peerproxy e2e) passes
- [x] `cargo check --workspace` — Rust workspace builds
- [x] `make daemon` — daemon binary builds clean
- [ ] CI signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Panes now include window and session details plus populated "last activity" timestamps for more accurate UI context.

* **Bug Fixes**
  * Improved instance-state logic: stale heartbeats preserve last-known state if the tracked process is alive; instances collapse to offline only when the process is confirmed dead or liveness is unknown and heartbeat is stale.

* **Tests**
  * End-to-end and unit tests updated/added to validate the new staleness and liveness behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/573)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #1

# Related issue

- #1

# Related issue

- #1