### PR TITLE
feat(daemon): auto-discover repos from tmux + claude conversations (closes #527)

### DIFF
--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -43,6 +43,7 @@ import (
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/manifest"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/peerproxy"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/ps"
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/repodiscovery"
 	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/tmux"
 )
 
@@ -145,7 +146,24 @@ func runStart(parentCtx context.Context, addr string, version string) error {
 	claudeProjectsRoot := claudeprojectsRoot()
 	claudeProjectsProvider := claudeprojects.New(claudeProjectsRoot, "local", logger)
 
-	gitProvider, err := buildGitProvider(ctx, configProvider, logger)
+	// Hydrate the claudeprojects cache before discovery runs so the
+	// claudeprojects source can contribute repo roots from the first
+	// boot tick (issue #527). Failures here are non-fatal — the
+	// discoverer simply gets a smaller initial union.
+	if err := claudeProjectsProvider.Start(ctx); err != nil {
+		logger.Warn("claudeprojects: pre-start failed; discovery may miss conversation cwds at boot", "err", err)
+	}
+
+	// Repo-discovery union (issue #527): configured repos + tmux pane
+	// CWDs + Claude conversation CWDs, with phantom guard and
+	// excluded[] filter. The git provider takes this as its
+	// project-lister so worktree enumeration covers every discovered
+	// repo, not just config.json entries.
+	repoDiscoverer := repodiscovery.NewProvider(configProvider, configProvider, logger).
+		AddSource("tmux", repodiscovery.NewTmuxSource()).
+		AddSource("claudeprojects", repodiscovery.NewClaudeProjectsSource(claudeProjectsProvider))
+
+	gitProvider, err := buildGitProvider(ctx, repoDiscoverer, logger)
 	if err != nil {
 		return fmt.Errorf("build git provider: %w", err)
 	}
@@ -214,7 +232,7 @@ func runStart(parentCtx context.Context, addr string, version string) error {
 
 	opts := []server.Option{
 		server.WithVersion(version),
-		server.WithRepos(configProvider),
+		server.WithRepos(repoDiscoverer),
 		server.WithGit(gitProvider),
 		server.WithPS(psProvider),
 		server.WithTmux(tmuxProvider),
@@ -242,27 +260,40 @@ func localHostID() tmux.HostID {
 }
 
 // buildGitProvider constructs the git provider and registers every
-// project the config provider has currently loaded. The git provider
-// owns a watcher per project; resolvers query it for `Project.worktrees`
-// and node-id lookups.
+// project from the supplied lister. The git provider owns a watcher
+// per project; resolvers query it for `Project.worktrees` and node-id
+// lookups.
+//
+// The lister parameter is a resolvers.ReposLister so callers can pass
+// either the raw configured provider (legacy) or the repodiscovery
+// union (issue #527). The git provider must learn about every repo
+// the resolver layer can surface, otherwise worktree lookups on
+// discovered repos return empty.
 //
 // Per-project AddProject failures (e.g. an fsnotify watcher couldn't be
 // installed) are logged and skipped so the daemon still boots — the
 // affected project simply won't surface live worktree updates until it
 // is reconfigured.
-func buildGitProvider(ctx context.Context, repos *configprovider.Provider, logger *slog.Logger) (*gitprovider.Provider, error) {
+func buildGitProvider(ctx context.Context, lister gitProjectLister, logger *slog.Logger) (*gitprovider.Provider, error) {
 	gp := gitprovider.NewProvider(logger)
-	configured, err := repos.List(ctx)
+	repos, err := lister.List(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list configured repos: %w", err)
+		return nil, fmt.Errorf("list repos: %w", err)
 	}
-	for _, p := range configured {
+	for _, p := range repos {
 		if err := gp.AddProject(gitprovider.Project{ID: string(p.ID), Dir: p.Path}); err != nil {
 			logger.Warn("git: skipping repo, watcher unavailable",
 				"repo", p.ID, "path", p.Path, "err", err)
 		}
 	}
 	return gp, nil
+}
+
+// gitProjectLister is the local narrow contract `buildGitProvider`
+// needs. Both [configprovider.Provider] and [repodiscovery.Provider]
+// satisfy it.
+type gitProjectLister interface {
+	List(ctx context.Context) ([]configprovider.Repo, error)
 }
 
 // buildHostServiceProvider resolves the local machine id, reads the

--- a/internal/server/providers/config/adapter.go
+++ b/internal/server/providers/config/adapter.go
@@ -106,6 +106,31 @@ func (a *JSONFileAdapter) FetchAll(ctx context.Context) (map[RepoID]Repo, error)
 	return out, nil
 }
 
+// FetchExcluded returns the `excluded` top-level array from the config
+// file as a slice of absolute paths (issue #527). A missing or empty
+// file returns nil, not an error — discovery degrades to "no
+// exclusions" rather than failing closed.
+func (a *JSONFileAdapter) FetchExcluded(ctx context.Context) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(a.path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", a.path, err)
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var f File
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", a.path, err)
+	}
+	return f.Excluded, nil
+}
+
 // Watch starts an fsnotify watcher on the parent directory of a.path
 // and emits allKey whenever an event matching the config file is
 // observed. The channel is closed when ctx is cancelled or Close is

--- a/internal/server/providers/config/provider.go
+++ b/internal/server/providers/config/provider.go
@@ -211,6 +211,28 @@ func (p *Provider) List(_ context.Context) ([]Repo, error) {
 	return out, nil
 }
 
+// Excluded returns the on-disk `excluded` list (issue #527). The
+// provider does not cache this list — it is consumed once per
+// discovery refresh by the repodiscovery layer, which already
+// throttles refreshes via its own TTL. A nil adapter returns nil, nil.
+//
+// The adapter contract here is the [ExcludedFetcher] interface; the
+// JSON file adapter satisfies it. Tests pass an in-memory adapter.
+func (p *Provider) Excluded(ctx context.Context) ([]string, error) {
+	if e, ok := p.adapter.(ExcludedFetcher); ok {
+		return e.FetchExcluded(ctx)
+	}
+	return nil, nil
+}
+
+// ExcludedFetcher is the optional capability for an adapter that can
+// surface the `excluded` config field separately from the repo list.
+// The JSON-file adapter implements it; in-memory test adapters can opt
+// in by implementing the method.
+type ExcludedFetcher interface {
+	FetchExcluded(ctx context.Context) ([]string, error)
+}
+
 // Subscribe returns a buffered channel that receives invalidation
 // events for as long as ctx is alive. Closing the returned context (or
 // calling Stop) cleans the subscription up.

--- a/internal/server/providers/config/types.go
+++ b/internal/server/providers/config/types.go
@@ -6,9 +6,10 @@
 // package owns the file format, the JSON adapter, and the provider that
 // surfaces Repos to the GraphQL resolver.
 //
-// Schema: per ADR-015 the file has exactly three top-level keys —
-// `version`, `repos`, and `peers`. Older shapes (`projects[]`) are not
-// supported on read or write.
+// Schema: per ADR-015 the file has four top-level keys —
+// `version`, `repos`, `peers`, and `excluded` (the last added in
+// issue #527). Older shapes (`projects[]`) are not supported on read
+// or write.
 package config
 
 import (

--- a/internal/server/providers/config/types.go
+++ b/internal/server/providers/config/types.go
@@ -43,14 +43,22 @@ type Repo struct {
 
 // File is the on-disk shape of ~/.orchard/config.json (ADR-015).
 //
-// Three top-level keys: `version`, `repos`, `peers`. Unknown fields are
-// tolerated on read (json.Unmarshal default behaviour) so older daemons
-// can read newer configs without crashing. On write, only these three
-// keys are emitted.
+// Top-level keys: `version`, `repos`, `peers`, `excluded`. Unknown
+// fields are tolerated on read (json.Unmarshal default behaviour) so
+// older daemons can read newer configs without crashing. On write, only
+// these keys are emitted; empty slices are elided.
+//
+// `excluded` is an opt-in list of absolute repo-root paths that the
+// repo-discovery layer (issue #527) drops from the auto-discovery
+// union. Configured `repos[]` are NOT filtered by `excluded` — a path
+// the operator explicitly added stays visible. The field is therefore
+// only consulted by the repodiscovery package; the config provider
+// itself simply round-trips it.
 type File struct {
-	Version int       `json:"version"`
-	Repos   []RepoRow `json:"repos"`
-	Peers   []PeerRow `json:"peers,omitempty"`
+	Version  int       `json:"version"`
+	Repos    []RepoRow `json:"repos"`
+	Peers    []PeerRow `json:"peers,omitempty"`
+	Excluded []string  `json:"excluded,omitempty"`
 }
 
 // RepoRow is one entry in `repos`. Identity is `slug`; display name is

--- a/internal/server/providers/repodiscovery/provider.go
+++ b/internal/server/providers/repodiscovery/provider.go
@@ -1,0 +1,354 @@
+package repodiscovery
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+)
+
+// DefaultTTL is the discovery cache lifetime. 30 seconds is short
+// enough that a new tmux pane or Claude conversation surfaces in the
+// dashboard within one poll cycle, and long enough that a burst of
+// `workView` queries from the TUI doesn't refire the union every tick.
+const DefaultTTL = 30 * time.Second
+
+// ExcludedFetcher is the optional capability the [Provider] uses to
+// load the `excluded[]` list from the config file. The [config.Provider]
+// implements it; tests pass an in-memory fake.
+type ExcludedFetcher interface {
+	Excluded(ctx context.Context) ([]string, error)
+}
+
+// Provider is the discoverer that the daemon wires into the
+// `Query.repos` (and therefore `workView.projects`) resolver. Its
+// [List] method returns the union of configured + tmux + claudeprojects
+// repos, with phantom configured rows dropped and excluded paths
+// filtered out.
+//
+// The provider is goroutine-safe and self-contained — no Start/Stop
+// lifecycle, no background goroutine. The first List call after a
+// cache expiry single-flights a refresh; concurrent callers wait on
+// the same in-flight result.
+type Provider struct {
+	configured ConfiguredLister
+	excluded   ExcludedFetcher
+	sources    []namedSource
+	ttl        time.Duration
+	clock      func() time.Time
+	logger     *slog.Logger
+
+	mu          sync.Mutex
+	cached      []config.Repo
+	cachedAt    time.Time
+	loggedGhost map[string]struct{}
+	inflight    *inflight
+}
+
+type namedSource struct {
+	name   string
+	source Source
+}
+
+// inflight gates concurrent refresh calls so a thundering herd of
+// `workView` queries only triggers one filesystem walk. The first
+// caller writes the result; the rest read it once Done is closed.
+type inflight struct {
+	done   chan struct{}
+	result []config.Repo
+}
+
+// NewProvider builds a discoverer.
+//
+// configured supplies the authoritative slug/id mapping; the [Provider]
+// reads it once per refresh and treats its entries as winning on
+// collision. The excluded fetcher is consulted on every refresh; pass
+// nil to skip exclusion.
+//
+// Additional discovery sources are attached via [AddSource]; the
+// constructor returns a discoverer with only the configured source
+// attached, ready to compose tmux and claudeprojects on top.
+func NewProvider(configured ConfiguredLister, excluded ExcludedFetcher, logger *slog.Logger) *Provider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Provider{
+		configured:  configured,
+		excluded:    excluded,
+		ttl:         DefaultTTL,
+		clock:       time.Now,
+		logger:      logger,
+		loggedGhost: map[string]struct{}{},
+	}
+}
+
+// AddSource attaches a discovery source by name. Names are used in
+// debug logs to identify which source contributed a given path.
+// Returns the receiver for chaining.
+func (p *Provider) AddSource(name string, src Source) *Provider {
+	if src == nil {
+		return p
+	}
+	p.sources = append(p.sources, namedSource{name: name, source: src})
+	return p
+}
+
+// WithTTL overrides [DefaultTTL]. Use a small TTL in tests to drive
+// the refresh path deterministically.
+func (p *Provider) WithTTL(d time.Duration) *Provider {
+	if d <= 0 {
+		return p
+	}
+	p.ttl = d
+	return p
+}
+
+// WithClock swaps the wall-clock for tests.
+func (p *Provider) WithClock(c func() time.Time) *Provider {
+	if c == nil {
+		return p
+	}
+	p.clock = c
+	return p
+}
+
+// List returns the union [config.Repo] set. The result is sorted by
+// slug for stable output across calls.
+//
+// The cache is consulted first; on miss (or stale entry), one caller
+// performs the refresh while concurrent callers block on the in-flight
+// result. The TTL is measured against the [Provider]'s clock so tests
+// can advance time deterministically.
+func (p *Provider) List(ctx context.Context) ([]config.Repo, error) {
+	p.mu.Lock()
+	if p.cached != nil && p.clock().Sub(p.cachedAt) < p.ttl {
+		out := append([]config.Repo(nil), p.cached...)
+		p.mu.Unlock()
+		return out, nil
+	}
+	if p.inflight != nil {
+		ch := p.inflight.done
+		p.mu.Unlock()
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		p.mu.Lock()
+		out := append([]config.Repo(nil), p.cached...)
+		p.mu.Unlock()
+		return out, nil
+	}
+	flight := &inflight{done: make(chan struct{})}
+	p.inflight = flight
+	p.mu.Unlock()
+
+	out, err := p.refresh(ctx)
+
+	p.mu.Lock()
+	if err == nil {
+		p.cached = out
+		p.cachedAt = p.clock()
+	}
+	flight.result = out
+	close(flight.done)
+	p.inflight = nil
+	result := append([]config.Repo(nil), p.cached...)
+	p.mu.Unlock()
+
+	if err != nil {
+		// Return the stale cache on refresh error if we have one — a
+		// transient tmux failure shouldn't blank the dashboard.
+		if len(result) > 0 {
+			p.logger.Warn("repodiscovery: refresh failed, serving stale cache", "err", err)
+			return result, nil
+		}
+		return nil, err
+	}
+	return append([]config.Repo(nil), out...), nil
+}
+
+// refresh performs one full union pass. Called under no lock; the
+// caller holds inflight gating so siblings wait.
+func (p *Provider) refresh(ctx context.Context) ([]config.Repo, error) {
+	configuredRepos, cfgErr := p.loadConfigured(ctx)
+	if cfgErr != nil {
+		// The configured source is authoritative; refusing to serve
+		// would mean returning no repos at all when the config file is
+		// briefly unreadable. Log and proceed with an empty configured
+		// set — discovered sources still contribute.
+		p.logger.Error("repodiscovery: configured load failed", "err", cfgErr)
+		configuredRepos = nil
+	}
+	excludedSet := p.loadExcluded(ctx)
+
+	// Build the keyed map of configured repos, dropping phantoms.
+	configuredByKey := make(map[string]config.Repo, len(configuredRepos))
+	configuredSlugs := make(map[string]struct{}, len(configuredRepos))
+	for _, r := range configuredRepos {
+		key, err := canonicalKey(r.Path)
+		if err != nil || !pathExists(key) {
+			p.logGhost(r)
+			continue
+		}
+		configuredByKey[key] = config.Repo{
+			ID:   r.ID,
+			Slug: r.Slug,
+			Path: key,
+		}
+		configuredSlugs[r.Slug] = struct{}{}
+	}
+
+	// Collect discovered roots from every non-configured source.
+	type discovered struct {
+		key      string
+		basename string
+		parent   string
+	}
+	var discoveredList []discovered
+	seenKey := make(map[string]struct{}, len(configuredByKey))
+	for k := range configuredByKey {
+		seenKey[k] = struct{}{}
+	}
+
+	for _, ns := range p.sources {
+		if ns.source == nil {
+			continue
+		}
+		roots, err := ns.source.Roots(ctx)
+		if err != nil {
+			p.logger.Warn("repodiscovery: source error", "source", ns.name, "err", err)
+			continue
+		}
+		for _, raw := range roots {
+			key, err := walkToRepoRoot(raw)
+			if err != nil {
+				continue
+			}
+			if !pathExists(key) {
+				continue
+			}
+			if _, dup := seenKey[key]; dup {
+				continue
+			}
+			if _, ex := excludedSet[key]; ex {
+				continue
+			}
+			seenKey[key] = struct{}{}
+			discoveredList = append(discoveredList, discovered{
+				key:      key,
+				basename: filepath.Base(key),
+				parent:   filepath.Base(filepath.Dir(key)),
+			})
+		}
+	}
+
+	// Synthesise auto-discovered Repo records, disambiguating slugs
+	// against configured + previously-seen-discovered names.
+	taken := make(map[string]struct{}, len(configuredSlugs)+len(discoveredList))
+	for s := range configuredSlugs {
+		taken[s] = struct{}{}
+	}
+
+	for _, d := range discoveredList {
+		slug := uniqueSlug(d.basename, d.parent, taken)
+		taken[slug] = struct{}{}
+		configuredByKey[d.key] = config.Repo{
+			ID:   config.RepoID(slug),
+			Slug: slug,
+			Path: d.key,
+		}
+	}
+
+	out := make([]config.Repo, 0, len(configuredByKey))
+	for _, r := range configuredByKey {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Slug < out[j].Slug })
+	return out, nil
+}
+
+func (p *Provider) loadConfigured(ctx context.Context) ([]config.Repo, error) {
+	if p.configured == nil {
+		return nil, nil
+	}
+	return p.configured.List(ctx)
+}
+
+func (p *Provider) loadExcluded(ctx context.Context) map[string]struct{} {
+	if p.excluded == nil {
+		return nil
+	}
+	raw, err := p.excluded.Excluded(ctx)
+	if err != nil {
+		p.logger.Warn("repodiscovery: excluded fetch failed", "err", err)
+		return nil
+	}
+	out := make(map[string]struct{}, len(raw))
+	for _, e := range raw {
+		key, err := canonicalKey(e)
+		if err != nil {
+			continue
+		}
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func (p *Provider) logGhost(r config.Repo) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, seen := p.loggedGhost[r.Path]; seen {
+		return
+	}
+	p.loggedGhost[r.Path] = struct{}{}
+	p.logger.Warn("repodiscovery: skipping phantom configured repo (directory missing)",
+		"slug", r.Slug, "path", r.Path)
+}
+
+// canonicalKey resolves a path to its absolute symlink-resolved form
+// without requiring `.git`. Used for configured rows (which are already
+// repo roots) and for excluded entries (which the operator typed in
+// raw).
+func canonicalKey(path string) (string, error) {
+	if path == "" {
+		return "", errors.New("repodiscovery: empty path")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		return resolved, nil
+	}
+	return abs, nil
+}
+
+// uniqueSlug derives a slug for an auto-discovered repo, suffixing the
+// parent-dir basename when [basename] is already taken. Falls back to a
+// "-N" counter when the suffix collides too.
+func uniqueSlug(basename, parent string, taken map[string]struct{}) string {
+	candidate := basename
+	if _, dup := taken[candidate]; !dup {
+		return candidate
+	}
+	if parent != "" && parent != "." && parent != "/" {
+		candidate = basename + "-" + parent
+		if _, dup := taken[candidate]; !dup {
+			return candidate
+		}
+	}
+	for n := 2; n < 1024; n++ {
+		c := basename + "-" + strconv.Itoa(n)
+		if _, dup := taken[c]; !dup {
+			return c
+		}
+	}
+	return basename + "-x"
+}

--- a/internal/server/providers/repodiscovery/provider.go
+++ b/internal/server/providers/repodiscovery/provider.go
@@ -57,11 +57,14 @@ type namedSource struct {
 }
 
 // inflight gates concurrent refresh calls so a thundering herd of
-// `workView` queries only triggers one filesystem walk. The first
-// caller writes the result; the rest read it once Done is closed.
+// `workView` queries only triggers one filesystem walk. The leader
+// writes either result or err before closing done; followers read
+// both so they observe the same outcome (success-with-stale,
+// success-with-fresh, or error-with-no-cache) the leader did.
 type inflight struct {
 	done   chan struct{}
 	result []config.Repo
+	err    error
 }
 
 // NewProvider builds a discoverer.
@@ -133,17 +136,19 @@ func (p *Provider) List(ctx context.Context) ([]config.Repo, error) {
 		return out, nil
 	}
 	if p.inflight != nil {
-		ch := p.inflight.done
+		flight := p.inflight
 		p.mu.Unlock()
 		select {
-		case <-ch:
+		case <-flight.done:
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
-		p.mu.Lock()
-		out := append([]config.Repo(nil), p.cached...)
-		p.mu.Unlock()
-		return out, nil
+		// Mirror the leader's outcome: if it errored with no cache,
+		// surface the same error; otherwise return its result slice.
+		if flight.err != nil {
+			return nil, flight.err
+		}
+		return append([]config.Repo(nil), flight.result...), nil
 	}
 	flight := &inflight{done: make(chan struct{})}
 	p.inflight = flight
@@ -156,18 +161,24 @@ func (p *Provider) List(ctx context.Context) ([]config.Repo, error) {
 		p.cached = out
 		p.cachedAt = p.clock()
 	}
-	flight.result = out
+	// Decide what followers (and this caller) get back. A transient
+	// refresh failure that still has a previous cache to fall back on
+	// serves stale rather than blanking the dashboard; a failure with
+	// no cache propagates so callers know discovery is dead.
+	served := append([]config.Repo(nil), p.cached...)
+	if err != nil && len(served) == 0 {
+		flight.err = err
+	} else {
+		flight.result = served
+	}
 	close(flight.done)
 	p.inflight = nil
-	result := append([]config.Repo(nil), p.cached...)
 	p.mu.Unlock()
 
 	if err != nil {
-		// Return the stale cache on refresh error if we have one — a
-		// transient tmux failure shouldn't blank the dashboard.
-		if len(result) > 0 {
+		if len(served) > 0 {
 			p.logger.Warn("repodiscovery: refresh failed, serving stale cache", "err", err)
-			return result, nil
+			return served, nil
 		}
 		return nil, err
 	}

--- a/internal/server/providers/repodiscovery/provider_test.go
+++ b/internal/server/providers/repodiscovery/provider_test.go
@@ -398,3 +398,54 @@ type delegatingSource struct {
 func (d *delegatingSource) Roots(_ context.Context) ([]string, error) {
 	return d.provider(), nil
 }
+
+func TestProvider_List_PropagatesCtxErrorToWaitingFollower(t *testing.T) {
+	// When a waiter's ctx is cancelled while it's blocked on the
+	// leader's refresh, List returns the ctx error — the inflight
+	// gating must not swallow it. (The leader path's no-cache error
+	// propagation is exercised by code review rather than a test
+	// because the current refresh() degrades all backing errors to
+	// logs + empty data; this test pins the ctx half of the same
+	// contract.)
+	tmp := t.TempDir()
+	repo := mkRepo(t, filepath.Join(tmp, "repo"))
+
+	// A slow source forces the leader to remain inside refresh() so
+	// the follower can race in and cancel its ctx before done fires.
+	gate := make(chan struct{})
+	slow := &delegatingSource{provider: func() []string {
+		<-gate
+		return []string{repo}
+	}}
+
+	p := NewProvider(&fakeConfigLister{}, nil, silentLogger()).
+		AddSource("slow", slow)
+
+	leaderDone := make(chan struct{})
+	go func() {
+		_, _ = p.List(context.Background())
+		close(leaderDone)
+	}()
+
+	// Wait until the leader is inside refresh (i.e. holding the
+	// inflight slot). A short retry loop is enough — the goroutine
+	// reaches the slow source within microseconds.
+	for tries := 0; tries < 100; tries++ {
+		p.mu.Lock()
+		inflight := p.inflight != nil
+		p.mu.Unlock()
+		if inflight {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	followerCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := p.List(followerCtx); err == nil {
+		t.Errorf("follower with cancelled ctx: expected error, got nil")
+	}
+
+	close(gate)
+	<-leaderDone
+}

--- a/internal/server/providers/repodiscovery/provider_test.go
+++ b/internal/server/providers/repodiscovery/provider_test.go
@@ -1,0 +1,400 @@
+package repodiscovery
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+)
+
+// silentLogger discards all log output so tests stay quiet.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type fakeConfigLister struct {
+	repos []config.Repo
+	err   error
+}
+
+func (f *fakeConfigLister) List(_ context.Context) ([]config.Repo, error) {
+	return f.repos, f.err
+}
+
+type fakeExcludedFetcher struct {
+	paths []string
+	err   error
+}
+
+func (f *fakeExcludedFetcher) Excluded(_ context.Context) ([]string, error) {
+	return f.paths, f.err
+}
+
+type fakeSource struct {
+	roots []string
+	err   error
+	calls int32
+}
+
+func (f *fakeSource) Roots(_ context.Context) ([]string, error) {
+	atomic.AddInt32(&f.calls, 1)
+	return f.roots, f.err
+}
+
+// mkRepo creates dir + dir/.git and returns the symlink-resolved path.
+func mkRepo(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkrepo: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	return resolved
+}
+
+func TestProvider_List_ConfiguredOnly(t *testing.T) {
+	tmp := t.TempDir()
+	repo := mkRepo(t, filepath.Join(tmp, "myrepo"))
+
+	p := NewProvider(
+		&fakeConfigLister{repos: []config.Repo{
+			{ID: "myrepo", Slug: "myrepo", Path: repo},
+		}},
+		nil,
+		silentLogger(),
+	)
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d repos, want 1", len(got))
+	}
+	if got[0].Slug != "myrepo" {
+		t.Errorf("got slug %q, want myrepo", got[0].Slug)
+	}
+}
+
+func TestProvider_List_UnionWithDiscovered(t *testing.T) {
+	tmp := t.TempDir()
+	configured := mkRepo(t, filepath.Join(tmp, "configured"))
+	discovered := mkRepo(t, filepath.Join(tmp, "discovered"))
+
+	p := NewProvider(
+		&fakeConfigLister{repos: []config.Repo{
+			{ID: "configured", Slug: "configured", Path: configured},
+		}},
+		nil,
+		silentLogger(),
+	).AddSource("fake", &fakeSource{roots: []string{discovered}})
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d repos, want 2: %+v", len(got), got)
+	}
+	slugs := map[string]config.Repo{}
+	for _, r := range got {
+		slugs[r.Slug] = r
+	}
+	if _, ok := slugs["configured"]; !ok {
+		t.Errorf("missing configured")
+	}
+	if r, ok := slugs["discovered"]; !ok || r.Path != discovered {
+		t.Errorf("missing discovered (path=%v)", r)
+	}
+}
+
+func TestProvider_List_DedupesAcrossSources(t *testing.T) {
+	tmp := t.TempDir()
+	repo := mkRepo(t, filepath.Join(tmp, "shared"))
+
+	p := NewProvider(
+		&fakeConfigLister{},
+		nil,
+		silentLogger(),
+	).
+		AddSource("tmux", &fakeSource{roots: []string{repo, repo}}).
+		AddSource("claude", &fakeSource{roots: []string{repo}})
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1 deduped repo: %+v", len(got), got)
+	}
+}
+
+func TestProvider_List_DedupesViaSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	repo := mkRepo(t, filepath.Join(tmp, "real"))
+	link := filepath.Join(tmp, "link")
+	if err := os.Symlink(repo, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	p := NewProvider(
+		&fakeConfigLister{},
+		nil,
+		silentLogger(),
+	).
+		AddSource("by-real", &fakeSource{roots: []string{repo}}).
+		AddSource("by-link", &fakeSource{roots: []string{link}})
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("symlink-aliased paths not deduped: %+v", got)
+	}
+}
+
+func TestProvider_List_ConfiguredWinsOnCollision(t *testing.T) {
+	tmp := t.TempDir()
+	repo := mkRepo(t, filepath.Join(tmp, "myrepo"))
+
+	// Configured pinned a custom slug "renamed" for this path.
+	p := NewProvider(
+		&fakeConfigLister{repos: []config.Repo{
+			{ID: "renamed", Slug: "renamed", Path: repo},
+		}},
+		nil,
+		silentLogger(),
+	).AddSource("tmux", &fakeSource{roots: []string{repo}})
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1: %+v", len(got), got)
+	}
+	if got[0].Slug != "renamed" {
+		t.Errorf("collision: got slug %q, want %q (configured wins)", got[0].Slug, "renamed")
+	}
+}
+
+func TestProvider_List_DropsPhantomConfigured(t *testing.T) {
+	tmp := t.TempDir()
+	real := mkRepo(t, filepath.Join(tmp, "real"))
+
+	// A configured row pointing at a missing path — phantom.
+	phantom := filepath.Join(tmp, "ghost", "TestAddRepo_X")
+
+	p := NewProvider(
+		&fakeConfigLister{repos: []config.Repo{
+			{ID: "real", Slug: "real", Path: real},
+			{ID: "002", Slug: "002", Path: phantom},
+		}},
+		nil,
+		silentLogger(),
+	)
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("phantom not dropped: %+v", got)
+	}
+	if got[0].Slug != "real" {
+		t.Errorf("kept wrong row: %+v", got)
+	}
+}
+
+func TestProvider_List_DropsExcluded(t *testing.T) {
+	tmp := t.TempDir()
+	keep := mkRepo(t, filepath.Join(tmp, "keep"))
+	skip := mkRepo(t, filepath.Join(tmp, "skip"))
+
+	p := NewProvider(
+		&fakeConfigLister{},
+		&fakeExcludedFetcher{paths: []string{skip}},
+		silentLogger(),
+	).AddSource("tmux", &fakeSource{roots: []string{keep, skip}})
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 || got[0].Path != keep {
+		t.Errorf("exclude failed: %+v", got)
+	}
+}
+
+func TestProvider_List_DiscoveryWalksToRepoRoot(t *testing.T) {
+	// The tmux source feeds raw pane CWDs (which are often subdirs
+	// inside the repo); the Provider must walk up to the .git parent.
+	tmp := t.TempDir()
+	repo := mkRepo(t, filepath.Join(tmp, "repo"))
+	sub := filepath.Join(repo, "src", "deep")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir sub: %v", err)
+	}
+
+	p := NewProvider(
+		&fakeConfigLister{},
+		nil,
+		silentLogger(),
+	).AddSource("tmux", &fakeSource{roots: []string{sub}})
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1: %+v", len(got), got)
+	}
+	if got[0].Path != repo {
+		t.Errorf("got path %q, want %q", got[0].Path, repo)
+	}
+}
+
+func TestProvider_List_SlugCollisionDisambiguatesByParent(t *testing.T) {
+	tmp := t.TempDir()
+	// Two repos with the same basename in different parent dirs.
+	a := mkRepo(t, filepath.Join(tmp, "owner-a", "myrepo"))
+	b := mkRepo(t, filepath.Join(tmp, "owner-b", "myrepo"))
+
+	p := NewProvider(
+		&fakeConfigLister{},
+		nil,
+		silentLogger(),
+	).AddSource("tmux", &fakeSource{roots: []string{a, b}})
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2: %+v", len(got), got)
+	}
+	// One should get "myrepo", the other "myrepo-<parent>".
+	slugs := map[string]bool{}
+	for _, r := range got {
+		slugs[r.Slug] = true
+	}
+	if !slugs["myrepo"] {
+		t.Errorf("missing plain myrepo slug: %+v", got)
+	}
+	// Either "myrepo-owner-a" or "myrepo-owner-b" should be present.
+	if !slugs["myrepo-owner-a"] && !slugs["myrepo-owner-b"] {
+		t.Errorf("missing parent-suffixed slug: %+v", got)
+	}
+}
+
+func TestProvider_List_CachesUntilTTLExpires(t *testing.T) {
+	tmp := t.TempDir()
+	repo := mkRepo(t, filepath.Join(tmp, "repo"))
+
+	src := &fakeSource{roots: []string{repo}}
+	now := time.Unix(0, 0)
+	clock := func() time.Time { return now }
+
+	p := NewProvider(
+		&fakeConfigLister{},
+		nil,
+		silentLogger(),
+	).
+		AddSource("tmux", src).
+		WithTTL(10 * time.Second).
+		WithClock(clock)
+
+	if _, err := p.List(context.Background()); err != nil {
+		t.Fatalf("List 1: %v", err)
+	}
+	if _, err := p.List(context.Background()); err != nil {
+		t.Fatalf("List 2: %v", err)
+	}
+	if got := atomic.LoadInt32(&src.calls); got != 1 {
+		t.Errorf("expected one source call within TTL, got %d", got)
+	}
+
+	now = now.Add(11 * time.Second)
+	if _, err := p.List(context.Background()); err != nil {
+		t.Fatalf("List 3: %v", err)
+	}
+	if got := atomic.LoadInt32(&src.calls); got != 2 {
+		t.Errorf("expected one source call after TTL expiry, got %d total", got)
+	}
+}
+
+func TestProvider_List_SourceErrorDoesNotKillUnion(t *testing.T) {
+	tmp := t.TempDir()
+	repo := mkRepo(t, filepath.Join(tmp, "repo"))
+
+	p := NewProvider(
+		&fakeConfigLister{repos: []config.Repo{{ID: "cfg", Slug: "cfg", Path: repo}}},
+		nil,
+		silentLogger(),
+	).
+		AddSource("broken", &fakeSource{err: errors.New("boom")}).
+		AddSource("ok", &fakeSource{roots: nil})
+
+	got, err := p.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 1 || got[0].Slug != "cfg" {
+		t.Errorf("got %+v, want one configured row", got)
+	}
+}
+
+func TestProvider_List_RestoresFreshCacheOnNextRefresh(t *testing.T) {
+	// Demonstrates the TTL boundary: the same call after TTL expiry
+	// observes a *new* set of roots from the source.
+	tmp := t.TempDir()
+	first := mkRepo(t, filepath.Join(tmp, "first"))
+	second := mkRepo(t, filepath.Join(tmp, "second"))
+
+	var rootsToReturn atomic.Value
+	rootsToReturn.Store([]string{first})
+
+	src := &delegatingSource{provider: func() []string {
+		return rootsToReturn.Load().([]string)
+	}}
+
+	now := time.Unix(0, 0)
+	clock := func() time.Time { return now }
+
+	p := NewProvider(
+		&fakeConfigLister{},
+		nil,
+		silentLogger(),
+	).AddSource("tmux", src).WithTTL(time.Second).WithClock(clock)
+
+	got, err := p.List(context.Background())
+	if err != nil || len(got) != 1 || got[0].Path != first {
+		t.Fatalf("first refresh: got %+v, err %v", got, err)
+	}
+
+	rootsToReturn.Store([]string{first, second})
+	now = now.Add(2 * time.Second)
+
+	got, err = p.List(context.Background())
+	if err != nil || len(got) != 2 {
+		t.Fatalf("post-TTL refresh: got %+v, err %v", got, err)
+	}
+}
+
+type delegatingSource struct {
+	provider func() []string
+}
+
+func (d *delegatingSource) Roots(_ context.Context) ([]string, error) {
+	return d.provider(), nil
+}

