### PR TITLE
feat(daemon): version visibility (AC1-3) — daemon -ldflags, Query.version, Host.version + peer ferry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,12 @@
         install install-daemon install-dispatcher install-tui install-worktree-cli \
         test test-go test-rust
 
+VERSION ?= dev
+
 # Go binary — orchard-daemon. Built from cmd/orchard-daemon.
+# Pass VERSION=<semver> to bake a release version: make daemon VERSION=1.2.3
 daemon:
-	go build -o bin/orchard-daemon ./cmd/orchard-daemon
+	go build -ldflags "-X main.version=$(VERSION)" -o bin/orchard-daemon ./cmd/orchard-daemon
 
 # Generate gqlgen types/stubs from schema.graphql + gqlgen.yml.
 # Generated files live under internal/server/graphql/ and are committed

--- a/cmd/orchard-daemon/main.go
+++ b/cmd/orchard-daemon/main.go
@@ -35,7 +35,7 @@ func main() {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	root.AddCommand(daemon.Command())
+	root.AddCommand(daemon.Command(version))
 	root.AddCommand(config.Command())
 	root.AddCommand(query.Command())
 

--- a/cmd/orchard-daemon/version_test.go
+++ b/cmd/orchard-daemon/version_test.go
@@ -1,0 +1,102 @@
+// AC1 — Scenario 1 & 2: daemon version baked at release time via -ldflags.
+//
+// Scenario 1: go build with -ldflags "-X main.version=1.2.3" → binary
+// prints "1.2.3" when run with --version.
+//
+// Scenario 2: go build without -ldflags → binary prints "dev" (the
+// package-level default declared in main.go) when run with --version.
+package main_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestVersionBaked_LdflagsInjectsSemver covers AC1 Scenario 1:
+// make daemon VERSION=1.2.3 bakes the semver via -ldflags.
+func TestVersionBaked_LdflagsInjectsSemver(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping binary build test in short mode")
+	}
+
+	bin := buildDaemon(t, "-X main.version=1.2.3")
+
+	out := runVersion(t, bin)
+	if !strings.Contains(out, "1.2.3") {
+		t.Errorf("--version output = %q, want it to contain 1.2.3", out)
+	}
+}
+
+// TestVersionBaked_DefaultIsDevWithoutLdflags covers AC1 Scenario 2:
+// go build without -ldflags keeps "dev" as the version string.
+func TestVersionBaked_DefaultIsDevWithoutLdflags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping binary build test in short mode")
+	}
+
+	bin := buildDaemon(t, "")
+
+	out := runVersion(t, bin)
+	if !strings.Contains(out, "dev") {
+		t.Errorf("--version output = %q, want it to contain dev", out)
+	}
+}
+
+// buildDaemon compiles cmd/orchard-daemon into a temp dir and returns the
+// binary path. ldflags is the raw value passed to -ldflags; empty string
+// omits the flag entirely (plain go build).
+func buildDaemon(t *testing.T, ldflags string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "orchard-daemon")
+
+	repoRoot := findRepoRoot(t)
+	args := []string{"build", "-o", bin}
+	if ldflags != "" {
+		args = append(args, "-ldflags", ldflags)
+	}
+	args = append(args, "./cmd/orchard-daemon")
+
+	cmd := exec.Command("go", args...)
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// runVersion executes the binary with --version and returns stdout+stderr.
+func runVersion(t *testing.T, bin string) string {
+	t.Helper()
+	cmd := exec.Command(bin, "--version")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// cobra's --version exits 0; any exit error is unexpected.
+		t.Fatalf("%s --version: %v\n%s", bin, err, out)
+	}
+	return string(out)
+}
+
+// findRepoRoot walks up from the test file's directory looking for go.mod.
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found walking up from", dir)
+		}
+		dir = parent
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/graph-gophers/dataloader/v7 v7.1.3
 	github.com/spf13/cobra v1.10.2
 	github.com/vektah/gqlparser/v2 v2.5.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -30,5 +31,4 @@ require (
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/graph-gophers/dataloader/v7 v7.1.3
 	github.com/spf13/cobra v1.10.2
 	github.com/vektah/gqlparser/v2 v2.5.11
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -31,4 +30,5 @@ require (
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -59,11 +59,16 @@ models:
   # Host.processes accepts a filter argument, so route it through a custom
   # resolver instead of struct-field auto-binding. The resolver consults the
   # ps provider and applies the filter at the resolver layer (ADR-011 §6).
+  # Host.version is a resolver field: local host returns DaemonVersion; peer
+  # hosts return the version fetched from the peer's probe (cached, not
+  # fetched on every GraphQL request).
   Host:
     fields:
       processes:
         resolver: true
       peers:
+        resolver: true
+      version:
         resolver: true
 
   # Process is materialised by the ps provider's resolver layer. `args` and

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -47,23 +47,25 @@ import (
 )
 
 // Command returns the `daemon` subcommand group rooted with three leaves.
-func Command() *cobra.Command {
+// version is the binary version baked via -ldflags; it is surfaced through
+// Query.version in the GraphQL schema (AC2, #417).
+func Command(version string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "daemon",
 		Short: "Manage the orchard GraphQL daemon",
 		Long:  "Start, stop, or query the local orchard daemon listening on " + server.DefaultAddr + ".",
 	}
-	cmd.AddCommand(startCmd(), stopCmd(), statusCmd())
+	cmd.AddCommand(startCmd(version), stopCmd(), statusCmd())
 	return cmd
 }
 
-func startCmd() *cobra.Command {
+func startCmd(version string) *cobra.Command {
 	var addr string
 	c := &cobra.Command{
 		Use:   "start",
 		Short: "Run the orchard daemon in the foreground",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runStart(cmd.Context(), addr)
+			return runStart(cmd.Context(), addr, version)
 		},
 	}
 	c.Flags().StringVar(&addr, "addr", server.DefaultAddr, "host:port to bind")
@@ -92,7 +94,8 @@ func statusCmd() *cobra.Command {
 
 // runStart is the foreground daemon entry point. It honours SIGINT and
 // SIGTERM by cancelling the server context for a clean shutdown.
-func runStart(parentCtx context.Context, addr string) error {
+// version is the binary version injected via -ldflags; defaults to "dev".
+func runStart(parentCtx context.Context, addr string, version string) error {
 	pidPath, err := orchpaths.PidFile()
 	if err != nil {
 		return fmt.Errorf("resolve pidfile: %w", err)
@@ -210,6 +213,7 @@ func runStart(parentCtx context.Context, addr string) error {
 	)
 
 	opts := []server.Option{
+		server.WithVersion(version),
 		server.WithRepos(configProvider),
 		server.WithGit(gitProvider),
 		server.WithPS(psProvider),

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -285,6 +285,7 @@ type ComplexityRoot struct {
 		TmuxPanes        func(childComplexity int, filter *TmuxPaneFilter) int
 		TmuxServer       func(childComplexity int) int
 		TmuxSessions     func(childComplexity int, filter *TmuxSessionFilter) int
+		Version          func(childComplexity int) int
 		WorkView         func(childComplexity int) int
 		WorkflowRuns     func(childComplexity int, repo string) int
 	}
@@ -471,6 +472,7 @@ type QueryResolver interface {
 	SchemaSdl(ctx context.Context) (string, error)
 	WorkView(ctx context.Context) (*WorkView, error)
 	DaemonState(ctx context.Context) (*DaemonState, error)
+	Version(ctx context.Context) (string, error)
 }
 type RepoResolver interface {
 	Worktrees(ctx context.Context, obj *Repo) ([]*Worktree, error)
@@ -1863,6 +1865,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.TmuxSessions(childComplexity, args["filter"].(*TmuxSessionFilter)), true
 
+	case "Query.version":
+		if e.complexity.Query.Version == nil {
+			break
+		}
+
+		return e.complexity.Query.Version(childComplexity), true
+
 	case "Query.workView":
 		if e.complexity.Query.WorkView == nil {
 			break
@@ -3043,6 +3052,9 @@ type Query {
   meta envelope. Cheap — reads in-memory counters, no I/O.
   """
   daemonState: DaemonState!
+
+  "Daemon binary version. Set at build time via -ldflags -X main.version=<semver>; ` + "`" + `dev` + "`" + ` for plain ` + "`" + `go build` + "`" + `."
+  version: String!
 }
 
 """
@@ -13517,6 +13529,50 @@ func (ec *executionContext) fieldContext_Query_daemonState(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_version(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_version(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Version(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_version(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query___type(ctx, field)
 	if err != nil {
@@ -23224,6 +23280,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_daemonState(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "version":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_version(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -154,6 +154,7 @@ type ComplexityRoot struct {
 		Reachable          func(childComplexity int) int
 		ResourceLoad       func(childComplexity int) int
 		Role               func(childComplexity int) int
+		Version            func(childComplexity int) int
 	}
 
 	HostService struct {
@@ -427,6 +428,7 @@ type ClaudeInstanceResolver interface {
 }
 type HostResolver interface {
 	Peers(ctx context.Context, obj *Host) ([]*Host, error)
+	Version(ctx context.Context, obj *Host) (*string, error)
 	Processes(ctx context.Context, obj *Host, filter *ProcessFilter) ([]*Process, error)
 }
 type ProcessResolver interface {
@@ -1092,6 +1094,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Host.Role(childComplexity), true
+
+	case "Host.version":
+		if e.complexity.Host.Version == nil {
+			break
+		}
+
+		return e.complexity.Host.Version(childComplexity), true
 
 	case "HostService.exitCode":
 		if e.complexity.HostService.ExitCode == nil {
@@ -3276,6 +3285,15 @@ type Host implements Node {
   "Peer hosts this daemon federates with. v1: always empty; Workstream F populates."
   peers: [Host!]!
 
+  """
+  Daemon binary version running on this host. Set at build time via
+  -ldflags -X main.version=<semver>; ` + "`" + `dev` + "`" + ` for plain ` + "`" + `go build` + "`" + `.
+  Non-null on the local host (always at least "dev"). Null for a peer
+  host whose probe has not yet succeeded — "unknown" is represented as
+  null rather than an error so dashboards can render partial information.
+  """
+  version: String
+
   "Processes visible to this host's ` + "`" + `ps` + "`" + ` adapter, optionally filtered."
   processes(filter: ProcessFilter): [Process!]!
 
@@ -4965,6 +4983,8 @@ func (ec *executionContext) fieldContext_ClaudeAccount_host(ctx context.Context,
 				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
+			case "version":
+				return ec.fieldContext_Host_version(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
@@ -7746,6 +7766,8 @@ func (ec *executionContext) fieldContext_Host_peers(ctx context.Context, field g
 				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
+			case "version":
+				return ec.fieldContext_Host_version(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
@@ -7764,6 +7786,47 @@ func (ec *executionContext) fieldContext_Host_peers(ctx context.Context, field g
 				return ec.fieldContext_Host_inManifest(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Host_version(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_version(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Host().Version(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_version(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -8264,6 +8327,8 @@ func (ec *executionContext) fieldContext_HostService_host(ctx context.Context, f
 				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
+			case "version":
+				return ec.fieldContext_Host_version(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
@@ -9698,6 +9763,8 @@ func (ec *executionContext) fieldContext_Process_host(ctx context.Context, field
 				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
+			case "version":
+				return ec.fieldContext_Host_version(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
@@ -11772,6 +11839,8 @@ func (ec *executionContext) fieldContext_Query_host(ctx context.Context, field g
 				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
+			case "version":
+				return ec.fieldContext_Host_version(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
@@ -11854,6 +11923,8 @@ func (ec *executionContext) fieldContext_Query_hosts(ctx context.Context, field 
 				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
+			case "version":
+				return ec.fieldContext_Host_version(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
@@ -12648,6 +12719,8 @@ func (ec *executionContext) fieldContext_Query_peers(ctx context.Context, field 
 				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
+			case "version":
+				return ec.fieldContext_Host_version(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
@@ -21682,6 +21755,39 @@ func (ec *executionContext) _Host(ctx context.Context, sel ast.SelectionSet, obj
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "version":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Host_version(ctx, field, obj)
 				return res
 			}
 

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -254,6 +254,12 @@ type Host struct {
 	ResourceLoad *ResourceLoad `json:"resourceLoad,omitempty"`
 	// Peer hosts this daemon federates with. v1: always empty; Workstream F populates.
 	Peers []*Host `json:"peers"`
+	// Daemon binary version running on this host. Set at build time via
+	// -ldflags -X main.version=<semver>; `dev` for plain `go build`.
+	// Non-null on the local host (always at least "dev"). Null for a peer
+	// host whose probe has not yet succeeded — "unknown" is represented as
+	// null rather than an error so dashboards can render partial information.
+	Version *string `json:"version,omitempty"`
 	// Processes visible to this host's `ps` adapter, optionally filtered.
 	Processes []*Process `json:"processes"`
 	// Curated launchd / systemd watchlist for this host, drawn from `services` in ~/.orchard/config.json.

--- a/internal/server/providers/peerproxy/adapter.go
+++ b/internal/server/providers/peerproxy/adapter.go
@@ -56,6 +56,10 @@ type PeerAdapter struct {
 	lastReachedAt  time.Time
 	lastProbedAt   time.Time
 	subscriptionOn bool
+	// version holds the peer daemon's binary version fetched via
+	// `{ version }` on every successful Probe. Nil until the first
+	// successful probe — represents "unknown" rather than an error.
+	version *string
 }
 
 // NewPeerAdapter wires a PeerConfig up to a transport Client.
@@ -83,8 +87,10 @@ func (a *PeerAdapter) Reachable() (bool, time.Time) {
 }
 
 // Probe runs a one-shot health query against the peer and records the
-// outcome. Used by the dashboard to decide whether to mark the peer
-// reachable; safe to call concurrently with Subscribe.
+// outcome. On success, also fetches `{ version }` from the peer and
+// caches the result so Host.peers[].version resolvers can serve it
+// without issuing a network call per GraphQL request.
+// Safe to call concurrently with Subscribe.
 func (a *PeerAdapter) Probe(ctx context.Context) error {
 	err := a.client.Ping(ctx)
 	now := a.now()
@@ -96,9 +102,45 @@ func (a *PeerAdapter) Probe(ctx context.Context) error {
 		a.lastReachedAt = now
 	} else {
 		a.reachable = false
+		a.version = nil
 	}
 	a.mu.Unlock()
+
+	if err == nil {
+		// Fetch version outside the lock — Query does its own synchronisation.
+		a.fetchVersion(ctx)
+	}
 	return err
+}
+
+// fetchVersion issues `{ version }` against the peer and caches the
+// result. Called from Probe on each successful health check so the
+// version stays fresh without adding latency to every GraphQL request.
+// Failures are silently swallowed — a nil version is the legitimate
+// "unknown" signal.
+func (a *PeerAdapter) fetchVersion(ctx context.Context) {
+	res, err := a.client.Query(ctx, `{ version }`, nil)
+	if err != nil || res.AsError() != nil {
+		return
+	}
+	var data struct {
+		Version *string `json:"version"`
+	}
+	if err := json.Unmarshal(res.Data, &data); err != nil {
+		return
+	}
+	a.mu.Lock()
+	a.version = data.Version
+	a.mu.Unlock()
+}
+
+// Version returns the last-known version string fetched from the peer
+// daemon. Nil until the first successful Probe completes — callers
+// should treat nil as "unknown".
+func (a *PeerAdapter) Version() *string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.version
 }
 
 // FetchNode proxies a single `node(id)` lookup through the client.

--- a/internal/server/providers/peerproxy/provider.go
+++ b/internal/server/providers/peerproxy/provider.go
@@ -282,6 +282,20 @@ func (p *Provider) HasPeer(name string) bool {
 	return ok
 }
 
+// PeerVersion returns the last-known binary version fetched from the
+// named peer via `{ version }` on each successful probe. Returns nil
+// when the peer is unknown or the probe has not yet succeeded — callers
+// should treat nil as "unknown" and render it as a null GraphQL value.
+func (p *Provider) PeerVersion(name string) *string {
+	p.mu.RLock()
+	a, ok := p.adapters[name]
+	p.mu.RUnlock()
+	if !ok {
+		return nil
+	}
+	return a.Version()
+}
+
 // SpawnCount returns the number of times startPeer has been called for name.
 // It is intended for tests that need to verify a peer's goroutine was NOT
 // restarted across an ApplyPeers call — a count of 1 means the goroutine

--- a/internal/server/resolvers/host_version_test.go
+++ b/internal/server/resolvers/host_version_test.go
@@ -1,0 +1,258 @@
+// Tests for Host.version resolver (AC3, issue #417).
+//
+// Scenarios:
+//   - A daemon built with -X main.version=1.2.3 returns "1.2.3" from
+//     { host { version } } (local host, non-nullable in practice).
+//   - A local daemon configured with peer "boxd-vm" at version "1.2.4"
+//     returns peers[0].version = "1.2.4" from { host { peers { version } } }.
+//     The value is fetched via peerproxy.Provider on probe/reconnect —
+//     NOT on every GraphQL request.
+//   - peers[0].version is null when the peer probe has failed (unreachable).
+//     No error is raised — null is the legitimate "unknown" value.
+//
+// Each test boots an httptest.Server with the gqlgen handler wired to
+// an orchard server.Server. The peer scenarios also boot a second
+// httptest.Server acting as the remote daemon.
+
+package resolvers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"log/slog"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
+)
+
+// hostVersionPost posts query against the graphqlURL and returns the decoded envelope.
+func hostVersionPost(t *testing.T, graphqlURL, query string) map[string]any {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"query": query})
+	req, _ := http.NewRequest(http.MethodPost, graphqlURL, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post query: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return out
+}
+
+// newLocalDaemon boots an httptest.Server with the orchard daemon at
+// the given version and with an optional peerProxy provider.
+func newLocalDaemon(t *testing.T, version string, peerProv *peerproxy.Provider) *httptest.Server {
+	t.Helper()
+	opts := []server.Option{server.WithVersion(version)}
+	if peerProv != nil {
+		opts = append(opts, server.WithPeerProxy(peerProv))
+	}
+	srv := server.New("", slog.Default(), opts...)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	if peerProv != nil {
+		if err := peerProv.Start(ctx); err != nil {
+			t.Fatalf("peerProxy.Start: %v", err)
+		}
+		t.Cleanup(func() { _ = peerProv.Stop() })
+	}
+
+	if err := srv.StartHostProvider(ctx); err != nil {
+		t.Fatalf("StartHostProvider: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", srv.GraphQLHandler())
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// fakePeerDaemon is a minimal HTTP handler simulating a remote orchard
+// daemon. It responds to:
+//   - `{ health { status } }` — the probe ping
+//   - `{ version }` — the version ferry
+//
+// The handler routes by inspecting the `query` field of the POST body.
+type fakePeerDaemon struct {
+	version   string
+	pingCount atomic.Int64
+}
+
+func (f *fakePeerDaemon) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Query string `json:"query"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	q := strings.TrimSpace(body.Query)
+	switch {
+	case strings.Contains(q, "health"):
+		f.pingCount.Add(1)
+		fmt.Fprintf(w, `{"data":{"health":{"status":"ok"}}}`)
+	case strings.Contains(q, "version"):
+		fmt.Fprintf(w, `{"data":{"version":%q}}`, f.version)
+	default:
+		// Unknown query — return empty data rather than an error so the
+		// probe health-check still passes even if the test sends something
+		// unexpected.
+		fmt.Fprintf(w, `{"data":{}}`)
+	}
+}
+
+// newFakePeerServer boots an httptest.Server for the given peer version.
+// Returns the server and the address (host:port) for PeerConfig.Address.
+func newFakePeerServer(t *testing.T, version string) (*httptest.Server, string) {
+	t.Helper()
+	handler := &fakePeerDaemon{version: version}
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+	u, _ := url.Parse(ts.URL)
+	return ts, u.Host
+}
+
+// waitForPeerProbe polls until PeerVersion returns a non-nil value or the
+// timeout elapses. It returns true on success so tests can skip assertion
+// if the probe never fired (a rare but possible CI flake guard).
+func waitForPeerProbe(p *peerproxy.Provider, peerName string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if p.PeerVersion(peerName) != nil {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// TestHostVersion_LocalReturnsVersion asserts that { host { version } }
+// returns the baked version on the local host.
+//
+// BDD: "Host.version on the local host returns the local daemon's baked version".
+func TestHostVersion_LocalReturnsVersion(t *testing.T) {
+	ts := newLocalDaemon(t, "1.2.3", nil)
+	resp := hostVersionPost(t, ts.URL+"/graphql", `{ host { version } }`)
+
+	if errs, ok := resp["errors"]; ok {
+		t.Fatalf("unexpected GraphQL errors: %v", errs)
+	}
+
+	data, _ := resp["data"].(map[string]any)
+	host, _ := data["host"].(map[string]any)
+	got, ok := host["version"].(string)
+	if !ok {
+		t.Fatalf("host.version is not a string: %v", host["version"])
+	}
+	if got != "1.2.3" {
+		t.Errorf("host.version = %q; want %q", got, "1.2.3")
+	}
+}
+
+// TestHostVersion_PeerVersionFerried asserts that peers[0].version equals
+// the value fetched via peerproxy on probe/reconnect.
+//
+// BDD: "Host.peers[].version is populated by ferrying `query { version }`
+// over peerproxy".
+func TestHostVersion_PeerVersionFerried(t *testing.T) {
+	const peerName = "boxd-vm"
+	const peerVersion = "1.2.4"
+
+	_, peerAddr := newFakePeerServer(t, peerVersion)
+
+	cfg := peerproxy.FederationConfig{
+		Peers: []peerproxy.PeerConfig{
+			{Name: peerName, Address: peerAddr, TLS: false},
+		},
+	}
+	peerProv := peerproxy.NewProvider(cfg, slog.Default())
+	ts := newLocalDaemon(t, "1.2.3", peerProv)
+
+	// Wait for the probe goroutine to fire and cache the version.
+	if !waitForPeerProbe(peerProv, peerName, 2*time.Second) {
+		t.Fatal("peerproxy probe did not fire within 2s — version never cached")
+	}
+
+	resp := hostVersionPost(t, ts.URL+"/graphql", `{ host { peers { version } } }`)
+
+	if errs, ok := resp["errors"]; ok {
+		t.Fatalf("unexpected GraphQL errors: %v", errs)
+	}
+
+	data, _ := resp["data"].(map[string]any)
+	host, _ := data["host"].(map[string]any)
+	peers, _ := host["peers"].([]any)
+	if len(peers) == 0 {
+		t.Fatal("host.peers is empty")
+	}
+	peer, _ := peers[0].(map[string]any)
+	got, ok := peer["version"].(string)
+	if !ok {
+		t.Fatalf("peers[0].version is not a string: %v", peer["version"])
+	}
+	if got != peerVersion {
+		t.Errorf("peers[0].version = %q; want %q", got, peerVersion)
+	}
+}
+
+// TestHostVersion_PeerNullWhenUnreachable asserts that peers[0].version
+// is null (Go nil) when the peer probe has failed, and that no error is
+// raised — null is the legitimate "unknown" signal.
+//
+// BDD: "Host.peers[].version is null when the peer is unreachable".
+func TestHostVersion_PeerNullWhenUnreachable(t *testing.T) {
+	const peerName = "dead-vm"
+
+	// Point at a port that is not listening. The probe will fail quickly.
+	cfg := peerproxy.FederationConfig{
+		Peers: []peerproxy.PeerConfig{
+			{Name: peerName, Address: "127.0.0.1:1", TLS: false},
+		},
+	}
+	peerProv := peerproxy.NewProvider(cfg, slog.Default())
+	ts := newLocalDaemon(t, "1.2.3", peerProv)
+
+	// Give the probe goroutine a moment to attempt (and fail) the probe.
+	// We do not use waitForPeerProbe here — we expect nil to remain nil.
+	time.Sleep(150 * time.Millisecond)
+
+	resp := hostVersionPost(t, ts.URL+"/graphql", `{ host { peers { version } } }`)
+
+	if errs, ok := resp["errors"]; ok {
+		t.Fatalf("unexpected GraphQL errors: %v", errs)
+	}
+
+	data, _ := resp["data"].(map[string]any)
+	host, _ := data["host"].(map[string]any)
+	peers, _ := host["peers"].([]any)
+	if len(peers) == 0 {
+		t.Fatal("host.peers is empty — expected the dead peer to still be listed")
+	}
+	peer, _ := peers[0].(map[string]any)
+	// version must be explicitly null (the map key should map to nil or be absent).
+	if v, exists := peer["version"]; exists && v != nil {
+		t.Errorf("peers[0].version = %v; want null", v)
+	}
+}

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -29,26 +29,41 @@ type ReposLister interface {
 
 // Resolver is the dependency-injection root for GraphQL resolvers.
 type Resolver struct {
-	StartedAt           time.Time
-	HostProvider        *host.Provider
-	ReposProvider       ReposLister
-	Git                 *gitprovider.Provider
-	PS                  *ps.Provider
-	Tmux                *tmux.Provider
-	ClaudeProjects      *claudeprojects.Provider
-	ClaudeAccount       *claudeaccount.Provider
+	StartedAt time.Time
+	// DaemonVersion is the binary version, injected at boot from the
+	// -ldflags -X main.version=<semver> bake. Named DaemonVersion (not
+	// Version) to avoid shadowing the Query.Version resolver method on
+	// the embedded queryResolver. Defaults to "dev" when no ldflags
+	// were used (plain `go build`).
+	DaemonVersion          string
+	HostProvider           *host.Provider
+	ReposProvider          ReposLister
+	Git                    *gitprovider.Provider
+	PS                     *ps.Provider
+	Tmux                   *tmux.Provider
+	ClaudeProjects         *claudeprojects.Provider
+	ClaudeAccount          *claudeaccount.Provider
 	HostServiceProvider    *hostservice.Provider
 	ContractsProvider      *contracts.Provider
 	ClaudeInstanceProvider *claudeinstance.Provider
 	GH                     *gh.Provider
-	PeerProxy           *peerproxy.Provider
-	LocalEvents         *peerproxy.LocalInvalidator
-	Manifest            *manifest.Provider
+	PeerProxy              *peerproxy.Provider
+	LocalEvents            *peerproxy.LocalInvalidator
+	Manifest               *manifest.Provider
 }
 
 // New constructs a Resolver with the daemon's start time captured.
+// DaemonVersion defaults to "dev"; call WithVersion to inject a build-time semver.
 func New(startedAt time.Time) *Resolver {
-	return &Resolver{StartedAt: startedAt}
+	return &Resolver{StartedAt: startedAt, DaemonVersion: "dev"}
+}
+
+// WithVersion injects the daemon binary version into the resolver so
+// Query.version can surface it. The value is set by -ldflags at release
+// time; callers pass the package-level `version` variable from main.
+func (r *Resolver) WithVersion(v string) *Resolver {
+	r.DaemonVersion = v
+	return r
 }
 
 // WithHost wires the host provider.

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -542,6 +542,15 @@ type Host implements Node {
   "Peer hosts this daemon federates with. v1: always empty; Workstream F populates."
   peers: [Host!]!
 
+  """
+  Daemon binary version running on this host. Set at build time via
+  -ldflags -X main.version=<semver>; `dev` for plain `go build`.
+  Non-null on the local host (always at least "dev"). Null for a peer
+  host whose probe has not yet succeeded — "unknown" is represented as
+  null rather than an error so dashboards can render partial information.
+  """
+  version: String
+
   "Processes visible to this host's `ps` adapter, optionally filtered."
   processes(filter: ProcessFilter): [Process!]!
 

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -318,6 +318,9 @@ type Query {
   meta envelope. Cheap — reads in-memory counters, no I/O.
   """
   daemonState: DaemonState!
+
+  "Daemon binary version. Set at build time via -ldflags -X main.version=<semver>; `dev` for plain `go build`."
+  version: String!
 }
 
 """

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -91,6 +91,24 @@ func (r *hostResolver) Peers(ctx context.Context, obj *graphql1.Host) ([]*graphq
 	return out, nil
 }
 
+// Version is the resolver for the host.version field (#417 AC3).
+//
+// Local host: returns DaemonVersion (set at boot via WithVersion / -ldflags).
+// Peer host: returns the version the peerproxy provider cached on the
+// most recent successful probe, or nil when the peer has never been reached.
+// Null is the legitimate "unknown" — no error is raised.
+func (r *hostResolver) Version(ctx context.Context, obj *graphql1.Host) (*string, error) {
+	if isLocalHostNode(r, obj) {
+		v := r.DaemonVersion
+		return &v, nil
+	}
+	// Peer host — return the version cached by the probe, or nil.
+	if r.PeerProxy == nil {
+		return nil, nil
+	}
+	return r.PeerProxy.PeerVersion(obj.MachineID), nil
+}
+
 // Processes is the resolver for the host.processes field. Local host: in-process ps. Peer Host: federate via peerproxy (#465 — never return local ps for a peer).
 func (r *hostResolver) Processes(ctx context.Context, obj *graphql1.Host, filter *graphql1.ProcessFilter) ([]*graphql1.Process, error) {
 	if isLocalHostNode(r, obj) {

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -630,6 +630,15 @@ func (r *queryResolver) DaemonState(ctx context.Context) (*graphql1.DaemonState,
 	}, nil
 }
 
+// Version is the resolver for Query.version (#417 AC2). Returns the daemon
+// binary version baked in via -ldflags at release time, or "dev" when
+// built without ldflags (plain `go build`). The value originates from the
+// package-level `version` variable in cmd/orchard-daemon/main.go, injected
+// into the resolver at boot via Resolver.WithVersion.
+func (r *queryResolver) Version(ctx context.Context) (string, error) {
+	return r.DaemonVersion, nil
+}
+
 // Worktrees is the resolver for the repo.worktrees field.
 func (r *repoResolver) Worktrees(ctx context.Context, obj *graphql1.Repo) ([]*graphql1.Worktree, error) {
 	if r.Git == nil {

--- a/internal/server/resolvers/version_test.go
+++ b/internal/server/resolvers/version_test.go
@@ -1,0 +1,103 @@
+// Tests for Query.version resolver (AC2, issue #417).
+//
+// Scenarios:
+//   - A daemon built with -X main.version=1.2.3 returns "1.2.3" from { version }.
+//   - A daemon built without -ldflags returns "dev" from { version }.
+//
+// Each test constructs the resolver with a known version string (simulating
+// the -ldflags injection path), stands up an httptest Server with the gqlgen
+// handler, and asserts the GraphQL response JSON.
+
+package resolvers_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+	gqlgen "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/resolvers"
+)
+
+// newVersionDaemon stands up an httptest.Server with the GraphQL handler
+// and the given version injected via WithVersion.
+func newVersionDaemon(t *testing.T, version string) *httptest.Server {
+	t.Helper()
+	cfg := gqlgen.Config{Resolvers: resolvers.New(time.Now()).WithVersion(version)}
+	gqlSrv := handler.New(gqlgen.NewExecutableSchema(cfg))
+	gqlSrv.AddTransport(transport.POST{})
+	mux := http.NewServeMux()
+	mux.Handle("/graphql", gqlSrv)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// postVersionQuery posts `{ version }` against the daemon and returns the
+// decoded response envelope.
+func postVersionQuery(t *testing.T, url string) map[string]any {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"query": "{ version }"})
+	req, _ := http.NewRequest(http.MethodPost, url+"/graphql", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post { version }: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return out
+}
+
+// TestVersion_ReturnsBakedVersion asserts that a daemon constructed with
+// WithVersion("1.2.3") returns "1.2.3" from `{ version }`.
+// Corresponds to the BDD scenario: `Query.version` returns the baked binary version.
+func TestVersion_ReturnsBakedVersion(t *testing.T) {
+	srv := newVersionDaemon(t, "1.2.3")
+	resp := postVersionQuery(t, srv.URL)
+
+	if errs, ok := resp["errors"]; ok {
+		t.Fatalf("unexpected GraphQL errors: %v", errs)
+	}
+
+	data, _ := resp["data"].(map[string]any)
+	got, ok := data["version"].(string)
+	if !ok {
+		t.Fatalf("data.version is not a string: %v", data["version"])
+	}
+	if got != "1.2.3" {
+		t.Errorf("Query.version = %q; want %q", got, "1.2.3")
+	}
+}
+
+// TestVersion_ReturnsDevOnNonReleaseBuild asserts that a daemon constructed
+// with the default version (no WithVersion call / "dev") returns "dev" from
+// `{ version }`.
+// Corresponds to the BDD scenario: `Query.version` returns `dev` on a
+// non-release build.
+func TestVersion_ReturnsDevOnNonReleaseBuild(t *testing.T) {
+	// Use the default version ("dev") — simulates plain `go build` with no -ldflags.
+	srv := newVersionDaemon(t, "dev")
+	resp := postVersionQuery(t, srv.URL)
+
+	if errs, ok := resp["errors"]; ok {
+		t.Fatalf("unexpected GraphQL errors: %v", errs)
+	}
+
+	data, _ := resp["data"].(map[string]any)
+	got, ok := data["version"].(string)
+	if !ok {
+		t.Fatalf("data.version is not a string: %v", data["version"])
+	}
+	if got != "dev" {
+		t.Errorf("Query.version = %q; want %q", got, "dev")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -230,6 +230,13 @@ func WithManifest(m *manifest.Provider) Option {
 	}
 }
 
+// WithVersion injects the daemon binary version so Query.version can
+// surface it. Callers pass the package-level `version` variable from
+// cmd/orchard-daemon/main.go; the value is "dev" when no -ldflags were used.
+func WithVersion(v string) Option {
+	return func(_ *Server, r *resolvers.Resolver) { r.WithVersion(v) }
+}
+
 // New constructs a Server bound to addr.
 func New(addr string, logger *slog.Logger, opts ...Option) *Server {
 	if addr == "" {

--- a/schema.graphql
+++ b/schema.graphql
@@ -542,6 +542,15 @@ type Host implements Node {
   "Peer hosts this daemon federates with. v1: always empty; Workstream F populates."
   peers: [Host!]!
 
+  """
+  Daemon binary version running on this host. Set at build time via
+  -ldflags -X main.version=<semver>; `dev` for plain `go build`.
+  Non-null on the local host (always at least "dev"). Null for a peer
+  host whose probe has not yet succeeded — "unknown" is represented as
+  null rather than an error so dashboards can render partial information.
+  """
+  version: String
+
   "Processes visible to this host's `ps` adapter, optionally filtered."
   processes(filter: ProcessFilter): [Process!]!
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -318,6 +318,9 @@ type Query {
   meta envelope. Cheap — reads in-memory counters, no I/O.
   """
   daemonState: DaemonState!
+
+  "Daemon binary version. Set at build time via -ldflags -X main.version=<semver>; `dev` for plain `go build`."
+  version: String!
 }
 
 """

--- a/specs/features/version-drift-and-orchard-upgrade.feature
+++ b/specs/features/version-drift-and-orchard-upgrade.feature
@@ -1,0 +1,315 @@
+Feature: Version drift visibility + local `orchard upgrade` (#417)
+  As an orchardist running a federated orchard fleet
+  I want each daemon to advertise its version + schema-contract-version, derive a per-peer compatibility class, surface drift in the TUI/CLI, and let me self-update the local Rust CLI
+  So that schema drift across federation peers is visible before it silently breaks GraphQL joins, and upgrading the local CLI does not require re-running `cargo install` by hand
+
+  # Scope: visibility plumbing + LOCAL upgrade only. Peer-driven upgrade
+  # (`Mutation.upgradeSelf`, `orchard upgrade --peer`, `--all-peers`) is
+  # split into a follow-up issue with its own auth + supervisor-presence
+  # ACs. See the Investigation + Plan sections of #417.
+
+  Background:
+    Given the Go daemon at `cmd/orchard-daemon/main.go` declares `var version = "dev"`
+    And the daemon's GraphQL schema lives at `internal/server/graphql/schema.graphql`
+    And the daemon's peerproxy provider at `internal/server/providers/peerproxy/` can already speak `graphql-transport-ws` + HTTPS POST to peers
+    And the Rust CLI at `crates/orchard/src/main.rs` has a stub `handle_upgrade()` that only prints a release-page URL
+    And `release-please-config.json` currently tracks only the Rust crate (`crates/orchard`)
+
+  # =======================================================================
+  # AC1 — Daemon version baked at release time via -ldflags
+  # =======================================================================
+
+  @integration @issue-417
+  Scenario: Release build bakes a real semver into the daemon binary
+    Given the Makefile `daemon` target is invoked with `VERSION=1.2.3`
+    When the daemon is built
+    Then the resulting `orchard-daemon` binary, when run with `--version`, prints `1.2.3`
+    And the bake mechanism is `-ldflags -X main.version=1.2.3` (no manual constant edits)
+
+  @integration @issue-417
+  Scenario: Plain `go build` without -ldflags keeps `dev` as the version
+    Given a developer runs `go build ./cmd/orchard-daemon` with no ldflags
+    When the resulting binary is run with `--version`
+    Then it prints `dev`
+    And the same string is what `Query.version` will return at runtime
+
+  @integration @issue-417
+  Scenario: Release-please Go build matrix bakes the version via the same flag
+    Given `.github/workflows/release-please.yml` runs the daemon build job
+    When the workflow builds `cmd/orchard-daemon` on linux × {amd64, arm64} and darwin × {amd64, arm64}
+    Then every artifact embeds the release-please-published semver via `-X main.version=<semver>`
+    And running `--version` on the downloaded binary prints that same semver
+
+  # =======================================================================
+  # AC2 — Query.version resolver exposes the baked version
+  # =======================================================================
+
+  @e2e @issue-417
+  Scenario: `Query.version` returns the baked binary version
+    Given a daemon built with `-X main.version=1.2.3`
+    When a client queries `{ version }` against the daemon's `/graphql` endpoint
+    Then the response is `{ "data": { "version": "1.2.3" } }`
+    And the resolver is non-nullable (`String!`)
+
+  @e2e @issue-417
+  Scenario: `Query.version` returns `dev` on a non-release build
+    Given a daemon built without `-ldflags`
+    When a client queries `{ version }` against the daemon's `/graphql` endpoint
+    Then the response is `{ "data": { "version": "dev" } }`
+
+  # =======================================================================
+  # AC3 — Host.version populated for local + peers (ferried over peerproxy)
+  # =======================================================================
+
+  @e2e @issue-417
+  Scenario: `Host.version` on the local host returns the local daemon's baked version
+    Given a daemon built with `-X main.version=1.2.3`
+    When a client queries `{ host { version } }` against that daemon
+    Then `host.version` equals `1.2.3`
+
+  @e2e @issue-417
+  Scenario: `Host.peers[].version` is populated by ferrying `query { version }` over peerproxy
+    Given a local daemon at version `1.2.3` configured with peer `boxd-vm` at version `1.2.4`
+    And the peerproxy probe has successfully reconnected to `boxd-vm`
+    When a client queries `{ host { peers { version } } }` against the local daemon
+    Then `peers[0].version` equals `1.2.4`
+    And the daemon fetched the value via `peerproxy.Provider.Query(ctx, "boxd-vm", "{ version }", nil)` on probe/reconnect, not on every GraphQL request
+
+  @integration @issue-417
+  Scenario: `Host.peers[].version` is null when the peer is unreachable
+    Given a local daemon configured with peer `dead-vm` whose peerproxy probe has failed
+    When a client queries `{ host { peers { version } } }` against the local daemon
+    Then `peers[0].version` is null
+    And no error is raised (null is the legitimate value for "unknown")
+
+  # =======================================================================
+  # AC4 — Host.schemaContractVersion (explicit integer counter)
+  # =======================================================================
+
+  @e2e @issue-417
+  Scenario: `Host.schemaContractVersion` on the local host returns the package-level constant
+    Given the daemon package declares `const SchemaContractVersion = 1`
+    When a client queries `{ host { schemaContractVersion } }` against the daemon
+    Then the response value equals `1`
+    And the field is non-nullable (`Int!`)
+
+  @e2e @issue-417
+  Scenario: `Host.peers[].schemaContractVersion` is ferried over peerproxy alongside version
+    Given a local daemon with `SchemaContractVersion = 1` configured with peer `boxd-vm` whose daemon has `SchemaContractVersion = 2`
+    And the peerproxy probe has successfully reconnected to `boxd-vm`
+    When a client queries `{ host { peers { schemaContractVersion } } }` against the local daemon
+    Then `peers[0].schemaContractVersion` equals `2`
+
+  @integration @issue-417
+  Scenario: `Host.peers[].schemaContractVersion` is null on unreachable peers
+    Given a local daemon configured with peer `dead-vm` whose peerproxy probe has failed
+    When a client queries `{ host { peers { schemaContractVersion } } }` against the local daemon
+    Then `peers[0].schemaContractVersion` is null
+
+  @integration @issue-417
+  Scenario: An older peer that lacks the field resolves to null, not error
+    Given a pre-#417 peer daemon that does not yet expose `Query.schemaContractVersion`
+    When the local daemon's peerproxy probe asks for `{ schemaContractVersion }` against that peer
+    Then the local daemon records the peer's `schemaContractVersion` as null
+    And a subsequent `Host.peers[].schemaContractVersion` query returns null without raising
+
+  # =======================================================================
+  # AC5 — Host.peers[].compatibilityClass derivation (golden cases)
+  # =======================================================================
+
+  @unit @issue-417
+  Scenario Outline: `compatibilityClass` is derived from local vs peer `schemaContractVersion`
+    Given local `schemaContractVersion` is <local>
+    And peer `schemaContractVersion` is <peer>
+    When `compatibilityClass` is computed for that peer
+    Then the result equals <expectedClass>
+
+    Examples:
+      | local | peer | expectedClass  |
+      | 1     | 1    | COMPATIBLE     |
+      | 2     | 2    | COMPATIBLE     |
+      | 2     | 1    | DEGRADED       |
+      | 1     | 2    | DEGRADED       |
+      | 3     | 1    | INCOMPATIBLE   |
+      | 1     | 3    | INCOMPATIBLE   |
+      | 1     | null | UNKNOWN        |
+      | null  | 1    | UNKNOWN        |
+      | null  | null | UNKNOWN        |
+
+  @e2e @issue-417
+  Scenario: `Host.peers[].compatibilityClass` is non-nullable in the schema
+    Given the daemon's GraphQL schema
+    When introspection runs against `Host.peers` element type
+    Then the `compatibilityClass` field is declared as `CompatibilityClass!`
+    And the enum `CompatibilityClass` has exactly the values { COMPATIBLE, DEGRADED, INCOMPATIBLE, UNKNOWN }
+
+  # =======================================================================
+  # AC6 — Drift banner in TUI + `orchard status`
+  # =======================================================================
+
+  @e2e @issue-417
+  Scenario: Drift banner appears when any peer is DEGRADED on a released local daemon
+    Given the local daemon was built with `-X main.version=1.2.3`
+    And the local daemon has one peer `boxd-vm` whose `compatibilityClass` is `DEGRADED`
+    When the operator opens the TUI
+    Then a drift banner row is rendered above the worktree list
+    And the banner names the peer `boxd-vm`
+    And the banner instructs the operator to run `orchard upgrade` on that host
+
+  @e2e @issue-417
+  Scenario: Drift banner appears when any peer is INCOMPATIBLE on a released local daemon
+    Given the local daemon was built with `-X main.version=1.2.3`
+    And the local daemon has peers `[boxd-vm: COMPATIBLE, drew-mac: INCOMPATIBLE]`
+    When the operator opens the TUI
+    Then a drift banner row is rendered
+    And the banner names `drew-mac` (the INCOMPATIBLE peer)
+
+  @e2e @issue-417
+  Scenario: Drift banner is hidden when local version is `dev` even if peers are drifted
+    Given the local daemon reports `version = "dev"` (no ldflags)
+    And the local daemon has one peer whose `compatibilityClass` is `INCOMPATIBLE`
+    When the operator opens the TUI
+    Then no drift banner is rendered
+    And the dev loop is not polluted by drift warnings
+
+  @e2e @issue-417
+  Scenario: Drift banner is hidden when all peers are COMPATIBLE or UNKNOWN
+    Given the local daemon was built with `-X main.version=1.2.3`
+    And every peer's `compatibilityClass` is either `COMPATIBLE` or `UNKNOWN`
+    When the operator opens the TUI
+    Then no drift banner is rendered
+
+  @e2e @issue-417
+  Scenario: `orchard status` CLI surfaces the same drift banner
+    Given the local daemon was built with `-X main.version=1.2.3`
+    And the local daemon has one peer whose `compatibilityClass` is `DEGRADED`
+    When the operator runs `orchard status`
+    Then the CLI output includes a drift banner naming that peer
+    And the banner instructs the operator to run `orchard upgrade` on that host
+
+  # =======================================================================
+  # AC7 — `orchard upgrade` (local) via the `self_update` crate
+  # =======================================================================
+
+  @e2e @issue-417
+  Scenario: `orchard upgrade` self-updates the local Rust CLI from the latest GitHub release
+    Given the user is running `orchard` version `1.2.3`
+    And GitHub has a release at `1.2.4` with a matching asset for the current platform
+    When the user runs `orchard upgrade`
+    Then the `self_update` crate fetches the `1.2.4` asset for the current LLVM triple
+    And the running binary is atomically replaced on disk
+    And the command exits with status 0
+
+  @e2e @issue-417
+  Scenario: `orchard upgrade --check` reports the available release without writing
+    Given the user is running `orchard` version `1.2.3`
+    And GitHub has a release at `1.2.4` available
+    When the user runs `orchard upgrade --check`
+    Then the output reports `1.2.3 → 1.2.4`
+    And the binary on disk is unchanged
+
+  @e2e @issue-417
+  Scenario: `orchard upgrade --check` reports up-to-date when no newer release exists
+    Given the user is running `orchard` version `1.2.4`
+    And GitHub's latest release is `1.2.4`
+    When the user runs `orchard upgrade --check`
+    Then the output indicates the local binary is already up to date
+
+  @unit @issue-417
+  Scenario: Asset-name template is explicit per binary (no inferred matcher)
+    Given the `self_update` configuration for the Rust CLI
+    Then the asset-name template uses the LLVM target triple (e.g. `x86_64-apple-darwin`)
+    And the template is declared explicitly in code, not relying on `self_update`'s defaults
+
+  @unit @issue-417
+  Scenario: `orchard upgrade` rejects `--peer` and `--all-peers` flags in this issue's scope
+    When the user runs `orchard upgrade --peer boxd-vm`
+    Then the CLI exits with a non-zero status
+    And the error message indicates peer-driven upgrade is out of scope for this release
+    And points the user at the follow-up issue
+
+  # =======================================================================
+  # AC8 — Release-please tracks `cmd/orchard-daemon` as a second package
+  # =======================================================================
+
+  @integration @issue-417
+  Scenario: `release-please-config.json` declares the daemon as a Go package
+    Given the release-please configuration
+    Then it has an entry for `cmd/orchard-daemon` with `"release-type": "go"`
+    And the existing entry for `crates/orchard` is unchanged
+
+  @integration @issue-417
+  Scenario: The release workflow builds the daemon across linux/darwin × amd64/arm64
+    Given `.github/workflows/release-please.yml` runs after a release-please PR merges
+    When the daemon build matrix executes
+    Then artifacts are produced for { linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 }
+    And each artifact is published to GitHub Releases as `orchard-daemon_<version>_<goos>_<goarch>.tar.gz`
+    And every artifact embeds the release version via `-X main.version=<version>`
+
+  @integration @issue-417
+  Scenario: Both packages tag from the same release SHA on a single release-please PR
+    Given a commit on `main` that touches both `crates/orchard` and `cmd/orchard-daemon`
+    When release-please opens its next release PR
+    Then the PR bumps both package versions
+    And merging it tags both packages from the same SHA
+    And the GitHub Releases page shows both Rust and Go artifacts side by side
+
+  # =======================================================================
+  # AC9 — Bootstrap doc for pre-#417 daemons
+  # =======================================================================
+
+  @e2e @issue-417
+  Scenario: Bootstrap doc explains the one-time manual upgrade for pre-#417 daemons
+    Given the repository at `main` after #417 merges
+    Then `docs/operations/upgrade.md` (or the next-best home agreed by review) exists
+    And it documents how to manually copy a new daemon binary onto a pre-#417 peer once
+    And it explicitly notes that subsequent upgrades will surface in the drift banner
+    And it does NOT prescribe new SSH plumbing
+
+  @e2e @issue-417
+  Scenario: The drift banner links to the bootstrap doc
+    Given the drift banner is rendered (any peer DEGRADED or INCOMPATIBLE, local version != `dev`)
+    When the operator reads the banner text
+    Then the banner includes a stable path or URL pointing at the bootstrap doc
+
+# --- AC Coverage Map ---
+# AC1 "Daemon version baked at release time via -ldflags" →
+#   - Release build bakes a real semver into the daemon binary
+#   - Plain `go build` without -ldflags keeps `dev` as the version
+#   - Release-please Go build matrix bakes the version via the same flag
+# AC2 "Query.version: String! resolver returns the baked version" →
+#   - `Query.version` returns the baked binary version
+#   - `Query.version` returns `dev` on a non-release build
+# AC3 "Host.version populated for local + ferried from peers, null on unreachable" →
+#   - `Host.version` on the local host returns the local daemon's baked version
+#   - `Host.peers[].version` is populated by ferrying `query { version }` over peerproxy
+#   - `Host.peers[].version` is null when the peer is unreachable
+# AC4 "Host.schemaContractVersion: Int! integer counter, bumped manually, surfaced for local + peers, null on unreachable" →
+#   - `Host.schemaContractVersion` on the local host returns the package-level constant
+#   - `Host.peers[].schemaContractVersion` is ferried over peerproxy alongside version
+#   - `Host.peers[].schemaContractVersion` is null on unreachable peers
+#   - An older peer that lacks the field resolves to null, not error
+# AC5 "Host.peers[].compatibilityClass: CompatibilityClass! with all four golden cases" →
+#   - `compatibilityClass` is derived from local vs peer `schemaContractVersion` (Scenario Outline covers all 4 classes)
+#   - `Host.peers[].compatibilityClass` is non-nullable in the schema
+# AC6 "Drift banner in TUI + `orchard status`, gated on peer DEGRADED/INCOMPATIBLE AND local != dev" →
+#   - Drift banner appears when any peer is DEGRADED on a released local daemon
+#   - Drift banner appears when any peer is INCOMPATIBLE on a released local daemon
+#   - Drift banner is hidden when local version is `dev` even if peers are drifted
+#   - Drift banner is hidden when all peers are COMPATIBLE or UNKNOWN
+#   - `orchard status` CLI surfaces the same drift banner
+# AC7 "`orchard upgrade` (local) via self_update crate, --check flag, no --peer/--all-peers" →
+#   - `orchard upgrade` self-updates the local Rust CLI from the latest GitHub release
+#   - `orchard upgrade --check` reports the available release without writing
+#   - `orchard upgrade --check` reports up-to-date when no newer release exists
+#   - Asset-name template is explicit per binary (no inferred matcher)
+#   - `orchard upgrade` rejects `--peer` and `--all-peers` flags in this issue's scope
+# AC8 "Release-please tracks cmd/orchard-daemon, builds linux × {amd64,arm64} and darwin × {amd64,arm64}" →
+#   - `release-please-config.json` declares the daemon as a Go package
+#   - The release workflow builds the daemon across linux/darwin × amd64/arm64
+#   - Both packages tag from the same release SHA on a single release-please PR
+# AC9 "Bootstrap doc for pre-#417 daemons; drift banner links to it" →
+#   - Bootstrap doc explains the one-time manual upgrade for pre-#417 daemons
+#   - The drift banner links to the bootstrap doc
+#
+# Coverage check: 9 ACs in the issue body → all 9 mapped. ✓


### PR DESCRIPTION
## Summary

Lands AC1-3 of #417 (version drift visibility). AC4-9 deferred to a follow-up PR.

Adds:
- **AC1 — daemon version baked via `-ldflags`** in the Makefile (`cmd/orchard-daemon` builds with `-X main.version=<semver>`). Plain `go build` falls back to `"dev"`. Verified in `cmd/orchard-daemon/version_test.go`.
- **AC2 — `Query.version: String!`** GraphQL resolver. Returns the baked binary version. Verified in `internal/server/resolvers/version_test.go`.
- **AC3 — `Host.version: String`** GraphQL resolver. Local host returns the daemon's own baked version (always at least `"dev"`); peer hosts return the version cached by peerproxy on each probe (via `fetchVersion()` + `PeerProvider.PeerVersion(name)`). Verified in `internal/server/resolvers/host_version_test.go`.

Deferred to follow-up PR:
- AC4 `Host.schemaContractVersion`
- AC5 `Host.peers[].compatibilityClass`
- AC6 TUI drift banner gating
- AC7 `orchard upgrade` local self-update
- AC8 release-please daemon Go-package tracking
- AC9 bootstrap doc

## Test plan

Driven by `specs/features/version-drift-and-orchard-upgrade.feature` (scenarios for AC1-3 only land here; AC4-9 scenarios remain in the spec as guard rails for the follow-up).

- [x] AC1 daemon version baked (`cmd/orchard-daemon/version_test.go`)
- [x] AC2 `Query.version` (`internal/server/resolvers/version_test.go`)
- [x] AC3 `Host.version` local + peer ferry (`internal/server/resolvers/host_version_test.go`)
- [x] Full Go test suite green (`go test ./internal/...`)
- [x] Rust workspace builds (`cargo build --release`)
- [x] Federation snapshot test green locally
- [x] CI all checks green on 4b11120

## Notes

- Rebased onto 5630525 (#586 manifest ingest merged first); generated.go + schema.resolvers.go auto-merged cleanly with main's manifest additions.
- Investigation, plan, and revised ACs live in the [issue body](https://github.com/drewdrewthis/git-orchard-rs/issues/417).
- Driven by or-grinder ralph-loop session; rebase + merge driven by autonomous orchardist run (Drew away).
- Known tech-debt: `make generate` regen mangles `schema.resolvers.go` (gqlgen v0.17.45 strips `//` prefixes from custom docstrings that don't match its template). Auto-merged generated artifacts are correct; build + tests prove it. Worth a follow-up issue.

# Related issue

- #417


# Related issue

- #417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added daemon binary version tracking accessible via GraphQL API
  * Version information now available for both local and peer daemons
  * Version is set at build time and defaults to "dev" for development builds

* **Tests**
  * Added comprehensive test coverage for version tracking and GraphQL resolvers

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/582)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #417