### PR TITLE
feat(daemon): Issue dependency graph + paginated gh-client (closes #563 #579)

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -223,9 +223,23 @@ models:
   # list) and projected to the GraphQL Label type by a custom resolver
   # so the orchard phase-label filter and color/description mapping live
   # in one place — same shape as PullRequest.labels.
+  #
+  # Dependency fields (blockedByIssues, blockingIssues, subIssues,
+  # parentIssue — #563) hit GitHub's GraphQL with the preview-gated
+  # `issue_types,sub_issues` features. EnrichIssueDependencies fetches
+  # all four edges in one round-trip and caches them with a short TTL;
+  # each field resolver projects one edge.
   Issue:
     fields:
       labels:
+        resolver: true
+      blockedByIssues:
+        resolver: true
+      blockingIssues:
+        resolver: true
+      subIssues:
+        resolver: true
+      parentIssue:
         resolver: true
 
   # JSON scalar binds to gqlgen's Any marshaller, which round-trips any

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -158,19 +158,23 @@ type ComplexityRoot struct {
 	}
 
 	Issue struct {
-		AuthorLogin func(childComplexity int) int
-		Body        func(childComplexity int) int
-		Comments    func(childComplexity int) int
-		CreatedAt   func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Labels      func(childComplexity int) int
-		Number      func(childComplexity int) int
-		RepoName    func(childComplexity int) int
-		RepoOwner   func(childComplexity int) int
-		State       func(childComplexity int) int
-		Title       func(childComplexity int) int
-		URL         func(childComplexity int) int
-		UpdatedAt   func(childComplexity int) int
+		AuthorLogin     func(childComplexity int) int
+		BlockedByIssues func(childComplexity int) int
+		BlockingIssues  func(childComplexity int) int
+		Body            func(childComplexity int) int
+		Comments        func(childComplexity int) int
+		CreatedAt       func(childComplexity int) int
+		ID              func(childComplexity int) int
+		Labels          func(childComplexity int) int
+		Number          func(childComplexity int) int
+		ParentIssue     func(childComplexity int) int
+		RepoName        func(childComplexity int) int
+		RepoOwner       func(childComplexity int) int
+		State           func(childComplexity int) int
+		SubIssues       func(childComplexity int) int
+		Title           func(childComplexity int) int
+		URL             func(childComplexity int) int
+		UpdatedAt       func(childComplexity int) int
 	}
 
 	IssueComment struct {
@@ -432,6 +436,10 @@ type HostResolver interface {
 }
 type IssueResolver interface {
 	Labels(ctx context.Context, obj *Issue) ([]*Label, error)
+	BlockedByIssues(ctx context.Context, obj *Issue) ([]*Issue, error)
+	BlockingIssues(ctx context.Context, obj *Issue) ([]*Issue, error)
+	SubIssues(ctx context.Context, obj *Issue) ([]*Issue, error)
+	ParentIssue(ctx context.Context, obj *Issue) (*Issue, error)
 }
 type ProcessResolver interface {
 	Host(ctx context.Context, obj *Process) (*Host, error)
@@ -1081,6 +1089,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Issue.AuthorLogin(childComplexity), true
+	case "Issue.blockedByIssues":
+		if e.ComplexityRoot.Issue.BlockedByIssues == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Issue.BlockedByIssues(childComplexity), true
+	case "Issue.blockingIssues":
+		if e.ComplexityRoot.Issue.BlockingIssues == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Issue.BlockingIssues(childComplexity), true
 	case "Issue.body":
 		if e.ComplexityRoot.Issue.Body == nil {
 			break
@@ -1117,6 +1137,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Issue.Number(childComplexity), true
+	case "Issue.parentIssue":
+		if e.ComplexityRoot.Issue.ParentIssue == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Issue.ParentIssue(childComplexity), true
 	case "Issue.repoName":
 		if e.ComplexityRoot.Issue.RepoName == nil {
 			break
@@ -1135,6 +1161,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Issue.State(childComplexity), true
+	case "Issue.subIssues":
+		if e.ComplexityRoot.Issue.SubIssues == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Issue.SubIssues(childComplexity), true
 	case "Issue.title":
 		if e.ComplexityRoot.Issue.Title == nil {
 			break
@@ -3893,6 +3925,31 @@ type Issue implements Node {
   ones are surfaced, matching ` + "`" + `PullRequest.labels` + "`" + ` semantics.
   """
   labels: [Label!]!
+
+  """
+  Issues that block this one (#563). Mirrors GitHub's
+  ` + "`" + `Issue.blockedByIssues` + "`" + ` connection, fetched via the preview-gated
+  GraphQL features ` + "`" + `issue_types,sub_issues` + "`" + `. Empty list when none.
+  """
+  blockedByIssues: [Issue!]!
+
+  """
+  Issues this one blocks (#563). The inverse of ` + "`" + `blockedByIssues` + "`" + `.
+  Empty list when none.
+  """
+  blockingIssues: [Issue!]!
+
+  """
+  Sub-issues nested under this issue when it acts as a tracker (#563).
+  Empty list when this issue is a leaf, not a tracker.
+  """
+  subIssues: [Issue!]!
+
+  """
+  Parent tracker issue when this issue is itself a sub-issue (#563).
+  Null when this issue has no parent.
+  """
+  parentIssue: Issue
 }
 
 """
@@ -4196,6 +4253,14 @@ func (ec *executionContext) childFields_Issue(ctx context.Context, field graphql
 		return ec.fieldContext_Issue_comments(ctx, field)
 	case "labels":
 		return ec.fieldContext_Issue_labels(ctx, field)
+	case "blockedByIssues":
+		return ec.fieldContext_Issue_blockedByIssues(ctx, field)
+	case "blockingIssues":
+		return ec.fieldContext_Issue_blockingIssues(ctx, field)
+	case "subIssues":
+		return ec.fieldContext_Issue_subIssues(ctx, field)
+	case "parentIssue":
+		return ec.fieldContext_Issue_parentIssue(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Issue", field.Name)
 }
@@ -7589,6 +7654,134 @@ func (ec *executionContext) fieldContext_Issue_labels(_ context.Context, field g
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_Label(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Issue_blockedByIssues(ctx context.Context, field graphql.CollectedField, obj *Issue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Issue_blockedByIssues(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Issue().BlockedByIssues(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*Issue) graphql.Marshaler {
+			return ec.marshalNIssue2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssueᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Issue_blockedByIssues(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Issue",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Issue(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Issue_blockingIssues(ctx context.Context, field graphql.CollectedField, obj *Issue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Issue_blockingIssues(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Issue().BlockingIssues(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*Issue) graphql.Marshaler {
+			return ec.marshalNIssue2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssueᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Issue_blockingIssues(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Issue",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Issue(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Issue_subIssues(ctx context.Context, field graphql.CollectedField, obj *Issue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Issue_subIssues(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Issue().SubIssues(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*Issue) graphql.Marshaler {
+			return ec.marshalNIssue2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssueᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Issue_subIssues(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Issue",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Issue(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Issue_parentIssue(ctx context.Context, field graphql.CollectedField, obj *Issue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Issue_parentIssue(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Issue().ParentIssue(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *Issue) graphql.Marshaler {
+			return ec.marshalOIssue2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssue(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Issue_parentIssue(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Issue",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Issue(ctx, field)
 		},
 	}
 	return fc, nil
@@ -15211,6 +15404,147 @@ func (ec *executionContext) _Issue(ctx context.Context, sel ast.SelectionSet, ob
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "blockedByIssues":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Issue_blockedByIssues(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "blockingIssues":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Issue_blockingIssues(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "subIssues":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Issue_subIssues(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "parentIssue":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Issue_parentIssue(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -19644,6 +19978,22 @@ func (ec *executionContext) marshalNInt2int64(ctx context.Context, sel ast.Selec
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNIssue2ᚕᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssueᚄ(ctx context.Context, sel ast.SelectionSet, v []*Issue) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNIssue2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssue(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNIssue2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐIssue(ctx context.Context, sel ast.SelectionSet, v *Issue) graphql.Marshaler {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -353,6 +353,19 @@ type Issue struct {
 	// (e.g. `in-progress`, `pr-ready`) are filtered out — only the user-set
 	// ones are surfaced, matching `PullRequest.labels` semantics.
 	Labels []*Label `json:"labels"`
+	// Issues that block this one (#563). Mirrors GitHub's
+	// `Issue.blockedByIssues` connection, fetched via the preview-gated
+	// GraphQL features `issue_types,sub_issues`. Empty list when none.
+	BlockedByIssues []*Issue `json:"blockedByIssues"`
+	// Issues this one blocks (#563). The inverse of `blockedByIssues`.
+	// Empty list when none.
+	BlockingIssues []*Issue `json:"blockingIssues"`
+	// Sub-issues nested under this issue when it acts as a tracker (#563).
+	// Empty list when this issue is a leaf, not a tracker.
+	SubIssues []*Issue `json:"subIssues"`
+	// Parent tracker issue when this issue is itself a sub-issue (#563).
+	// Null when this issue has no parent.
+	ParentIssue *Issue `json:"parentIssue,omitempty"`
 }
 
 func (Issue) IsNode() {}

--- a/internal/server/loaders/loaders.go
+++ b/internal/server/loaders/loaders.go
@@ -394,14 +394,11 @@ func loadProcesses(providers *ProvidersBundle, keys []ProcessKey) []*dataloader.
 // same number as the previous open-only fetch — at the cost of a larger
 // response body.
 //
-// LIMITATION (issue #579): defaultPerPage = 100 caps the response and
-// the underlying gh client does NOT paginate. On repos with >100 PRs
-// (open + closed + merged), matches beyond page 1 are dropped — the
-// resolver may return null or a stale fallback for a branch whose
-// real PR is older than the most recent 100 by UpdatedAt. This is a
-// pre-existing repo-wide pattern (every list endpoint in
-// providers/gh/endpoints.go fetches a single page); #579 tracks the
-// fix across all endpoints.
+// Pagination (issue #579): the gh client walks GitHub's Link rel="next"
+// chain up to gh.MaxPages (1000 items at per_page=100), so matches
+// across multiple pages are now visible to the headRef→branch join.
+// Repos with more than gh.MaxPages × per_page PRs surface as a
+// truncated slice rather than an unbounded fetch.
 //
 // Slice-sharing contract: when multiple positions in keys map to the same
 // RepoKey, every position receives the SAME *graphql1.PullRequest slice

--- a/internal/server/providers/gh/client.go
+++ b/internal/server/providers/gh/client.go
@@ -50,6 +50,11 @@ type Client struct {
 	// requires a non-empty UA; defaults to "orchard/v1" via
 	// NewClient.
 	UserAgent string
+
+	// MaxPagesOverride caps pagination at a lower-than-default value.
+	// Zero (default) means use the package-level MaxPages constant.
+	// Tests stub this to walk a shorter chain without hitting GitHub.
+	MaxPagesOverride int
 }
 
 // NewClient constructs a Client with sane defaults. baseURL is
@@ -157,9 +162,10 @@ func SplitRepo(repo string) (owner, name string, err error) {
 	return parts[0], parts[1], nil
 }
 
-// listPullRequestsRaw is the wire-shape decoder for `/repos/{o}/{n}/pulls`.
-// Kept private — callers go through the typed adapter methods.
-type listPullRequestsRaw []struct {
+// listPullRequestsRawItem is the wire-shape element for
+// `/repos/{o}/{n}/pulls`. Extracted from the slice alias so the
+// paginating helper can express it as a named type parameter.
+type listPullRequestsRawItem struct {
 	Number    int    `json:"number"`
 	Title     string `json:"title"`
 	Body      string `json:"body"`
@@ -179,6 +185,10 @@ type listPullRequestsRaw []struct {
 		Ref string `json:"ref"`
 	} `json:"head"`
 }
+
+// listPullRequestsRaw is the wire-shape decoder for `/repos/{o}/{n}/pulls`.
+// Kept private — callers go through the typed adapter methods.
+type listPullRequestsRaw []listPullRequestsRawItem
 
 func (raws listPullRequestsRaw) toPullRequests(owner, name string) []PullRequest {
 	out := make([]PullRequest, 0, len(raws))
@@ -210,8 +220,10 @@ func (raws listPullRequestsRaw) toPullRequests(owner, name string) []PullRequest
 	return out
 }
 
-// listIssuesRaw is the wire-shape decoder for `/repos/{o}/{n}/issues`.
-type listIssuesRaw []struct {
+// listIssuesRawItem is the wire-shape element for
+// `/repos/{o}/{n}/issues`. Extracted so the paginating helper can use
+// a named type parameter.
+type listIssuesRawItem struct {
 	Number      int    `json:"number"`
 	Title       string `json:"title"`
 	Body        string `json:"body"`
@@ -227,6 +239,9 @@ type listIssuesRaw []struct {
 	} `json:"user"`
 	Labels []restLabelRaw `json:"labels"`
 }
+
+// listIssuesRaw is the wire-shape decoder for `/repos/{o}/{n}/issues`.
+type listIssuesRaw []listIssuesRawItem
 
 // restLabelRaw mirrors the GitHub REST label payload. Color and
 // description are missing on some labels; defaulting to empty string is
@@ -321,8 +336,9 @@ func (raws listWorkflowRunsRaw) toRuns(owner, name string) []WorkflowRun {
 	return out
 }
 
-// listReviewsRaw is the wire-shape for `/repos/{o}/{n}/pulls/{n}/reviews`.
-type listReviewsRaw []struct {
+// listReviewsRawItem is the wire-shape element for the reviews
+// endpoint, extracted so pagination can express it as a named type.
+type listReviewsRawItem struct {
 	ID          int64  `json:"id"`
 	State       string `json:"state"`
 	Body        string `json:"body"`
@@ -331,6 +347,9 @@ type listReviewsRaw []struct {
 		Login string `json:"login"`
 	} `json:"user"`
 }
+
+// listReviewsRaw is the wire-shape for `/repos/{o}/{n}/pulls/{n}/reviews`.
+type listReviewsRaw []listReviewsRawItem
 
 func (raws listReviewsRaw) toReviews() []PullRequestReview {
 	out := make([]PullRequestReview, 0, len(raws))
@@ -346,8 +365,9 @@ func (raws listReviewsRaw) toReviews() []PullRequestReview {
 	return out
 }
 
-// listCommentsRaw is the wire-shape for issue comments.
-type listCommentsRaw []struct {
+// listCommentsRawItem is the wire-shape element for the comments
+// endpoint, extracted so pagination can express it as a named type.
+type listCommentsRawItem struct {
 	ID        int64  `json:"id"`
 	Body      string `json:"body"`
 	CreatedAt string `json:"created_at"`
@@ -356,6 +376,9 @@ type listCommentsRaw []struct {
 		Login string `json:"login"`
 	} `json:"user"`
 }
+
+// listCommentsRaw is the wire-shape for issue comments.
+type listCommentsRaw []listCommentsRawItem
 
 func (raws listCommentsRaw) toComments() []IssueComment {
 	out := make([]IssueComment, 0, len(raws))

--- a/internal/server/providers/gh/client_pagination.go
+++ b/internal/server/providers/gh/client_pagination.go
@@ -1,0 +1,197 @@
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// MaxPages is the safety cap on paginated list endpoints. With
+// defaultPerPage = 100 this yields 1000 items per logical list call.
+// Repos with more results than that need a different access pattern
+// (cursor-based GraphQL, scoped sub-queries); silently returning a
+// truncated slice is preferable to an unbounded fetch that could
+// stall the daemon or exhaust the rate-limit window.
+//
+// The cap is exported so tests can stub a smaller value via the
+// `WithMaxPages` override on Client.
+const MaxPages = 10
+
+// doListPaginated is the paginating sibling of `do` for top-level JSON
+// array responses. It walks GitHub's `Link: <…>; rel="next"` chain up
+// to MaxPages and appends each page's decoded items into accum.
+//
+// `T` is the element type (e.g. one of the anonymous structs that
+// listPullRequestsRaw / listIssuesRaw expand into); `accum` receives
+// every decoded page concatenated in order.
+//
+// Per-page errors short-circuit the loop. Rate-limit and 401 errors
+// surface as the typed sentinels the single-page `do` returns.
+func doListPaginated[T any](ctx context.Context, c *Client, path string, q url.Values, accum *[]T) error {
+	if c == nil {
+		return errors.New("gh client not initialised")
+	}
+	first := c.BaseURL + path
+	if len(q) > 0 {
+		first += "?" + q.Encode()
+	}
+	return walkPaginated(ctx, c, first, path, func(body io.Reader) error {
+		var page []T
+		if err := json.NewDecoder(body).Decode(&page); err != nil {
+			return fmt.Errorf("decode %s body: %w", path, err)
+		}
+		*accum = append(*accum, page...)
+		return nil
+	})
+}
+
+// doEnvelopePaginated is the paginating sibling of `do` for
+// envelope-shaped list responses (e.g. `{ "workflow_runs": [...] }`).
+// Each page's body is decoded via the caller's `decode` closure, which
+// is responsible for extracting and appending the items into its own
+// accumulator. Loop control and safety cap stay here.
+func doEnvelopePaginated(ctx context.Context, c *Client, path string, q url.Values, decode func(io.Reader) error) error {
+	if c == nil {
+		return errors.New("gh client not initialised")
+	}
+	first := c.BaseURL + path
+	if len(q) > 0 {
+		first += "?" + q.Encode()
+	}
+	return walkPaginated(ctx, c, first, path, decode)
+}
+
+// walkPaginated drives the paged GET loop. nextURL is the resolved
+// absolute URL for each iteration (Link headers from GitHub are
+// already absolute). `relPath` is the slash-prefixed REST path retained
+// for error wrapping so callers see the original endpoint, not the
+// full URL.
+func walkPaginated(ctx context.Context, c *Client, nextURL, relPath string, decode func(io.Reader) error) error {
+	cap := c.effectiveMaxPages()
+	for page := 1; ; page++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			return fmt.Errorf("build request: %w", err)
+		}
+		applyRESTHeaders(c, req)
+
+		resp, err := c.httpClient().Do(req)
+		if err != nil {
+			return fmt.Errorf("github GET %s: %w", relPath, err)
+		}
+
+		if err := checkRESTStatus(resp, relPath); err != nil {
+			_ = resp.Body.Close()
+			return err
+		}
+
+		if err := decode(resp.Body); err != nil {
+			_ = resp.Body.Close()
+			return err
+		}
+		link := resp.Header.Get("Link")
+		_ = resp.Body.Close()
+
+		next := parseLinkNext(link)
+		if next == "" {
+			return nil
+		}
+		if page >= cap {
+			return nil
+		}
+		nextURL = next
+	}
+}
+
+// applyRESTHeaders attaches the standard GitHub REST headers a
+// list-endpoint request expects. Factored out so the paginating loop
+// and the single-call `do` stay in step on auth / API version.
+func applyRESTHeaders(c *Client, req *http.Request) {
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if ua := c.UserAgent; ua != "" {
+		req.Header.Set("User-Agent", ua)
+	}
+}
+
+// checkRESTStatus mirrors the rate-limit / auth / non-2xx handling in
+// `Client.do`. Body is left open for the caller to decode on success.
+func checkRESTStatus(resp *http.Response, path string) error {
+	if remaining := resp.Header.Get("X-RateLimit-Remaining"); remaining == "0" && resp.StatusCode == http.StatusForbidden {
+		var resetAt int64
+		if rs := resp.Header.Get("X-RateLimit-Reset"); rs != "" {
+			if v, perr := strconv.ParseInt(rs, 10, 64); perr == nil {
+				resetAt = v
+			}
+		}
+		return &ErrRateLimitedT{ResetAt: resetAt}
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return ErrNotAuthenticated
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return &httpError{
+			Status:   resp.StatusCode,
+			Message:  strings.TrimSpace(string(body)),
+			Endpoint: path,
+		}
+	}
+	return nil
+}
+
+// parseLinkNext extracts the URL for `rel="next"` from a GitHub Link
+// header. Returns "" when there is no next page.
+//
+// Link header shape:
+//
+//	<https://api.github.com/.../pulls?page=2>; rel="next",
+//	<https://api.github.com/.../pulls?page=5>; rel="last"
+//
+// The parser splits on commas (top-level — URLs never contain unescaped
+// commas in GitHub responses), then on semicolons, and matches the
+// `rel="next"` parameter.
+func parseLinkNext(header string) string {
+	if header == "" {
+		return ""
+	}
+	for _, segment := range strings.Split(header, ",") {
+		parts := strings.Split(strings.TrimSpace(segment), ";")
+		if len(parts) < 2 {
+			continue
+		}
+		urlPart := strings.TrimSpace(parts[0])
+		if !strings.HasPrefix(urlPart, "<") || !strings.HasSuffix(urlPart, ">") {
+			continue
+		}
+		for _, p := range parts[1:] {
+			p = strings.TrimSpace(p)
+			if p == `rel="next"` || p == `rel=next` {
+				return strings.TrimSuffix(strings.TrimPrefix(urlPart, "<"), ">")
+			}
+		}
+	}
+	return ""
+}
+
+// effectiveMaxPages returns the configured per-client override (if
+// set via test helpers) or the package-level MaxPages cap.
+func (c *Client) effectiveMaxPages() int {
+	if c == nil || c.MaxPagesOverride <= 0 {
+		return MaxPages
+	}
+	return c.MaxPagesOverride
+}

--- a/internal/server/providers/gh/client_pagination_test.go
+++ b/internal/server/providers/gh/client_pagination_test.go
@@ -1,0 +1,292 @@
+package gh_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
+)
+
+// TestParseLinkNext exercises the Link-header parser used by the
+// paginating helper. The fixtures cover GitHub's documented shapes
+// plus the empty/no-next degenerate cases.
+func TestParseLinkNext(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"only_last", `<https://api.github.com/x?page=5>; rel="last"`, ""},
+		{
+			"next_then_last",
+			`<https://api.github.com/x?page=2>; rel="next", <https://api.github.com/x?page=5>; rel="last"`,
+			"https://api.github.com/x?page=2",
+		},
+		{
+			"prev_next_last",
+			`<https://api.github.com/x?page=1>; rel="prev", <https://api.github.com/x?page=3>; rel="next", <https://api.github.com/x?page=5>; rel="last"`,
+			"https://api.github.com/x?page=3",
+		},
+		{
+			"rel_without_quotes",
+			`<https://api.github.com/x?page=2>; rel=next`,
+			"https://api.github.com/x?page=2",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gh.ExportParseLinkNext(tc.in)
+			if got != tc.want {
+				t.Fatalf("ParseLinkNext(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestListPulls_PaginationFollowsLinkRelNext asserts the client walks
+// the Link header chain and concatenates results across pages.
+func TestListPulls_PaginationFollowsLinkRelNext(t *testing.T) {
+	var hits int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/alice/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		page := r.URL.Query().Get("page")
+		switch page {
+		case "", "1":
+			// First page: link to page 2.
+			w.Header().Set(
+				"Link",
+				fmt.Sprintf(`<%s?page=2>; rel="next", <%s?page=2>; rel="last"`,
+					"http://"+r.Host+"/repos/alice/repo/pulls",
+					"http://"+r.Host+"/repos/alice/repo/pulls",
+				),
+			)
+			_, _ = w.Write([]byte(`[{"number":1,"title":"one","state":"open","html_url":"u1","user":{"login":"bob"},"base":{"ref":"main"},"head":{"ref":"feature-1"}}]`))
+		case "2":
+			// Last page: no Link rel="next".
+			_, _ = w.Write([]byte(`[{"number":2,"title":"two","state":"open","html_url":"u2","user":{"login":"bob"},"base":{"ref":"main"},"head":{"ref":"feature-2"}}]`))
+		default:
+			t.Errorf("unexpected page %q", page)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c := gh.NewClient(ts.URL, "tok")
+	prs, err := c.ListPulls(context.Background(), "alice", "repo", gh.PullRequestStateOpen)
+	if err != nil {
+		t.Fatalf("ListPulls: %v", err)
+	}
+	if hits := atomic.LoadInt32(&hits); hits != 2 {
+		t.Fatalf("hits = %d, want 2 (one per page)", hits)
+	}
+	if len(prs) != 2 {
+		t.Fatalf("len(prs) = %d, want 2: %+v", len(prs), prs)
+	}
+	if prs[0].Number != 1 || prs[1].Number != 2 {
+		t.Errorf("PR numbers = [%d %d], want [1 2]", prs[0].Number, prs[1].Number)
+	}
+}
+
+// TestListIssues_PaginationFollowsLinkRelNext mirrors the PRs case for
+// the issues endpoint — a different top-level wire shape (no PR field
+// stripping) so the assertion catches per-endpoint regressions.
+func TestListIssues_PaginationFollowsLinkRelNext(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/alice/repo/issues", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		switch page {
+		case "", "1":
+			w.Header().Set(
+				"Link",
+				fmt.Sprintf(`<http://%s/repos/alice/repo/issues?page=2>; rel="next"`, r.Host),
+			)
+			_, _ = w.Write([]byte(`[{"number":10,"title":"i10","state":"open","html_url":"u","user":{"login":"bob"},"labels":[]}]`))
+		case "2":
+			_, _ = w.Write([]byte(`[{"number":20,"title":"i20","state":"open","html_url":"u","user":{"login":"bob"},"labels":[]}]`))
+		default:
+			t.Errorf("unexpected page %q", page)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c := gh.NewClient(ts.URL, "tok")
+	issues, err := c.ListIssues(context.Background(), "alice", "repo", gh.IssueStateOpen)
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("len(issues) = %d, want 2", len(issues))
+	}
+	if issues[0].Number != 10 || issues[1].Number != 20 {
+		t.Errorf("issue numbers = [%d %d], want [10 20]", issues[0].Number, issues[1].Number)
+	}
+}
+
+// TestListWorkflowRuns_PaginationEnvelopeShape verifies pagination
+// works for the envelope-shaped workflow runs endpoint.
+func TestListWorkflowRuns_PaginationEnvelopeShape(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/alice/repo/actions/runs", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		switch page {
+		case "", "1":
+			w.Header().Set(
+				"Link",
+				fmt.Sprintf(`<http://%s/repos/alice/repo/actions/runs?page=2>; rel="next"`, r.Host),
+			)
+			_, _ = w.Write([]byte(`{"workflow_runs":[{"id":111,"name":"a","path":"a.yml"}]}`))
+		case "2":
+			_, _ = w.Write([]byte(`{"workflow_runs":[{"id":222,"name":"b","path":"b.yml"}]}`))
+		default:
+			t.Errorf("unexpected page %q", page)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c := gh.NewClient(ts.URL, "tok")
+	runs, err := c.ListWorkflowRuns(context.Background(), "alice", "repo")
+	if err != nil {
+		t.Fatalf("ListWorkflowRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("len(runs) = %d, want 2", len(runs))
+	}
+	if runs[0].RunID != 111 || runs[1].RunID != 222 {
+		t.Errorf("run ids = [%d %d], want [111 222]", runs[0].RunID, runs[1].RunID)
+	}
+}
+
+// TestListPulls_SafetyCapBoundsTotalRequests asserts the pagination
+// loop stops at MaxPagesOverride even when GitHub keeps offering a
+// rel="next" link.
+func TestListPulls_SafetyCapBoundsTotalRequests(t *testing.T) {
+	var hits int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/alice/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&hits, 1)
+		// Always serve a rel="next" pointing at the next page number;
+		// the cap should stop us regardless.
+		w.Header().Set(
+			"Link",
+			fmt.Sprintf(`<http://%s/repos/alice/repo/pulls?page=%d>; rel="next"`, r.Host, count+1),
+		)
+		fmt.Fprintf(w, `[{"number":%d,"title":"t","state":"open","html_url":"u","user":{"login":"bob"},"base":{"ref":"main"},"head":{"ref":"f%d"}}]`, count, count)
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c := gh.NewClient(ts.URL, "tok")
+	c.MaxPagesOverride = 3
+	prs, err := c.ListPulls(context.Background(), "alice", "repo", gh.PullRequestStateOpen)
+	if err != nil {
+		t.Fatalf("ListPulls: %v", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 3 {
+		t.Fatalf("hits = %d, want 3 (cap)", got)
+	}
+	if len(prs) != 3 {
+		t.Fatalf("len(prs) = %d, want 3", len(prs))
+	}
+}
+
+// TestListPulls_PaginationRateLimitPropagates asserts rate-limit on a
+// second page propagates the typed error rather than silently
+// truncating.
+func TestListPulls_PaginationRateLimitPropagates(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/alice/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		switch page {
+		case "", "1":
+			w.Header().Set(
+				"Link",
+				fmt.Sprintf(`<http://%s/repos/alice/repo/pulls?page=2>; rel="next"`, r.Host),
+			)
+			_, _ = w.Write([]byte(`[{"number":1,"title":"t","state":"open","html_url":"u","user":{"login":"bob"},"base":{"ref":"main"},"head":{"ref":"f1"}}]`))
+		case "2":
+			w.Header().Set("X-RateLimit-Remaining", "0")
+			w.Header().Set("X-RateLimit-Reset", "1700000000")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"rate limit"}`))
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c := gh.NewClient(ts.URL, "tok")
+	_, err := c.ListPulls(context.Background(), "alice", "repo", gh.PullRequestStateOpen)
+	if !gh.IsRateLimited(err) {
+		t.Fatalf("err = %v, want rate-limited", err)
+	}
+}
+
+// TestListPulls_PaginationUnauthorizedPropagates asserts a 401 on
+// page 2 surfaces ErrNotAuthenticated cleanly.
+func TestListPulls_PaginationUnauthorizedPropagates(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/alice/repo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		switch page {
+		case "", "1":
+			w.Header().Set(
+				"Link",
+				fmt.Sprintf(`<http://%s/repos/alice/repo/pulls?page=2>; rel="next"`, r.Host),
+			)
+			_, _ = w.Write([]byte(`[]`))
+		case "2":
+			w.WriteHeader(http.StatusUnauthorized)
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c := gh.NewClient(ts.URL, "tok")
+	_, err := c.ListPulls(context.Background(), "alice", "repo", gh.PullRequestStateOpen)
+	if !errors.Is(err, gh.ErrNotAuthenticated) {
+		t.Fatalf("err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
+// TestListPulls_SinglePageNoLinkHeader keeps the single-page path
+// trivially correct: a response without a Link header completes after
+// one round-trip.
+func TestListPulls_SinglePageNoLinkHeader(t *testing.T) {
+	var hits int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/alice/repo/pulls", func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_, _ = w.Write([]byte(`[{"number":1,"title":"only","state":"open","html_url":"u","user":{"login":"bob"},"base":{"ref":"main"},"head":{"ref":"only"}}]`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	c := gh.NewClient(ts.URL, "tok")
+	prs, err := c.ListPulls(context.Background(), "alice", "repo", gh.PullRequestStateOpen)
+	if err != nil {
+		t.Fatalf("ListPulls: %v", err)
+	}
+	if hits := atomic.LoadInt32(&hits); hits != 1 {
+		t.Fatalf("hits = %d, want 1", hits)
+	}
+	if len(prs) != 1 {
+		t.Fatalf("len(prs) = %d, want 1", len(prs))
+	}
+}
+
+// TestMaxPagesDefault confirms the public constant matches the cap
+// described in #579: 10 pages at per_page=100 = 1000 items.
+func TestMaxPagesDefault(t *testing.T) {
+	if gh.MaxPages != 10 {
+		t.Errorf("MaxPages = %d, want 10", gh.MaxPages)
+	}
+}
+

--- a/internal/server/providers/gh/endpoints.go
+++ b/internal/server/providers/gh/endpoints.go
@@ -2,7 +2,9 @@ package gh
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"strconv"
 )
@@ -27,6 +29,11 @@ import (
 
 // ListPulls fetches the list of pull requests for a repository.
 // state must be one of OPEN, CLOSED, MERGED, ALL.
+//
+// The underlying request is paginated through GitHub's Link header up
+// to MaxPages (1000 items at defaultPerPage = 100); repos with more
+// PRs than that surface as a truncated slice rather than an
+// open-ended fetch.
 func (c *Client) ListPulls(ctx context.Context, owner, name string, state PullRequestState) ([]PullRequest, error) {
 	q := url.Values{}
 	q.Set("per_page", strconv.Itoa(defaultPerPage))
@@ -45,11 +52,11 @@ func (c *Client) ListPulls(ctx context.Context, owner, name string, state PullRe
 	q.Set("sort", "updated")
 	q.Set("direction", "desc")
 
-	var raw listPullRequestsRaw
-	if err := c.do(ctx, fmt.Sprintf("/repos/%s/%s/pulls", owner, name), q, &raw); err != nil {
+	var items []listPullRequestsRawItem
+	if err := doListPaginated(ctx, c, fmt.Sprintf("/repos/%s/%s/pulls", owner, name), q, &items); err != nil {
 		return nil, err
 	}
-	prs := raw.toPullRequests(owner, name)
+	prs := listPullRequestsRaw(items).toPullRequests(owner, name)
 	if state == PullRequestStateMerged {
 		filtered := prs[:0]
 		for _, p := range prs {
@@ -122,7 +129,8 @@ func (c *Client) GetPull(ctx context.Context, owner, name string, number int) (P
 }
 
 // ListIssues fetches the list of issues for a repository. PRs are
-// filtered out — see types.go.
+// filtered out — see types.go. Pagination walks Link rel="next" up
+// to MaxPages.
 func (c *Client) ListIssues(ctx context.Context, owner, name string, state IssueState) ([]Issue, error) {
 	q := url.Values{}
 	q.Set("per_page", strconv.Itoa(defaultPerPage))
@@ -137,11 +145,11 @@ func (c *Client) ListIssues(ctx context.Context, owner, name string, state Issue
 		return nil, fmt.Errorf("unknown IssueState %q", state)
 	}
 
-	var raw listIssuesRaw
-	if err := c.do(ctx, fmt.Sprintf("/repos/%s/%s/issues", owner, name), q, &raw); err != nil {
+	var items []listIssuesRawItem
+	if err := doListPaginated(ctx, c, fmt.Sprintf("/repos/%s/%s/issues", owner, name), q, &items); err != nil {
 		return nil, err
 	}
-	return raw.toIssues(owner, name), nil
+	return listIssuesRaw(items).toIssues(owner, name), nil
 }
 
 // GetIssue fetches one issue by number.
@@ -188,14 +196,25 @@ func (c *Client) GetIssue(ctx context.Context, owner, name string, number int) (
 }
 
 // ListWorkflowRuns fetches the most recent workflow runs for a repo.
+// Pagination walks Link rel="next" up to MaxPages. GitHub's response
+// is enveloped (`{ "workflow_runs": [...] }`), so each page is decoded
+// per-iteration and the inner slice concatenated.
 func (c *Client) ListWorkflowRuns(ctx context.Context, owner, name string) ([]WorkflowRun, error) {
 	q := url.Values{}
 	q.Set("per_page", strconv.Itoa(defaultPerPage))
-	var raw listWorkflowRunsRaw
-	if err := c.do(ctx, fmt.Sprintf("/repos/%s/%s/actions/runs", owner, name), q, &raw); err != nil {
+	var accum listWorkflowRunsRaw
+	decode := func(body io.Reader) error {
+		var page listWorkflowRunsRaw
+		if err := json.NewDecoder(body).Decode(&page); err != nil {
+			return fmt.Errorf("decode /repos/%s/%s/actions/runs body: %w", owner, name, err)
+		}
+		accum.WorkflowRuns = append(accum.WorkflowRuns, page.WorkflowRuns...)
+		return nil
+	}
+	if err := doEnvelopePaginated(ctx, c, fmt.Sprintf("/repos/%s/%s/actions/runs", owner, name), q, decode); err != nil {
 		return nil, err
 	}
-	return raw.toRuns(owner, name), nil
+	return accum.toRuns(owner, name), nil
 }
 
 // GetWorkflowRun fetches one workflow run by id.
@@ -231,15 +250,16 @@ func (c *Client) GetWorkflowRun(ctx context.Context, owner, name string, runID i
 	}, nil
 }
 
-// ListPullReviews fetches reviews on one pull request.
+// ListPullReviews fetches reviews on one pull request. Pagination
+// walks Link rel="next" up to MaxPages.
 func (c *Client) ListPullReviews(ctx context.Context, owner, name string, number int) ([]PullRequestReview, error) {
 	q := url.Values{}
 	q.Set("per_page", strconv.Itoa(defaultPerPage))
-	var raw listReviewsRaw
-	if err := c.do(ctx, fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, name, number), q, &raw); err != nil {
+	var items []listReviewsRawItem
+	if err := doListPaginated(ctx, c, fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", owner, name, number), q, &items); err != nil {
 		return nil, err
 	}
-	return raw.toReviews(), nil
+	return listReviewsRaw(items).toReviews(), nil
 }
 
 // ListPullComments fetches conversation comments on a pull request.
@@ -257,11 +277,11 @@ func (c *Client) ListIssueComments(ctx context.Context, owner, name string, numb
 func (c *Client) listIssueLikeComments(ctx context.Context, owner, name string, number int) ([]IssueComment, error) {
 	q := url.Values{}
 	q.Set("per_page", strconv.Itoa(defaultPerPage))
-	var raw listCommentsRaw
-	if err := c.do(ctx, fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, name, number), q, &raw); err != nil {
+	var items []listCommentsRawItem
+	if err := doListPaginated(ctx, c, fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, name, number), q, &items); err != nil {
 		return nil, err
 	}
-	return raw.toComments(), nil
+	return listCommentsRaw(items).toComments(), nil
 }
 
 // GetRepo fetches the repository metadata.

--- a/internal/server/providers/gh/export_test.go
+++ b/internal/server/providers/gh/export_test.go
@@ -36,3 +36,9 @@ func (p *Provider) ExportEnrichTimestamp(key PullRequestKey) time.Time {
 	defer p.prMu.RUnlock()
 	return p.enrichAt[key]
 }
+
+// ExportParseLinkNext wraps parseLinkNext so external tests can assert
+// the Link-header parser without touching the package-private symbol.
+func ExportParseLinkNext(header string) string {
+	return parseLinkNext(header)
+}

--- a/internal/server/providers/gh/graphql.go
+++ b/internal/server/providers/gh/graphql.go
@@ -37,6 +37,15 @@ const graphqlPath = "/graphql"
 // `variables` may be nil for queries that take no variables; callers
 // pass a `map[string]any` keyed by GraphQL variable name.
 func (c *Client) GraphQL(ctx context.Context, query string, variables map[string]any) (json.RawMessage, error) {
+	return c.GraphQLWithHeaders(ctx, query, variables, nil)
+}
+
+// GraphQLWithHeaders is the same as GraphQL but lets the caller attach
+// extra request headers — required for GitHub's preview-gated fields
+// (`GraphQL-Features: issue_types,sub_issues`, etc). Headers passed
+// here are added AFTER the standard auth / content-type / API-version
+// headers; callers cannot override the core set.
+func (c *Client) GraphQLWithHeaders(ctx context.Context, query string, variables map[string]any, extraHeaders map[string]string) (json.RawMessage, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -73,6 +82,9 @@ func (c *Client) GraphQL(ctx context.Context, query string, variables map[string
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	if ua := c.UserAgent; ua != "" {
 		req.Header.Set("User-Agent", ua)
+	}
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
 	}
 
 	resp, err := c.httpClient().Do(req)

--- a/internal/server/providers/gh/graphql_issue_deps.go
+++ b/internal/server/providers/gh/graphql_issue_deps.go
@@ -1,0 +1,180 @@
+// Package gh — GraphQL enrichment for Issue dependency graph fields.
+//
+// GitHub exposes blocked-by / blocking / sub-issue / parent relationships
+// behind the `GraphQL-Features: issue_types,sub_issues` preview header.
+// This file adds a Provider method that fetches those edges in one
+// GraphQL round-trip and caches the result on the per-issue map.
+//
+// Closes #563.
+package gh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// issueDepsTTL governs how long an enriched dependency snapshot is
+// trusted before the next call re-fetches. Same shape as enrichmentTTL
+// for PullRequest — short enough that newly-added blocked-by edges
+// surface within a minute, long enough that batched UI queries reuse
+// one fetch.
+const issueDepsTTL = 60 * time.Second
+
+// issueDepsPreviewHeaders are the preview gates required for the
+// dependency nodes. GitHub returns the fields without them on some
+// repositories, but sending the headers is the documented contract and
+// avoids silent-empty regressions when GitHub tightens the gating.
+var issueDepsPreviewHeaders = map[string]string{
+	"GraphQL-Features":         "issue_types,sub_issues",
+	"X-Github-Next-Global-ID":  "1",
+}
+
+// issueDepsQuery requests the four dependency edges in one round-trip.
+// Each connection caps at 50 nodes — enough for any real tracker
+// hierarchy; oversize trackers can be revisited if they appear.
+//
+// Wire-format field names are GitHub's: `blockedBy`, `blocking`,
+// `subIssues`, `parent`. We alias them to the orchard schema names
+// (`blockedByIssues`, `blockingIssues`) so the resolver-side decoder
+// stays in step with our public surface.
+const issueDepsQuery = `query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    issue(number:$number){
+      blockedByIssues:blockedBy(first:50){
+        nodes{ number, title, repository{ owner{ login } name } }
+      }
+      blockingIssues:blocking(first:50){
+        nodes{ number, title, repository{ owner{ login } name } }
+      }
+      subIssues(first:50){
+        nodes{ number, title, repository{ owner{ login } name } }
+      }
+      parent{ number, title, repository{ owner{ login } name } }
+    }
+  }
+}`
+
+// issueDepsRaw is the wire-shape decoder for issueDepsQuery.
+type issueDepsRaw struct {
+	Data struct {
+		Repository struct {
+			Issue struct {
+				BlockedByIssues struct {
+					Nodes []issueRefRaw `json:"nodes"`
+				} `json:"blockedByIssues"`
+				BlockingIssues struct {
+					Nodes []issueRefRaw `json:"nodes"`
+				} `json:"blockingIssues"`
+				SubIssues struct {
+					Nodes []issueRefRaw `json:"nodes"`
+				} `json:"subIssues"`
+				Parent *issueRefRaw `json:"parent"`
+			} `json:"issue"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors,omitempty"`
+}
+
+// issueRefRaw mirrors GitHub's Issue node with enough fields to
+// hydrate a thin Issue for the cross-issue projection. Title is
+// included so common selections (`blockedByIssues { number title }`)
+// don't need a second GetIssue round-trip per node.
+type issueRefRaw struct {
+	Number     int    `json:"number"`
+	Title      string `json:"title"`
+	Repository struct {
+		Owner struct {
+			Login string `json:"login"`
+		} `json:"owner"`
+		Name string `json:"name"`
+	} `json:"repository"`
+}
+
+func (r issueRefRaw) toRef() IssueRef {
+	return IssueRef{
+		Owner:  r.Repository.Owner.Login,
+		Name:   r.Repository.Name,
+		Number: r.Number,
+		Title:  r.Title,
+	}
+}
+
+// EnrichIssueDependencies fetches the four dependency edges for one
+// issue and caches the result on the provider's per-issue map. The
+// cache TTL is issueDepsTTL; subsequent calls within that window
+// return the cached snapshot.
+//
+// Returns the live IssueDependencies value. Empty slices (not nil) are
+// returned when GitHub reports no edges so callers can treat the
+// result as iterable without a nil guard.
+func (p *Provider) EnrichIssueDependencies(ctx context.Context, key IssueKey) (IssueDependencies, error) {
+	// --- cache check ---
+	p.issueMu.RLock()
+	if cached, ok := p.issueDeps[key]; ok && p.clock().Sub(cached.at) < issueDepsTTL {
+		out := cached.value
+		p.issueMu.RUnlock()
+		return out, nil
+	}
+	p.issueMu.RUnlock()
+
+	c, err := p.httpClient(ctx)
+	if err != nil {
+		return IssueDependencies{}, err
+	}
+
+	variables := map[string]any{
+		"owner":  key.Owner,
+		"name":   key.Name,
+		"number": key.Number,
+	}
+	raw, err := c.GraphQLWithHeaders(ctx, issueDepsQuery, variables, issueDepsPreviewHeaders)
+	if err != nil {
+		return IssueDependencies{}, fmt.Errorf("EnrichIssueDependencies graphql: %w", err)
+	}
+
+	var envelope issueDepsRaw
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return IssueDependencies{}, fmt.Errorf("EnrichIssueDependencies decode: %w", err)
+	}
+	if len(envelope.Errors) > 0 {
+		msgs := make([]string, 0, len(envelope.Errors))
+		for _, e := range envelope.Errors {
+			msgs = append(msgs, e.Message)
+		}
+		return IssueDependencies{}, fmt.Errorf("EnrichIssueDependencies graphql errors: %s", strings.Join(msgs, "; "))
+	}
+
+	wire := envelope.Data.Repository.Issue
+	deps := IssueDependencies{
+		BlockedBy: refsFromNodes(wire.BlockedByIssues.Nodes),
+		Blocking:  refsFromNodes(wire.BlockingIssues.Nodes),
+		SubIssues: refsFromNodes(wire.SubIssues.Nodes),
+	}
+	if wire.Parent != nil {
+		ref := wire.Parent.toRef()
+		deps.Parent = &ref
+	}
+
+	now := p.clock()
+	p.issueMu.Lock()
+	p.issueDeps[key] = issueDepsEntry{value: deps, at: now}
+	p.issueMu.Unlock()
+
+	return deps, nil
+}
+
+// refsFromNodes projects a slice of issueRefRaw onto the public
+// IssueRef shape. Returns an empty (non-nil) slice when nodes is empty
+// so resolvers can iterate without a nil guard.
+func refsFromNodes(in []issueRefRaw) []IssueRef {
+	out := make([]IssueRef, 0, len(in))
+	for _, n := range in {
+		out = append(out, n.toRef())
+	}
+	return out
+}

--- a/internal/server/providers/gh/graphql_issue_deps_test.go
+++ b/internal/server/providers/gh/graphql_issue_deps_test.go
@@ -1,0 +1,179 @@
+package gh_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/gh"
+)
+
+// newDepsProvider mirrors newEnrichProvider but serves a single
+// dependency-edge body. The atomic counts /graphql requests so cache
+// tests can assert second/third calls don't hit the wire.
+func newDepsProvider(t *testing.T, body []byte, clock func() time.Time) (*gh.Provider, *atomic.Int32, *http.Header) {
+	t.Helper()
+	var count atomic.Int32
+	var lastHeader http.Header
+	mux := http.NewServeMux()
+	mux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
+		count.Add(1)
+		lastHeader = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected request to %s", r.URL.Path)
+		http.NotFound(w, r)
+	})
+	srv := httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+
+	auth := &gh.StaticAuthSource{TokenValue: "test-token-fixture"}
+	p := gh.NewWith(nil, srv.URL, auth, clock)
+	if err := p.Start(context.Background()); err != nil {
+		t.Logf("provider start (non-fatal): %v", err)
+	}
+	gh.SetHTTPClientForTest(p, srv.Client())
+	return p, &count, &lastHeader
+}
+
+// TestEnrichIssueDependencies_ParsesAllFourEdges confirms the
+// envelope is parsed into the four edges (#563). AC1–AC4.
+func TestEnrichIssueDependencies_ParsesAllFourEdges(t *testing.T) {
+	body := []byte(`{
+		"data": {
+			"repository": {
+				"issue": {
+					"blockedByIssues": { "nodes": [
+						{"number": 558, "title": "blocked-by-558", "repository": {"owner": {"login":"alice"}, "name":"repo"}}
+					]},
+					"blockingIssues": { "nodes": [
+						{"number": 600, "title": "blocking-600", "repository": {"owner": {"login":"alice"}, "name":"repo"}}
+					]},
+					"subIssues": { "nodes": [
+						{"number": 700, "title": "sub-700", "repository": {"owner": {"login":"alice"}, "name":"repo"}},
+						{"number": 701, "title": "sub-701", "repository": {"owner": {"login":"alice"}, "name":"repo"}}
+					]},
+					"parent": {"number": 800, "title": "parent-800", "repository": {"owner": {"login":"alice"}, "name":"repo"}}
+				}
+			}
+		}
+	}`)
+	p, count, lastHeader := newDepsProvider(t, body, time.Now)
+
+	deps, err := p.EnrichIssueDependencies(context.Background(), gh.IssueKey{Owner: "alice", Name: "repo", Number: 544})
+	if err != nil {
+		t.Fatalf("EnrichIssueDependencies: %v", err)
+	}
+	if got := count.Load(); got != 1 {
+		t.Errorf("count = %d, want 1", got)
+	}
+	if got := lastHeader.Get("GraphQL-Features"); !strings.Contains(got, "sub_issues") {
+		t.Errorf("GraphQL-Features = %q, want it to contain sub_issues", got)
+	}
+	if got := lastHeader.Get("X-Github-Next-Global-ID"); got != "1" {
+		t.Errorf("X-Github-Next-Global-ID = %q, want 1", got)
+	}
+	if len(deps.BlockedBy) != 1 || deps.BlockedBy[0].Number != 558 {
+		t.Errorf("BlockedBy = %+v, want [#558]", deps.BlockedBy)
+	}
+	if len(deps.Blocking) != 1 || deps.Blocking[0].Number != 600 {
+		t.Errorf("Blocking = %+v, want [#600]", deps.Blocking)
+	}
+	if len(deps.SubIssues) != 2 {
+		t.Errorf("SubIssues = %+v, want 2 entries", deps.SubIssues)
+	}
+	if deps.Parent == nil || deps.Parent.Number != 800 {
+		t.Errorf("Parent = %+v, want #800", deps.Parent)
+	}
+	if deps.BlockedBy[0].Title != "blocked-by-558" {
+		t.Errorf("BlockedBy[0].Title = %q, want %q", deps.BlockedBy[0].Title, "blocked-by-558")
+	}
+	if deps.Parent.Title != "parent-800" {
+		t.Errorf("Parent.Title = %q, want %q", deps.Parent.Title, "parent-800")
+	}
+}
+
+// TestEnrichIssueDependencies_EmptyEdges asserts the resolver returns
+// empty (non-nil) slices and a nil parent when GitHub reports no
+// dependencies. Guards the GraphQL non-null-list contract.
+func TestEnrichIssueDependencies_EmptyEdges(t *testing.T) {
+	body := []byte(`{"data":{"repository":{"issue":{
+		"blockedByIssues":{"nodes":[]},
+		"blockingIssues":{"nodes":[]},
+		"subIssues":{"nodes":[]},
+		"parent":null
+	}}}}`)
+	p, _, _ := newDepsProvider(t, body, time.Now)
+
+	deps, err := p.EnrichIssueDependencies(context.Background(), gh.IssueKey{Owner: "alice", Name: "repo", Number: 1})
+	if err != nil {
+		t.Fatalf("EnrichIssueDependencies: %v", err)
+	}
+	if deps.BlockedBy == nil || len(deps.BlockedBy) != 0 {
+		t.Errorf("BlockedBy = %+v, want empty non-nil slice", deps.BlockedBy)
+	}
+	if deps.Blocking == nil || len(deps.Blocking) != 0 {
+		t.Errorf("Blocking = %+v, want empty non-nil slice", deps.Blocking)
+	}
+	if deps.SubIssues == nil || len(deps.SubIssues) != 0 {
+		t.Errorf("SubIssues = %+v, want empty non-nil slice", deps.SubIssues)
+	}
+	if deps.Parent != nil {
+		t.Errorf("Parent = %+v, want nil", deps.Parent)
+	}
+}
+
+// TestEnrichIssueDependencies_CachesWithinTTL asserts repeat calls
+// within the 60s TTL hit the cache and never re-fetch.
+func TestEnrichIssueDependencies_CachesWithinTTL(t *testing.T) {
+	body := []byte(`{"data":{"repository":{"issue":{
+		"blockedByIssues":{"nodes":[]},
+		"blockingIssues":{"nodes":[]},
+		"subIssues":{"nodes":[]},
+		"parent":null
+	}}}}`)
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{t: now}
+	p, count, _ := newDepsProvider(t, body, clock.Now)
+
+	for i := 0; i < 3; i++ {
+		if _, err := p.EnrichIssueDependencies(context.Background(), gh.IssueKey{Owner: "alice", Name: "repo", Number: 1}); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if got := count.Load(); got != 1 {
+		t.Fatalf("count = %d, want 1 (cache served calls 2 and 3)", got)
+	}
+}
+
+// TestEnrichIssueDependencies_GraphqlErrorsSurface confirms a
+// GraphQL-level error envelope propagates as a Go error so the
+// resolver layer can translate to a per-field GraphQL error.
+func TestEnrichIssueDependencies_GraphqlErrorsSurface(t *testing.T) {
+	body := []byte(`{"errors":[{"message":"Field 'issueDependencies' doesn't exist on type 'Issue'"}]}`)
+	p, _, _ := newDepsProvider(t, body, time.Now)
+
+	_, err := p.EnrichIssueDependencies(context.Background(), gh.IssueKey{Owner: "alice", Name: "repo", Number: 1})
+	if err == nil {
+		t.Fatalf("err = nil, want a graphql errors wrapper")
+	}
+	if !strings.Contains(err.Error(), "issueDependencies") {
+		t.Errorf("err = %v, want it to mention the GraphQL error message", err)
+	}
+}
+
+// TestIssueRefID asserts the GraphQL-stable id format matches the
+// Issue.ID() format so resolver projections produce identical ids
+// whether the value comes from a full Issue or a thin IssueRef.
+func TestIssueRefID(t *testing.T) {
+	ref := gh.IssueRef{Owner: "alice", Name: "repo", Number: 42}
+	if got, want := ref.ID(), "Issue:alice/repo#42"; got != want {
+		t.Errorf("ID() = %q, want %q", got, want)
+	}
+}

--- a/internal/server/providers/gh/provider.go
+++ b/internal/server/providers/gh/provider.go
@@ -49,8 +49,9 @@ type Provider struct {
 	prs      map[PullRequestKey]prEntry
 	enrichAt map[PullRequestKey]time.Time // when EnrichPullRequest last populated the enrichment fields
 
-	issueMu sync.RWMutex
-	issues  map[IssueKey]issueEntry
+	issueMu   sync.RWMutex
+	issues    map[IssueKey]issueEntry
+	issueDeps map[IssueKey]issueDepsEntry // per-issue dependency snapshot (#563); shorter TTL than issues
 
 	runMu sync.RWMutex
 	runs  map[WorkflowRunKey]runEntry
@@ -77,6 +78,13 @@ type prEntry struct {
 
 type issueEntry struct {
 	value Issue
+	at    time.Time
+}
+
+// issueDepsEntry caches the dependency-edge fetch for an issue. The
+// shorter TTL (issueDepsTTL) lives in graphql_issue_deps.go.
+type issueDepsEntry struct {
+	value IssueDependencies
 	at    time.Time
 }
 
@@ -145,6 +153,7 @@ func NewWith(logger *slog.Logger, baseURL string, auth AuthSource, clock func() 
 		prs:          map[PullRequestKey]prEntry{},
 		enrichAt:     map[PullRequestKey]time.Time{},
 		issues:       map[IssueKey]issueEntry{},
+		issueDeps:    map[IssueKey]issueDepsEntry{},
 		runs:         map[WorkflowRunKey]runEntry{},
 		listPRsCache: map[listPRsKey]listPRsEntry{},
 		listIssCache: map[listIssKey]listIssEntry{},

--- a/internal/server/providers/gh/types.go
+++ b/internal/server/providers/gh/types.go
@@ -206,6 +206,36 @@ func (i Issue) ID() string {
 	return fmt.Sprintf("Issue:%s/%s#%d", i.RepoOwner, i.RepoName, i.Number)
 }
 
+// IssueRef carries the cross-issue identity (Owner, Name, Number)
+// plus the title — enough for typical UI projections without a
+// follow-up GetIssue per node. Heavier fields (body, labels, comments)
+// hydrate lazily on field selection via the standard Issue resolvers.
+type IssueRef struct {
+	Owner  string
+	Name   string
+	Number int
+	Title  string
+}
+
+// ID renders the same GraphQL id Issue.ID() does. Lets resolvers turn
+// an IssueRef into a thin *graphql.Issue without re-fetching when only
+// the id and identity triple are needed.
+func (r IssueRef) ID() string {
+	return fmt.Sprintf("Issue:%s/%s#%d", r.Owner, r.Name, r.Number)
+}
+
+// IssueDependencies aggregates the four dependency edges GitHub exposes
+// on an issue: blocked-by, blocking, sub-issues, and parent tracker.
+// Lazily populated by EnrichIssueDependencies; resolvers project each
+// edge into the GraphQL schema fields blockedByIssues, blockingIssues,
+// subIssues, parentIssue (#563).
+type IssueDependencies struct {
+	BlockedBy []IssueRef
+	Blocking  []IssueRef
+	SubIssues []IssueRef
+	Parent    *IssueRef
+}
+
 // IssueComment mirrors a GitHub issue / PR conversation comment.
 type IssueComment struct {
 	GitHubID    int64

--- a/internal/server/providers/gh/webhook.go
+++ b/internal/server/providers/gh/webhook.go
@@ -235,6 +235,7 @@ func (p *Provider) dropPRCache(k PullRequestKey) {
 func (p *Provider) dropIssueCache(k IssueKey) {
 	p.issueMu.Lock()
 	delete(p.issues, k)
+	delete(p.issueDeps, k)
 	p.issueMu.Unlock()
 	p.listMu.Lock()
 	for lk := range p.listIssCache {

--- a/internal/server/resolvers/gh.go
+++ b/internal/server/resolvers/gh.go
@@ -361,6 +361,49 @@ func toGraphQLIssue(i gh.Issue) *graphql1.Issue {
 	}
 }
 
+// issueRefToGraphQL projects a thin gh.IssueRef into a graphql.Issue
+// carrying identity + title. Body / labels / comments hydrate lazily
+// on field selection via the standard Issue resolvers — the
+// dependency fetch stays one round-trip for tree-shaped queries.
+func issueRefToGraphQL(ref gh.IssueRef) *graphql1.Issue {
+	return &graphql1.Issue{
+		ID:        ref.ID(),
+		RepoOwner: ref.Owner,
+		RepoName:  ref.Name,
+		Number:    int64(ref.Number),
+		Title:     ref.Title,
+	}
+}
+
+// issueRefsToGraphQL projects a slice of gh.IssueRef. Returns an empty
+// (non-nil) slice so callers don't have to guard against null.
+func issueRefsToGraphQL(refs []gh.IssueRef) []*graphql1.Issue {
+	out := make([]*graphql1.Issue, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, issueRefToGraphQL(r))
+	}
+	return out
+}
+
+// issueDependencies fetches the dependency-edge snapshot for an Issue
+// resolver root. Returns nil deps and nil error on the soft-fail cases
+// (gh not configured, malformed node id) so the field resolvers fall
+// back to empty results without surfacing a GraphQL error.
+func (r *issueResolver) issueDependencies(ctx context.Context, obj *graphql1.Issue) (*gh.IssueDependencies, error) {
+	if r.GH == nil || obj == nil {
+		return nil, nil
+	}
+	owner, name, number, ok := splitGHNodeID(obj.ID, "Issue:")
+	if !ok {
+		return nil, nil
+	}
+	deps, err := r.GH.EnrichIssueDependencies(ctx, gh.IssueKey{Owner: owner, Name: name, Number: number})
+	if err != nil {
+		return nil, err
+	}
+	return &deps, nil
+}
+
 // toGraphQLLabels projects gh.Label slice to the GraphQL Label list,
 // preserving order. Returns an empty (non-nil) slice so callers don't
 // have to guard against null. Used by both Issue.labels and

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -1384,6 +1384,31 @@ type Issue implements Node {
   ones are surfaced, matching `PullRequest.labels` semantics.
   """
   labels: [Label!]!
+
+  """
+  Issues that block this one (#563). Mirrors GitHub's
+  `Issue.blockedByIssues` connection, fetched via the preview-gated
+  GraphQL features `issue_types,sub_issues`. Empty list when none.
+  """
+  blockedByIssues: [Issue!]!
+
+  """
+  Issues this one blocks (#563). The inverse of `blockedByIssues`.
+  Empty list when none.
+  """
+  blockingIssues: [Issue!]!
+
+  """
+  Sub-issues nested under this issue when it acts as a tracker (#563).
+  Empty list when this issue is a leaf, not a tracker.
+  """
+  subIssues: [Issue!]!
+
+  """
+  Parent tracker issue when this issue is itself a sub-issue (#563).
+  Null when this issue has no parent.
+  """
+  parentIssue: Issue
 }
 
 """

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -141,6 +141,45 @@ func (r *issueResolver) Labels(ctx context.Context, obj *graphql1.Issue) ([]*gra
 	return toGraphQLLabels(issue.Labels), nil
 }
 
+// BlockedByIssues is the resolver for the issue.blockedByIssues field (#563).
+// Delegates to issueDependencies which loads all four dependency edges
+// in one round-trip and caches the result.
+func (r *issueResolver) BlockedByIssues(ctx context.Context, obj *graphql1.Issue) ([]*graphql1.Issue, error) {
+	deps, err := r.issueDependencies(ctx, obj)
+	if err != nil || deps == nil {
+		return []*graphql1.Issue{}, err
+	}
+	return issueRefsToGraphQL(deps.BlockedBy), nil
+}
+
+// BlockingIssues is the resolver for the issue.blockingIssues field (#563).
+func (r *issueResolver) BlockingIssues(ctx context.Context, obj *graphql1.Issue) ([]*graphql1.Issue, error) {
+	deps, err := r.issueDependencies(ctx, obj)
+	if err != nil || deps == nil {
+		return []*graphql1.Issue{}, err
+	}
+	return issueRefsToGraphQL(deps.Blocking), nil
+}
+
+// SubIssues is the resolver for the issue.subIssues field (#563).
+func (r *issueResolver) SubIssues(ctx context.Context, obj *graphql1.Issue) ([]*graphql1.Issue, error) {
+	deps, err := r.issueDependencies(ctx, obj)
+	if err != nil || deps == nil {
+		return []*graphql1.Issue{}, err
+	}
+	return issueRefsToGraphQL(deps.SubIssues), nil
+}
+
+// ParentIssue is the resolver for the issue.parentIssue field (#563).
+func (r *issueResolver) ParentIssue(ctx context.Context, obj *graphql1.Issue) (*graphql1.Issue, error) {
+	deps, err := r.issueDependencies(ctx, obj)
+	if err != nil || deps == nil || deps.Parent == nil {
+		return nil, err
+	}
+	out := issueRefToGraphQL(*deps.Parent)
+	return out, nil
+}
+
 // Host is the resolver for the process.host field.
 func (r *processResolver) Host(ctx context.Context, obj *graphql1.Process) (*graphql1.Host, error) {
 	hostID, _ := splitProcessNodeID(obj.ID)
@@ -1731,5 +1770,3 @@ type tmuxServerResolver struct{ *Resolver }
 type tmuxSessionResolver struct{ *Resolver }
 type tmuxWindowResolver struct{ *Resolver }
 type worktreeResolver struct{ *Resolver }
-
-

--- a/schema.graphql
+++ b/schema.graphql
@@ -1384,6 +1384,31 @@ type Issue implements Node {
   ones are surfaced, matching `PullRequest.labels` semantics.
   """
   labels: [Label!]!
+
+  """
+  Issues that block this one (#563). Mirrors GitHub's
+  `Issue.blockedByIssues` connection, fetched via the preview-gated
+  GraphQL features `issue_types,sub_issues`. Empty list when none.
+  """
+  blockedByIssues: [Issue!]!
+
+  """
+  Issues this one blocks (#563). The inverse of `blockedByIssues`.
+  Empty list when none.
+  """
+  blockingIssues: [Issue!]!
+
+  """
+  Sub-issues nested under this issue when it acts as a tracker (#563).
+  Empty list when this issue is a leaf, not a tracker.
+  """
+  subIssues: [Issue!]!
+
+  """
+  Parent tracker issue when this issue is itself a sub-issue (#563).
+  Null when this issue has no parent.
+  """
+  parentIssue: Issue
 }
 
 """


### PR DESCRIPTION
## Why bundled

Both touch `internal/server/providers/gh/`, share one `make generate` cycle, and the review surface stays tighter than two separate PRs would. Bundling decision: orchardist + Drew confirmed 2026-05-13.

## #563 — Issue dependency graph

Adds `blockedByIssues`, `blockingIssues`, `subIssues`, `parentIssue` to the daemon's `Issue` GraphQL type.

- GitHub's GraphQL exposes these as `blockedBy`/`blocking`/`subIssues`/`parent`, gated behind preview headers — the daemon now sends `GraphQL-Features: issue_types,sub_issues` + `X-Github-Next-Global-ID: 1` via the new `Client.GraphQLWithHeaders` entry point.
- `EnrichIssueDependencies` fetches all four edges in one round-trip; resolvers project one edge per field selection.
- `IssueRef` carries identity + title so a common projection `{ number title }` avoids an N+1 `GetIssue` per node. Heavier fields hydrate lazily via the existing Issue resolvers.
- 60s TTL on per-issue dep snapshots (same shape as PR enrichment), cleared on webhook invalidation.

**Live verified**:
- `issue(repo:"drewdrewthis/git-orchard-rs", number:544)` returns its 5 Tailwind-migration blockers (#558–#562) under `blockingIssues`.
- `issue(... number:558)` returns `#544` under `blockedByIssues` and `parentIssue: null`.

## #579 — gh-client pagination

Walks GitHub's `Link: <...>; rel="next"` chain up to `MaxPages = 10` (1000-item cap at `per_page=100`) for every list endpoint:

| Endpoint | Function |
|---|---|
| `/repos/{o}/{n}/pulls` | `ListPulls` |
| `/repos/{o}/{n}/issues` | `ListIssues` |
| `/repos/{o}/{n}/actions/runs` | `ListWorkflowRuns` |
| `/repos/{o}/{n}/pulls/{n}/reviews` | `ListPullReviews` |
| `/repos/{o}/{n}/issues/{n}/comments` | `ListPullComments` / `ListIssueComments` |

- Per-client `MaxPagesOverride` for test injection.
- Rate-limit / 401 propagate cleanly from any page.
- `loadPullRequestsForRepo` doc comment in `loaders.go` updated to drop the page-1 caveat.
- Workflow-runs envelope (`{ workflow_runs: [...] }`) handled via a sibling `doEnvelopePaginated` helper so the top-level-array helper stays type-safe.

**Live verified**: `issues(repo:"drewdrewthis/git-orchard-rs", state:ALL)` now returns 348 issues — previously truncated to ≤ 100.

## Test plan
- [x] `go test ./internal/...` — all green (pre-existing flake on `TestWorktreeTmuxJoin_E2E_LiveQuery` is environment-dependent and present on `main`)
- [x] `cargo build --release -p orchard`
- [x] `cargo test -p orchard --lib` — 1517 passed
- [x] Live daemon introspection: 4 new fields on `Issue`
- [x] Live resolver round-trip against #544 + #558
- [x] Live pagination round-trip (348 issues > 100/page cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #563

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added issue relationship tracking—view issues blocked by this one, issues this one blocks, sub-issues, and parent issue references.

* **Bug Fixes**
  * Improved pagination for GitHub data to properly handle large repositories, ensuring all results are visible across multiple pages instead of being truncated.

* **Tests**
  * Added comprehensive test coverage for pagination and issue dependency enrichment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/590)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #563