### PR TITLE
feat(daemon): two schema additions — #489 #506

### DIFF
--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -3201,7 +3201,18 @@ type Worktree implements Node {
   "owner/repo slug derived from origin remote. Null when origin is not a GitHub URL."
   repo: String
 
-  "Open PR whose headRef matches this worktree's branch. Null when no match, branch is detached, or branch is the project's default branch."
+  """
+  PR whose headRef matches this worktree's branch.
+
+  Selection precedence (issue #489): an OPEN PR is returned when one exists;
+  otherwise the most-recent CLOSED/MERGED PR with the matching headRef is
+  returned so the TUI stale-fade UX can render the post-merge cleanup
+  affordance. The ` + "`" + `state` + "`" + ` field on the returned PullRequest disambiguates
+  between live and post-merge.
+
+  Null when no PR has ever existed for this branch in any state, when the
+  branch is detached, or when the branch is the project's default branch.
+  """
   pr: PullRequest
 
   "Issue linked from the worktree's branch (issue<N>/... convention). Null when the branch doesn't carry an issue number."
@@ -3303,7 +3314,21 @@ type TmuxSession implements Node {
   "Clients currently attached to this session."
   attachedClients: [TmuxClient!]!
 
-  "Most recent activity timestamp across all panes/windows. RFC3339; null if never observed."
+  """
+  Most recent activity timestamp across all panes/windows. RFC3339; null
+  if never observed.
+
+  Tracks tmux's ` + "`" + `pane_activity` + "`" + ` field, which fires on NEW pane content —
+  not on in-place redraws. A Claude REPL spinner ticking in place
+  (` + "\"" + `Elucidating… 1m 11s` + "\"" + `) does NOT bump ` + "`" + `lastActivityAt` + "`" + `, so a long
+  agentic turn can look identical to a hung pane (issue #506).
+
+  Do NOT use this field as a Claude-REPL stall signal. The canonical
+  signal is ` + "`" + `Worktree.claudeInstances[].state` + "`" + ` (working|idle|input|stalled,
+  issue #501) once that lands, OR the heartbeat freshness exposed on
+  ` + "`" + `ClaudeInstance` + "`" + ` directly. ` + "`" + `lastActivityAt` + "`" + ` remains useful for plain
+  shell panes and for the lex-tie-breaker in ` + "`" + `Worktree.tmuxSession` + "`" + `.
+  """
   lastActivityAt: String
 
   "Windows in this session."

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -3320,12 +3320,12 @@ type TmuxSession implements Node {
 
   Tracks tmux's ` + "`" + `pane_activity` + "`" + ` field, which fires on NEW pane content —
   not on in-place redraws. A Claude REPL spinner ticking in place
-  (` + "\"" + `Elucidating… 1m 11s` + "\"" + `) does NOT bump ` + "`" + `lastActivityAt` + "`" + `, so a long
+  ("Elucidating… 1m 11s") does NOT bump ` + "`" + `lastActivityAt` + "`" + `, so a long
   agentic turn can look identical to a hung pane (issue #506).
 
   Do NOT use this field as a Claude-REPL stall signal. The canonical
   signal is ` + "`" + `Worktree.claudeInstances[].state` + "`" + ` (working|idle|input|stalled,
-  issue #501) once that lands, OR the heartbeat freshness exposed on
+  issue #501), OR the heartbeat freshness exposed on
   ` + "`" + `ClaudeInstance` + "`" + ` directly. ` + "`" + `lastActivityAt` + "`" + ` remains useful for plain
   shell panes and for the lex-tie-breaker in ` + "`" + `Worktree.tmuxSession` + "`" + `.
   """

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -662,7 +662,19 @@ type TmuxSession struct {
 	ActiveAttached bool `json:"activeAttached"`
 	// Clients currently attached to this session.
 	AttachedClients []*TmuxClient `json:"attachedClients"`
-	// Most recent activity timestamp across all panes/windows. RFC3339; null if never observed.
+	// Most recent activity timestamp across all panes/windows. RFC3339;
+	// null if never observed.
+	//
+	// Tracks tmux's `pane_activity` field, which fires on NEW pane content —
+	// not on in-place redraws. A Claude REPL spinner ticking in place
+	// ("Elucidating… 1m 11s") does NOT bump `lastActivityAt`, so a long
+	// agentic turn can look identical to a hung pane (issue #506).
+	//
+	// Do NOT use this field as a Claude-REPL stall signal. The canonical
+	// signal is `Worktree.claudeInstances[].state` (working|idle|input|stalled,
+	// issue #501) once that lands, OR the heartbeat freshness exposed on
+	// `ClaudeInstance` directly. `lastActivityAt` remains useful for plain
+	// shell panes and for the lex-tie-breaker in `Worktree.tmuxSession`.
 	LastActivityAt *string `json:"lastActivityAt,omitempty"`
 	// Windows in this session.
 	Windows []*TmuxWindow `json:"windows"`
@@ -761,7 +773,14 @@ type Worktree struct {
 	Host string `json:"host"`
 	// owner/repo slug derived from origin remote. Null when origin is not a GitHub URL.
 	Repo *string `json:"repo,omitempty"`
-	// Open PR whose headRef matches this worktree's branch. Null when no match, branch is detached, or branch is the project's default branch.
+	// PR whose headRef matches this worktree's branch. Selection precedence
+	// (issue #489): an OPEN PR is returned when one exists; otherwise the
+	// most-recent CLOSED/MERGED PR with the matching headRef is returned so
+	// the TUI stale-fade UX can render the post-merge cleanup affordance.
+	// The `state` field on the returned PullRequest disambiguates between
+	// live and post-merge. Null when no PR has ever existed for this branch
+	// in any state, when the branch is detached, or when the branch is the
+	// project's default branch.
 	Pr *PullRequest `json:"pr,omitempty"`
 	// Issue linked from the worktree's branch (issue<N>/... convention). Null when the branch doesn't carry an issue number.
 	Issue *Issue `json:"issue,omitempty"`

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -662,8 +662,8 @@ type TmuxSession struct {
 	ActiveAttached bool `json:"activeAttached"`
 	// Clients currently attached to this session.
 	AttachedClients []*TmuxClient `json:"attachedClients"`
-	// Most recent activity timestamp across all panes/windows. RFC3339;
-	// null if never observed.
+	// Most recent activity timestamp across all panes/windows. RFC3339; null
+	// if never observed.
 	//
 	// Tracks tmux's `pane_activity` field, which fires on NEW pane content —
 	// not on in-place redraws. A Claude REPL spinner ticking in place
@@ -672,7 +672,7 @@ type TmuxSession struct {
 	//
 	// Do NOT use this field as a Claude-REPL stall signal. The canonical
 	// signal is `Worktree.claudeInstances[].state` (working|idle|input|stalled,
-	// issue #501) once that lands, OR the heartbeat freshness exposed on
+	// issue #501), OR the heartbeat freshness exposed on
 	// `ClaudeInstance` directly. `lastActivityAt` remains useful for plain
 	// shell panes and for the lex-tie-breaker in `Worktree.tmuxSession`.
 	LastActivityAt *string `json:"lastActivityAt,omitempty"`
@@ -773,14 +773,16 @@ type Worktree struct {
 	Host string `json:"host"`
 	// owner/repo slug derived from origin remote. Null when origin is not a GitHub URL.
 	Repo *string `json:"repo,omitempty"`
-	// PR whose headRef matches this worktree's branch. Selection precedence
-	// (issue #489): an OPEN PR is returned when one exists; otherwise the
-	// most-recent CLOSED/MERGED PR with the matching headRef is returned so
-	// the TUI stale-fade UX can render the post-merge cleanup affordance.
-	// The `state` field on the returned PullRequest disambiguates between
-	// live and post-merge. Null when no PR has ever existed for this branch
-	// in any state, when the branch is detached, or when the branch is the
-	// project's default branch.
+	// PR whose headRef matches this worktree's branch.
+	//
+	// Selection precedence (issue #489): an OPEN PR is returned when one exists;
+	// otherwise the most-recent CLOSED/MERGED PR with the matching headRef is
+	// returned so the TUI stale-fade UX can render the post-merge cleanup
+	// affordance. The `state` field on the returned PullRequest disambiguates
+	// between live and post-merge.
+	//
+	// Null when no PR has ever existed for this branch in any state, when the
+	// branch is detached, or when the branch is the project's default branch.
 	Pr *PullRequest `json:"pr,omitempty"`
 	// Issue linked from the worktree's branch (issue<N>/... convention). Null when the branch doesn't carry an issue number.
 	Issue *Issue `json:"issue,omitempty"`

--- a/internal/server/loaders/loaders.go
+++ b/internal/server/loaders/loaders.go
@@ -392,7 +392,16 @@ func loadProcesses(providers *ProvidersBundle, keys []ProcessKey) []*dataloader.
 // the Worktree.pr semantics defined in schema.graphql (issue #489).
 // The all-states fetch costs one round-trip per repo per request — the
 // same number as the previous open-only fetch — at the cost of a larger
-// response body. defaultPerPage = 100 caps the response.
+// response body.
+//
+// LIMITATION (issue #579): defaultPerPage = 100 caps the response and
+// the underlying gh client does NOT paginate. On repos with >100 PRs
+// (open + closed + merged), matches beyond page 1 are dropped — the
+// resolver may return null or a stale fallback for a branch whose
+// real PR is older than the most recent 100 by UpdatedAt. This is a
+// pre-existing repo-wide pattern (every list endpoint in
+// providers/gh/endpoints.go fetches a single page); #579 tracks the
+// fix across all endpoints.
 //
 // Slice-sharing contract: when multiple positions in keys map to the same
 // RepoKey, every position receives the SAME *graphql1.PullRequest slice

--- a/internal/server/loaders/loaders.go
+++ b/internal/server/loaders/loaders.go
@@ -385,9 +385,14 @@ func loadProcesses(providers *ProvidersBundle, keys []ProcessKey) []*dataloader.
 // internally so the gh provider is called at most once per unique repo,
 // regardless of how many Load calls arrived with the same key.
 //
-// Returns the full open-PR slice for each position in keys (including
-// duplicate positions). The resolver layer does the headRef→branch match
-// locally against this slice.
+// Returns PRs across all states (open + closed + merged) for each
+// position in keys, sorted by UpdatedAt DESC (GitHub's sort order on
+// the list endpoint). The resolver layer does the headRef→branch match
+// locally against this slice and chooses OPEN over CLOSED/MERGED per
+// the Worktree.pr semantics defined in schema.graphql (issue #489).
+// The all-states fetch costs one round-trip per repo per request — the
+// same number as the previous open-only fetch — at the cost of a larger
+// response body. defaultPerPage = 100 caps the response.
 //
 // Slice-sharing contract: when multiple positions in keys map to the same
 // RepoKey, every position receives the SAME *graphql1.PullRequest slice
@@ -416,7 +421,12 @@ func loadPullRequestsForRepo(ctx context.Context, providers *ProvidersBundle, ke
 		if _, seen := cache[key]; seen {
 			continue
 		}
-		prs, err := ghp.ListPullRequests(ctx, key.Owner, key.Name, ghprovider.PullRequestStateOpen)
+		// state=ALL so the Worktree.pr resolver can return the most-recent
+		// CLOSED/MERGED PR when no OPEN PR matches the branch (issue #489).
+		// Stays a single round-trip — the GitHub /pulls endpoint accepts a
+		// state query param and returns one page (per_page=100) sorted by
+		// UpdatedAt DESC.
+		prs, err := ghp.ListPullRequests(ctx, key.Owner, key.Name, ghprovider.PullRequestStateAll)
 		if err != nil {
 			cache[key] = &repoResult{err: err}
 			continue

--- a/internal/server/loaders/loaders_test.go
+++ b/internal/server/loaders/loaders_test.go
@@ -268,6 +268,30 @@ func TestPullRequestsForRepo_BatchesAcrossRepos(t *testing.T) {
 	}
 }
 
+// TestPullRequestsForRepo_FetchesAllStates asserts that the loader requests
+// state=ALL from the gh provider so the Worktree.pr resolver can return the
+// most-recent CLOSED/MERGED PR when no OPEN PR matches the branch (issue
+// #489 — TUI stale-fade UX needs post-merge PR data).
+func TestPullRequestsForRepo_FetchesAllStates(t *testing.T) {
+	stub := &prStub{prs: map[string]int{"owner/repo": 1}}
+	bundle := &loaders.ProvidersBundle{GH: stub}
+	l := loaders.NewLoaders(bundle)
+
+	ctx := context.Background()
+	if _, err := l.PullRequestsForRepo.Load(ctx, loaders.RepoKey{Owner: "owner", Name: "repo"})(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	states := stub.StateRequests()
+	if len(states) != 1 {
+		t.Fatalf("StateRequests = %v, want exactly 1 call", states)
+	}
+	if states[0] != ghprovider.PullRequestStateAll {
+		t.Errorf("loader requested state=%q, want state=%q (issue #489: need CLOSED/MERGED for stale-fade)",
+			states[0], ghprovider.PullRequestStateAll)
+	}
+}
+
 // TestPullRequestsForRepo_PerRequestScoped asserts that two separate
 // Loaders instances do not share state: each fires its own batch, so
 // the provider receives two calls for the same repo.
@@ -305,15 +329,18 @@ func TestPullRequestsForRepo_PerRequestScoped(t *testing.T) {
 
 // prStub implements loaders.GHPullRequestLister with a call counter.
 // prs maps "owner/name" to the number of dummy PRs to return.
+// stateRequests records the PullRequestState arg of each call (for #489).
 type prStub struct {
-	mu    sync.Mutex
-	calls int
-	prs   map[string]int // slug → PR count
+	mu             sync.Mutex
+	calls          int
+	prs            map[string]int // slug → PR count
+	stateRequests  []ghprovider.PullRequestState
 }
 
-func (s *prStub) ListPullRequests(_ context.Context, owner, name string, _ ghprovider.PullRequestState) ([]ghprovider.PullRequest, error) {
+func (s *prStub) ListPullRequests(_ context.Context, owner, name string, state ghprovider.PullRequestState) ([]ghprovider.PullRequest, error) {
 	s.mu.Lock()
 	s.calls++
+	s.stateRequests = append(s.stateRequests, state)
 	s.mu.Unlock()
 
 	slug := owner + "/" + name
@@ -335,4 +362,14 @@ func (s *prStub) CallCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.calls
+}
+
+// StateRequests returns a snapshot of the PullRequestState values the loader
+// passed on each ListPullRequests call. Used to assert the loader requests
+// state=ALL so the Worktree.pr resolver can fall back to CLOSED/MERGED
+// matches when no OPEN PR exists (issue #489).
+func (s *prStub) StateRequests() []ghprovider.PullRequestState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]ghprovider.PullRequestState(nil), s.stateRequests...)
 }

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -575,7 +575,18 @@ type Worktree implements Node {
   "owner/repo slug derived from origin remote. Null when origin is not a GitHub URL."
   repo: String
 
-  "Open PR whose headRef matches this worktree's branch. Null when no match, branch is detached, or branch is the project's default branch."
+  """
+  PR whose headRef matches this worktree's branch.
+
+  Selection precedence (issue #489): an OPEN PR is returned when one exists;
+  otherwise the most-recent CLOSED/MERGED PR with the matching headRef is
+  returned so the TUI stale-fade UX can render the post-merge cleanup
+  affordance. The `state` field on the returned PullRequest disambiguates
+  between live and post-merge.
+
+  Null when no PR has ever existed for this branch in any state, when the
+  branch is detached, or when the branch is the project's default branch.
+  """
   pr: PullRequest
 
   "Issue linked from the worktree's branch (issue<N>/... convention). Null when the branch doesn't carry an issue number."
@@ -677,7 +688,21 @@ type TmuxSession implements Node {
   "Clients currently attached to this session."
   attachedClients: [TmuxClient!]!
 
-  "Most recent activity timestamp across all panes/windows. RFC3339; null if never observed."
+  """
+  Most recent activity timestamp across all panes/windows. RFC3339; null
+  if never observed.
+
+  Tracks tmux's `pane_activity` field, which fires on NEW pane content —
+  not on in-place redraws. A Claude REPL spinner ticking in place
+  ("Elucidating… 1m 11s") does NOT bump `lastActivityAt`, so a long
+  agentic turn can look identical to a hung pane (issue #506).
+
+  Do NOT use this field as a Claude-REPL stall signal. The canonical
+  signal is `Worktree.claudeInstances[].state` (working|idle|input|stalled,
+  issue #501) once that lands, OR the heartbeat freshness exposed on
+  `ClaudeInstance` directly. `lastActivityAt` remains useful for plain
+  shell panes and for the lex-tie-breaker in `Worktree.tmuxSession`.
+  """
   lastActivityAt: String
 
   "Windows in this session."

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -699,7 +699,7 @@ type TmuxSession implements Node {
 
   Do NOT use this field as a Claude-REPL stall signal. The canonical
   signal is `Worktree.claudeInstances[].state` (working|idle|input|stalled,
-  issue #501) once that lands, OR the heartbeat freshness exposed on
+  issue #501), OR the heartbeat freshness exposed on
   `ClaudeInstance` directly. `lastActivityAt` remains useful for plain
   shell panes and for the lex-tie-breaker in `Worktree.tmuxSession`.
   """

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -1437,12 +1437,12 @@ func (r *worktreeResolver) Repo(ctx context.Context, obj *graphql1.Worktree) (*s
 	return &slug, nil
 }
 
-// Pr is the resolver for the worktree.pr field. Looks up the open PR whose headRef matches the worktree's branch via the PullRequestsForRepo DataLoader (concurrent resolver calls for the same repo collapse into one ListPullRequests call). Returns nil for missing obj, empty branch, default branch, non-GitHub origin, or no headRef match. Errors only when the DataLoader is missing from context or the gh provider fails hard.
+// Pr is the resolver for the worktree.pr field. Looks up a PR whose headRef matches the worktree's branch via the PullRequestsForRepo DataLoader (which fetches PRs in all states per issue #489 so the TUI stale-fade UX works post-merge). Selection precedence: an OPEN match wins; otherwise the most-recent CLOSED/MERGED match. Returns nil for missing obj, empty branch, default branch, non-GitHub origin, or no headRef match in any state.
 func (r *worktreeResolver) Pr(ctx context.Context, obj *graphql1.Worktree) (*graphql1.PullRequest, error) {
 	if obj == nil || obj.Branch == "" {
 		return nil, nil
 	}
-	// Default-branch exclusion: the default branch never has an open PR
+	// Default-branch exclusion: the default branch never has its own PR
 	// targeting itself, so skip the DataLoader call entirely.
 	if defaultBranch, ok := readDefaultBranch(obj.Path); ok && defaultBranch == obj.Branch {
 		return nil, nil
@@ -1456,7 +1456,7 @@ func (r *worktreeResolver) Pr(ctx context.Context, obj *graphql1.Worktree) (*gra
 	if !ok {
 		return nil, nil // non-GitHub origin → null
 	}
-	// Load all open PRs for the repo via the DataLoader.
+	// Load all PRs (across all states) for the repo via the DataLoader.
 	ldrs := loaders.FromContext(ctx)
 	if ldrs == nil {
 		return nil, fmt.Errorf("loaders not in context")
@@ -1465,12 +1465,22 @@ func (r *worktreeResolver) Pr(ctx context.Context, obj *graphql1.Worktree) (*gra
 	if err != nil {
 		return nil, err
 	}
+	// First pass: prefer any OPEN PR — the list is already sorted UpdatedAt
+	// DESC by the GitHub API, so the first match is most-recent. Track the
+	// first non-OPEN match as a fallback for the post-merge stale-fade case.
+	var fallback *graphql1.PullRequest
 	for _, pr := range prs {
-		if pr != nil && pr.HeadRef == obj.Branch {
+		if pr == nil || pr.HeadRef != obj.Branch {
+			continue
+		}
+		if pr.State == graphql1.PullRequestStateOpen {
 			return pr, nil
 		}
+		if fallback == nil {
+			fallback = pr
+		}
 	}
-	return nil, nil
+	return fallback, nil
 }
 
 // Issue is the resolver for the worktree.issue field. Parses the issue number from the worktree branch (rules ported from crates/orchard/src/github.rs) then fetches via the gh provider. Returns nil for empty branch, unparseable branch, missing/non-GitHub origin, unwired gh provider, or 404.

--- a/schema.graphql
+++ b/schema.graphql
@@ -575,7 +575,18 @@ type Worktree implements Node {
   "owner/repo slug derived from origin remote. Null when origin is not a GitHub URL."
   repo: String
 
-  "Open PR whose headRef matches this worktree's branch. Null when no match, branch is detached, or branch is the project's default branch."
+  """
+  PR whose headRef matches this worktree's branch.
+
+  Selection precedence (issue #489): an OPEN PR is returned when one exists;
+  otherwise the most-recent CLOSED/MERGED PR with the matching headRef is
+  returned so the TUI stale-fade UX can render the post-merge cleanup
+  affordance. The `state` field on the returned PullRequest disambiguates
+  between live and post-merge.
+
+  Null when no PR has ever existed for this branch in any state, when the
+  branch is detached, or when the branch is the project's default branch.
+  """
   pr: PullRequest
 
   "Issue linked from the worktree's branch (issue<N>/... convention). Null when the branch doesn't carry an issue number."
@@ -677,7 +688,21 @@ type TmuxSession implements Node {
   "Clients currently attached to this session."
   attachedClients: [TmuxClient!]!
 
-  "Most recent activity timestamp across all panes/windows. RFC3339; null if never observed."
+  """
+  Most recent activity timestamp across all panes/windows. RFC3339; null
+  if never observed.
+
+  Tracks tmux's `pane_activity` field, which fires on NEW pane content —
+  not on in-place redraws. A Claude REPL spinner ticking in place
+  ("Elucidating… 1m 11s") does NOT bump `lastActivityAt`, so a long
+  agentic turn can look identical to a hung pane (issue #506).
+
+  Do NOT use this field as a Claude-REPL stall signal. The canonical
+  signal is `Worktree.claudeInstances[].state` (working|idle|input|stalled,
+  issue #501) once that lands, OR the heartbeat freshness exposed on
+  `ClaudeInstance` directly. `lastActivityAt` remains useful for plain
+  shell panes and for the lex-tie-breaker in `Worktree.tmuxSession`.
+  """
   lastActivityAt: String
 
   "Windows in this session."

--- a/schema.graphql
+++ b/schema.graphql
@@ -699,7 +699,7 @@ type TmuxSession implements Node {
 
   Do NOT use this field as a Claude-REPL stall signal. The canonical
   signal is `Worktree.claudeInstances[].state` (working|idle|input|stalled,
-  issue #501) once that lands, OR the heartbeat freshness exposed on
+  issue #501), OR the heartbeat freshness exposed on
   `ClaudeInstance` directly. `lastActivityAt` remains useful for plain
   shell panes and for the lex-tie-breaker in `Worktree.tmuxSession`.
   """


### PR DESCRIPTION
## Summary

Cluster 2 (TUI ergonomics) — daemon schema half. Sister PR is #574 (Rust TUI ergonomics).

## Closes

- **#489** — `Worktree.pr` now returns the most-recent CLOSED/MERGED PR when no OPEN PR matches the branch.
  - Loader: `loadPullRequestsForRepo` requests `state=ALL` instead of `state=OPEN`. Single round-trip per repo per request (same as before), bounded by `per_page=100`. The GitHub list endpoint sorts UpdatedAt DESC so the first non-OPEN match is the most-recent.
  - Resolver: `worktreeResolver.Pr` does a single pass — return any OPEN match first, otherwise the first non-OPEN match (which is most-recent due to API sort).
  - Schema docstring updated in `schema.graphql` AND `internal/server/resolvers/schema.graphql` AND mirrored into the gqlgen-generated SDL string in `graphql/generated.go` (and the Go-side struct comment in `models_gen.go`).
  - TUI consumer (`derive.rs` + `signal.rs::is_open`) needs zero changes — `is_open(pr)` checks the state field, so a returned CLOSED/MERGED PR feeds naturally into the existing stale-fade path.

- **#506** — `TmuxSession.lastActivityAt` docstring clarifies what the field actually tracks (tmux `pane_activity`, NEW content only — NOT in-place redraws) and explicitly warns against using it as a Claude-REPL stall signal. Points consumers at the canonical signal (`Worktree.claudeInstances[].state` from cluster1 / #501) or heartbeat freshness on `ClaudeInstance`. Documentation-only.

## Why we mirror docstrings manually instead of `make generate`

`make generate` on origin/main corrupts multi-line resolver doc comments — gqlgen 0.17.45 drops the `//` prefix on continuation lines, producing unparseable Go. Confirmed reproducible on a clean branch with no other changes. The actual schema behavior change ships regardless; introspection now serves the new description because we manually mirrored the SDL strings.

**Follow-up**: file an issue to bump gqlgen and re-enable `make generate` cleanly. Out of scope for this PR.

## Test plan

- [x] `go build ./...` — green
- [x] `go test ./internal/server/...` — all packages pass (1517 tests across daemon)
- [x] `cargo build -p orchard` — green (no Rust changes; daemon schema-only)
- [x] `cargo test -p orchard --lib` — 1514 pass (one pre-existing parallel-test flake in `sources::hosts::tests`, unrelated)
- [x] New test: `TestPullRequestsForRepo_FetchesAllStates` asserts the loader requests state=ALL.
- [ ] Manual: after merging, a recently-merged worktree should show its post-merge state (CLOSED/MERGED PR) in the TUI until cleanup, instead of dropping to DisplayGroup::Other.

## Out of scope

- Adding `tmuxSession.lastClaudeHeartbeatAt` (option 1 from #506 body) — that overlaps with cluster1's #501 work on `ClaudeInstance.state`. We documented the field for now; cluster1 lands the canonical lifecycle signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR selection now prefers an OPEN PR matching a branch head, falling back to the most-recent CLOSED/MERGED match to support post-merge scenarios.

* **Documentation**
  * Clarified Worktree.pr selection precedence and null conditions.
  * Expanded TmuxSession.lastActivityAt semantics and warned not to use it as a Claude-REPL stall signal.

* **Tests**
  * Added a loader test to verify fetching PRs across all states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/575)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #2

# Related issue

- #2

# Related issue

- #2