### PR TITLE
feat(daemon): Worktree.ahead and Worktree.behind (closes #483)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3147,7 +3147,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchard"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/orchard/src/daemon/client.rs
+++ b/crates/orchard/src/daemon/client.rs
@@ -178,6 +178,8 @@ impl Client {
                     bare
                     host
                     repo
+                    ahead
+                    behind
                     pr {
                       number
                       state

--- a/crates/orchard/src/daemon/types.rs
+++ b/crates/orchard/src/daemon/types.rs
@@ -181,6 +181,15 @@ pub struct WorkViewWorktree {
     /// Repository slug (`owner/repo`).
     pub repo: String,
 
+    /// Commits ahead of upstream. `None` when no upstream is configured, HEAD
+    /// is detached, or the count could not be determined (#483).
+    #[serde(default)]
+    pub ahead: Option<u32>,
+
+    /// Commits behind upstream. Same null semantics as `ahead`.
+    #[serde(default)]
+    pub behind: Option<u32>,
+
     /// Open PR whose head branch matches this worktree's branch. `None` when
     /// there is no open matching PR. Note: closed/merged PRs are **not**
     /// included in v1 (see research/035 for the schema limitation).

--- a/crates/orchard/src/daemon/work_view_adapter.rs
+++ b/crates/orchard/src/daemon/work_view_adapter.rs
@@ -309,8 +309,8 @@ fn work_view_worktree_to_cached(wt: &crate::daemon::types::WorkViewWorktree) -> 
         } else {
             Some(wt.host.clone())
         },
-        ahead: wt.ahead.filter(|&n| n > 0),
-        behind: wt.behind.filter(|&n| n > 0),
+        ahead: wt.ahead,
+        behind: wt.behind,
         last_commit_at: None,
         layout: WorktreeLayout::Bare,
     }

--- a/crates/orchard/src/daemon/work_view_adapter.rs
+++ b/crates/orchard/src/daemon/work_view_adapter.rs
@@ -39,13 +39,6 @@ use crate::session::{
     EnrichedSession, Host, SessionStatus, StandaloneConfig, StandaloneSessionRow, TmuxSessionInfo,
 };
 
-/// Two-level map of ahead/behind commit counts: `project_dir → branch → (ahead, behind)`.
-///
-/// Populated by `tui::App::start_full_refresh` via `git branch -vv` per project
-/// directory, until daemon issue #483 lands and the daemon's `Worktree` type
-/// exposes `ahead`/`behind` directly.
-pub type AheadBehindMap = HashMap<String, HashMap<String, (u32, u32)>>;
-
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -64,18 +57,12 @@ pub type AheadBehindMap = HashMap<String, HashMap<String, (u32, u32)>>;
 /// Remote enrichment (`*_remote_worktrees.json` / `*_remote_tmux_sessions.json`)
 /// is folded in by the existing `merge_remote::merge_remote_snapshot` path.
 ///
-/// # ahead_behind carve-out
-///
-/// `ahead_behind` is a two-level map `project_dir → branch → (ahead, behind)`.
-/// It is populated by `tui::App::start_full_refresh` via `git branch -vv` per
-/// project directory. Pass `None` when ahead/behind data is unavailable (daemon
-/// unreachable, cold start, or local-only refresh). Remove once the daemon's
-/// `Worktree` type exposes `ahead`/`behind` directly.
+/// Ahead/behind counts come from `WorkViewWorktree.ahead` / `.behind` (daemon
+/// issue #483) — populated server-side by the git provider.
 pub fn build_local_state(
     snapshot: &WorkViewSnapshot,
     config: &GlobalConfig,
     hosts: &HashMap<String, HostState>,
-    ahead_behind: Option<&AheadBehindMap>,
 ) -> OrchardState {
     // 1. Convert ClaudeInstances → ClaudeStateFiles (indexed by session name).
     let claude_states: Vec<ClaudeStateFile> = snapshot
@@ -116,12 +103,8 @@ pub fn build_local_state(
                 }
             }
 
-            // Worktree entry (with ahead/behind from git branch -vv carve-out).
-            let wt_ab = ahead_behind
-                .and_then(|ab| ab.get(&repo.path))
-                .and_then(|branch_map| branch_map.get(&wt.branch))
-                .copied();
-            entry.3.push(work_view_worktree_to_cached(wt, wt_ab));
+            // Worktree entry. Ahead/behind come from the daemon (#483).
+            entry.3.push(work_view_worktree_to_cached(wt));
         }
     }
 