--- a/internal/server/providers/repodiscovery/source_claudeprojects.go
+++ b/internal/server/providers/repodiscovery/source_claudeprojects.go
@@ -1,0 +1,50 @@
+package repodiscovery
+
+import (
+	"context"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
+)
+
+// ConversationLister is the narrow read-side contract the
+// [ClaudeProjectsSource] depends on. The package-local [claudeprojects.Provider]
+// already implements it.
+type ConversationLister interface {
+	List(ctx context.Context) ([]claudeprojects.Conversation, error)
+}
+
+// ClaudeProjectsSource discovers candidate repo CWDs by reading every
+// known Claude Code conversation's `cwd` record. Conversations without
+// a CWD (older transcripts that predate the `cwd` JSONL record) are
+// skipped silently — they contribute nothing rather than failing the
+// source.
+type ClaudeProjectsSource struct {
+	lister ConversationLister
+}
+
+// NewClaudeProjectsSource wraps a [ConversationLister].
+func NewClaudeProjectsSource(lister ConversationLister) *ClaudeProjectsSource {
+	return &ClaudeProjectsSource{lister: lister}
+}
+
+// Roots returns every distinct `Conversation.Cwd` known to the
+// provider. Walk-to-repo-root + dedupe happens at the [Provider] layer.
+// A nil lister or a List error degrades to "no contribution this tick";
+// the [Provider]'s union still produces a result from the other sources.
+func (s *ClaudeProjectsSource) Roots(ctx context.Context) ([]string, error) {
+	if s == nil || s.lister == nil {
+		return nil, nil
+	}
+	convs, err := s.lister.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(convs))
+	for _, c := range convs {
+		if c.Cwd == nil || *c.Cwd == "" {
+			continue
+		}
+		out = append(out, *c.Cwd)
+	}
+	return out, nil
+}

