### PR TITLE
fix(tui): three UX ergonomics fixes — #331 #438 #545

### DIFF
--- a/crates/orchard/src/main.rs
+++ b/crates/orchard/src/main.rs
@@ -384,12 +384,27 @@ fn build_output() -> JsonOutput {
 }
 
 fn handle_json() {
+    emit_json_deprecation_warning("orchard-tui --json");
     let output = build_output();
     let json = serde_json::to_string_pretty(&output).unwrap_or_else(|e| {
         eprintln!("Error serializing JSON: {e}");
         std::process::exit(1);
     });
     println!("{json}");
+}
+
+/// Emits a deprecation warning for `--json` flag surfaces (issue #438).
+///
+/// The daemon's GraphQL endpoint at `http://127.0.0.1:7777/graphql` is the
+/// canonical read surface. Full removal of `--json` is blocked by #404
+/// (peerproxy cross-host federation); the warning ships first so consumers
+/// have a migration runway.
+fn emit_json_deprecation_warning(surface: &str) {
+    eprintln!(
+        "[deprecated] `{surface}` is deprecated and will be removed. \
+         Query the daemon's GraphQL endpoint at http://127.0.0.1:7777/graphql instead. \
+         See https://github.com/drewdrewthis/git-orchard-rs/issues/438."
+    );
 }
 
 /// Handles `orchard-tui sessions --json` — comprehensive sessions index keyed by host.