@@ -314,13 +297,10 @@ fn build_standalone_sessions(
 
 /// Converts a [`WorkViewWorktree`] into a [`CachedWorktree`].
 ///
-/// `ahead_behind` carries the `(ahead, behind)` counts from the `git branch -vv`
-/// carve-out in `tui::App::start_full_refresh`. Pass `None` when unavailable.
+/// Ahead/behind are read directly from the daemon-supplied fields (#483).
 fn work_view_worktree_to_cached(
     wt: &crate::daemon::types::WorkViewWorktree,
-    ahead_behind: Option<(u32, u32)>,
 ) -> CachedWorktree {
-    let (ahead, behind) = ahead_behind.unwrap_or((0, 0));
     CachedWorktree {
         path: wt.path.clone(),
         branch: wt.branch.clone(),
@@ -331,8 +311,8 @@ fn work_view_worktree_to_cached(
         } else {
             Some(wt.host.clone())
         },
-        ahead: if ahead > 0 { Some(ahead) } else { None },
-        behind: if behind > 0 { Some(behind) } else { None },
+        ahead: wt.ahead.filter(|&n| n > 0),
+        behind: wt.behind.filter(|&n| n > 0),
         last_commit_at: None,
         layout: WorktreeLayout::Bare,
     }
@@ -589,6 +569,8 @@ mod tests {
                 bare: false,
                 host: "local".to_string(),
                 repo: repo.to_string(),
+                ahead: None,
+                behind: None,
                 pr,
                 issue,
             });
@@ -679,7 +661,7 @@ mod tests {
             )
             .build();
 
-        let state = build_local_state(&snapshot, &empty_config(), &HashMap::new(), None);
+        let state = build_local_state(&snapshot, &empty_config(), &HashMap::new());
 
         assert_eq!(state.repos.len(), 1);
         let repo = &state.repos[0];
@@ -718,7 +700,7 @@ mod tests {
             .session("issue429", Some(wt_path))
             .build();
 
-        let state = build_local_state(&snapshot, &empty_config(), &HashMap::new(), None);
+        let state = build_local_state(&snapshot, &empty_config(), &HashMap::new());
 
         let wt = state
             .repos
@@ -754,7 +736,7 @@ mod tests {
             .claude("issue429", "working", session_uuid)
             .build();
 
-        let state = build_local_state(&snapshot, &empty_config(), &HashMap::new(), None);
+        let state = build_local_state(&snapshot, &empty_config(), &HashMap::new());
 
         let wt = state
             .repos
@@ -799,7 +781,7 @@ mod tests {
             .session("shepherd", Some("/home/user"))
             .build();
 
-        let state = build_local_state(&snapshot, &empty_config(), &HashMap::new(), None);
+        let state = build_local_state(&snapshot, &empty_config(), &HashMap::new());
 
         // The shepherd session should be standalone, not attached to a worktree.
         let worktree_sessions: Vec<&str> = state
@@ -842,7 +824,7 @@ mod tests {
             HostState { reachable: true },
         );
 
-        let state = build_local_state(&snapshot, &empty_config(), &hosts, None);
+        let state = build_local_state(&snapshot, &empty_config(), &hosts);
 
         assert!(state.repos.is_empty());
         assert!(state.standalone_sessions.is_empty());

--- a/crates/orchard/src/daemon/work_view_adapter.rs
+++ b/crates/orchard/src/daemon/work_view_adapter.rs
@@ -298,9 +298,7 @@ fn build_standalone_sessions(
 /// Converts a [`WorkViewWorktree`] into a [`CachedWorktree`].
 ///
 /// Ahead/behind are read directly from the daemon-supplied fields (#483).
-fn work_view_worktree_to_cached(
-    wt: &crate::daemon::types::WorkViewWorktree,
-) -> CachedWorktree {
+fn work_view_worktree_to_cached(wt: &crate::daemon::types::WorkViewWorktree) -> CachedWorktree {
     CachedWorktree {
         path: wt.path.clone(),
         branch: wt.branch.clone(),

--- a/crates/orchard/src/tui/mod.rs
+++ b/crates/orchard/src/tui/mod.rs
@@ -222,30 +222,6 @@ pub struct App {
     /// the message handler can share it across the channel boundary.
     work_view_snapshot: std::sync::Arc<std::sync::Mutex<Option<crate::daemon::WorkViewSnapshot>>>,
 
-    /// Ahead/behind counts fetched via `git branch -vv` in `start_full_refresh`.
-    ///
-    /// Keyed by project directory path → branch name → `(ahead, behind)`.
-    ///
-    /// # Carve-out: ahead/behind via `git branch -vv`
-    ///
-    /// The daemon's `Worktree` schema does not yet expose `ahead`/`behind`
-    /// counts. Until the daemon exposes these fields, the refresh thread
-    /// shells out to `git branch -vv` per project directory to populate them.
-    /// Remove this field and the corresponding `git branch -vv` call in
-    /// `start_full_refresh` once the daemon exposes `Worktree.ahead` and
-    /// `Worktree.behind` (tracked as daemon issue #483).
-    ///
-    /// **Staleness note**: this slot is populated by `start_full_refresh` only —
-    /// the local-only refresh path (`start_local_refresh`) does NOT re-run
-    /// `git branch -vv` per project to keep the local tick fast. Worst-case
-    /// staleness for ahead/behind data is bounded by the full refresh cadence
-    /// (~60s + focus events). New branches that appear between full refreshes
-    /// render with stale (or zero) ahead/behind until the next full tick. This
-    /// is acceptable because ahead/behind is a hint, not a contract — and
-    /// tracked-for-removal in #483 (daemon to expose ahead/behind directly).
-    ahead_behind_snapshot:
-        std::sync::Arc<std::sync::Mutex<Option<crate::daemon::work_view_adapter::AheadBehindMap>>>,
-
     /// Injectable source for `workView` GraphQL queries.
     ///
     /// In production this is a real [`crate::daemon::Client`].
@@ -354,7 +330,6 @@ impl App {
                 let initial_snap = crate::daemon::work_view_cache::read_snapshot();
                 std::sync::Arc::new(std::sync::Mutex::new(initial_snap))
             },
-            ahead_behind_snapshot: std::sync::Arc::new(std::sync::Mutex::new(None)),
             work_view_source: {
                 // Build the daemon client; fall back to a no-op source if the
                 // client cannot be constructed (e.g. invalid URL env var).
@@ -780,7 +755,6 @@ impl App {
         let config = self.global_config.clone();
         let tx = self.tx.clone();
         let work_view_slot = self.work_view_snapshot.clone();
-        let ahead_behind_slot = self.ahead_behind_snapshot.clone();
         let work_view_source = self.work_view_source.clone();
         std::thread::spawn(move || {
             // Probe each unique remote host concurrently before attempting remote
@@ -804,14 +778,6 @@ impl App {
             //           refresh_worktrees + refresh_tmux_sessions
             match work_view_source.work_view() {
                 Ok(snapshot) => {
-                    // Carve-out: ahead/behind via `git branch -vv` — runs in
-                    // parallel across all configured repos via
-                    // `fetch_ahead_behind_for_snapshot`. Remove once the daemon
-                    // exposes `Worktree.ahead`/`Worktree.behind` (tracked as #483).
-                    let ahead_behind = fetch_ahead_behind_for_snapshot(&config);
-                    if let Ok(mut slot) = ahead_behind_slot.lock() {
-                        *slot = Some(ahead_behind);
-                    }
                     // Persist snapshot so cold-start fallback has fresh data.
                     if let Err(e) = crate::daemon::work_view_cache::write_snapshot(&snapshot) {
                         crate::logger::LOG.warn(&format!("work_view_cache write failed: {e}"));
@@ -848,16 +814,6 @@ impl App {
     /// `cache_sources::refresh_tmux_sessions` calls with a single round-trip
     /// to the daemon. No remote host probing, no GitHub API calls.
     /// Sends `AppMsg::LocalCacheRefreshed` when done.
-    ///
-    /// **Staleness note**: `ahead_behind_snapshot` is populated by
-    /// `start_full_refresh` only — this local-only refresh path does NOT
-    /// re-run `git branch -vv` per project to keep the local tick fast.
-    /// Worst-case staleness for ahead/behind data is bounded by the full
-    /// refresh cadence (~60s + focus events). New branches that appear
-    /// between full refreshes render with stale (or zero) ahead/behind
-    /// until the next full tick. This is acceptable because ahead/behind
-    /// is a hint, not a contract — and tracked-for-removal in #483
-    /// (daemon to expose ahead/behind directly).
     fn start_local_refresh(&self) {
         let tx = self.tx.clone();
         let work_view_slot = self.work_view_snapshot.clone();
@@ -895,18 +851,12 @@ impl App {
     fn rebuild_state_from_snapshot(&self) -> crate::orchard_state::OrchardState {
         let hosts = crate::cache::read_host_reachability();
         let snapshot_opt = self.work_view_snapshot.lock().ok().and_then(|g| g.clone());
-        let ahead_behind_opt = self
-            .ahead_behind_snapshot
-            .lock()
-            .ok()
-            .and_then(|g| g.clone());
 
         let mut state = if let Some(snapshot) = snapshot_opt {
             crate::daemon::work_view_adapter::build_local_state(
                 &snapshot,
                 &self.global_config,
                 &hosts,
-                ahead_behind_opt.as_ref(),
             )
         } else {
             crate::build_state::build_state_with_hosts(&self.global_config, &hosts)
@@ -2329,7 +2279,6 @@ impl App {
             seen_expandable_keys: HashSet::new(),
             seen_window_keys: HashSet::new(),
             work_view_snapshot: std::sync::Arc::new(std::sync::Mutex::new(None)),
-            ahead_behind_snapshot: std::sync::Arc::new(std::sync::Mutex::new(None)),
             work_view_source: std::sync::Arc::new(crate::tui::refresh::NullWorkViewSource),
             daemon_status: DaemonStatus::Unknown,
         };
@@ -2519,31 +2468,6 @@ pub(crate) fn current_selection(app: &App) -> Option<last_selection::LastSelecti
         });
     }
     None
-}
-
-/// Fetches ahead/behind commit counts for every configured repo by running
-/// `git branch -vv` per repo directory, in parallel.
-///
-/// The daemon's `Worktree` schema does not yet expose `ahead`/`behind` counts
-/// (tracked in #483); this is a temporary carve-out that will be removed when
-/// the daemon ships those fields.
-///
-/// Returns a `HashMap` keyed by repo directory path → branch name →
-/// `(ahead, behind)`.
-fn fetch_ahead_behind_for_snapshot(
-    config: &global_config::GlobalConfig,
-) -> crate::daemon::work_view_adapter::AheadBehindMap {
-    let result: std::sync::Mutex<crate::daemon::work_view_adapter::AheadBehindMap> =
-        std::sync::Mutex::new(HashMap::new());
-    crate::refresh_parallel::for_each_repo_parallel(config, |repo| {
-        if let Ok(out) = crate::cache_sources::run_local_in("git", &["branch", "-vv"], &repo.path) {
-            let branch_map = crate::cache_sources::parse_git_ahead_behind(&out);
-            if let Ok(mut acc) = result.lock() {
-                acc.insert(repo.path.clone(), branch_map);
-            }
-        }
-    });
-    result.into_inner().unwrap_or_default()
 }
 
 // ---------------------------------------------------------------------------
@@ -5904,6 +5828,8 @@ mod tests {
                     bare: false,
                     host: "local".to_string(),
                     repo: "owner/repo".to_string(),
+                    ahead: None,
+                    behind: None,
                     pr: None,
                     issue: None,
                 }],
@@ -6076,6 +6002,8 @@ mod tests {
                     bare: false,
                     host: "local".to_string(),
                     repo: "owner/repo".to_string(),
+                    ahead: None,
+                    behind: None,
                     pr: None,
                     issue: None,
                 }],
@@ -6174,6 +6102,8 @@ mod tests {
                     bare: false,
                     host: "local".to_string(),
                     repo: "owner/repo".to_string(),
+                    ahead: None,
+                    behind: None,
                     pr: None,
                     issue: None,
                 }],

--- a/crates/orchard/src/tui/refresh.rs
+++ b/crates/orchard/src/tui/refresh.rs
@@ -536,8 +536,7 @@ mod tests {
             claude_instances: vec![],
         };
 
-        let mut state =
-            build_local_state(&snapshot, &GlobalConfig::default(), &HashMap::new());
+        let mut state = build_local_state(&snapshot, &GlobalConfig::default(), &HashMap::new());
 
         // ---- Remote data via merge_remote_snapshot -------------------------
 

--- a/crates/orchard/src/tui/refresh.rs
+++ b/crates/orchard/src/tui/refresh.rs
@@ -513,6 +513,8 @@ mod tests {
                         bare: false,
                         host: "local".to_string(),
                         repo: "owner/repo".to_string(),
+                        ahead: None,
+                        behind: None,
                         pr: None,
                         issue: None,
                     },
@@ -523,6 +525,8 @@ mod tests {
                         bare: false,
                         host: "local".to_string(),
                         repo: "owner/repo".to_string(),
+                        ahead: None,
+                        behind: None,
                         pr: None,
                         issue: None,
                     },
@@ -533,7 +537,7 @@ mod tests {
         };
 
         let mut state =
-            build_local_state(&snapshot, &GlobalConfig::default(), &HashMap::new(), None);
+            build_local_state(&snapshot, &GlobalConfig::default(), &HashMap::new());
 
         // ---- Remote data via merge_remote_snapshot -------------------------
 

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -406,7 +406,9 @@ type ComplexityRoot struct {
 	}
 
 	Worktree struct {
+		Ahead           func(childComplexity int) int
 		Bare            func(childComplexity int) int
+		Behind          func(childComplexity int) int
 		Branch          func(childComplexity int) int
 		ClaudeInstances func(childComplexity int) int
 		Head            func(childComplexity int) int
@@ -2538,12 +2540,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.WorkflowRun.WorkflowPath(childComplexity), true
 
+	case "Worktree.ahead":
+		if e.complexity.Worktree.Ahead == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Ahead(childComplexity), true
+
 	case "Worktree.bare":
 		if e.complexity.Worktree.Bare == nil {
 			break
 		}
 
 		return e.complexity.Worktree.Bare(childComplexity), true
+
+	case "Worktree.behind":
+		if e.complexity.Worktree.Behind == nil {
+			break
+		}
+
+		return e.complexity.Worktree.Behind(childComplexity), true
 
 	case "Worktree.branch":
 		if e.complexity.Worktree.Branch == nil {
@@ -3468,6 +3484,22 @@ type Worktree implements Node {
   grouping of windows/panes). A worktree can carry zero or many of each.
   """
   claudeInstances: [ClaudeInstance!]!
+
+  """
+  Number of commits the worktree's branch is AHEAD of its upstream tracking
+  branch (issue #483). Computed from ` + "`" + `git rev-list --left-right --count <upstream>...HEAD` + "`" + `.
+  Null when the branch has no upstream configured, when HEAD is detached, or
+  when the count cannot be determined.
+  """
+  ahead: Int
+
+  """
+  Number of commits the worktree's branch is BEHIND its upstream tracking
+  branch (issue #483). Computed from ` + "`" + `git rev-list --left-right --count <upstream>...HEAD` + "`" + `.
+  Null when the branch has no upstream configured, when HEAD is detached, or
+  when the count cannot be determined.
+  """
+  behind: Int
 }
 
 # ---------------------------------------------------------------------
@@ -5637,6 +5669,10 @@ func (ec *executionContext) fieldContext_ClaudeInstance_worktree(ctx context.Con
 				return ec.fieldContext_Worktree_tmuxSession(ctx, field)
 			case "claudeInstances":
 				return ec.fieldContext_Worktree_claudeInstances(ctx, field)
+			case "ahead":
+				return ec.fieldContext_Worktree_ahead(ctx, field)
+			case "behind":
+				return ec.fieldContext_Worktree_behind(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Worktree", field.Name)
 		},
@@ -10237,6 +10273,10 @@ func (ec *executionContext) fieldContext_Process_worktree(ctx context.Context, f
 				return ec.fieldContext_Worktree_tmuxSession(ctx, field)
 			case "claudeInstances":
 				return ec.fieldContext_Worktree_claudeInstances(ctx, field)
+			case "ahead":
+				return ec.fieldContext_Worktree_ahead(ctx, field)
+			case "behind":
+				return ec.fieldContext_Worktree_behind(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Worktree", field.Name)
 		},
@@ -13972,6 +14012,10 @@ func (ec *executionContext) fieldContext_Repo_worktrees(ctx context.Context, fie
 				return ec.fieldContext_Worktree_tmuxSession(ctx, field)
 			case "claudeInstances":
 				return ec.fieldContext_Worktree_claudeInstances(ctx, field)
+			case "ahead":
+				return ec.fieldContext_Worktree_ahead(ctx, field)
+			case "behind":
+				return ec.fieldContext_Worktree_behind(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Worktree", field.Name)
 		},
@@ -14833,6 +14877,10 @@ func (ec *executionContext) fieldContext_Subscription_worktreeChanged(ctx contex
 				return ec.fieldContext_Worktree_tmuxSession(ctx, field)
 			case "claudeInstances":
 				return ec.fieldContext_Worktree_claudeInstances(ctx, field)
+			case "ahead":
+				return ec.fieldContext_Worktree_ahead(ctx, field)
+			case "behind":
+				return ec.fieldContext_Worktree_behind(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Worktree", field.Name)
 		},
@@ -19038,6 +19086,88 @@ func (ec *executionContext) fieldContext_Worktree_claudeInstances(ctx context.Co
 				return ec.fieldContext_ClaudeInstance_conversation(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ClaudeInstance", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_ahead(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_ahead(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Ahead, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_ahead(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Worktree_behind(ctx context.Context, field graphql.CollectedField, obj *Worktree) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Worktree_behind(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Behind, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int64)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Worktree_behind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Worktree",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -25724,6 +25854,10 @@ func (ec *executionContext) _Worktree(ctx context.Context, sel ast.SelectionSet,
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "ahead":
+			out.Values[i] = ec._Worktree_ahead(ctx, field, obj)
+		case "behind":
+			out.Values[i] = ec._Worktree_behind(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -853,6 +853,16 @@ type Worktree struct {
 	// sessionUuid) is distinct from a *tmux session* (TmuxSession — server
 	// grouping of windows/panes). A worktree can carry zero or many of each.
 	ClaudeInstances []*ClaudeInstance `json:"claudeInstances"`
+	// Number of commits the worktree's branch is AHEAD of its upstream tracking
+	// branch (issue #483). Computed from `git rev-list --left-right --count <upstream>...HEAD`.
+	// Null when the branch has no upstream configured, when HEAD is detached, or
+	// when the count cannot be determined.
+	Ahead *int64 `json:"ahead,omitempty"`
+	// Number of commits the worktree's branch is BEHIND its upstream tracking
+	// branch (issue #483). Computed from `git rev-list --left-right --count <upstream>...HEAD`.
+	// Null when the branch has no upstream configured, when HEAD is detached, or
+	// when the count cannot be determined.
+	Behind *int64 `json:"behind,omitempty"`
 }
 
 func (Worktree) IsNode() {}

--- a/internal/server/providers/git/adapter.go
+++ b/internal/server/providers/git/adapter.go
@@ -192,8 +192,9 @@ func readLinkedWorktree(p Project, name string) (Worktree, error) {
 }
 
 // computeAheadBehind shells out to `git rev-list --left-right --count
-// @{u}...HEAD` from worktreePath and parses the two-column "ahead\tbehind"
-// output (#483).
+// @{u}...HEAD` from worktreePath and parses the two-column
+// "behind\tahead" output (`--left-right` prints upstream-only commits
+// first, then HEAD-only) (#483).
 //
 // Returns (nil, nil) when:
 //   - branch is empty (detached HEAD) or bare is true (deleted upstream)

--- a/internal/server/providers/git/adapter.go
+++ b/internal/server/providers/git/adapter.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // GitWorktreeAdapter reads `.git/worktrees/<name>/HEAD` + `gitdir` files
@@ -98,6 +101,7 @@ func readMainWorktree(p Project) (Worktree, error) {
 	if err != nil {
 		return Worktree{}, fmt.Errorf("read HEAD: %w", err)
 	}
+	ahead, behind := computeAheadBehind(p.Dir, branch, bare)
 	return Worktree{
 		ID:        NewWorktreeID(p.ID, MainWorktreeName),
 		ProjectID: p.ID,
@@ -106,6 +110,8 @@ func readMainWorktree(p Project) (Worktree, error) {
 		Branch:    branch,
 		Head:      head,
 		Bare:      bare,
+		Ahead:     ahead,
+		Behind:    behind,
 	}, nil
 }
 
@@ -171,6 +177,7 @@ func readLinkedWorktree(p Project, name string) (Worktree, error) {
 		return Worktree{}, fmt.Errorf("read HEAD for %q: %w", name, err)
 	}
 
+	ahead, behind := computeAheadBehind(worktreeRoot, branch, bare)
 	return Worktree{
 		ID:        NewWorktreeID(p.ID, name),
 		ProjectID: p.ID,
@@ -179,7 +186,49 @@ func readLinkedWorktree(p Project, name string) (Worktree, error) {
 		Branch:    branch,
 		Head:      head,
 		Bare:      bare,
+		Ahead:     ahead,
+		Behind:    behind,
 	}, nil
+}
+
+// computeAheadBehind shells out to `git rev-list --left-right --count
+// @{u}...HEAD` from worktreePath and parses the two-column "ahead\tbehind"
+// output (#483).
+//
+// Returns (nil, nil) when:
+//   - branch is empty (detached HEAD) or bare is true (deleted upstream)
+//   - the worktree has no upstream configured (`@{u}` resolution fails)
+//   - the git command times out, errors, or produces unparseable output
+//
+// All failure modes are silent. ahead/behind is enrichment, not load-bearing.
+func computeAheadBehind(worktreePath, branch string, bare bool) (*int64, *int64) {
+	if branch == "" || bare {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", worktreePath, "rev-list",
+		"--left-right", "--count", "@{u}...HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, nil
+	}
+	fields := strings.Fields(strings.TrimSpace(string(out)))
+	if len(fields) != 2 {
+		return nil, nil
+	}
+	// `--left-right --count A...B` prints "<left>\t<right>" where
+	// left=A-only commits (behind from B's view) and right=B-only (ahead).
+	// We invoked with @{u}...HEAD so behind=fields[0], ahead=fields[1].
+	behindN, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil {
+		return nil, nil
+	}
+	aheadN, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return nil, nil
+	}
+	return &aheadN, &behindN
 }
 
 // readHeadFile parses HEAD. Either a `ref: refs/heads/<branch>` line

--- a/internal/server/providers/git/adapter_ahead_behind_test.go
+++ b/internal/server/providers/git/adapter_ahead_behind_test.go
@@ -1,0 +1,101 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// TestComputeAheadBehind_NoUpstream verifies that a branch without a
+// configured upstream returns (nil, nil) — #483 ahead/behind enrichment
+// must be silent on failure, never blocking the worktree read.
+func TestComputeAheadBehind_NoUpstream(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	repo := initRepoWithCommit(t)
+	ahead, behind := computeAheadBehind(repo, "main", false)
+	if ahead != nil || behind != nil {
+		t.Fatalf("no-upstream branch: got ahead=%v behind=%v, want nil/nil", ahead, behind)
+	}
+}
+
+// TestComputeAheadBehind_DetachedOrBare verifies the cheap pre-checks.
+func TestComputeAheadBehind_DetachedOrBare(t *testing.T) {
+	ahead, behind := computeAheadBehind("/nonexistent", "", false)
+	if ahead != nil || behind != nil {
+		t.Errorf("detached: got ahead=%v behind=%v, want nil/nil", ahead, behind)
+	}
+	ahead, behind = computeAheadBehind("/nonexistent", "main", true)
+	if ahead != nil || behind != nil {
+		t.Errorf("bare: got ahead=%v behind=%v, want nil/nil", ahead, behind)
+	}
+}
+
+// TestComputeAheadBehind_WithUpstream exercises the happy path against a
+// real git repo: clone-and-diverge sets up known ahead/behind counts and
+// the helper must parse them in the documented order (ahead, behind).
+func TestComputeAheadBehind_WithUpstream(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	origin := initRepoWithCommit(t)
+	// Add two more commits to origin so the clone can fall behind by 2.
+	commitFile(t, origin, "second.txt", "two")
+	commitFile(t, origin, "third.txt", "three")
+
+	cloneDir := t.TempDir()
+	runGitT(t, "", "clone", "--branch", "main", origin, cloneDir)
+
+	// Roll the clone back two commits so it is BEHIND origin by 2.
+	runGitT(t, cloneDir, "reset", "--hard", "HEAD~2")
+	// Add one local commit to be AHEAD by 1.
+	commitFile(t, cloneDir, "local.txt", "local")
+
+	ahead, behind := computeAheadBehind(cloneDir, "main", false)
+	if ahead == nil || behind == nil {
+		t.Fatalf("ahead/behind nil: ahead=%v behind=%v", ahead, behind)
+	}
+	if *ahead != 1 {
+		t.Errorf("ahead: got %d, want 1", *ahead)
+	}
+	if *behind != 2 {
+		t.Errorf("behind: got %d, want 2", *behind)
+	}
+}
+
+// initRepoWithCommit creates a real git repo at a temp dir with one
+// initial commit on main. Returns the worktree path.
+func initRepoWithCommit(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGitT(t, "", "init", "--initial-branch=main", "-q", dir)
+	runGitT(t, dir, "config", "user.email", "test@example.com")
+	runGitT(t, dir, "config", "user.name", "Test")
+	runGitT(t, dir, "config", "commit.gpgsign", "false")
+	commitFile(t, dir, "README.md", "hello")
+	return dir
+}
+
+func commitFile(t *testing.T, repo, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	runGitT(t, repo, "add", name)
+	runGitT(t, repo, "commit", "-q", "-m", "add "+name)
+}
+
+func runGitT(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}

--- a/internal/server/providers/git/types.go
+++ b/internal/server/providers/git/types.go
@@ -63,6 +63,13 @@ type Worktree struct {
 	Branch    string // empty when detached or bare
 	Head      string // 40-char SHA, or "" when HEAD cannot be resolved
 	Bare      bool
+	// Ahead is the commit count this branch is ahead of its upstream (#483).
+	// Nil when the branch has no upstream, HEAD is detached, or the count
+	// could not be computed (e.g. transient git failure).
+	Ahead *int64
+	// Behind is the commit count this branch is behind its upstream (#483).
+	// Same nil semantics as Ahead.
+	Behind *int64
 }
 
 // CleanPath returns p with [filepath.Clean] applied. We keep this in a

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -725,6 +725,22 @@ type Worktree implements Node {
   grouping of windows/panes). A worktree can carry zero or many of each.
   """
   claudeInstances: [ClaudeInstance!]!
+
+  """
+  Number of commits the worktree's branch is AHEAD of its upstream tracking
+  branch (issue #483). Computed from `git rev-list --left-right --count <upstream>...HEAD`.
+  Null when the branch has no upstream configured, when HEAD is detached, or
+  when the count cannot be determined.
+  """
+  ahead: Int
+
+  """
+  Number of commits the worktree's branch is BEHIND its upstream tracking
+  branch (issue #483). Computed from `git rev-list --left-right --count <upstream>...HEAD`.
+  Null when the branch has no upstream configured, when HEAD is detached, or
+  when the count cannot be determined.
+  """
+  behind: Int
 }
 
 # ---------------------------------------------------------------------

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -1842,6 +1842,8 @@ func toGraphQLWorktree(w gitprovider.Worktree) *graphql1.Worktree {
 		Head:   w.Head,
 		Bare:   w.Bare,
 		Host:   "local",
+		Ahead:  w.Ahead,
+		Behind: w.Behind,
 	}
 }
 func projectProcess(p *ps.Process, hostID string) *graphql1.Process {

--- a/schema.graphql
+++ b/schema.graphql
@@ -725,6 +725,22 @@ type Worktree implements Node {
   grouping of windows/panes). A worktree can carry zero or many of each.
   """
   claudeInstances: [ClaudeInstance!]!
+
+  """
+  Number of commits the worktree's branch is AHEAD of its upstream tracking
+  branch (issue #483). Computed from `git rev-list --left-right --count <upstream>...HEAD`.
+  Null when the branch has no upstream configured, when HEAD is detached, or
+  when the count cannot be determined.
+  """
+  ahead: Int
+
+  """
+  Number of commits the worktree's branch is BEHIND its upstream tracking
+  branch (issue #483). Computed from `git rev-list --left-right --count <upstream>...HEAD`.
+  Null when the branch has no upstream configured, when HEAD is detached, or
+  when the count cannot be determined.
+  """
+  behind: Int
 }
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Daemon's `Worktree` GraphQL type now exposes `ahead: Int` and `behind: Int`, populated by `git rev-list --left-right --count @{u}...HEAD` inside the git provider. Null when no upstream, detached HEAD, or the command fails (silent — ahead/behind is enrichment).
- Rust client `workView` query selects the new fields; `WorkViewWorktree` carries `Option<u32>` for each.
- Retires the TUI's `git branch -vv` workaround from PR #482: removes `App.ahead_behind_snapshot`, the per-repo parallel shell-out in `start_full_refresh`, the `ahead_behind` parameter on `build_local_state`/`work_view_worktree_to_cached`, and the `fetch_ahead_behind_for_snapshot` helper.

## Verification

- `go test ./internal/...` — green, including new `TestComputeAheadBehind_{NoUpstream,DetachedOrBare,WithUpstream}` in `internal/server/providers/git/`.
- `cargo build --release` + `cargo test -p orchard` — green (two pre-existing macOS flakes in `json_freshness_integration` confirmed unchanged on main).
- **Live daemon introspection** (rebuilt binary, side instance on 7778):
  ```
  Worktree fields → ...,claudeInstances,ahead,behind
  workView → drewdrewthis/git-orchard-rs main → ahead:0 behind:1
             issue336/bootstrap-orchard-on-remotes → ahead:9 behind:117
             worktree-named branches (no upstream) → ahead:null behind:null
  ```

## Test plan

- [x] gqlgen regen via `make generate` with snapshot guard for `schema.resolvers.go` (#582 trap held — reverted from `/tmp` snapshot after generate)
- [x] Go provider unit tests cover no-upstream, detached/bare, and the happy-path parse-order assertion
- [x] Rust test-fixture `WorkViewWorktree` literals updated with explicit `ahead: None, behind: None`
- [x] Live introspection + workView query verify both schema shape and real values

Closes #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display ahead/behind commit counts for each worktree (how many commits a branch is ahead/behind its upstream). Values are null when upstream is missing, HEAD is detached, or the count can’t be determined.

* **Refactor**
  * Startup now pre-populates the view from a cached snapshot so the first render shows stale-but-populated data; refresh flow simplified to use daemon-provided ahead/behind data.

* **Tests**
  * Added tests validating ahead/behind computation and behavior for missing upstreams and detached states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/587)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #483

# Related issue

- #483

# Related issue

- #483

# Related issue

- #483

# Related issue

- #483