--- a/internal/server/providers/repodiscovery/source_claudeprojects_test.go
+++ b/internal/server/providers/repodiscovery/source_claudeprojects_test.go
@@ -1,0 +1,69 @@
+package repodiscovery
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/claudeprojects"
+)
+
+type fakeConversationLister struct {
+	convs []claudeprojects.Conversation
+	err   error
+}
+
+func (f *fakeConversationLister) List(_ context.Context) ([]claudeprojects.Conversation, error) {
+	return f.convs, f.err
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestClaudeProjectsSource_Roots_ExtractsCwds(t *testing.T) {
+	src := NewClaudeProjectsSource(&fakeConversationLister{
+		convs: []claudeprojects.Conversation{
+			{Cwd: strPtr("/Users/me/work/foo")},
+			{Cwd: strPtr("/Users/me/work/bar")},
+		},
+	})
+	got, err := src.Roots(context.Background())
+	if err != nil {
+		t.Fatalf("Roots: %v", err)
+	}
+	if !equalSlices(got, []string{"/Users/me/work/foo", "/Users/me/work/bar"}) {
+		t.Errorf("got %v", got)
+	}
+}
+
+func TestClaudeProjectsSource_Roots_SkipsNilCwd(t *testing.T) {
+	src := NewClaudeProjectsSource(&fakeConversationLister{
+		convs: []claudeprojects.Conversation{
+			{Cwd: nil},                          // older transcript without cwd
+			{Cwd: strPtr("")},                   // empty cwd
+			{Cwd: strPtr("/Users/me/work/baz")}, // valid
+		},
+	})
+	got, err := src.Roots(context.Background())
+	if err != nil {
+		t.Fatalf("Roots: %v", err)
+	}
+	if !equalSlices(got, []string{"/Users/me/work/baz"}) {
+		t.Errorf("got %v, want [/Users/me/work/baz]", got)
+	}
+}
+
+func TestClaudeProjectsSource_Roots_NilLister(t *testing.T) {
+	src := NewClaudeProjectsSource(nil)
+	got, err := src.Roots(context.Background())
+	if err != nil || got != nil {
+		t.Errorf("nil lister: got (%v, %v); want (nil, nil)", got, err)
+	}
+}
+
+func TestClaudeProjectsSource_Roots_ListerError(t *testing.T) {
+	src := NewClaudeProjectsSource(&fakeConversationLister{err: errors.New("boom")})
+	_, err := src.Roots(context.Background())
+	if err == nil {
+		t.Errorf("expected error from lister to propagate")
+	}
+}

--- a/internal/server/providers/repodiscovery/source_configured.go
+++ b/internal/server/providers/repodiscovery/source_configured.go
@@ -1,0 +1,43 @@
+package repodiscovery
+
+import "context"
+
+// ConfiguredSource lifts the existing config provider into the
+// discovery [Source] contract. The wrapper exists so the [Provider]
+// can treat all three feeds (configured + tmux + claudeprojects)
+// uniformly, even though configured paths arrive pre-canonicalised.
+//
+// The wrapped [ConfiguredLister] retains authority over slug / id
+// metadata — [Provider] re-reads it separately to apply overrides.
+type ConfiguredSource struct {
+	lister ConfiguredLister
+}
+
+// NewConfiguredSource wraps a [ConfiguredLister]. A nil lister yields
+// an empty source; the [Provider] tolerates that for tests.
+func NewConfiguredSource(lister ConfiguredLister) *ConfiguredSource {
+	return &ConfiguredSource{lister: lister}
+}
+
+// Roots returns the absolute paths of every configured repo.
+// Phantom entries (paths that no longer exist on disk) are NOT filtered
+// here — that belongs to the [Provider] so it can log once. Returning
+// every configured path keeps the source's contract simple and lets
+// the [Provider] reconcile against the configured slug map.
+func (s *ConfiguredSource) Roots(ctx context.Context) ([]string, error) {
+	if s == nil || s.lister == nil {
+		return nil, nil
+	}
+	repos, err := s.lister.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(repos))
+	for _, r := range repos {
+		if r.Path == "" {
+			continue
+		}
+		out = append(out, r.Path)
+	}
+	return out, nil
+}