@@ -410,6 +425,7 @@ fn handle_json() {
 /// worktree-centric `--json` output.
 fn handle_sessions(json: bool) {
     if json {
+        emit_json_deprecation_warning("orchard-tui sessions --json");
         // `--json` keeps the legacy SessionsIndexOutput shape so the
         // orchardist `/prune` skill (and other downstream consumers that
         // pin on it) don't break. Issue #426 introduces the federated

--- a/crates/orchard/src/tui/list.rs
+++ b/crates/orchard/src/tui/list.rs
@@ -465,7 +465,15 @@ impl App {
         match self.reachability(host) {
             Reachability::Reachable | Reachability::Unknown => false,
             Reachability::Unreachable => {
-                self.warning = Some((format!("@{} is unreachable", host), Instant::now()));
+                // #331: a transient `warning` fades after WARNING_DURATION_SECS
+                // and is invisible in practice during active redraws. Mirror
+                // the message into `sticky_error` so it persists until the
+                // user takes another action.
+                let msg = format!(
+                    "@{host} is unreachable. Press R to retry the probe, or check the host's network/VM state."
+                );
+                self.warning = Some((msg.clone(), Instant::now()));
+                self.sticky_error = Some(msg);
                 true
             }
         }
@@ -1036,7 +1044,15 @@ impl App {
                     true
                 }
                 Err(e) => {
-                    self.warning = Some((format!("remote session error: {e}"), Instant::now()));
+                    // #331: name the host and the underlying reason so the
+                    // user can act without dropping to a shell. Persist via
+                    // `sticky_error` because the transient `warning` banner
+                    // fades after 3s and is invisible during redraws.
+                    let msg = format!(
+                        "@{host}: remote session error — {e}. Press R to retry probe, or check SSH/VM state."
+                    );
+                    self.warning = Some((msg.clone(), Instant::now()));
+                    self.sticky_error = Some(msg);
                     false
                 }
             }
@@ -1053,7 +1069,12 @@ impl App {
                     true
                 }
                 Err(e) => {
-                    self.warning = Some((format!("session error: {e}"), Instant::now()));
+                    // #331: persist local session failures too — they're
+                    // rarer but equally invisible behind the transient
+                    // warning banner.
+                    let msg = format!("session error: {e}");
+                    self.warning = Some((msg.clone(), Instant::now()));
+                    self.sticky_error = Some(msg);
                     false
                 }
             }
@@ -1196,6 +1217,12 @@ impl App {
             .as_ref()
             .is_some_and(|(_, t)| t.elapsed().as_secs() < WARNING_DURATION_SECS);
 
+        // #331: sticky_error is a persistent banner that does NOT auto-expire.
+        // Reserves its own row in the layout below the preview so the user
+        // can see it across multiple redraws after an Enter failure on an
+        // unreachable host. Wraps to two lines when the message is long.
+        let has_sticky_error = self.sticky_error.is_some();
+
         // Calculate total table body height from individual row heights
         let body_height: u16 = row_heights.iter().sum::<u16>();
         let table_height = body_height.saturating_add(3); // +2 borders +1 header row
@@ -1228,6 +1255,11 @@ impl App {
 
         if has_warning {
             constraints.push(Constraint::Length(1));
+        }
+
+        if has_sticky_error {
+            // 2 rows so a message with a host name + reason wraps cleanly.
+            constraints.push(Constraint::Length(2));
         }
 
         constraints.push(Constraint::Length(1)); // hints
@@ -1357,6 +1389,21 @@ impl App {
                     .style(Style::default().fg(theme.warning))
                     .alignment(Alignment::Center);
                 f.render_widget(warn, chunks[idx]);
+            }
+            idx += 1;
+        }
+
+        if has_sticky_error {
+            if let Some(ref msg) = self.sticky_error {
+                let err = Paragraph::new(msg.as_str())
+                    .style(
+                        Style::default()
+                            .fg(theme.error)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .alignment(Alignment::Center)
+                    .wrap(Wrap { trim: true });
+                f.render_widget(err, chunks[idx]);
             }
             idx += 1;
         }

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -106,6 +106,15 @@ pub struct App {
     refreshing: bool,
     error: Option<String>,
     warning: Option<(String, Instant)>,
+    /// Persistent error banner that does NOT auto-expire (issue #331).
+    ///
+    /// Set by Enter-action failure paths whose error must remain visible
+    /// until the user explicitly takes another action (typically a
+    /// "remote session error" for an unreachable host). Cleared at the
+    /// top of `update()` so any subsequent input dismisses it — unlike
+    /// `warning`, which fades after `WARNING_DURATION_SECS` and is
+    /// invisible in practice for transient failures.
+    sticky_error: Option<String>,
     repo_root: String,
     repo_name: String,
     pane_content: String,
@@ -304,6 +313,7 @@ impl App {
             refreshing: false,
             error: None,
             warning: None,
+            sticky_error: None,
             repo_root,
             repo_name,
             pane_content: String::new(),
@@ -1408,6 +1418,13 @@ impl App {
             }
         }
 
+        // #331: clear the persistent error banner on any user-driven message.
+        // The banner is set by failure paths (e.g. Enter on an unreachable
+        // remote) and must remain visible until the user takes another
+        // action. Background refresh signals are dispatched as `AppMsg`,
+        // not `Message`, so this site only fires on real user input.
+        self.sticky_error = None;
+
         match msg {
             Message::Quit => UpdateResult {
                 quit: true,
@@ -2277,6 +2294,7 @@ impl App {
             refreshing: false,
             error: None,
             warning: None,
+            sticky_error: None,
             repo_root: "/test".to_string(),
             repo_name: "test-repo".to_string(),
             pane_content: String::new(),
@@ -3053,6 +3071,49 @@ mod tests {
         assert!(
             app.warning.as_ref().unwrap().0.contains("unreachable"),
             "expected 'unreachable' in warning message"
+        );
+        // #331: the persistent banner must also be set so the message
+        // survives the WARNING_DURATION_SECS fade.
+        assert!(
+            app.sticky_error.is_some(),
+            "expected sticky_error to be set (issue #331)"
+        );
+        let sticky = app.sticky_error.as_ref().unwrap();
+        assert!(
+            sticky.contains("gpu1"),
+            "sticky_error must name the host, got: {sticky}"
+        );
+        assert!(
+            sticky.contains("unreachable"),
+            "sticky_error must name the reason, got: {sticky}"
+        );
+    }
+
+    /// #331: any subsequent user-driven Message dismisses the sticky_error
+    /// banner. Background AppMsg signals (refresh completions) do not.
+    #[test]
+    fn sticky_error_clears_on_next_user_message() {
+        let mut app = App::new_test(vec![]);
+        app.sticky_error = Some("@gpu1 is unreachable.".to_string());
+        let _ = app.update(Message::CursorDown);
+        assert!(
+            app.sticky_error.is_none(),
+            "sticky_error must clear on user input (issue #331)"
+        );
+    }
+
+    /// #331: rendering the sticky_error must produce visible text in the
+    /// terminal buffer — not just set internal state. Guards against the
+    /// transient-banner regression where state was set but invisible.
+    #[test]
+    fn sticky_error_renders_in_terminal_buffer() {
+        let row = make_task_row(1, DisplayGroup::Other);
+        let mut app = App::new_test(vec![row]);
+        app.sticky_error = Some("@gpu1 is unreachable".to_string());
+        let output = render_to_string(&mut app, 120, 40);
+        assert!(
+            output.contains("@gpu1 is unreachable"),
+            "sticky_error message must appear in the rendered output (issue #331); got:\n{output}"
         );
     }
 
@@ -6308,6 +6369,41 @@ mod tests {
         assert!(
             !output.contains("daemon: connecting"),
             "header must NOT contain 'daemon: connecting' when daemon is reachable"
+        );
+    }
+
+    /// Regression test for #545: orchard-tui must NEVER silently mutate
+    /// `~/.orchard/config.json`.
+    ///
+    /// `App::new` previously called `register_cwd_repo_if_new` which wrote
+    /// to disk on every TUI launch from an untracked repo. Only explicit
+    /// CLI commands (`orchard config init`, `orchard config write`,
+    /// `orchard init` wizard) may mutate the global config.
+    ///
+    /// This is a source-content invariant — we grep `App::new` for any
+    /// reference to the silent writer. A behavioral test isn't possible
+    /// here because `App::new` reads `~/.orchard/config.json` via
+    /// `dirs::home_dir()` with no test override.
+    #[test]
+    fn app_new_does_not_register_cwd_repo() {
+        let src = include_str!("mod.rs");
+        let new_fn_start = src
+            .find("    fn new(command: &str) -> Self {")
+            .expect("App::new function must exist");
+        // Scan from the start of `fn new` to the next top-level `}` (end of impl block boundary
+        // before next function). Use a conservative window: 200 lines of body.
+        let window_end = src[new_fn_start..]
+            .char_indices()
+            .filter(|(_, c)| *c == '\n')
+            .nth(200)
+            .map(|(idx, _)| new_fn_start + idx)
+            .unwrap_or(src.len());
+        let body = &src[new_fn_start..window_end];
+        assert!(
+            !body.contains("register_cwd_repo_if_new"),
+            "App::new must not call register_cwd_repo_if_new (issue #545). \
+             The TUI startup path must NOT silently mutate ~/.orchard/config.json. \
+             Only explicit CLI commands (`orchard config init`, `orchard init`) may write it."
         );
     }
 }


### PR DESCRIPTION
## Summary

Cluster 2 (TUI ergonomics) — Rust surface. Three independent UX fixes bundled because they all live in `crates/orchard/src/{main.rs,tui/}` and share a common review path. The daemon-schema half of cluster 2 (#489 #506) ships as a separate PR (Go vs Rust review path).

## Closes

- **#331** — Enter on a remote worktree whose host is unreachable used to fail silently. The transient `warning` banner faded after 3s and was invisible during active redraws.
  - Adds a sibling `sticky_error: Option<String>` field that does NOT auto-expire.
  - Set from `block_if_host_unreachable` (pre-check path) AND both error branches of `join_or_create_session` (remote SSH failure, local tmux failure).
  - Cleared at the top of `update()` on any user-driven `Message` (background `AppMsg` signals do not dismiss it).
  - Renders below the preview pane in `theme.error` color, bold, centered, wrapped — survives the 3s warning fade.
  - Names the host + underlying reason so the user can act without dropping to a shell.

- **#438** — `orchard-tui --json` and `orchard-tui sessions --json` now emit a deprecation warning on stderr pointing consumers at the daemon's GraphQL endpoint at `http://127.0.0.1:7777/graphql`.
  - Full removal stays blocked on #404 (peerproxy cross-host federation) per the issue's sequencing notes.
  - Stdout JSON shape is unchanged so existing consumers keep working during the migration window.

- **#545** — Adds a source-content regression test asserting `App::new` contains no call to `register_cwd_repo_if_new`. The silent writer was already removed from the TUI startup path (mod.rs:262 carries Drew's 2026-05-10 comment); this guards against re-introduction.

## Test plan

- [x] `cargo build --workspace` — green
- [x] `cargo test -p orchard --lib` — 1517 passed, 0 failed
- [x] New tests:
  - `tui::tests::sticky_error_clears_on_next_user_message`
  - `tui::tests::sticky_error_renders_in_terminal_buffer`
  - `tui::tests::unreachable_host_blocks_enter` (extended with sticky_error asserts)
  - `tui::tests::app_new_does_not_register_cwd_repo` (regression for #545)
- [x] `cargo clippy -p orchard --lib` — clean
- [ ] Manual TUI verification — Drew can try Enter on an unreachable boxd VM to see the persistent banner

## Out of scope (deferred)

- Inline recovery action (the stretch AC on #331 — "press a key to wake the VM"). Lands as a follow-up because it touches boxd CLI shellout and warrants its own surface design.
- Daemon schema work for #489 and #506 — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deprecation warning when using JSON output, directing users to the GraphQL endpoint
  * Persistent error banners now remain visible for host connectivity and session creation failures across screen redraws

* **Tests**
  * Added test coverage for sticky error persistence and rendering behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/574)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #2