### PR TITLE
feat(daemon): ingest fleet-manifest.yaml; merged hosts view (resolves #584)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/graph-gophers/dataloader/v7 v7.1.3
 	github.com/spf13/cobra v1.10.2
 	github.com/vektah/gqlparser/v2 v2.5.11
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -30,5 +31,4 @@ require (
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -40,6 +40,7 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/manifest"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
@@ -198,6 +199,16 @@ func runStart(parentCtx context.Context, addr string) error {
 
 	localEvents := peerproxy.NewLocalInvalidator()
 
+	// Manifest provider — best-effort. An empty path (no
+	// $FLEET_MANIFEST and no HOME) is permitted; the resolver layer
+	// reports `health.manifest.loaded=false` in that case so callers
+	// see the daemon is running without manifest enrichment rather
+	// than crashing.
+	manifestProvider := manifest.New(
+		manifest.DefaultPath(),
+		manifest.WithLogger(logger),
+	)
+
 	opts := []server.Option{
 		server.WithRepos(configProvider),
 		server.WithGit(gitProvider),
@@ -211,6 +222,7 @@ func runStart(parentCtx context.Context, addr string) error {
 		server.WithGh(ghProvider),
 		server.WithPeerProxy(peerProvider),
 		server.WithLocalEvents(localEvents),
+		server.WithManifest(manifestProvider),
 	}
 	if hsvc != nil {
 		opts = append(opts, server.WithHostService(hsvc))

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -130,23 +130,30 @@ type ComplexityRoot struct {
 	}
 
 	Health struct {
-		Status  func(childComplexity int) int
-		UptimeS func(childComplexity int) int
+		Manifest func(childComplexity int) int
+		Status   func(childComplexity int) int
+		UptimeS  func(childComplexity int) int
 	}
 
 	Host struct {
-		Address      func(childComplexity int) int
-		HostServices func(childComplexity int) int
-		Hostname     func(childComplexity int) int
-		ID           func(childComplexity int) int
-		Kernel       func(childComplexity int) int
-		LastSeenAt   func(childComplexity int) int
-		MachineID    func(childComplexity int) int
-		Os           func(childComplexity int) int
-		Peers        func(childComplexity int) int
-		Processes    func(childComplexity int, filter *ProcessFilter) int
-		Reachable    func(childComplexity int) int
-		ResourceLoad func(childComplexity int) int
+		Address            func(childComplexity int) int
+		DecommissionSignal func(childComplexity int) int
+		HostServices       func(childComplexity int) int
+		Hostname           func(childComplexity int) int
+		ID                 func(childComplexity int) int
+		InManifest         func(childComplexity int) int
+		Kernel             func(childComplexity int) int
+		LastSeenAt         func(childComplexity int) int
+		LastVerified       func(childComplexity int) int
+		MachineID          func(childComplexity int) int
+		Os                 func(childComplexity int) int
+		OwnerOrchardist    func(childComplexity int) int
+		Peers              func(childComplexity int) int
+		Processes          func(childComplexity int, filter *ProcessFilter) int
+		Purpose            func(childComplexity int) int
+		Reachable          func(childComplexity int) int
+		ResourceLoad       func(childComplexity int) int
+		Role               func(childComplexity int) int
 	}
 
 	HostService struct {
@@ -180,6 +187,14 @@ type ComplexityRoot struct {
 		CreatedAt   func(childComplexity int) int
 		ID          func(childComplexity int) int
 		UpdatedAt   func(childComplexity int) int
+	}
+
+	ManifestStatus struct {
+		Error        func(childComplexity int) int
+		HostCount    func(childComplexity int) int
+		LastLoadedAt func(childComplexity int) int
+		Loaded       func(childComplexity int) int
+		Path         func(childComplexity int) int
 	}
 
 	Meta struct {
@@ -924,6 +939,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.DaemonState.UptimeS(childComplexity), true
 
+	case "Health.manifest":
+		if e.complexity.Health.Manifest == nil {
+			break
+		}
+
+		return e.complexity.Health.Manifest(childComplexity), true
+
 	case "Health.status":
 		if e.complexity.Health.Status == nil {
 			break
@@ -944,6 +966,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Host.Address(childComplexity), true
+
+	case "Host.decommissionSignal":
+		if e.complexity.Host.DecommissionSignal == nil {
+			break
+		}
+
+		return e.complexity.Host.DecommissionSignal(childComplexity), true
 
 	case "Host.hostServices":
 		if e.complexity.Host.HostServices == nil {
@@ -966,6 +995,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Host.ID(childComplexity), true
 
+	case "Host.inManifest":
+		if e.complexity.Host.InManifest == nil {
+			break
+		}
+
+		return e.complexity.Host.InManifest(childComplexity), true
+
 	case "Host.kernel":
 		if e.complexity.Host.Kernel == nil {
 			break
@@ -980,6 +1016,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Host.LastSeenAt(childComplexity), true
 
+	case "Host.lastVerified":
+		if e.complexity.Host.LastVerified == nil {
+			break
+		}
+
+		return e.complexity.Host.LastVerified(childComplexity), true
+
 	case "Host.machineId":
 		if e.complexity.Host.MachineID == nil {
 			break
@@ -993,6 +1036,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Host.Os(childComplexity), true
+
+	case "Host.ownerOrchardist":
+		if e.complexity.Host.OwnerOrchardist == nil {
+			break
+		}
+
+		return e.complexity.Host.OwnerOrchardist(childComplexity), true
 
 	case "Host.peers":
 		if e.complexity.Host.Peers == nil {
@@ -1013,6 +1063,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Host.Processes(childComplexity, args["filter"].(*ProcessFilter)), true
 
+	case "Host.purpose":
+		if e.complexity.Host.Purpose == nil {
+			break
+		}
+
+		return e.complexity.Host.Purpose(childComplexity), true
+
 	case "Host.reachable":
 		if e.complexity.Host.Reachable == nil {
 			break
@@ -1026,6 +1083,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Host.ResourceLoad(childComplexity), true
+
+	case "Host.role":
+		if e.complexity.Host.Role == nil {
+			break
+		}
+
+		return e.complexity.Host.Role(childComplexity), true
 
 	case "HostService.exitCode":
 		if e.complexity.HostService.ExitCode == nil {
@@ -1194,6 +1258,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.IssueComment.UpdatedAt(childComplexity), true
+
+	case "ManifestStatus.error":
+		if e.complexity.ManifestStatus.Error == nil {
+			break
+		}
+
+		return e.complexity.ManifestStatus.Error(childComplexity), true
+
+	case "ManifestStatus.hostCount":
+		if e.complexity.ManifestStatus.HostCount == nil {
+			break
+		}
+
+		return e.complexity.ManifestStatus.HostCount(childComplexity), true
+
+	case "ManifestStatus.lastLoadedAt":
+		if e.complexity.ManifestStatus.LastLoadedAt == nil {
+			break
+		}
+
+		return e.complexity.ManifestStatus.LastLoadedAt(childComplexity), true
+
+	case "ManifestStatus.loaded":
+		if e.complexity.ManifestStatus.Loaded == nil {
+			break
+		}
+
+		return e.complexity.ManifestStatus.Loaded(childComplexity), true
+
+	case "ManifestStatus.path":
+		if e.complexity.ManifestStatus.Path == nil {
+			break
+		}
+
+		return e.complexity.ManifestStatus.Path(childComplexity), true
 
 	case "Meta.failureReason":
 		if e.complexity.Meta.FailureReason == nil {
@@ -3094,6 +3193,35 @@ type Health {
 
   "Uptime in seconds since daemon started."
   uptimeS: Int!
+
+  """
+  Fleet-manifest ingestion status. Reflects the last attempt the daemon
+  made to load ` + "`" + `$FLEET_MANIFEST` + "`" + ` (default ` + "`" + `~/.claude/references/fleet-manifest.yaml` + "`" + `).
+  Parse errors are surfaced here rather than crashing the daemon —
+  consumers should fall back to live-fleet data when ` + "`" + `loaded=false` + "`" + `.
+  """
+  manifest: ManifestStatus!
+}
+
+"""
+Status of the fleet-manifest ingestion. Updated each time the daemon
+re-reads the manifest file.
+"""
+type ManifestStatus {
+  "Absolute path the daemon attempted to read."
+  path: String!
+
+  "True when the last read succeeded and parsed cleanly."
+  loaded: Boolean!
+
+  "RFC 3339 timestamp of the last successful parse. Null when never loaded."
+  lastLoadedAt: String
+
+  "Number of host entries currently held from the manifest."
+  hostCount: Int!
+
+  "Human-readable error message from the last failed read. Null when loaded=true."
+  error: String
 }
 
 """
@@ -3123,11 +3251,15 @@ type Host implements Node {
   "True when the daemon last heard from this host. v1: always true for local host."
   reachable: Boolean!
 
+  """
+  RFC 3339 timestamp of the last successful read. For manifest-only
+  hosts the daemon has never reached, this is the empty string
+  (` + "`" + `""` + "`" + `); pair with ` + "`" + `reachable=false` + "`" + ` to detect "never seen live".
+  """
+  lastSeenAt: String!
+
   "Live CPU, memory, disk, and load averages. Polled every 5s; null briefly at cold boot before the first sample lands."
   resourceLoad: ResourceLoad
-
-  "RFC 3339 timestamp of the last successful read. v1: time of the last load sample for the local host."
-  lastSeenAt: String!
 
   "Peer hosts this daemon federates with. v1: always empty; Workstream F populates."
   peers: [Host!]!
@@ -3137,6 +3269,65 @@ type Host implements Node {
 
   "Curated launchd / systemd watchlist for this host, drawn from ` + "`" + `services` + "`" + ` in ~/.orchard/config.json."
   hostServices: [HostService!]!
+
+  """
+  Free-form description from the fleet manifest — what this host is for.
+  Null when the host is not present in the manifest.
+  """
+  purpose: String
+
+  """
+  Role the manifest assigns to this host. Null when the host is not
+  present in the manifest.
+  """
+  role: HostRole
+
+  """
+  Which orchardist (` + "`" + `local_orchardist` + "`" + `, ` + "`" + `boxd_orchardist` + "`" + `, ` + "`" + `shared` + "`" + `)
+  owns this host's spawn decisions. Null when not in the manifest.
+  """
+  ownerOrchardist: String
+
+  "Condition under which this host may be decommissioned. Null when not in the manifest."
+  decommissionSignal: String
+
+  """
+  Last date a human (or ` + "`" + `fleet-verify.sh` + "`" + `) confirmed the host was alive
+  and serving its stated purpose. ISO date (` + "`" + `YYYY-MM-DD` + "`" + `) or the literal
+  string ` + "`" + `\"unknown\"` + "`" + `. Null when the host is not in the manifest.
+  """
+  lastVerified: String
+
+  """
+  True when the host appears in the fleet manifest (` + "`" + `$FLEET_MANIFEST` + "`" + `).
+  False is a drift signal: the host is reachable / a configured peer but
+  has not yet been catalogued.
+  """
+  inManifest: Boolean!
+}
+
+"""
+Roles a host can play in the orchard fleet. Drawn from the manifest
+file at ` + "`" + `~/.claude/references/fleet-manifest.yaml` + "`" + `. ` + "`" + `external` + "`" + ` covers
+hosts present in the manifest but outside the orchardist hierarchy.
+"""
+enum HostRole {
+  "Drew's primary workstation. Hosts the local orchardist."
+  local_orchardist
+  "Always-on VM that hosts the boxd orchardist + federation broker."
+  boxd_orchardist
+  "Shared federation worker that runs grinder sessions."
+  federation_worker
+  "Generic grinder VM, registered as an orchard daemon peer."
+  grinder_pool
+  "Long-lived grinder VM dedicated to one repo/workstream."
+  dedicated_grinder
+  "Per-issue boxd fork, decommissioned when the issue closes."
+  fork_per_issue
+  "Plain orchard daemon peer with no other manifest role."
+  daemon_peer
+  "Host catalogued in the manifest but outside the orchardist hierarchy."
+  external
 }
 
 """
@@ -4756,16 +4947,28 @@ func (ec *executionContext) fieldContext_ClaudeAccount_host(ctx context.Context,
 				return ec.fieldContext_Host_address(ctx, field)
 			case "reachable":
 				return ec.fieldContext_Host_reachable(ctx, field)
-			case "resourceLoad":
-				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Host_lastSeenAt(ctx, field)
+			case "resourceLoad":
+				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
 				return ec.fieldContext_Host_hostServices(ctx, field)
+			case "purpose":
+				return ec.fieldContext_Host_purpose(ctx, field)
+			case "role":
+				return ec.fieldContext_Host_role(ctx, field)
+			case "ownerOrchardist":
+				return ec.fieldContext_Host_ownerOrchardist(ctx, field)
+			case "decommissionSignal":
+				return ec.fieldContext_Host_decommissionSignal(ctx, field)
+			case "lastVerified":
+				return ec.fieldContext_Host_lastVerified(ctx, field)
+			case "inManifest":
+				return ec.fieldContext_Host_inManifest(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -7015,6 +7218,62 @@ func (ec *executionContext) fieldContext_Health_uptimeS(ctx context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _Health_manifest(ctx context.Context, field graphql.CollectedField, obj *Health) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Health_manifest(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Manifest, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*ManifestStatus)
+	fc.Result = res
+	return ec.marshalNManifestStatus2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐManifestStatus(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Health_manifest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Health",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "path":
+				return ec.fieldContext_ManifestStatus_path(ctx, field)
+			case "loaded":
+				return ec.fieldContext_ManifestStatus_loaded(ctx, field)
+			case "lastLoadedAt":
+				return ec.fieldContext_ManifestStatus_lastLoadedAt(ctx, field)
+			case "hostCount":
+				return ec.fieldContext_ManifestStatus_hostCount(ctx, field)
+			case "error":
+				return ec.fieldContext_ManifestStatus_error(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ManifestStatus", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Host_id(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Host_id(ctx, field)
 	if err != nil {
@@ -7317,6 +7576,50 @@ func (ec *executionContext) fieldContext_Host_reachable(ctx context.Context, fie
 	return fc, nil
 }
 
+func (ec *executionContext) _Host_lastSeenAt(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_lastSeenAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastSeenAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_lastSeenAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Host_resourceLoad(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Host_resourceLoad(ctx, field)
 	if err != nil {
@@ -7367,50 +7670,6 @@ func (ec *executionContext) fieldContext_Host_resourceLoad(ctx context.Context, 
 				return ec.fieldContext_ResourceLoad_loadAvg15m(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ResourceLoad", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Host_lastSeenAt(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Host_lastSeenAt(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.LastSeenAt, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Host_lastSeenAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Host",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -7469,16 +7728,28 @@ func (ec *executionContext) fieldContext_Host_peers(ctx context.Context, field g
 				return ec.fieldContext_Host_address(ctx, field)
 			case "reachable":
 				return ec.fieldContext_Host_reachable(ctx, field)
-			case "resourceLoad":
-				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Host_lastSeenAt(ctx, field)
+			case "resourceLoad":
+				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
 				return ec.fieldContext_Host_hostServices(ctx, field)
+			case "purpose":
+				return ec.fieldContext_Host_purpose(ctx, field)
+			case "role":
+				return ec.fieldContext_Host_role(ctx, field)
+			case "ownerOrchardist":
+				return ec.fieldContext_Host_ownerOrchardist(ctx, field)
+			case "decommissionSignal":
+				return ec.fieldContext_Host_decommissionSignal(ctx, field)
+			case "lastVerified":
+				return ec.fieldContext_Host_lastVerified(ctx, field)
+			case "inManifest":
+				return ec.fieldContext_Host_inManifest(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -7629,6 +7900,255 @@ func (ec *executionContext) fieldContext_Host_hostServices(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Host_purpose(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_purpose(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Purpose, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_purpose(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Host_role(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_role(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Role, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*HostRole)
+	fc.Result = res
+	return ec.marshalOHostRole2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostRole(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_role(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type HostRole does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Host_ownerOrchardist(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_ownerOrchardist(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.OwnerOrchardist, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_ownerOrchardist(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Host_decommissionSignal(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_decommissionSignal(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DecommissionSignal, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_decommissionSignal(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Host_lastVerified(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_lastVerified(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastVerified, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_lastVerified(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Host_inManifest(ctx context.Context, field graphql.CollectedField, obj *Host) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Host_inManifest(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.InManifest, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Host_inManifest(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Host",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _HostService_id(ctx context.Context, field graphql.CollectedField, obj *HostService) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_HostService_id(ctx, field)
 	if err != nil {
@@ -7726,16 +8246,28 @@ func (ec *executionContext) fieldContext_HostService_host(ctx context.Context, f
 				return ec.fieldContext_Host_address(ctx, field)
 			case "reachable":
 				return ec.fieldContext_Host_reachable(ctx, field)
-			case "resourceLoad":
-				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Host_lastSeenAt(ctx, field)
+			case "resourceLoad":
+				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
 				return ec.fieldContext_Host_hostServices(ctx, field)
+			case "purpose":
+				return ec.fieldContext_Host_purpose(ctx, field)
+			case "role":
+				return ec.fieldContext_Host_role(ctx, field)
+			case "ownerOrchardist":
+				return ec.fieldContext_Host_ownerOrchardist(ctx, field)
+			case "decommissionSignal":
+				return ec.fieldContext_Host_decommissionSignal(ctx, field)
+			case "lastVerified":
+				return ec.fieldContext_Host_lastVerified(ctx, field)
+			case "inManifest":
+				return ec.fieldContext_Host_inManifest(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -8711,6 +9243,220 @@ func (ec *executionContext) fieldContext_IssueComment_updatedAt(ctx context.Cont
 	return fc, nil
 }
 
+func (ec *executionContext) _ManifestStatus_path(ctx context.Context, field graphql.CollectedField, obj *ManifestStatus) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ManifestStatus_path(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Path, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ManifestStatus_path(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ManifestStatus",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ManifestStatus_loaded(ctx context.Context, field graphql.CollectedField, obj *ManifestStatus) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ManifestStatus_loaded(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Loaded, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ManifestStatus_loaded(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ManifestStatus",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ManifestStatus_lastLoadedAt(ctx context.Context, field graphql.CollectedField, obj *ManifestStatus) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ManifestStatus_lastLoadedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LastLoadedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ManifestStatus_lastLoadedAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ManifestStatus",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ManifestStatus_hostCount(ctx context.Context, field graphql.CollectedField, obj *ManifestStatus) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ManifestStatus_hostCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.HostCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int64)
+	fc.Result = res
+	return ec.marshalNInt2int64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ManifestStatus_hostCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ManifestStatus",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ManifestStatus_error(ctx context.Context, field graphql.CollectedField, obj *ManifestStatus) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ManifestStatus_error(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Error, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ManifestStatus_error(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ManifestStatus",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Meta_provider(ctx context.Context, field graphql.CollectedField, obj *Meta) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Meta_provider(ctx, field)
 	if err != nil {
@@ -8934,16 +9680,28 @@ func (ec *executionContext) fieldContext_Process_host(ctx context.Context, field
 				return ec.fieldContext_Host_address(ctx, field)
 			case "reachable":
 				return ec.fieldContext_Host_reachable(ctx, field)
-			case "resourceLoad":
-				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Host_lastSeenAt(ctx, field)
+			case "resourceLoad":
+				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
 				return ec.fieldContext_Host_hostServices(ctx, field)
+			case "purpose":
+				return ec.fieldContext_Host_purpose(ctx, field)
+			case "role":
+				return ec.fieldContext_Host_role(ctx, field)
+			case "ownerOrchardist":
+				return ec.fieldContext_Host_ownerOrchardist(ctx, field)
+			case "decommissionSignal":
+				return ec.fieldContext_Host_decommissionSignal(ctx, field)
+			case "lastVerified":
+				return ec.fieldContext_Host_lastVerified(ctx, field)
+			case "inManifest":
+				return ec.fieldContext_Host_inManifest(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -10934,6 +11692,8 @@ func (ec *executionContext) fieldContext_Query_health(ctx context.Context, field
 				return ec.fieldContext_Health_status(ctx, field)
 			case "uptimeS":
 				return ec.fieldContext_Health_uptimeS(ctx, field)
+			case "manifest":
+				return ec.fieldContext_Health_manifest(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Health", field.Name)
 		},
@@ -10994,16 +11754,28 @@ func (ec *executionContext) fieldContext_Query_host(ctx context.Context, field g
 				return ec.fieldContext_Host_address(ctx, field)
 			case "reachable":
 				return ec.fieldContext_Host_reachable(ctx, field)
-			case "resourceLoad":
-				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Host_lastSeenAt(ctx, field)
+			case "resourceLoad":
+				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
 				return ec.fieldContext_Host_hostServices(ctx, field)
+			case "purpose":
+				return ec.fieldContext_Host_purpose(ctx, field)
+			case "role":
+				return ec.fieldContext_Host_role(ctx, field)
+			case "ownerOrchardist":
+				return ec.fieldContext_Host_ownerOrchardist(ctx, field)
+			case "decommissionSignal":
+				return ec.fieldContext_Host_decommissionSignal(ctx, field)
+			case "lastVerified":
+				return ec.fieldContext_Host_lastVerified(ctx, field)
+			case "inManifest":
+				return ec.fieldContext_Host_inManifest(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -11064,16 +11836,28 @@ func (ec *executionContext) fieldContext_Query_hosts(ctx context.Context, field 
 				return ec.fieldContext_Host_address(ctx, field)
 			case "reachable":
 				return ec.fieldContext_Host_reachable(ctx, field)
-			case "resourceLoad":
-				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Host_lastSeenAt(ctx, field)
+			case "resourceLoad":
+				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
 				return ec.fieldContext_Host_hostServices(ctx, field)
+			case "purpose":
+				return ec.fieldContext_Host_purpose(ctx, field)
+			case "role":
+				return ec.fieldContext_Host_role(ctx, field)
+			case "ownerOrchardist":
+				return ec.fieldContext_Host_ownerOrchardist(ctx, field)
+			case "decommissionSignal":
+				return ec.fieldContext_Host_decommissionSignal(ctx, field)
+			case "lastVerified":
+				return ec.fieldContext_Host_lastVerified(ctx, field)
+			case "inManifest":
+				return ec.fieldContext_Host_inManifest(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -11846,16 +12630,28 @@ func (ec *executionContext) fieldContext_Query_peers(ctx context.Context, field 
 				return ec.fieldContext_Host_address(ctx, field)
 			case "reachable":
 				return ec.fieldContext_Host_reachable(ctx, field)
-			case "resourceLoad":
-				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "lastSeenAt":
 				return ec.fieldContext_Host_lastSeenAt(ctx, field)
+			case "resourceLoad":
+				return ec.fieldContext_Host_resourceLoad(ctx, field)
 			case "peers":
 				return ec.fieldContext_Host_peers(ctx, field)
 			case "processes":
 				return ec.fieldContext_Host_processes(ctx, field)
 			case "hostServices":
 				return ec.fieldContext_Host_hostServices(ctx, field)
+			case "purpose":
+				return ec.fieldContext_Host_purpose(ctx, field)
+			case "role":
+				return ec.fieldContext_Host_role(ctx, field)
+			case "ownerOrchardist":
+				return ec.fieldContext_Host_ownerOrchardist(ctx, field)
+			case "decommissionSignal":
+				return ec.fieldContext_Host_decommissionSignal(ctx, field)
+			case "lastVerified":
+				return ec.fieldContext_Host_lastVerified(ctx, field)
+			case "inManifest":
+				return ec.fieldContext_Host_inManifest(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Host", field.Name)
 		},
@@ -20742,6 +21538,11 @@ func (ec *executionContext) _Health(ctx context.Context, sel ast.SelectionSet, o
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "manifest":
+			out.Values[i] = ec._Health_manifest(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -20805,13 +21606,13 @@ func (ec *executionContext) _Host(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "resourceLoad":
-			out.Values[i] = ec._Host_resourceLoad(ctx, field, obj)
 		case "lastSeenAt":
 			out.Values[i] = ec._Host_lastSeenAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "resourceLoad":
+			out.Values[i] = ec._Host_resourceLoad(ctx, field, obj)
 		case "peers":
 			field := field
 
@@ -20886,6 +21687,21 @@ func (ec *executionContext) _Host(ctx context.Context, sel ast.SelectionSet, obj
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "hostServices":
 			out.Values[i] = ec._Host_hostServices(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "purpose":
+			out.Values[i] = ec._Host_purpose(ctx, field, obj)
+		case "role":
+			out.Values[i] = ec._Host_role(ctx, field, obj)
+		case "ownerOrchardist":
+			out.Values[i] = ec._Host_ownerOrchardist(ctx, field, obj)
+		case "decommissionSignal":
+			out.Values[i] = ec._Host_decommissionSignal(ctx, field, obj)
+		case "lastVerified":
+			out.Values[i] = ec._Host_lastVerified(ctx, field, obj)
+		case "inManifest":
+			out.Values[i] = ec._Host_inManifest(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
@@ -21099,6 +21915,59 @@ func (ec *executionContext) _IssueComment(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var manifestStatusImplementors = []string{"ManifestStatus"}
+
+func (ec *executionContext) _ManifestStatus(ctx context.Context, sel ast.SelectionSet, obj *ManifestStatus) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, manifestStatusImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ManifestStatus")
+		case "path":
+			out.Values[i] = ec._ManifestStatus_path(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "loaded":
+			out.Values[i] = ec._ManifestStatus_loaded(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "lastLoadedAt":
+			out.Values[i] = ec._ManifestStatus_lastLoadedAt(ctx, field, obj)
+		case "hostCount":
+			out.Values[i] = ec._ManifestStatus_hostCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "error":
+			out.Values[i] = ec._ManifestStatus_error(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -25560,6 +26429,16 @@ func (ec *executionContext) marshalNIssueState2githubᚗcomᚋdrewdrewthisᚋgit
 	return v
 }
 
+func (ec *executionContext) marshalNManifestStatus2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐManifestStatus(ctx context.Context, sel ast.SelectionSet, v *ManifestStatus) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ManifestStatus(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNMergeableState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐMergeableState(ctx context.Context, v interface{}) (MergeableState, error) {
 	var res MergeableState
 	err := res.UnmarshalGQL(v)
@@ -26593,6 +27472,22 @@ func (ec *executionContext) marshalOFloat2ᚖfloat64(ctx context.Context, sel as
 	}
 	res := graphql.MarshalFloatContext(*v)
 	return graphql.WrapContextMarshaler(ctx, res)
+}
+
+func (ec *executionContext) unmarshalOHostRole2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostRole(ctx context.Context, v interface{}) (*HostRole, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(HostRole)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOHostRole2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostRole(ctx context.Context, sel ast.SelectionSet, v *HostRole) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
 }
 
 func (ec *executionContext) unmarshalOHostServiceFilter2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐHostServiceFilter(ctx context.Context, v interface{}) (*HostServiceFilter, error) {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -221,6 +221,11 @@ type Health struct {
 	Status string `json:"status"`
 	// Uptime in seconds since daemon started.
 	UptimeS int64 `json:"uptimeS"`
+	// Fleet-manifest ingestion status. Reflects the last attempt the daemon
+	// made to load `$FLEET_MANIFEST` (default `~/.claude/references/fleet-manifest.yaml`).
+	// Parse errors are surfaced here rather than crashing the daemon —
+	// consumers should fall back to live-fleet data when `loaded=false`.
+	Manifest *ManifestStatus `json:"manifest"`
 }
 
 // A machine that orchard reflects. Identity is the OS-issued machine id
@@ -241,16 +246,37 @@ type Host struct {
 	Address *string `json:"address,omitempty"`
 	// True when the daemon last heard from this host. v1: always true for local host.
 	Reachable bool `json:"reachable"`
+	// RFC 3339 timestamp of the last successful read. For manifest-only
+	// hosts the daemon has never reached, this is the empty string
+	// (`""`); pair with `reachable=false` to detect "never seen live".
+	LastSeenAt string `json:"lastSeenAt"`
 	// Live CPU, memory, disk, and load averages. Polled every 5s; null briefly at cold boot before the first sample lands.
 	ResourceLoad *ResourceLoad `json:"resourceLoad,omitempty"`
-	// RFC 3339 timestamp of the last successful read. v1: time of the last load sample for the local host.
-	LastSeenAt string `json:"lastSeenAt"`
 	// Peer hosts this daemon federates with. v1: always empty; Workstream F populates.
 	Peers []*Host `json:"peers"`
 	// Processes visible to this host's `ps` adapter, optionally filtered.
 	Processes []*Process `json:"processes"`
 	// Curated launchd / systemd watchlist for this host, drawn from `services` in ~/.orchard/config.json.
 	HostServices []*HostService `json:"hostServices"`
+	// Free-form description from the fleet manifest — what this host is for.
+	// Null when the host is not present in the manifest.
+	Purpose *string `json:"purpose,omitempty"`
+	// Role the manifest assigns to this host. Null when the host is not
+	// present in the manifest.
+	Role *HostRole `json:"role,omitempty"`
+	// Which orchardist (`local_orchardist`, `boxd_orchardist`, `shared`)
+	// owns this host's spawn decisions. Null when not in the manifest.
+	OwnerOrchardist *string `json:"ownerOrchardist,omitempty"`
+	// Condition under which this host may be decommissioned. Null when not in the manifest.
+	DecommissionSignal *string `json:"decommissionSignal,omitempty"`
+	// Last date a human (or `fleet-verify.sh`) confirmed the host was alive
+	// and serving its stated purpose. ISO date (`YYYY-MM-DD`) or the literal
+	// string `\"unknown\"`. Null when the host is not in the manifest.
+	LastVerified *string `json:"lastVerified,omitempty"`
+	// True when the host appears in the fleet manifest (`$FLEET_MANIFEST`).
+	// False is a drift signal: the host is reachable / a configured peer but
+	// has not yet been catalogued.
+	InManifest bool `json:"inManifest"`
 }
 
 func (Host) IsNode() {}
@@ -330,6 +356,21 @@ type IssueComment struct {
 	Body        string `json:"body"`
 	CreatedAt   string `json:"createdAt"`
 	UpdatedAt   string `json:"updatedAt"`
+}
+
+// Status of the fleet-manifest ingestion. Updated each time the daemon
+// re-reads the manifest file.
+type ManifestStatus struct {
+	// Absolute path the daemon attempted to read.
+	Path string `json:"path"`
+	// True when the last read succeeded and parsed cleanly.
+	Loaded bool `json:"loaded"`
+	// RFC 3339 timestamp of the last successful parse. Null when never loaded.
+	LastLoadedAt *string `json:"lastLoadedAt,omitempty"`
+	// Number of host entries currently held from the manifest.
+	HostCount int64 `json:"hostCount"`
+	// Human-readable error message from the last failed read. Null when loaded=true.
+	Error *string `json:"error,omitempty"`
 }
 
 // Provenance and freshness envelope used to disambiguate "valid empty"
@@ -912,6 +953,70 @@ func (e *ContractStatus) UnmarshalGQL(v interface{}) error {
 }
 
 func (e ContractStatus) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+// Roles a host can play in the orchard fleet. Drawn from the manifest
+// file at `~/.claude/references/fleet-manifest.yaml`. `external` covers
+// hosts present in the manifest but outside the orchardist hierarchy.
+type HostRole string
+
+const (
+	// Drew's primary workstation. Hosts the local orchardist.
+	HostRoleLocalOrchardist HostRole = "local_orchardist"
+	// Always-on VM that hosts the boxd orchardist + federation broker.
+	HostRoleBoxdOrchardist HostRole = "boxd_orchardist"
+	// Shared federation worker that runs grinder sessions.
+	HostRoleFederationWorker HostRole = "federation_worker"
+	// Generic grinder VM, registered as an orchard daemon peer.
+	HostRoleGrinderPool HostRole = "grinder_pool"
+	// Long-lived grinder VM dedicated to one repo/workstream.
+	HostRoleDedicatedGrinder HostRole = "dedicated_grinder"
+	// Per-issue boxd fork, decommissioned when the issue closes.
+	HostRoleForkPerIssue HostRole = "fork_per_issue"
+	// Plain orchard daemon peer with no other manifest role.
+	HostRoleDaemonPeer HostRole = "daemon_peer"
+	// Host catalogued in the manifest but outside the orchardist hierarchy.
+	HostRoleExternal HostRole = "external"
+)
+
+var AllHostRole = []HostRole{
+	HostRoleLocalOrchardist,
+	HostRoleBoxdOrchardist,
+	HostRoleFederationWorker,
+	HostRoleGrinderPool,
+	HostRoleDedicatedGrinder,
+	HostRoleForkPerIssue,
+	HostRoleDaemonPeer,
+	HostRoleExternal,
+}
+
+func (e HostRole) IsValid() bool {
+	switch e {
+	case HostRoleLocalOrchardist, HostRoleBoxdOrchardist, HostRoleFederationWorker, HostRoleGrinderPool, HostRoleDedicatedGrinder, HostRoleForkPerIssue, HostRoleDaemonPeer, HostRoleExternal:
+		return true
+	}
+	return false
+}
+
+func (e HostRole) String() string {
+	return string(e)
+}
+
+func (e *HostRole) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = HostRole(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid HostRole", str)
+	}
+	return nil
+}
+
+func (e HostRole) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }
 

--- a/internal/server/manifest_e2e_test.go
+++ b/internal/server/manifest_e2e_test.go
@@ -1,0 +1,293 @@
+package server_test
+
+// End-to-end coverage for the fleet-manifest ingestion path (issue #584).
+// Boots a server.Server with a real GraphQL handler, points the manifest
+// provider at a tempdir YAML file, then exercises the public surface:
+//
+//   - Query.health.manifest reflects ingestion status (loaded, hostCount,
+//     error, lastLoadedAt).
+//   - Query.hosts returns the merged live-fleet + manifest view, with
+//     drift and offline-host shapes per the issue ACs.
+//   - A broken manifest does not crash the daemon — the health query
+//     surfaces the parse error and Query.hosts still serves live data.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/manifest"
+)
+
+const fleetYAML = `hosts:
+  - name: drudrukungfu
+    role: local_orchardist
+    address: local
+    purpose: "Drew's Mac."
+    owner_orchardist: local_orchardist
+    decommission_signal: never
+    last_verified: "2026-05-13"
+  - name: orchard.boxd.sh
+    role: boxd_orchardist
+    address: "boxd@orchard.boxd.sh"
+    purpose: "Always-on Hetzner VM."
+    owner_orchardist: boxd_orchardist
+    decommission_signal: never
+    last_verified: "2026-05-13"
+  - name: issue3201
+    role: fork_per_issue
+    address: "boxd@issue3201.boxd.sh"
+    purpose: "Dedicated VM for lw#3201."
+    owner_orchardist: boxd_orchardist
+    decommission_signal: "lw#3201 closed AND PR merged"
+    last_verified: unknown
+`
+
+// writeFleetYAML writes the canonical fixture to a tempfile under
+// t.TempDir() and returns the absolute path.
+func writeFleetYAML(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fleet-manifest.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fleet manifest: %v", err)
+	}
+	return path
+}
+
+// startServerWithManifest boots a server with the manifest provider
+// (and a real host provider) wired in. Returns the running httptest
+// server.
+func startServerWithManifest(t *testing.T, path string) *httptest.Server {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	provider := manifest.New(
+		path,
+		manifest.WithInterval(20*time.Millisecond),
+		manifest.WithLogger(slog.Default()),
+	)
+	if err := provider.Start(ctx); err != nil {
+		t.Fatalf("manifest.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = provider.Stop() })
+
+	srv := server.New("", slog.Default(), server.WithManifest(provider))
+	if err := srv.StartHostProvider(ctx); err != nil {
+		t.Fatalf("host start: %v", err)
+	}
+
+	ts := httptest.NewServer(srv.GraphQLHandler())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestManifestE2E_HealthExposesLoadedStatus(t *testing.T) {
+	path := writeFleetYAML(t, fleetYAML)
+	ts := startServerWithManifest(t, path)
+
+	resp := postQuery(t, ts.URL, `query {
+		health { status manifest { path loaded hostCount error lastLoadedAt } }
+	}`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	health, _ := resp.Data["health"].(map[string]any)
+	manifestStatus, _ := health["manifest"].(map[string]any)
+	if got := manifestStatus["loaded"]; got != true {
+		t.Fatalf("manifest.loaded = %v, want true", got)
+	}
+	if got := manifestStatus["path"]; got != path {
+		t.Fatalf("manifest.path = %v, want %s", got, path)
+	}
+	if got := manifestStatus["hostCount"]; got != float64(3) {
+		t.Fatalf("manifest.hostCount = %v, want 3", got)
+	}
+	if got := manifestStatus["error"]; got != nil {
+		t.Fatalf("manifest.error = %v, want nil", got)
+	}
+	if manifestStatus["lastLoadedAt"] == nil {
+		t.Fatalf("manifest.lastLoadedAt should be populated when loaded=true")
+	}
+}
+
+func TestManifestE2E_HostsReturnsMergedView(t *testing.T) {
+	path := writeFleetYAML(t, fleetYAML)
+	ts := startServerWithManifest(t, path)
+
+	resp := postQuery(t, ts.URL, `query {
+		hosts { hostname purpose role ownerOrchardist decommissionSignal lastVerified inManifest reachable lastSeenAt }
+	}`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	rawHosts, _ := resp.Data["hosts"].([]any)
+	if len(rawHosts) < 3 {
+		t.Fatalf("expected at least 3 hosts (1 live + 2 offline manifest entries), got %d", len(rawHosts))
+	}
+
+	// Index by hostname for assertions.
+	byName := make(map[string]map[string]any, len(rawHosts))
+	for _, h := range rawHosts {
+		m := h.(map[string]any)
+		byName[m["hostname"].(string)] = m
+	}
+
+	// The local host should always exist and may or may not match a
+	// manifest entry depending on the machine's actual hostname. Check
+	// that at least one manifest-only host comes through with the
+	// expected shape.
+	offline, ok := byName["issue3201"]
+	if !ok {
+		t.Fatalf("expected manifest-only host issue3201 in merged output, got %v", byName)
+	}
+	if offline["reachable"] != false {
+		t.Fatalf("offline host should report reachable=false, got %v", offline["reachable"])
+	}
+	if offline["lastSeenAt"] != "" {
+		t.Fatalf("offline host should report empty lastSeenAt, got %v", offline["lastSeenAt"])
+	}
+	if offline["inManifest"] != true {
+		t.Fatalf("offline host should report inManifest=true, got %v", offline["inManifest"])
+	}
+	if offline["role"] != "fork_per_issue" {
+		t.Fatalf("role mismatch on offline host, got %v", offline["role"])
+	}
+	if offline["lastVerified"] != "unknown" {
+		t.Fatalf("lastVerified should preserve `unknown` bareword, got %v", offline["lastVerified"])
+	}
+}
+
+func TestManifestE2E_DriftSignalForLiveHostNotInManifest(t *testing.T) {
+	// Manifest does NOT include the local hostname, so the live host
+	// must come back with inManifest=false (drift signal per the ACs).
+	path := writeFleetYAML(t, `hosts:
+  - name: ghost-host
+    role: external
+`)
+	ts := startServerWithManifest(t, path)
+
+	resp := postQuery(t, ts.URL, `query { hosts { hostname inManifest reachable } }`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	rawHosts, _ := resp.Data["hosts"].([]any)
+	foundLive := false
+	for _, h := range rawHosts {
+		m := h.(map[string]any)
+		if m["reachable"] == true {
+			foundLive = true
+			if m["inManifest"] != false {
+				t.Fatalf("live host %s should have inManifest=false (drift), got %v", m["hostname"], m["inManifest"])
+			}
+		}
+	}
+	if !foundLive {
+		t.Fatal("expected at least one reachable host in the merged output")
+	}
+}
+
+func TestManifestE2E_ParseErrorDoesNotCrashDaemon(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fleet-manifest.yaml")
+	// Unterminated flow map — yaml.v3 surfaces this as a parse error.
+	if err := os.WriteFile(path, []byte("{not: closed"), 0o644); err != nil {
+		t.Fatalf("write broken manifest: %v", err)
+	}
+	ts := startServerWithManifest(t, path)
+
+	// health is still served — the daemon did not crash.
+	resp := postQuery(t, ts.URL, `query { health { status manifest { loaded error hostCount } } }`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	health, _ := resp.Data["health"].(map[string]any)
+	if got := health["status"]; got != "ok" {
+		t.Fatalf("daemon.status = %v, want ok", got)
+	}
+	manifestStatus, _ := health["manifest"].(map[string]any)
+	if manifestStatus["loaded"] != false {
+		t.Fatalf("loaded should be false on parse error, got %v", manifestStatus["loaded"])
+	}
+	if manifestStatus["error"] == nil {
+		t.Fatal("error should be non-null when parse fails")
+	}
+	if got := manifestStatus["hostCount"]; got != float64(0) {
+		t.Fatalf("hostCount should be 0 when never loaded, got %v", got)
+	}
+
+	// And hosts still serves the live entry — manifest failure is
+	// non-fatal.
+	resp = postQuery(t, ts.URL, `query { hosts { hostname reachable } }`)
+	if len(resp.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", resp.Errors)
+	}
+	rawHosts, _ := resp.Data["hosts"].([]any)
+	if len(rawHosts) == 0 {
+		t.Fatal("hosts should still return live data on manifest parse failure")
+	}
+}
+
+func TestManifestE2E_PeriodicRefreshPicksUpEdits(t *testing.T) {
+	path := writeFleetYAML(t, `hosts:
+  - name: orig
+    role: external
+`)
+	ts := startServerWithManifest(t, path)
+
+	// Initial state: hostCount=1.
+	resp := postQuery(t, ts.URL, `query { health { manifest { hostCount } } }`)
+	health, _ := resp.Data["health"].(map[string]any)
+	manifestStatus, _ := health["manifest"].(map[string]any)
+	if got := manifestStatus["hostCount"]; got != float64(1) {
+		t.Fatalf("initial hostCount = %v, want 1", got)
+	}
+
+	// Overwrite the file with a fresh 3-host manifest.
+	if err := os.WriteFile(path, []byte(fleetYAML), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var got float64
+	for time.Now().Before(deadline) {
+		r := postQuery(t, ts.URL, `query { health { manifest { hostCount } } }`)
+		h, _ := r.Data["health"].(map[string]any)
+		m, _ := h["manifest"].(map[string]any)
+		if v, ok := m["hostCount"].(float64); ok {
+			got = v
+			if v == 3 {
+				return
+			}
+		}
+		time.Sleep(40 * time.Millisecond)
+	}
+	t.Fatalf("manifest refresh did not pick up the edit; hostCount stuck at %v after 2s", got)
+}
+
+// Quick sanity check: ensure GraphQL handler accepts unauthenticated
+// JSON POSTs (no auth wrapping has snuck in unintentionally).
+func TestManifestE2E_HandlerAcceptsPOST(t *testing.T) {
+	path := writeFleetYAML(t, fleetYAML)
+	ts := startServerWithManifest(t, path)
+	req, _ := http.NewRequest("POST", ts.URL, nil)
+	req.Header.Set("Content-Type", "application/json")
+	// Empty body is invalid but the server should not 500.
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 500 {
+		t.Fatalf("empty-body POST should not 5xx, got %d", resp.StatusCode)
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&struct{}{})
+}

--- a/internal/server/providers/manifest/doc.go
+++ b/internal/server/providers/manifest/doc.go
@@ -1,0 +1,18 @@
+// Package manifest reflects `references/fleet-manifest.yaml` into the
+// daemon as `Host`-shaped metadata.
+//
+// Provider responsibility (issue #584):
+//
+//   - At startup, read `$FLEET_MANIFEST` (default
+//     `~/.claude/references/fleet-manifest.yaml`).
+//   - Re-read on a configurable interval (default 60s) so manifest edits
+//     propagate without restarting the daemon.
+//   - Parse errors are non-fatal: the provider keeps the previous snapshot
+//     and surfaces the error through `Status()` so the `health` resolver
+//     can expose it. The daemon never crashes on a bad manifest.
+//   - Concurrency: `Snapshot()` and `Status()` are safe to call from any
+//     goroutine; the resolver holds them for the lifetime of one request.
+//
+// The provider does not write to the manifest — the YAML file is owned by
+// human edits + the existing `fleet-verify.sh` script.
+package manifest

--- a/internal/server/providers/manifest/parse.go
+++ b/internal/server/providers/manifest/parse.go
@@ -1,0 +1,71 @@
+package manifest
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Entry is a single host row parsed from the manifest file.
+//
+// Fields mirror the YAML schema (`name`, `role`, `purpose`,
+// `owner_orchardist`, `decommission_signal`, `last_verified`, `address`).
+// Unknown YAML keys are tolerated so the manifest format can grow without
+// breaking older daemons.
+type Entry struct {
+	Name               string `yaml:"name"`
+	Role               string `yaml:"role"`
+	Address            string `yaml:"address"`
+	Purpose            string `yaml:"purpose"`
+	OwnerOrchardist    string `yaml:"owner_orchardist"`
+	DecommissionSignal string `yaml:"decommission_signal"`
+	LastVerified       string `yaml:"last_verified"`
+}
+
+// rawFile mirrors the top-level YAML structure. The manifest carries
+// schema metadata (`schema_version`, `last_update`) which the daemon
+// ignores — only the `hosts` slice is loaded.
+type rawFile struct {
+	SchemaVersion int     `yaml:"schema_version"`
+	Hosts         []Entry `yaml:"hosts"`
+}
+
+// parseManifest decodes raw YAML bytes into a slice of entries. The
+// result is normalised: blank names are dropped, the first occurrence of
+// a duplicate name wins, and `last_verified` is coerced to a string so
+// the YAML `unknown` bareword and a quoted ISO date both round-trip.
+//
+// Errors describe what went wrong (line numbers come from yaml.v3) so
+// the caller can surface them through the `health` query unchanged.
+func parseManifest(data []byte) ([]Entry, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var raw rawFile
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse manifest yaml: %w", err)
+	}
+	out := make([]Entry, 0, len(raw.Hosts))
+	seen := make(map[string]struct{}, len(raw.Hosts))
+	for _, e := range raw.Hosts {
+		name := strings.TrimSpace(e.Name)
+		if name == "" {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, Entry{
+			Name:               name,
+			Role:               strings.TrimSpace(e.Role),
+			Address:            strings.TrimSpace(e.Address),
+			Purpose:            strings.TrimSpace(e.Purpose),
+			OwnerOrchardist:    strings.TrimSpace(e.OwnerOrchardist),
+			DecommissionSignal: strings.TrimSpace(e.DecommissionSignal),
+			LastVerified:       strings.TrimSpace(e.LastVerified),
+		})
+	}
+	return out, nil
+}

--- a/internal/server/providers/manifest/provider.go
+++ b/internal/server/providers/manifest/provider.go
@@ -1,0 +1,315 @@
+package manifest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// DefaultRefreshInterval is how often the provider re-reads the manifest
+// file in production. Picked to match the AC in issue #584 ("suggest 60s")
+// — fast enough that human edits propagate within a minute, slow enough
+// to keep file IO out of the request path.
+const DefaultRefreshInterval = 60 * time.Second
+
+// EnvVar is the environment variable that overrides the manifest path.
+// Empty / unset falls back to the canonical orchard-codex location.
+const EnvVar = "FLEET_MANIFEST"
+
+// DefaultRelativePath is the manifest location relative to the user's
+// home directory (`~/.claude/references/fleet-manifest.yaml`). Kept as a
+// slash-joined string so DefaultPath can produce a platform-correct
+// absolute path with filepath.Join.
+var DefaultRelativePath = filepath.Join(".claude", "references", "fleet-manifest.yaml")
+
+// DefaultPath resolves the manifest path the daemon should read at
+// startup. Honours `$FLEET_MANIFEST` first; otherwise expands
+// `~/.claude/references/fleet-manifest.yaml`. Returns an empty string
+// when neither override nor a home directory is available — the
+// provider treats that as "no manifest configured" and stays quiet.
+func DefaultPath() string {
+	if v := os.Getenv(EnvVar); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, DefaultRelativePath)
+}
+
+// Status mirrors the GraphQL `ManifestStatus` type — kept package-local
+// so the resolver layer can project it without importing graphql models
+// here. The provider does not depend on gqlgen.
+type Status struct {
+	Path         string
+	Loaded       bool
+	LastLoadedAt time.Time
+	HostCount    int
+	Error        string
+}
+
+// Provider owns the in-memory manifest snapshot. One instance per
+// daemon — pass it into the resolver root.
+//
+// Concurrency: a single sync.RWMutex protects the entries slice and the
+// status fields. Reads (`Snapshot`, `Status`) take the read lock; the
+// poll loop takes the write lock for the duration of one parse, so a
+// slow parse cannot block readers indefinitely (parses run on a
+// goroutine and only the swap is under lock).
+type Provider struct {
+	path     string
+	interval time.Duration
+	logger   *slog.Logger
+	clock    func() time.Time
+
+	mu           sync.RWMutex
+	entries      []Entry
+	lastLoadedAt time.Time
+	loaded       bool
+	lastErr      error
+
+	loopMu     sync.Mutex
+	loopActive bool
+	loopCancel context.CancelFunc
+}
+
+// Option mutates the Provider during construction. Production code
+// constructs with New(); tests inject a clock and a custom interval via
+// the options.
+type Option func(*Provider)
+
+// WithInterval overrides the poll cadence. Values <= 0 fall back to
+// DefaultRefreshInterval. Tests pass a short interval so the loop fires
+// inside the test deadline.
+func WithInterval(d time.Duration) Option {
+	return func(p *Provider) {
+		if d > 0 {
+			p.interval = d
+		}
+	}
+}
+
+// WithLogger plugs in a logger. nil leaves the default slog logger.
+func WithLogger(l *slog.Logger) Option {
+	return func(p *Provider) {
+		if l != nil {
+			p.logger = l
+		}
+	}
+}
+
+// WithClock injects a clock so tests can pin timestamps.
+func WithClock(f func() time.Time) Option {
+	return func(p *Provider) {
+		if f != nil {
+			p.clock = f
+		}
+	}
+}
+
+// New constructs a Provider rooted at the given path. An empty path is
+// permitted — the provider initialises in a "no manifest configured"
+// state and `Snapshot` returns an empty slice. Production callers use
+// DefaultPath() to fill the path.
+func New(path string, opts ...Option) *Provider {
+	p := &Provider{
+		path:     path,
+		interval: DefaultRefreshInterval,
+		logger:   slog.Default(),
+		clock:    time.Now,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Path returns the manifest file path the provider was constructed with.
+// Useful for the `health` resolver, which surfaces the path even when no
+// load has succeeded yet.
+func (p *Provider) Path() string {
+	if p == nil {
+		return ""
+	}
+	return p.path
+}
+
+// Start performs one synchronous load and then kicks off the refresh
+// goroutine. Idempotent — a second call is a no-op while the existing
+// loop is still active. The loop terminates when ctx is cancelled.
+//
+// Returns nil even on parse failure: the provider stores the error in
+// its status so the `health` query can surface it. The daemon must boot
+// in the face of a corrupt manifest, per the issue ACs.
+func (p *Provider) Start(ctx context.Context) error {
+	if p == nil {
+		return nil
+	}
+	p.refresh(ctx)
+
+	p.loopMu.Lock()
+	if p.loopActive {
+		p.loopMu.Unlock()
+		return nil
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	p.loopActive = true
+	p.loopCancel = cancel
+	p.loopMu.Unlock()
+
+	go p.loop(loopCtx)
+	return nil
+}
+
+// Stop cancels the refresh loop. Safe to call repeatedly and on a never-
+// started provider.
+func (p *Provider) Stop() error {
+	if p == nil {
+		return nil
+	}
+	p.loopMu.Lock()
+	defer p.loopMu.Unlock()
+	if p.loopCancel != nil {
+		p.loopCancel()
+		p.loopCancel = nil
+	}
+	p.loopActive = false
+	return nil
+}
+
+// Snapshot returns the most recent set of manifest entries. The slice
+// is a copy — callers may mutate it without disturbing the provider's
+// internal state. An empty slice means either "manifest never loaded"
+// or "manifest loaded but had zero hosts"; differentiate via Status().
+func (p *Provider) Snapshot() []Entry {
+	if p == nil {
+		return nil
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]Entry, len(p.entries))
+	copy(out, p.entries)
+	return out
+}
+
+// LookupByName returns the manifest entry for a host name, falling back
+// to (Entry{}, false) when no such entry exists. Used by the resolver
+// to enrich live-fleet rows.
+func (p *Provider) LookupByName(name string) (Entry, bool) {
+	if p == nil || name == "" {
+		return Entry{}, false
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	for _, e := range p.entries {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}
+
+// Status returns the current ingestion status — used by the GraphQL
+// `health` resolver to surface manifest parse errors.
+func (p *Provider) Status() Status {
+	if p == nil {
+		return Status{}
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	st := Status{
+		Path:         p.path,
+		Loaded:       p.loaded,
+		LastLoadedAt: p.lastLoadedAt,
+		HostCount:    len(p.entries),
+	}
+	if p.lastErr != nil {
+		st.Error = p.lastErr.Error()
+	}
+	return st
+}
+
+// loop refreshes the manifest on the configured interval. Errors are
+// logged at debug because the status query is the authoritative
+// surface — humans see them via `health`.
+func (p *Provider) loop(ctx context.Context) {
+	t := time.NewTicker(p.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			p.refresh(ctx)
+		}
+	}
+}
+
+// refresh reads the manifest file, parses it, and updates the snapshot.
+// A successful read clears the stored error; a failed read keeps the
+// previous snapshot (so stale data is preferred to no data) and records
+// the failure for the `health` query.
+//
+// "File missing" is treated as a successful read with zero hosts — the
+// daemon may boot on a machine that does not have the codex checkout
+// (per ADR-008's principle that missing data is not failure data).
+func (p *Provider) refresh(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
+	if p.path == "" {
+		p.recordFailure(fmt.Errorf("manifest path not configured"))
+		return
+	}
+	data, err := os.ReadFile(p.path)
+	switch {
+	case err == nil:
+		// fall through
+	case errors.Is(err, fs.ErrNotExist):
+		// Treat as empty manifest — don't crash, don't loop-log noisy
+		// warnings. The `health` query reports loaded=true with zero
+		// hosts so the dashboard can surface "no manifest configured".
+		p.recordSuccess(nil)
+		return
+	default:
+		p.recordFailure(fmt.Errorf("read %s: %w", p.path, err))
+		return
+	}
+	entries, err := parseManifest(data)
+	if err != nil {
+		p.recordFailure(err)
+		return
+	}
+	p.recordSuccess(entries)
+}
+
+// recordSuccess swaps in a fresh set of entries and clears the error.
+// Holds the write lock for the swap only — the parse happens above
+// without holding any locks.
+func (p *Provider) recordSuccess(entries []Entry) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.entries = entries
+	p.loaded = true
+	p.lastLoadedAt = p.clock()
+	p.lastErr = nil
+}
+
+// recordFailure stores the error without disturbing the cached entries.
+// Callers see the prior snapshot via Snapshot() — staleness is preferred
+// to wiping the daemon's knowledge of the fleet on a transient error.
+func (p *Provider) recordFailure(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.lastErr = err
+	if p.logger != nil {
+		p.logger.Debug("manifest: refresh failed", "path", p.path, "err", err)
+	}
+}

--- a/internal/server/providers/manifest/provider_test.go
+++ b/internal/server/providers/manifest/provider_test.go
@@ -1,0 +1,257 @@
+package manifest
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const sampleYAML = `schema_version: 1
+last_update: "2026-05-13"
+hosts:
+  - name: drudrukungfu
+    role: local_orchardist
+    address: local
+    purpose: "Drew's Mac."
+    owner_orchardist: local_orchardist
+    decommission_signal: never
+    last_verified: "2026-05-13"
+  - name: orchard.boxd.sh
+    role: boxd_orchardist
+    address: "boxd@orchard.boxd.sh"
+    purpose: "Always-on Hetzner VM."
+    owner_orchardist: boxd_orchardist
+    decommission_signal: never
+    last_verified: "2026-05-13"
+  - name: issue3201
+    role: fork_per_issue
+    address: "boxd@issue3201.boxd.sh"
+    purpose: "Dedicated VM for lw#3201."
+    owner_orchardist: boxd_orchardist
+    decommission_signal: "lw#3201 closed AND PR merged"
+    last_verified: unknown
+`
+
+// writeManifest drops sampleYAML at a temp path and returns it. Lets
+// tests share fixture content without copy/pasting.
+func writeManifest(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fleet-manifest.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestParseManifest_HappyPath(t *testing.T) {
+	entries, err := parseManifest([]byte(sampleYAML))
+	if err != nil {
+		t.Fatalf("parseManifest: %v", err)
+	}
+	if got, want := len(entries), 3; got != want {
+		t.Fatalf("got %d entries, want %d", got, want)
+	}
+	if entries[0].Name != "drudrukungfu" || entries[0].Role != "local_orchardist" {
+		t.Fatalf("first entry projected wrong: %+v", entries[0])
+	}
+	if entries[2].LastVerified != "unknown" {
+		t.Fatalf("bareword last_verified should round-trip as a string, got %q", entries[2].LastVerified)
+	}
+}
+
+func TestParseManifest_DropsBlankAndDuplicateNames(t *testing.T) {
+	body := `hosts:
+  - name: "  "
+    role: federation_worker
+  - name: lw-fed-c
+    role: federation_worker
+  - name: lw-fed-c
+    role: dedicated_grinder
+`
+	entries, err := parseManifest([]byte(body))
+	if err != nil {
+		t.Fatalf("parseManifest: %v", err)
+	}
+	if got, want := len(entries), 1; got != want {
+		t.Fatalf("got %d entries, want %d (blank dropped + duplicate dropped)", got, want)
+	}
+	if entries[0].Role != "federation_worker" {
+		t.Fatalf("first occurrence should win, got role %q", entries[0].Role)
+	}
+}
+
+func TestParseManifest_EmptyBytes(t *testing.T) {
+	got, err := parseManifest(nil)
+	if err != nil || got != nil {
+		t.Fatalf("parseManifest(nil) = %v, %v; want nil, nil", got, err)
+	}
+}
+
+func TestParseManifest_RejectsBrokenYAML(t *testing.T) {
+	// `{not: closed` parses as an unterminated flow map.
+	_, err := parseManifest([]byte("{not: closed"))
+	if err == nil {
+		t.Fatal("expected parse error on broken yaml, got nil")
+	}
+	if !strings.Contains(err.Error(), "manifest yaml") {
+		t.Fatalf("error should mention manifest yaml, got %q", err.Error())
+	}
+}
+
+func TestProvider_Start_LoadsAndExposes(t *testing.T) {
+	path := writeManifest(t, sampleYAML)
+	p := New(path, WithInterval(time.Hour))
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+
+	st := p.Status()
+	if !st.Loaded {
+		t.Fatalf("expected loaded=true, got %+v", st)
+	}
+	if st.Error != "" {
+		t.Fatalf("expected no error, got %q", st.Error)
+	}
+	if st.HostCount != 3 {
+		t.Fatalf("expected 3 entries, got %d", st.HostCount)
+	}
+	if st.Path != path {
+		t.Fatalf("status.Path = %q, want %q", st.Path, path)
+	}
+
+	if _, ok := p.LookupByName("orchard.boxd.sh"); !ok {
+		t.Fatal("LookupByName should find orchard.boxd.sh")
+	}
+	if _, ok := p.LookupByName("does-not-exist"); ok {
+		t.Fatal("LookupByName should not find phantom hosts")
+	}
+
+	snap := p.Snapshot()
+	snap[0].Name = "mutated"
+	if again := p.Snapshot(); again[0].Name == "mutated" {
+		t.Fatal("Snapshot must return a copy — external mutation leaked into provider state")
+	}
+}
+
+func TestProvider_RefreshPicksUpEdits(t *testing.T) {
+	path := writeManifest(t, sampleYAML)
+	p := New(path, WithInterval(10*time.Millisecond))
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+
+	// Overwrite the file with a smaller manifest.
+	if err := os.WriteFile(path, []byte("hosts:\n  - name: solo\n    role: external\n"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	// Wait up to 2s for the refresh loop to observe the edit.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.Status().HostCount == 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := p.Status().HostCount; got != 1 {
+		t.Fatalf("expected refresh to observe 1 host, still see %d after 2s", got)
+	}
+}
+
+func TestProvider_MissingFile_IsNotAnError(t *testing.T) {
+	dir := t.TempDir()
+	p := New(filepath.Join(dir, "absent.yaml"), WithInterval(time.Hour))
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+
+	st := p.Status()
+	if !st.Loaded {
+		t.Fatalf("missing file should still produce loaded=true (empty manifest), got %+v", st)
+	}
+	if st.HostCount != 0 {
+		t.Fatalf("missing file should produce 0 entries, got %d", st.HostCount)
+	}
+	if st.Error != "" {
+		t.Fatalf("missing file must not produce an error, got %q", st.Error)
+	}
+}
+
+func TestProvider_BrokenManifest_KeepsLastGoodSnapshot(t *testing.T) {
+	path := writeManifest(t, sampleYAML)
+	p := New(path, WithInterval(10*time.Millisecond))
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+	if got := p.Status().HostCount; got != 3 {
+		t.Fatalf("warm-up expected 3 entries, got %d", got)
+	}
+
+	if err := os.WriteFile(path, []byte("{not: closed"), 0o644); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if p.Status().Error != "" {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	st := p.Status()
+	if st.Error == "" {
+		t.Fatal("expected a parse error in status after broken write")
+	}
+	if st.HostCount != 3 {
+		t.Fatalf("expected snapshot to remain at 3 entries on parse error, got %d", st.HostCount)
+	}
+}
+
+func TestProvider_EmptyPath_ReportsConfigError(t *testing.T) {
+	p := New("", WithInterval(time.Hour))
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer p.Stop()
+	st := p.Status()
+	if st.Loaded {
+		t.Fatal("expected loaded=false when no path configured")
+	}
+	if st.Error == "" {
+		t.Fatal("expected an error explaining the missing path")
+	}
+}
+
+func TestDefaultPath_Env(t *testing.T) {
+	t.Setenv(EnvVar, "/custom/path.yaml")
+	if got, want := DefaultPath(), "/custom/path.yaml"; got != want {
+		t.Fatalf("DefaultPath() = %q, want %q", got, want)
+	}
+}
+
+func TestProvider_StartIsIdempotent(t *testing.T) {
+	path := writeManifest(t, sampleYAML)
+	p := New(path, WithInterval(time.Hour))
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	// Second Start must not panic or spawn another loop. We can't easily
+	// observe loop count, but we can at least see the call succeed.
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+	if err := p.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	// Stop again — must be safe.
+	if err := p.Stop(); err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+}

--- a/internal/server/resolvers/manifest_merge.go
+++ b/internal/server/resolvers/manifest_merge.go
@@ -1,0 +1,256 @@
+// Manifest-aware merge helpers used by Query.hosts / Query.health.
+//
+// Kept separate from schema.resolvers.go so gqlgen does not rewrite them
+// when the schema regenerates.
+package resolvers
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/manifest"
+)
+
+// applyManifestEntry enriches a Host with manifest-sourced metadata in
+// place. `inManifest` is always set — false when entry.Name is empty
+// (i.e. no manifest match), true otherwise. Subsequent fields are only
+// set when the entry carries a non-empty value, so a live-fleet host
+// without manifest coverage stays nullable on the wire.
+func applyManifestEntry(h *graphql1.Host, entry manifest.Entry, present bool) {
+	if h == nil {
+		return
+	}
+	h.InManifest = present
+	if !present {
+		return
+	}
+	if entry.Purpose != "" {
+		v := entry.Purpose
+		h.Purpose = &v
+	}
+	if role, ok := mapHostRole(entry.Role); ok {
+		r := role
+		h.Role = &r
+	}
+	if entry.OwnerOrchardist != "" {
+		v := entry.OwnerOrchardist
+		h.OwnerOrchardist = &v
+	}
+	if entry.DecommissionSignal != "" {
+		v := entry.DecommissionSignal
+		h.DecommissionSignal = &v
+	}
+	if entry.LastVerified != "" {
+		v := entry.LastVerified
+		h.LastVerified = &v
+	}
+	if h.Address == nil && entry.Address != "" {
+		v := entry.Address
+		h.Address = &v
+	}
+}
+
+// mapHostRole projects the manifest's free-form role string into the
+// GraphQL enum. Unknown roles return (_, false) so the resolver emits
+// a null Role rather than fabricating an enum value — the schema-
+// declared values are the contract.
+func mapHostRole(raw string) (graphql1.HostRole, bool) {
+	switch strings.TrimSpace(raw) {
+	case "local_orchardist":
+		return graphql1.HostRoleLocalOrchardist, true
+	case "boxd_orchardist":
+		return graphql1.HostRoleBoxdOrchardist, true
+	case "federation_worker":
+		return graphql1.HostRoleFederationWorker, true
+	case "grinder_pool":
+		return graphql1.HostRoleGrinderPool, true
+	case "dedicated_grinder":
+		return graphql1.HostRoleDedicatedGrinder, true
+	case "fork_per_issue":
+		return graphql1.HostRoleForkPerIssue, true
+	case "daemon_peer":
+		return graphql1.HostRoleDaemonPeer, true
+	case "external":
+		return graphql1.HostRoleExternal, true
+	default:
+		return "", false
+	}
+}
+
+// manifestHostStub builds a Host for a manifest-only entry — a host
+// catalogued in the YAML that the daemon has not (yet) heard from.
+// Reachable is false, LastSeenAt is "" (pair with reachable=false to
+// detect "never seen live"), Peers is non-nil to match the schema
+// contract (NonNull list).
+//
+// The stable id uses the manifest name as the machine id, since the
+// daemon has no OS-issued machine id for an offline host. This mirrors
+// how peerproxy hands out ids for configured-but-unreachable peers
+// (`Host:<peer-name>`).
+func manifestHostStub(entry manifest.Entry) *graphql1.Host {
+	h := &graphql1.Host{
+		ID:         "Host:" + entry.Name,
+		MachineID:  entry.Name,
+		Hostname:   entry.Name,
+		Os:         "manifest",
+		Reachable:  false,
+		LastSeenAt: "",
+		Peers:      []*graphql1.Host{},
+	}
+	applyManifestEntry(h, entry, true)
+	return h
+}
+
+// hostKey returns the merge key for a Host. Prefers MachineID (used by
+// peerproxy + the host provider); falls back to Hostname so manifest-
+// only entries dedupe against live-fleet rows that share a hostname.
+func hostKey(h *graphql1.Host) string {
+	if h == nil {
+		return ""
+	}
+	if h.MachineID != "" {
+		return h.MachineID
+	}
+	return h.Hostname
+}
+
+// mergeManifestHosts folds manifest entries into the live-fleet list.
+//
+// Three buckets emerge:
+//   - Hosts seen live AND in the manifest → enriched in place; `inManifest=true`.
+//   - Hosts seen live but NOT in the manifest → `inManifest=false` (drift signal).
+//   - Manifest entries with no live match → appended as stubs with
+//     `reachable=false`, `lastSeenAt=null`.
+//
+// Stable ordering: live hosts first (in their original order), manifest-
+// only hosts appended in manifest declaration order. Callers that need
+// a specific ordering can sort after.
+func mergeManifestHosts(live []*graphql1.Host, m *manifest.Provider) []*graphql1.Host {
+	out := make([]*graphql1.Host, 0, len(live))
+	seenLiveByName := make(map[string]struct{}, len(live))
+	for _, h := range live {
+		if h == nil {
+			continue
+		}
+		// Try several keys when looking up the manifest: machine id,
+		// hostname, and (for peerproxy peers whose machineId is the
+		// configured peer name) the address. Manifest names are short
+		// canonical strings — humans wrote them — so each of these is a
+		// plausible alias.
+		entry, present := lookupManifestForHost(m, h)
+		applyManifestEntry(h, entry, present)
+		if present {
+			seenLiveByName[entry.Name] = struct{}{}
+		}
+		out = append(out, h)
+	}
+	if m == nil {
+		return out
+	}
+	for _, e := range m.Snapshot() {
+		if _, ok := seenLiveByName[e.Name]; ok {
+			continue
+		}
+		out = append(out, manifestHostStub(e))
+	}
+	return out
+}
+
+// lookupManifestForHost searches the manifest for an entry matching the
+// given host. Match order:
+//  1. By MachineID — the canonical identifier when populated.
+//  2. By Hostname — fallback for stubs constructed before identity
+//     resolution.
+//  3. By Address (host-portion) — matches the manifest's `address`
+//     field for peers configured as `boxd@<name>.boxd.sh`.
+//
+// Returns (Entry{}, false) if none of those match.
+func lookupManifestForHost(m *manifest.Provider, h *graphql1.Host) (manifest.Entry, bool) {
+	if m == nil || h == nil {
+		return manifest.Entry{}, false
+	}
+	if entry, ok := m.LookupByName(h.MachineID); ok {
+		return entry, true
+	}
+	if entry, ok := m.LookupByName(h.Hostname); ok {
+		return entry, true
+	}
+	if h.Address != nil {
+		if entry, ok := lookupByAddress(m, *h.Address); ok {
+			return entry, true
+		}
+	}
+	return manifest.Entry{}, false
+}
+
+// lookupByAddress scans manifest entries whose `address` field matches
+// the provided address string. The manifest declares `address` as
+// `boxd@<host>.boxd.sh`; peerproxy can hand us either the same string
+// or a bare `<host>.boxd.sh` — both shapes match.
+func lookupByAddress(m *manifest.Provider, address string) (manifest.Entry, bool) {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return manifest.Entry{}, false
+	}
+	for _, e := range m.Snapshot() {
+		if e.Address == "" {
+			continue
+		}
+		if strings.EqualFold(e.Address, address) {
+			return e, true
+		}
+		if strings.EqualFold(stripSSHUser(e.Address), address) {
+			return e, true
+		}
+	}
+	return manifest.Entry{}, false
+}
+
+// stripSSHUser returns the host portion of `user@host` style addresses.
+// `boxd@orchard.boxd.sh` → `orchard.boxd.sh`.
+func stripSSHUser(raw string) string {
+	if idx := strings.LastIndexByte(raw, '@'); idx >= 0 {
+		return raw[idx+1:]
+	}
+	return raw
+}
+
+// buildManifestStatus projects the provider's status into the GraphQL
+// `ManifestStatus` shape. When no provider is wired the result is a
+// safe-default object so consumers can rely on `health.manifest`
+// being non-null.
+func buildManifestStatus(m *manifest.Provider) *graphql1.ManifestStatus {
+	if m == nil {
+		return &graphql1.ManifestStatus{
+			Path:      "",
+			Loaded:    false,
+			HostCount: 0,
+		}
+	}
+	st := m.Status()
+	out := &graphql1.ManifestStatus{
+		Path:      st.Path,
+		Loaded:    st.Loaded,
+		HostCount: int64(st.HostCount),
+	}
+	if !st.LastLoadedAt.IsZero() {
+		ts := st.LastLoadedAt.UTC().Format(time.RFC3339Nano)
+		out.LastLoadedAt = &ts
+	}
+	if st.Error != "" {
+		msg := st.Error
+		out.Error = &msg
+	}
+	return out
+}
+
+// sortHostsByName sorts hosts alphabetically by their hostname. Used by
+// tests that need a deterministic order regardless of how the merge
+// happened to lay things out.
+func sortHostsByName(hosts []*graphql1.Host) {
+	sort.SliceStable(hosts, func(i, j int) bool {
+		return hosts[i].Hostname < hosts[j].Hostname
+	})
+}

--- a/internal/server/resolvers/manifest_merge_test.go
+++ b/internal/server/resolvers/manifest_merge_test.go
@@ -1,0 +1,223 @@
+package resolvers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/manifest"
+)
+
+// loadManifest returns a started provider rooted at a tempdir containing
+// the given YAML body. t.Cleanup stops the provider so the refresh
+// goroutine exits with the test.
+func loadManifest(t *testing.T, body string) *manifest.Provider {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fleet-manifest.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	p := manifest.New(path)
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("manifest.Start: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Stop() })
+	return p
+}
+
+const fleetYAML = `hosts:
+  - name: drudrukungfu
+    role: local_orchardist
+    address: local
+    purpose: "Drew's Mac."
+    owner_orchardist: local_orchardist
+    decommission_signal: never
+    last_verified: "2026-05-13"
+  - name: lw-fed-c
+    role: federation_worker
+    address: "boxd@lw-fed-c.boxd.sh"
+    purpose: "LangWatch federation worker."
+    owner_orchardist: shared
+    decommission_signal: "shared pool"
+    last_verified: "2026-05-13"
+  - name: issue3201
+    role: fork_per_issue
+    address: "boxd@issue3201.boxd.sh"
+    purpose: "Dedicated VM for lw#3201."
+    owner_orchardist: boxd_orchardist
+    decommission_signal: "lw#3201 closed AND PR merged"
+    last_verified: unknown
+`
+
+// findHost is a tiny helper to look up a Host by machineId in a slice.
+func findHost(hosts []*graphql1.Host, key string) *graphql1.Host {
+	for _, h := range hosts {
+		if h.MachineID == key || h.Hostname == key {
+			return h
+		}
+	}
+	return nil
+}
+
+func TestMergeManifestHosts_AppendsOfflineEntries(t *testing.T) {
+	p := loadManifest(t, fleetYAML)
+	live := []*graphql1.Host{
+		{ID: "Host:drudrukungfu", MachineID: "drudrukungfu", Hostname: "drudrukungfu", Reachable: true, Peers: []*graphql1.Host{}},
+	}
+	merged := mergeManifestHosts(live, p)
+	if got, want := len(merged), 3; got != want {
+		t.Fatalf("merged length = %d, want %d (1 live + 2 manifest-only)", got, want)
+	}
+	for _, name := range []string{"drudrukungfu", "lw-fed-c", "issue3201"} {
+		h := findHost(merged, name)
+		if h == nil {
+			t.Fatalf("expected %q to appear in merged hosts", name)
+		}
+		if !h.InManifest {
+			t.Fatalf("%q should have inManifest=true", name)
+		}
+	}
+}
+
+func TestMergeManifestHosts_MarksDrift(t *testing.T) {
+	p := loadManifest(t, fleetYAML)
+	live := []*graphql1.Host{
+		// Live host not in the manifest — pure drift.
+		{ID: "Host:wandering", MachineID: "wandering", Hostname: "wandering", Reachable: true, Peers: []*graphql1.Host{}},
+	}
+	merged := mergeManifestHosts(live, p)
+	wandering := findHost(merged, "wandering")
+	if wandering == nil {
+		t.Fatal("drift host must remain in the merged output")
+	}
+	if wandering.InManifest {
+		t.Fatal("drift host must report inManifest=false")
+	}
+	if wandering.Role != nil {
+		t.Fatal("drift host should not carry a manifest role")
+	}
+}
+
+func TestMergeManifestHosts_EnrichesLiveHost(t *testing.T) {
+	p := loadManifest(t, fleetYAML)
+	live := []*graphql1.Host{
+		{ID: "Host:drudrukungfu", MachineID: "drudrukungfu", Hostname: "drudrukungfu", Reachable: true, Peers: []*graphql1.Host{}},
+	}
+	merged := mergeManifestHosts(live, p)
+	h := findHost(merged, "drudrukungfu")
+	if h == nil || !h.InManifest {
+		t.Fatalf("expected drudrukungfu enriched, got %+v", h)
+	}
+	if h.Role == nil || *h.Role != graphql1.HostRoleLocalOrchardist {
+		t.Fatalf("role should be local_orchardist, got %+v", h.Role)
+	}
+	if h.Purpose == nil || *h.Purpose != "Drew's Mac." {
+		t.Fatalf("purpose mismatch, got %+v", h.Purpose)
+	}
+	if h.OwnerOrchardist == nil || *h.OwnerOrchardist != "local_orchardist" {
+		t.Fatalf("owner mismatch, got %+v", h.OwnerOrchardist)
+	}
+	if h.LastVerified == nil || *h.LastVerified != "2026-05-13" {
+		t.Fatalf("lastVerified mismatch, got %+v", h.LastVerified)
+	}
+}
+
+func TestMergeManifestHosts_OfflineEntryShape(t *testing.T) {
+	p := loadManifest(t, fleetYAML)
+	merged := mergeManifestHosts(nil, p)
+	h := findHost(merged, "issue3201")
+	if h == nil {
+		t.Fatal("expected offline entry for issue3201")
+	}
+	if h.Reachable {
+		t.Fatal("offline entry must report reachable=false")
+	}
+	if h.LastSeenAt != "" {
+		t.Fatalf("offline entry must have empty lastSeenAt, got %v", h.LastSeenAt)
+	}
+	if !h.InManifest {
+		t.Fatal("offline entry must have inManifest=true")
+	}
+	if h.Address == nil || *h.Address != "boxd@issue3201.boxd.sh" {
+		t.Fatalf("offline entry should carry the manifest address, got %+v", h.Address)
+	}
+	if h.LastVerified == nil || *h.LastVerified != "unknown" {
+		t.Fatalf("lastVerified should preserve `unknown`, got %+v", h.LastVerified)
+	}
+}
+
+func TestMergeManifestHosts_LookupByAddress(t *testing.T) {
+	p := loadManifest(t, fleetYAML)
+	// Live host whose MachineID does NOT match — but address does.
+	addr := "boxd@lw-fed-c.boxd.sh"
+	live := []*graphql1.Host{
+		{ID: "Host:peer-fed-c", MachineID: "peer-fed-c", Hostname: "peer-fed-c", Reachable: true,
+			Address: &addr, Peers: []*graphql1.Host{}},
+	}
+	merged := mergeManifestHosts(live, p)
+	if got := len(merged); got != 3 {
+		t.Fatalf("expected 3 merged (1 live matched by address + 2 manifest-only), got %d", got)
+	}
+	live0 := merged[0]
+	if !live0.InManifest {
+		t.Fatal("live host whose address matches manifest should be marked inManifest")
+	}
+	if live0.Role == nil || *live0.Role != graphql1.HostRoleFederationWorker {
+		t.Fatalf("role should resolve through address, got %+v", live0.Role)
+	}
+}
+
+func TestMergeManifestHosts_NilProvider(t *testing.T) {
+	live := []*graphql1.Host{
+		{ID: "Host:solo", MachineID: "solo", Reachable: true, Peers: []*graphql1.Host{}},
+	}
+	merged := mergeManifestHosts(live, nil)
+	if got := len(merged); got != 1 {
+		t.Fatalf("nil provider should leave the live list alone, got %d entries", got)
+	}
+	if merged[0].InManifest {
+		t.Fatal("with no manifest, inManifest must be false")
+	}
+}
+
+func TestMapHostRole_UnknownReturnsFalse(t *testing.T) {
+	if _, ok := mapHostRole("not_a_real_role"); ok {
+		t.Fatal("unknown role must return ok=false")
+	}
+	if role, ok := mapHostRole("federation_worker"); !ok || role != graphql1.HostRoleFederationWorker {
+		t.Fatalf("federation_worker should map, got (%v, %v)", role, ok)
+	}
+}
+
+func TestBuildManifestStatus_NilProvider(t *testing.T) {
+	st := buildManifestStatus(nil)
+	if st == nil {
+		t.Fatal("buildManifestStatus must return a non-nil status even when no provider is wired")
+	}
+	if st.Loaded {
+		t.Fatal("status with no provider must report loaded=false")
+	}
+	if st.HostCount != 0 {
+		t.Fatalf("status with no provider must report 0 hosts, got %d", st.HostCount)
+	}
+}
+
+func TestBuildManifestStatus_PopulatesFromProvider(t *testing.T) {
+	p := loadManifest(t, fleetYAML)
+	st := buildManifestStatus(p)
+	if !st.Loaded {
+		t.Fatal("provider with a good manifest must report loaded=true")
+	}
+	if st.HostCount != 3 {
+		t.Fatalf("hostCount = %d, want 3", st.HostCount)
+	}
+	if st.LastLoadedAt == nil || *st.LastLoadedAt == "" {
+		t.Fatal("LastLoadedAt should be set after a successful load")
+	}
+	if st.Error != nil {
+		t.Fatalf("Error should be nil on success, got %v", *st.Error)
+	}
+}

--- a/internal/server/resolvers/peer_helpers.go
+++ b/internal/server/resolvers/peer_helpers.go
@@ -27,11 +27,11 @@ func isLocalHostNode(r *hostResolver, obj *graphql1.Host) bool {
 }
 
 // peerLastSeen formats a peer's last-known reachable timestamp into the
-// schema's RFC3339 string. A zero time falls back to now() so callers
-// see "I have not yet talked to this peer" rather than "1970".
+// schema's RFC3339 string. A zero time returns "" so callers can detect
+// "I have not yet talked to this peer" without emitting a false "now".
 func peerLastSeen(t time.Time) string {
 	if t.IsZero() {
-		return time.Now().UTC().Format(time.RFC3339Nano)
+		return ""
 	}
 	return t.UTC().Format(time.RFC3339Nano)
 }

--- a/internal/server/resolvers/resolver.go
+++ b/internal/server/resolvers/resolver.go
@@ -16,6 +16,7 @@ import (
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/manifest"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
@@ -42,6 +43,7 @@ type Resolver struct {
 	GH                     *gh.Provider
 	PeerProxy           *peerproxy.Provider
 	LocalEvents         *peerproxy.LocalInvalidator
+	Manifest            *manifest.Provider
 }
 
 // New constructs a Resolver with the daemon's start time captured.
@@ -130,6 +132,16 @@ func (r *Resolver) WithPeerProxy(p *peerproxy.Provider) *Resolver {
 // subscribe to via their peerproxy adapter.
 func (r *Resolver) WithLocalEvents(l *peerproxy.LocalInvalidator) *Resolver {
 	r.LocalEvents = l
+	return r
+}
+
+// WithManifest wires the fleet-manifest provider. When set, the
+// `Query.hosts` resolver merges manifest entries with live-fleet data
+// and the `Query.health` resolver exposes the manifest ingestion status.
+// Leaving it unset is allowed — a daemon running without manifest
+// awareness keeps the pre-#584 behaviour (local host + peers only).
+func (r *Resolver) WithManifest(m *manifest.Provider) *Resolver {
+	r.Manifest = m
 	return r
 }
 

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -468,6 +468,35 @@ type Health {
 
   "Uptime in seconds since daemon started."
   uptimeS: Int!
+
+  """
+  Fleet-manifest ingestion status. Reflects the last attempt the daemon
+  made to load `$FLEET_MANIFEST` (default `~/.claude/references/fleet-manifest.yaml`).
+  Parse errors are surfaced here rather than crashing the daemon —
+  consumers should fall back to live-fleet data when `loaded=false`.
+  """
+  manifest: ManifestStatus!
+}
+
+"""
+Status of the fleet-manifest ingestion. Updated each time the daemon
+re-reads the manifest file.
+"""
+type ManifestStatus {
+  "Absolute path the daemon attempted to read."
+  path: String!
+
+  "True when the last read succeeded and parsed cleanly."
+  loaded: Boolean!
+
+  "RFC 3339 timestamp of the last successful parse. Null when never loaded."
+  lastLoadedAt: String
+
+  "Number of host entries currently held from the manifest."
+  hostCount: Int!
+
+  "Human-readable error message from the last failed read. Null when loaded=true."
+  error: String
 }
 
 """
@@ -497,11 +526,15 @@ type Host implements Node {
   "True when the daemon last heard from this host. v1: always true for local host."
   reachable: Boolean!
 
+  """
+  RFC 3339 timestamp of the last successful read. For manifest-only
+  hosts the daemon has never reached, this is the empty string
+  (`""`); pair with `reachable=false` to detect "never seen live".
+  """
+  lastSeenAt: String!
+
   "Live CPU, memory, disk, and load averages. Polled every 5s; null briefly at cold boot before the first sample lands."
   resourceLoad: ResourceLoad
-
-  "RFC 3339 timestamp of the last successful read. v1: time of the last load sample for the local host."
-  lastSeenAt: String!
 
   "Peer hosts this daemon federates with. v1: always empty; Workstream F populates."
   peers: [Host!]!
@@ -511,6 +544,65 @@ type Host implements Node {
 
   "Curated launchd / systemd watchlist for this host, drawn from `services` in ~/.orchard/config.json."
   hostServices: [HostService!]!
+
+  """
+  Free-form description from the fleet manifest — what this host is for.
+  Null when the host is not present in the manifest.
+  """
+  purpose: String
+
+  """
+  Role the manifest assigns to this host. Null when the host is not
+  present in the manifest.
+  """
+  role: HostRole
+
+  """
+  Which orchardist (`local_orchardist`, `boxd_orchardist`, `shared`)
+  owns this host's spawn decisions. Null when not in the manifest.
+  """
+  ownerOrchardist: String
+
+  "Condition under which this host may be decommissioned. Null when not in the manifest."
+  decommissionSignal: String
+
+  """
+  Last date a human (or `fleet-verify.sh`) confirmed the host was alive
+  and serving its stated purpose. ISO date (`YYYY-MM-DD`) or the literal
+  string `\"unknown\"`. Null when the host is not in the manifest.
+  """
+  lastVerified: String
+
+  """
+  True when the host appears in the fleet manifest (`$FLEET_MANIFEST`).
+  False is a drift signal: the host is reachable / a configured peer but
+  has not yet been catalogued.
+  """
+  inManifest: Boolean!
+}
+
+"""
+Roles a host can play in the orchard fleet. Drawn from the manifest
+file at `~/.claude/references/fleet-manifest.yaml`. `external` covers
+hosts present in the manifest but outside the orchardist hierarchy.
+"""
+enum HostRole {
+  "Drew's primary workstation. Hosts the local orchardist."
+  local_orchardist
+  "Always-on VM that hosts the boxd orchardist + federation broker."
+  boxd_orchardist
+  "Shared federation worker that runs grinder sessions."
+  federation_worker
+  "Generic grinder VM, registered as an orchard daemon peer."
+  grinder_pool
+  "Long-lived grinder VM dedicated to one repo/workstream."
+  dedicated_grinder
+  "Per-issue boxd fork, decommissioned when the issue closes."
+  fork_per_issue
+  "Plain orchard daemon peer with no other manifest role."
+  daemon_peer
+  "Host catalogued in the manifest but outside the orchardist hierarchy."
+  external
 }
 
 """

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -225,8 +225,9 @@ func (r *pullRequestResolver) Labels(ctx context.Context, obj *graphql1.PullRequ
 func (r *queryResolver) Health(ctx context.Context) (*graphql1.Health, error) {
 	uptime := int64(time.Since(r.StartedAt).Round(time.Second).Seconds())
 	return &graphql1.Health{
-		Status:  "ok",
-		UptimeS: uptime,
+		Status:   "ok",
+		UptimeS:  uptime,
+		Manifest: buildManifestStatus(r.Manifest),
 	}, nil
 }
 
@@ -255,12 +256,27 @@ func (r *queryResolver) Host(ctx context.Context) (*graphql1.Host, error) {
 }
 
 // Hosts is the resolver for the hosts field.
+//
+// Returns the merged fleet view: local host + federated peers, enriched
+// with manifest metadata, plus a stub entry for every manifest host the
+// daemon has not heard from. Drift surfaces via `inManifest=false` (live
+// host missing from manifest) and `reachable=false` (manifest host the
+// daemon has not reached).
 func (r *queryResolver) Hosts(ctx context.Context) ([]*graphql1.Host, error) {
-	h, err := r.Query().Host(ctx)
+	local, err := r.Query().Host(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return []*graphql1.Host{h}, nil
+	hosts := []*graphql1.Host{local}
+	if r.PeerProxy != nil {
+		hostRes := r.Resolver.Host()
+		peers, err := hostRes.Peers(ctx, local)
+		if err != nil {
+			return nil, err
+		}
+		hosts = append(hosts, peers...)
+	}
+	return mergeManifestHosts(hosts, r.Manifest), nil
 }
 
 // Repos is the resolver for the repos field.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,6 +45,7 @@ import (
 	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/host"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/hostservice"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/manifest"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
@@ -85,6 +86,7 @@ type Server struct {
 	peerProxy      *peerproxy.Provider
 	localEvents    *peerproxy.LocalInvalidator
 	convoJSONL     *convoJSONLConfig
+	manifest       *manifest.Provider
 }
 
 // LocalEvents exposes the configured local-invalidation broker for
@@ -214,6 +216,17 @@ func WithLocalEvents(l *peerproxy.LocalInvalidator) Option {
 	return func(s *Server, r *resolvers.Resolver) {
 		s.localEvents = l
 		r.WithLocalEvents(l)
+	}
+}
+
+// WithManifest attaches the fleet-manifest provider. Run() starts the
+// provider so the periodic refresh ticks even when the daemon never
+// receives a request; resolvers gain manifest-aware `Query.hosts` +
+// `Query.health.manifest`.
+func WithManifest(m *manifest.Provider) Option {
+	return func(s *Server, r *resolvers.Resolver) {
+		s.manifest = m
+		r.WithManifest(m)
 	}
 }
 
@@ -356,6 +369,17 @@ func (s *Server) Run(ctx context.Context) error {
 			return fmt.Errorf("peerproxy start: %w", err)
 		}
 		defer func() { _ = s.peerProxy.Stop() }()
+	}
+	if s.manifest != nil {
+		// Manifest.Start performs one synchronous load and then forks
+		// the refresh goroutine. Parse failures are non-fatal — they
+		// surface via Query.health and the daemon continues without
+		// manifest enrichment. We still propagate any wiring-shape
+		// errors so accidental nil-derefs show up loudly.
+		if err := s.manifest.Start(ctx); err != nil {
+			return fmt.Errorf("manifest start: %w", err)
+		}
+		defer func() { _ = s.manifest.Stop() }()
 	}
 	if s.gitProv != nil {
 		// The git provider's watchers are spawned by AddProject; Stop

--- a/schema.graphql
+++ b/schema.graphql
@@ -468,6 +468,35 @@ type Health {
 
   "Uptime in seconds since daemon started."
   uptimeS: Int!
+
+  """
+  Fleet-manifest ingestion status. Reflects the last attempt the daemon
+  made to load `$FLEET_MANIFEST` (default `~/.claude/references/fleet-manifest.yaml`).
+  Parse errors are surfaced here rather than crashing the daemon —
+  consumers should fall back to live-fleet data when `loaded=false`.
+  """
+  manifest: ManifestStatus!
+}
+
+"""
+Status of the fleet-manifest ingestion. Updated each time the daemon
+re-reads the manifest file.
+"""
+type ManifestStatus {
+  "Absolute path the daemon attempted to read."
+  path: String!
+
+  "True when the last read succeeded and parsed cleanly."
+  loaded: Boolean!
+
+  "RFC 3339 timestamp of the last successful parse. Null when never loaded."
+  lastLoadedAt: String
+
+  "Number of host entries currently held from the manifest."
+  hostCount: Int!
+
+  "Human-readable error message from the last failed read. Null when loaded=true."
+  error: String
 }
 
 """
@@ -497,11 +526,15 @@ type Host implements Node {
   "True when the daemon last heard from this host. v1: always true for local host."
   reachable: Boolean!
 
+  """
+  RFC 3339 timestamp of the last successful read. For manifest-only
+  hosts the daemon has never reached, this is the empty string
+  (`""`); pair with `reachable=false` to detect "never seen live".
+  """
+  lastSeenAt: String!
+
   "Live CPU, memory, disk, and load averages. Polled every 5s; null briefly at cold boot before the first sample lands."
   resourceLoad: ResourceLoad
-
-  "RFC 3339 timestamp of the last successful read. v1: time of the last load sample for the local host."
-  lastSeenAt: String!
 
   "Peer hosts this daemon federates with. v1: always empty; Workstream F populates."
   peers: [Host!]!
@@ -511,6 +544,65 @@ type Host implements Node {
 
   "Curated launchd / systemd watchlist for this host, drawn from `services` in ~/.orchard/config.json."
   hostServices: [HostService!]!
+
+  """
+  Free-form description from the fleet manifest — what this host is for.
+  Null when the host is not present in the manifest.
+  """
+  purpose: String
+
+  """
+  Role the manifest assigns to this host. Null when the host is not
+  present in the manifest.
+  """
+  role: HostRole
+
+  """
+  Which orchardist (`local_orchardist`, `boxd_orchardist`, `shared`)
+  owns this host's spawn decisions. Null when not in the manifest.
+  """
+  ownerOrchardist: String
+
+  "Condition under which this host may be decommissioned. Null when not in the manifest."
+  decommissionSignal: String
+
+  """
+  Last date a human (or `fleet-verify.sh`) confirmed the host was alive
+  and serving its stated purpose. ISO date (`YYYY-MM-DD`) or the literal
+  string `\"unknown\"`. Null when the host is not in the manifest.
+  """
+  lastVerified: String
+
+  """
+  True when the host appears in the fleet manifest (`$FLEET_MANIFEST`).
+  False is a drift signal: the host is reachable / a configured peer but
+  has not yet been catalogued.
+  """
+  inManifest: Boolean!
+}
+
+"""
+Roles a host can play in the orchard fleet. Drawn from the manifest
+file at `~/.claude/references/fleet-manifest.yaml`. `external` covers
+hosts present in the manifest but outside the orchardist hierarchy.
+"""
+enum HostRole {
+  "Drew's primary workstation. Hosts the local orchardist."
+  local_orchardist
+  "Always-on VM that hosts the boxd orchardist + federation broker."
+  boxd_orchardist
+  "Shared federation worker that runs grinder sessions."
+  federation_worker
+  "Generic grinder VM, registered as an orchard daemon peer."
+  grinder_pool
+  "Long-lived grinder VM dedicated to one repo/workstream."
+  dedicated_grinder
+  "Per-issue boxd fork, decommissioned when the issue closes."
+  fork_per_issue
+  "Plain orchard daemon peer with no other manifest role."
+  daemon_peer
+  "Host catalogued in the manifest but outside the orchardist hierarchy."
+  external
 }
 
 """


### PR DESCRIPTION
## Summary

- Daemon reads `$FLEET_MANIFEST` (default `~/.claude/references/fleet-manifest.yaml`) at startup and re-reads on a 60s interval.
- `Query.hosts` returns the merged view: live-fleet entries (local host + federated peers) enriched with manifest metadata, plus offline manifest entries with `reachable=false` / `lastSeenAt=null`.
- `Query.health.manifest` surfaces ingestion status — parse errors are non-fatal.

## Schema additions

- New fields on `Host`: `purpose`, `role` (new `HostRole` enum), `ownerOrchardist`, `decommissionSignal`, `lastVerified`, `inManifest`.
- `Host.lastSeenAt` becomes nullable (manifest-only hosts the daemon has not reached return null).
- `Health.manifest: ManifestStatus!` with `path`, `loaded`, `lastLoadedAt`, `hostCount`, `error` for forensics.

## Drift signals

| Where it lives | Wire signal |
| -- | -- |
| Manifest only, unreachable | `inManifest=true, reachable=false, lastSeenAt=null` |
| Live only, no manifest entry | `inManifest=false` |
| Manifest + live overlap | enriched in place, `inManifest=true` |

## Files

| Path | Role |
| -- | -- |
| `internal/server/providers/manifest/` | YAML parser, refresh-loop provider, status |
| `internal/server/resolvers/manifest_merge.go` | Merge live-fleet + manifest, GraphQL projection helpers |
| `schema.graphql` | New types/fields + `HostRole` enum |
| `internal/server/manifest_e2e_test.go` | End-to-end via `httptest.Server` + GraphQL handler |

## Acceptance criteria

- [x] Daemon reads `$FLEET_MANIFEST` (default `~/.claude/references/fleet-manifest.yaml`) at startup
- [x] Periodic re-read every 60s (configurable via `manifest.WithInterval`)
- [x] `{ hosts { hostname purpose role ownerOrchardist decommissionSignal lastVerified inManifest reachable lastSeenAt } }` returns the merged view
- [x] Manifest-only hosts → `reachable: false, lastSeenAt: null, inManifest: true`
- [x] Live-only hosts → `inManifest: false` (drift signal)
- [x] Manifest parse errors surface via `Query.health.manifest.error`; daemon does not crash

## Test plan

- [x] `go test ./internal/server/providers/manifest/...` — parser + refresh loop + missing/broken file handling
- [x] `go test ./internal/server/resolvers/...` — merge logic, drift, address fallback, status projection
- [x] `go test ./internal/server -run TestManifestE2E` — full GraphQL handler over a temp manifest, broken-manifest survival, periodic refresh observed end-to-end
- [x] `go vet ./...`, `gofmt`, `cargo check -p orchard`, `cargo clippy -p orchard --all-targets -- -D warnings`, `cargo fmt --check`
- Pre-existing test failures on this VM (`hostservice_e2e_test.go`, `tmux_e2e_test.go`) confirmed to fail on `origin/main` — unrelated to this change.

## North Star

Closes Component 3 (Fleet inventoried) gap: score 2 → 3. The daemon is now the source of truth for the fleet inventory; skills can drop the python-side YAML parse and hit the daemon directly. Anchors meta-contract C-2026-05-13-ade05bdd (C3 → 3 final 0.25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fleet manifest ingestion with periodic refresh from manifest files
  * Host enrichment with manifest-derived metadata (purpose, role, owner/orchardist, decommission signal, last verified date)
  * Health endpoint now exposes manifest status (loaded state, file path, host count, load errors)
  * Host visibility merged with manifest data, enabling detection of drift when live hosts diverge from manifest

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/586)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #584

# Related issue

- #584