--- a/internal/server/providers/repodiscovery/source_tmux.go
+++ b/internal/server/providers/repodiscovery/source_tmux.go
@@ -1,0 +1,84 @@
+package repodiscovery
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+)
+
+// Runner is the exec seam — production wires [execRunner]; tests pass a
+// fake. Mirrors the same shape used by the tmux provider so test
+// fixtures translate between packages.
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+type execRunner struct{}
+
+// Run executes name+args and returns combined stdout. Stderr is
+// discarded; discovery is opportunistic and noisy errors from a missing
+// tmux server would drown out the logs.
+func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}
+
+// TmuxSource discovers candidate repo CWDs by querying every tmux pane
+// on the local host for `pane_current_path`. The query runs as a single
+// `tmux list-panes -a` exec — the same coalesced shape the main tmux
+// provider uses for snapshots (issue #464). When no tmux server is
+// running, Roots returns an empty slice (not an error) so the [Provider]
+// keeps merging the other sources.
+type TmuxSource struct {
+	runner Runner
+}
+
+// NewTmuxSource returns a TmuxSource using the real `tmux` binary.
+func NewTmuxSource() *TmuxSource {
+	return &TmuxSource{runner: execRunner{}}
+}
+
+// WithRunner swaps the exec seam. Tests inject a fake that emits
+// canned pane lists. Returns a new TmuxSource so chained constructors
+// stay value-safe.
+func (s *TmuxSource) WithRunner(r Runner) *TmuxSource {
+	cp := *s
+	cp.runner = r
+	return &cp
+}
+
+// Roots queries `tmux list-panes -a -F '#{pane_current_path}'` and
+// returns one entry per non-empty line. The output is not deduplicated
+// here — duplicates fold out at the [Provider] layer once each path has
+// been walked to its repo root.
+//
+// A missing tmux server (the binary is installed but no daemon is
+// running) returns an empty slice and a nil error. Genuine exec
+// failures (binary missing) are also swallowed; the daemon must not
+// fail-closed on an opportunistic discovery source.
+func (s *TmuxSource) Roots(ctx context.Context) ([]string, error) {
+	out, err := s.runner.Run(ctx, "tmux", "list-panes", "-a", "-F", "#{pane_current_path}")
+	if err != nil {
+		return nil, nil
+	}
+	out = bytes.TrimRight(out, "\n")
+	if len(out) == 0 {
+		return nil, nil
+	}
+	lines := strings.Split(string(out), "\n")
+	roots := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		roots = append(roots, line)
+	}
+	return roots, nil
+}

--- a/internal/server/providers/repodiscovery/source_tmux_test.go
+++ b/internal/server/providers/repodiscovery/source_tmux_test.go
@@ -1,0 +1,97 @@
+package repodiscovery
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fakeRunner struct {
+	output []byte
+	err    error
+	calls  int
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
+	f.calls++
+	return f.output, f.err
+}
+
+func TestTmuxSource_Roots_Parses(t *testing.T) {
+	src := NewTmuxSource().WithRunner(&fakeRunner{output: []byte("/foo\n/bar\n/baz\n")})
+	got, err := src.Roots(context.Background())
+	if err != nil {
+		t.Fatalf("Roots: %v", err)
+	}
+	want := []string{"/foo", "/bar", "/baz"}
+	if !equalSlices(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestTmuxSource_Roots_TrimsEmptyLines(t *testing.T) {
+	src := NewTmuxSource().WithRunner(&fakeRunner{output: []byte("/foo\n\n /bar \n\n")})
+	got, err := src.Roots(context.Background())
+	if err != nil {
+		t.Fatalf("Roots: %v", err)
+	}
+	if !equalSlices(got, []string{"/foo", "/bar"}) {
+		t.Errorf("got %v, want [/foo /bar]", got)
+	}
+}
+
+func TestTmuxSource_Roots_NoServerReturnsEmpty(t *testing.T) {
+	// A missing tmux server (or a missing tmux binary entirely) should
+	// degrade silently — Roots returns nil, nil so the Provider keeps
+	// merging the other sources.
+	src := NewTmuxSource().WithRunner(&fakeRunner{err: errors.New("no server running")})
+	got, err := src.Roots(context.Background())
+	if err != nil {
+		t.Errorf("err: got %v, want nil", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestTmuxSource_Roots_EmptyOutput(t *testing.T) {
+	src := NewTmuxSource().WithRunner(&fakeRunner{output: []byte("")})
+	got, err := src.Roots(context.Background())
+	if err != nil {
+		t.Errorf("err: got %v, want nil", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty", got)
+	}
+}
+
+func TestTmuxSource_Roots_NewProductionConstructor(t *testing.T) {
+	// Ensure NewTmuxSource works without explicit runner injection.
+	src := NewTmuxSource()
+	if src.runner == nil {
+		t.Fatal("NewTmuxSource should wire a default runner")
+	}
+	// Smoke test: we don't actually want to shell out in unit tests,
+	// but the call should not panic if tmux is absent. The error
+	// degrades to "no contribution".
+	got, _ := src.Roots(context.Background())
+	// Just assert the type; the result depends on host state.
+	_ = got
+	// Sanity: passing tmux args don't include any shell metachars.
+	if strings.Contains(strings.Join([]string{"#{pane_current_path}"}, ""), ";") {
+		t.Errorf("format string contains shell metachar")
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/server/providers/repodiscovery/types.go
+++ b/internal/server/providers/repodiscovery/types.go
@@ -1,0 +1,50 @@
+// Package repodiscovery unifies configured repos with repos auto-discovered
+// from tmux pane CWDs and Claude Code conversation CWDs (issue #527).
+//
+// The package exposes a single [Provider] that implements the
+// resolvers.ReposLister contract by composing:
+//
+//  1. configured: the existing `~/.orchard/config.json repos[]` list,
+//     authoritative for slug / path overrides.
+//  2. tmux: every tmux pane's `pane_current_path`, walked up to the
+//     nearest `.git` parent.
+//  3. claudeprojects: every Claude Code conversation's `cwd`, walked up
+//     to the nearest `.git` parent.
+//
+// Dedupe key is the absolute, symlink-resolved path of the repo root
+// (the `.git` parent). Configured entries always win on collision; for
+// auto-discovered entries the [Provider] derives a slug from the
+// basename, suffixing with the parent directory when two basenames
+// would otherwise collide.
+//
+// A short-TTL cache fronts the union — discovery is cheap but not free,
+// and resolver-side calls fire on every `workView` query. Phantom
+// configured entries (those whose directory has been deleted) are
+// dropped at refresh time; the [Provider] logs the drop once per
+// refresh so stale fixture rows don't surface as `0 worktrees` ghosts
+// in the dashboard.
+package repodiscovery
+
+import (
+	"context"
+
+	"github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+)
+
+// Source returns absolute repo-root paths (the directory containing a
+// `.git` entry). The contract is loose on purpose: each adapter feeds
+// raw candidate CWDs through [walkToRepoRoot] before returning, so the
+// [Provider] receives already-canonical absolute paths.
+//
+// Roots is called on every discovery refresh; implementations should be
+// fast (a single CLI exec or in-memory snapshot read) and non-blocking
+// under network failure. Returning an error degrades to "this source
+// contributed nothing this tick" — siblings still feed the union.
+type Source interface {
+	Roots(ctx context.Context) ([]string, error)
+}
+
+// ConfiguredLister is the read-side dependency on the existing config
+// provider. The package only consumes its in-memory cache, never its
+// adapter.
+type ConfiguredLister = config.Lister

--- a/internal/server/providers/repodiscovery/walk.go
+++ b/internal/server/providers/repodiscovery/walk.go
@@ -1,0 +1,152 @@
+package repodiscovery
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// errNoRepoRoot is returned by walkToRepoRoot when no ancestor of the
+// input path contains a `.git` entry. Tested via [errors.Is].
+var errNoRepoRoot = errors.New("repodiscovery: no .git ancestor")
+
+// walkToRepoRoot returns the absolute, symlink-resolved path of the
+// nearest ancestor of path that contains a `.git` entry. The function
+// distinguishes three on-disk shapes:
+//
+//   - `.git` as a *directory*: a top-level git repo. The containing
+//     directory is the repo root and is returned as-is.
+//   - `.git` as a *file* whose content starts with `gitdir: …`: a
+//     [git worktree](https://git-scm.com/docs/git-worktree) checkout.
+//     The function follows the gitdir to recover the **main** repo's
+//     working tree and returns that — so all worktrees of one repo
+//     collapse to a single discovery key. This is the fix for issue
+//     #527's "every worktree shows up as its own repo" symptom.
+//   - `.git` as something else (corrupt, dangling): the function falls
+//     back to the directory containing it.
+//
+// Returns [errNoRepoRoot] when no ancestor up to and including the
+// filesystem root has a `.git` entry. Symlinks in any path segment are
+// resolved via [filepath.EvalSymlinks] on the final result so the
+// caller can use the return value as a stable dedupe key.
+//
+// The walk terminates at the filesystem root (`/`) or when
+// [filepath.Dir] stops shrinking (Windows drive root).
+func walkToRepoRoot(path string) (string, error) {
+	if path == "" {
+		return "", errNoRepoRoot
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	cur := abs
+	for {
+		gitPath := filepath.Join(cur, ".git")
+		info, err := os.Lstat(gitPath)
+		switch {
+		case err == nil:
+			if info.IsDir() {
+				return canonicalise(cur), nil
+			}
+			// `.git` is a file → worktree pointer. Resolve to main
+			// repo when the gitdir matches the standard worktree
+			// layout. For submodule worktrees (and other unrecognised
+			// shapes) we keep climbing so the walker eventually lands
+			// on the superproject's `.git` directory — better than
+			// surfacing every submodule worktree as its own ghost
+			// repo (issue #527).
+			if main, ok := mainRepoFromGitFile(gitPath); ok {
+				return canonicalise(main), nil
+			}
+		case errors.Is(err, fs.ErrNotExist):
+			// keep climbing
+		default:
+			// Permission errors — treat as not-here and keep climbing.
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return "", errNoRepoRoot
+		}
+		cur = parent
+	}
+}
+
+// canonicalise resolves symlinks on dir so the discovery union has a
+// stable dedupe key. Falls back to the un-resolved path when symlink
+// resolution fails (the directory was just stat'd, so the result is
+// still real; the dedupe is just imperfect).
+func canonicalise(dir string) string {
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		return resolved
+	}
+	return dir
+}
+
+// mainRepoFromGitFile reads a `.git` file (the worktree marker) and
+// returns the main repo's working-tree path.
+//
+// The file looks like:
+//
+//	gitdir: /Users/me/work/repo/.git/worktrees/feature-x
+//
+// The main repo's working tree is the directory containing `.git`,
+// which sits at `/Users/me/work/repo`. We derive it by trimming
+// `/.git/worktrees/<name>` from the gitdir path.
+//
+// Submodules complicate matters: a submodule worktree gitdir looks like:
+//
+//	gitdir: /Users/me/work/super/.git/modules/<sub>/worktrees/<name>
+//
+// Here the submodule's main working tree is `super/<sub>`, NOT
+// derivable purely from the gitdir text. We return ok=false in that
+// case so the caller falls back to the worktree path itself — better
+// than mis-pointing at the superproject.
+func mainRepoFromGitFile(gitFilePath string) (string, bool) {
+	data, err := os.ReadFile(gitFilePath)
+	if err != nil {
+		return "", false
+	}
+	line := strings.TrimSpace(string(data))
+	const prefix = "gitdir:"
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	gitdir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if gitdir == "" {
+		return "", false
+	}
+	// Relative gitdir paths are resolved against the file's directory.
+	if !filepath.IsAbs(gitdir) {
+		gitdir = filepath.Join(filepath.Dir(gitFilePath), gitdir)
+	}
+	gitdir = filepath.Clean(gitdir)
+
+	// Look for the `.git/worktrees/<name>` tail. Anything before it is
+	// the main repo's working tree (a regular `.git` directory's
+	// parent). Submodule worktree gitdirs contain
+	// `.git/modules/<sub>/worktrees/<name>` instead; the parent of
+	// `.git` there is the superproject, not the submodule, so we
+	// refuse and fall back.
+	const worktreesSeg = "/.git/worktrees/"
+	if idx := strings.Index(gitdir, worktreesSeg); idx >= 0 {
+		return gitdir[:idx], true
+	}
+	return "", false
+}
+
+// pathExists is a phantom-guard helper. Returns true when path resolves
+// to a directory readable by the daemon process. Permission errors and
+// dangling symlinks return false.
+func pathExists(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}

--- a/internal/server/providers/repodiscovery/walk_test.go
+++ b/internal/server/providers/repodiscovery/walk_test.go
@@ -1,0 +1,157 @@
+package repodiscovery
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// mustGitDir creates dir, writes a `.git` directory inside it, and
+// returns the symlink-resolved path so tests can compare against
+// walkToRepoRoot output directly.
+func mustGitDir(t *testing.T, dir string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	return resolved
+}
+
+func TestWalkToRepoRoot_FindsGitDir(t *testing.T) {
+	tmp := t.TempDir()
+	repo := mustGitDir(t, filepath.Join(tmp, "repo"))
+
+	// Walk from a nested subdir inside the repo.
+	deep := filepath.Join(repo, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatalf("mkdir deep: %v", err)
+	}
+
+	got, err := walkToRepoRoot(deep)
+	if err != nil {
+		t.Fatalf("walkToRepoRoot: %v", err)
+	}
+	if got != repo {
+		t.Errorf("got %q, want %q", got, repo)
+	}
+}
+
+func TestWalkToRepoRoot_FollowsWorktreePointer(t *testing.T) {
+	// A `.git` file containing `gitdir: <main>/.git/worktrees/<name>`
+	// is the worktree pointer git worktree creates. The walker must
+	// resolve it back to the main repo so every worktree of one repo
+	// dedupes to the same key. This is the fix for issue #527 — the
+	// previous walker stopped at the worktree dir and surfaced every
+	// worktree as its own repo with zero children.
+	tmp := t.TempDir()
+	main := mustGitDir(t, filepath.Join(tmp, "repo"))
+	// Create the real worktrees dir tree.
+	if err := os.MkdirAll(filepath.Join(main, ".git", "worktrees", "feature-x"), 0o755); err != nil {
+		t.Fatalf("mkdir worktrees: %v", err)
+	}
+	wt := filepath.Join(tmp, "wt")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatalf("mkdir wt: %v", err)
+	}
+	gitdirLine := "gitdir: " + filepath.Join(main, ".git", "worktrees", "feature-x") + "\n"
+	if err := os.WriteFile(filepath.Join(wt, ".git"), []byte(gitdirLine), 0o644); err != nil {
+		t.Fatalf("write .git: %v", err)
+	}
+
+	// Walking from any path inside the worktree must return the *main*
+	// repo path, not the worktree dir.
+	got, err := walkToRepoRoot(wt)
+	if err != nil {
+		t.Fatalf("walkToRepoRoot: %v", err)
+	}
+	if got != main {
+		t.Errorf("worktree did not resolve to main: got %q, want %q", got, main)
+	}
+}
+
+func TestWalkToRepoRoot_GitFileWithSubmoduleWorktreeWalksToSuperproject(t *testing.T) {
+	// A submodule worktree has `gitdir: <super>/.git/modules/<sub>/worktrees/<name>`
+	// — the path doesn't directly identify the submodule's working
+	// tree. The walker refuses to point at the worktree itself (which
+	// would surface every submodule worktree as its own ghost repo —
+	// issue #527's primary failure mode) and keeps climbing until it
+	// finds a directory-shaped `.git`. That's the superproject.
+	tmp := t.TempDir()
+	super := mustGitDir(t, filepath.Join(tmp, "super"))
+	subRoot := filepath.Join(super, "sub")
+	wt := filepath.Join(subRoot, "wt-x")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatalf("mkdir wt: %v", err)
+	}
+	// Submodule-style gitdir line: the walker can't decode this shape,
+	// so it falls back to climbing.
+	gitdirLine := "gitdir: " + filepath.Join(super, ".git", "modules", "sub", "worktrees", "x") + "\n"
+	if err := os.WriteFile(filepath.Join(wt, ".git"), []byte(gitdirLine), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := walkToRepoRoot(wt)
+	if err != nil {
+		t.Fatalf("walkToRepoRoot: %v", err)
+	}
+	if got != super {
+		t.Errorf("submodule worktree should resolve to superproject: got %q, want %q", got, super)
+	}
+}
+
+func TestWalkToRepoRoot_NoGitAncestor(t *testing.T) {
+	tmp := t.TempDir()
+	got, err := walkToRepoRoot(tmp)
+	if !errors.Is(err, errNoRepoRoot) {
+		t.Fatalf("got err %v, want errNoRepoRoot; got %q", err, got)
+	}
+}
+
+func TestWalkToRepoRoot_EmptyPath(t *testing.T) {
+	if _, err := walkToRepoRoot(""); !errors.Is(err, errNoRepoRoot) {
+		t.Errorf("empty path: got err %v, want errNoRepoRoot", err)
+	}
+}
+
+func TestWalkToRepoRoot_ResolvesSymlinks(t *testing.T) {
+	tmp := t.TempDir()
+	repo := mustGitDir(t, filepath.Join(tmp, "repo"))
+	link := filepath.Join(tmp, "link")
+	if err := os.Symlink(repo, link); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	got, err := walkToRepoRoot(link)
+	if err != nil {
+		t.Fatalf("walkToRepoRoot: %v", err)
+	}
+	if got != repo {
+		t.Errorf("symlink not resolved: got %q, want %q", got, repo)
+	}
+}
+
+func TestPathExists(t *testing.T) {
+	tmp := t.TempDir()
+	if !pathExists(tmp) {
+		t.Errorf("tmp dir should exist: %s", tmp)
+	}
+	if pathExists("") {
+		t.Errorf("empty path should not exist")
+	}
+	if pathExists(filepath.Join(tmp, "does-not-exist")) {
+		t.Errorf("missing path should not exist")
+	}
+	// File (not dir) should NOT count — repo roots are directories.
+	f := filepath.Join(tmp, "file")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if pathExists(f) {
+		t.Errorf("file should not satisfy directory check")
+	}
+}


### PR DESCRIPTION
## Summary

- Unifies `workView.repos` from three sources: configured (`~/.orchard/config.json repos[]`), tmux pane CWDs, Claude conversation CWDs.
- Phantom guard drops configured rows whose `directory` is missing; new `excluded: []string` config field filters auto-discovered entries.
- Worktree-pointer `.git` files resolve to the **main** repo, so every worktree of one repo dedupes to a single key. Submodule worktrees climb to the superproject.

## Why

Today, a worktree only appears in `workView.projects[].worktrees` if its parent repo is explicitly registered in `~/.orchard/config.json`. Every new repo required `orchard config add-repo <path>` before the GUI/TUI could show it, worktrees in tmux sessions and `~/.claude/projects/` were invisible, and stale `TestAddRepo_*` fixture rows accumulated as `0 worktrees` phantom projects.

## Verification (live, this branch)

```bash
curl -s -X POST http://127.0.0.1:7777/graphql -H 'Content-Type: application/json' \
  --data '{"query":"{ workView { repos { id slug worktrees { path } } } }"}' \
  | jq '{n: (.data.workView.repos | length), repos: (.data.workView.repos | map({id, count: (.worktrees | length)}))}'
```

Before this PR (only configured repos visible): 3 repos.
After this PR on the same machine: **5 real repos** with correct worktree counts (langwatch-saas: 2, langwatch/langwatch: 27, langwatch/scenario: 3, drewdrewthis/git-orchard-rs: 4, .claude: 1). The `002` / `alpha` / `beta` / `repo-name` / `second` phantom test-fixture rows are gone.

## Test plan

- [x] `go test ./internal/server/providers/repodiscovery/` — unit + integration tests cover union, dedupe, override, phantom guard, excluded list, slug-suffix collision, TTL refresh, walk-to-repo-root semantics
- [x] `go test ./internal/...` — full pkg test pass (one pre-existing tmux-E2E flake on darwin unrelated to this PR)
- [x] `make daemon` builds; live daemon rebuilt, restarted, schema introspection clean
- [x] `cargo build --release` succeeds; no Rust-side changes needed (clients consume `Query.repos` unchanged)
- [x] Manual: phantom test-fixture rows no longer in `workView.repos`; tmux + claude conversations surface their repos without `orchard config add-repo`

## Notes

- Out-of-scope (per #527, tracked separately): `TestAddRepo_*` Go tests writing to real config, cross-machine federation (ADR-008).
- Discovery refresh cadence: 30s cache TTL with single-flight gating, per orchardist's prescribed defaults in the brief.
- Lazy GitHub fetch: no change needed — `Query.repos` is a projection without gh calls; `worktree.pr` was already field-level lazy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add on-disk "excluded" list in config (missing file treated as non-error) to exclude paths from discovery
  * Automatic repository discovery now includes Claude Projects and tmux sources
  * Configured and discovered repositories are unified with deterministic deduplication, worktree-aware root detection, canonicalization, and caching

* **Tests**
  * Comprehensive tests added for discovery, tmux/Claude sources, repo-root walking, cache/TTL, and concurrency behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/595)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #527

# Related issue

- #527

# Related issue

- #527