### PR TITLE
fix(daemon): populate ClaudeInstance.pane when ps cross-check fails (closes #580)

### DIFF
--- a/internal/cli/daemon/claudeinstance_wiring.go
+++ b/internal/cli/daemon/claudeinstance_wiring.go
@@ -19,6 +19,7 @@ package daemon
 import (
 	"context"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -166,7 +167,9 @@ func (a *tmuxInputAdapter) PaneBySession(ctx context.Context, hostID, session st
 		return nil, false
 	}
 	snap := a.p.Snapshot()
-	var fallback *tmuxprovider.Pane
+	// Sort candidates by window index then pane id so "first pane" semantics are
+	// stable across runs — snap.Panes is a Go map and iteration is randomized.
+	candidates := make([]tmuxprovider.Pane, 0, len(snap.Panes))
 	for _, pn := range snap.Panes {
 		if string(pn.Key.Host) != hostID || pn.WindowKey.Session != session {
 			continue
@@ -174,6 +177,17 @@ func (a *tmuxInputAdapter) PaneBySession(ctx context.Context, hostID, session st
 		if pn.CurrentPid <= 0 {
 			continue
 		}
+		candidates = append(candidates, pn)
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].WindowKey.Index != candidates[j].WindowKey.Index {
+			return candidates[i].WindowKey.Index < candidates[j].WindowKey.Index
+		}
+		return candidates[i].Key.PaneID < candidates[j].Key.PaneID
+	})
+
+	var fallback *tmuxprovider.Pane
+	for _, pn := range candidates {
 		pnCopy := pn
 		if a.ps == nil {
 			// No ps provider: first pane with non-zero pid is the answer.

--- a/internal/cli/daemon/claudeinstance_wiring.go
+++ b/internal/cli/daemon/claudeinstance_wiring.go
@@ -147,17 +147,26 @@ func (a *tmuxInputAdapter) PaneByPid(ctx context.Context, hostID string, pid int
 // named session that is owned by a claude process.
 //
 // When a.ps is non-nil, every candidate pane's foreground pid is looked up in
-// the ps snapshot; only panes whose process Command basename contains "claude"
-// are eligible. This ensures that a session containing [vim, claude] returns
-// the claude pane even when vim is iterated first.
+// the ps snapshot; panes whose process Command basename contains "claude" win.
+// This preserves the multi-pane fix from issue #468 where a session like
+// [vim, claude] must surface the claude pane.
 //
-// When a.ps is nil (tests, no-ps mode), the first pane with a non-zero
-// currentPid is returned — v1 behaviour sufficient when ps data is unavailable.
+// Fallback (issue #580): if the ps cross-check finds no claude-named pane —
+// because the pid is missing from ps cache or the basename is a wrapper (e.g.
+// `node /usr/local/bin/claude`) — return the first pane in the session with a
+// non-zero currentPid, but with CurrentPid stripped. A heartbeat for this
+// session means SOME process here is claude; surfacing the pane (with
+// session/window edges) is strictly better than null for consumers that need
+// pane.window.session.name (e.g. attend.sh self-suppression). Stripping
+// CurrentPid keeps the composer's pid-liveness signal at alivenessUnknown,
+// so a stale heartbeat for a repurposed session still resolves to no_claude
+// when the heartbeat is past its freshness window — same as today.
 func (a *tmuxInputAdapter) PaneBySession(ctx context.Context, hostID, session string) (*gql.TmuxPane, bool) {
 	if a.p == nil || session == "" {
 		return nil, false
 	}
 	snap := a.p.Snapshot()
+	var fallback *tmuxprovider.Pane
 	for _, pn := range snap.Panes {
 		if string(pn.Key.Host) != hostID || pn.WindowKey.Session != session {
 			continue
@@ -165,19 +174,26 @@ func (a *tmuxInputAdapter) PaneBySession(ctx context.Context, hostID, session st
 		if pn.CurrentPid <= 0 {
 			continue
 		}
+		pnCopy := pn
 		if a.ps == nil {
-			// No ps provider: return first pane with a non-zero pid (v1 behaviour).
-			return projectPaneWithSession(pn, snap), true
+			// No ps provider: first pane with non-zero pid is the answer.
+			return projectPaneWithSession(pnCopy, snap), true
 		}
-		// ps cross-check: only return the pane if its foreground process Command
-		// basename contains "claude".
+		if fallback == nil {
+			fallback = &pnCopy
+		}
 		cmd, ok := a.ps.CommandForPid(ctx, hostID, pn.CurrentPid)
 		if !ok {
 			continue
 		}
 		if strings.Contains(strings.ToLower(filepath.Base(cmd)), "claude") {
-			return projectPaneWithSession(pn, snap), true
+			return projectPaneWithSession(pnCopy, snap), true
 		}
+	}
+	if fallback != nil {
+		fb := *fallback
+		fb.CurrentPid = 0 // Strip so aliveSignal stays alivenessUnknown; only the session edge matters here.
+		return projectPaneWithSession(fb, snap), true
 	}
 	return nil, false
 }

--- a/internal/cli/daemon/claudeinstance_wiring_test.go
+++ b/internal/cli/daemon/claudeinstance_wiring_test.go
@@ -54,16 +54,28 @@ func makePane(paneID, session string, currentPid int) tmuxprovider.Pane {
 	}
 }
 
-// snapshotWithPanes builds a RuntimeSnapshot containing exactly the given panes.
+// snapshotWithPanes builds a RuntimeSnapshot containing the given panes plus
+// synthesized Sessions/Windows entries keyed off each pane's WindowKey/Session.
+// Tests that assert pane.Window/Session edges in the projected GraphQL value
+// require Sessions to be populated (projectPaneWithSession reads from snap.Sessions).
 func snapshotWithPanes(panes ...tmuxprovider.Pane) tmuxprovider.RuntimeSnapshot {
-	m := make(map[tmuxprovider.PaneKey]tmuxprovider.Pane, len(panes))
+	paneMap := make(map[tmuxprovider.PaneKey]tmuxprovider.Pane, len(panes))
+	sessMap := make(map[tmuxprovider.SessionKey]tmuxprovider.Session)
+	winMap := make(map[tmuxprovider.WindowKey]tmuxprovider.Window)
 	for _, p := range panes {
-		m[p.Key] = p
+		paneMap[p.Key] = p
+		sk := tmuxprovider.SessionKey{Host: p.Key.Host, Name: p.WindowKey.Session}
+		if _, ok := sessMap[sk]; !ok {
+			sessMap[sk] = tmuxprovider.Session{Key: sk}
+		}
+		if _, ok := winMap[p.WindowKey]; !ok {
+			winMap[p.WindowKey] = tmuxprovider.Window{Key: p.WindowKey}
+		}
 	}
 	return tmuxprovider.RuntimeSnapshot{
-		Sessions: map[tmuxprovider.SessionKey]tmuxprovider.Session{},
-		Windows:  map[tmuxprovider.WindowKey]tmuxprovider.Window{},
-		Panes:    m,
+		Sessions: sessMap,
+		Windows:  winMap,
+		Panes:    paneMap,
 		Clients:  map[tmuxprovider.ClientKey]tmuxprovider.Client{},
 	}
 }
@@ -152,13 +164,16 @@ func TestTmuxInputAdapter_PaneBySession_NoClaudeMatch_ReturnsFallback(t *testing
 	if pane.CurrentPid != nil {
 		t.Errorf("PaneBySession (no claude match): expected stripped CurrentPid (nil), got %v", *pane.CurrentPid)
 	}
+	if pane.Window == nil || pane.Window.Session == nil || pane.Window.Session.Name != "no-claude" {
+		t.Errorf("PaneBySession (no claude match): expected pane.Window.Session.Name = %q, got %+v", "no-claude", pane.Window)
+	}
 }
 
 // TestTmuxInputAdapter_PaneBySession_PsCacheMiss_ReturnsFallback covers the
 // real-world issue #580 trigger: ps cross-check returns ok=false (pid not in
 // ps cache, ps provider stale, or ps unavailable). The fallback pane must be
-// returned with CurrentPid stripped so downstream liveness stays unknown but
-// pane.window.session edges are populated.
+// returned with CurrentPid stripped, but pane.window.session edges must be
+// populated so attend.sh self-suppression can match.
 func TestTmuxInputAdapter_PaneBySession_PsCacheMiss_ReturnsFallback(t *testing.T) {
 	snap := snapshotWithPanes(
 		makePane("%21", "orchardist", 95507),
@@ -182,6 +197,41 @@ func TestTmuxInputAdapter_PaneBySession_PsCacheMiss_ReturnsFallback(t *testing.T
 	}
 	if pane.CurrentPid != nil {
 		t.Errorf("PaneBySession (ps cache miss): expected stripped CurrentPid (nil), got %v", *pane.CurrentPid)
+	}
+	if pane.Window == nil || pane.Window.Session == nil || pane.Window.Session.Name != "orchardist" {
+		t.Errorf("PaneBySession (ps cache miss): expected pane.Window.Session.Name = %q, got %+v", "orchardist", pane.Window)
+	}
+}
+
+// TestTmuxInputAdapter_PaneBySession_DeterministicOrder verifies that when a
+// session has multiple eligible panes, PaneBySession picks the same one every
+// call. snap.Panes is a Go map (randomized iteration) so the implementation
+// must sort candidates explicitly. Running the call many times in a tight
+// loop catches map-order regressions even if a single run got lucky.
+func TestTmuxInputAdapter_PaneBySession_DeterministicOrder(t *testing.T) {
+	// Five non-claude vim panes in the same session. With map iteration the
+	// chosen fallback would drift; with sort it must lock onto %10 (lowest
+	// pane id) every time.
+	snap := snapshotWithPanes(
+		makePane("%14", "deterministic", 1004),
+		makePane("%10", "deterministic", 1000),
+		makePane("%13", "deterministic", 1003),
+		makePane("%11", "deterministic", 1001),
+		makePane("%12", "deterministic", 1002),
+	)
+	ps := &staticPsGetter{commands: map[int]string{
+		1000: "vim", 1001: "vim", 1002: "vim", 1003: "vim", 1004: "vim",
+	}}
+	a := &tmuxInputAdapter{p: &staticSnapshotter{snap: snap}, ps: ps}
+
+	for i := 0; i < 100; i++ {
+		pane, ok := a.PaneBySession(context.Background(), "local", "deterministic")
+		if !ok || pane == nil {
+			t.Fatalf("iteration %d: expected ok=true and non-nil pane", i)
+		}
+		if pane.PaneID != "%10" {
+			t.Fatalf("iteration %d: got pane %q, want %%10 (lowest pane id)", i, pane.PaneID)
+		}
 	}
 }
 
@@ -230,11 +280,10 @@ func TestTmuxInputAdapter_PaneBySession_NilPs_ReturnsFirstNonZeroPid(t *testing.
 	if pane == nil {
 		t.Fatal("PaneBySession (nil ps): expected non-nil pane, got nil")
 	}
-	// When ps is nil we expect the first pane with non-zero pid.
-	// Map iteration order is non-deterministic in Go, so we just assert
-	// we got one of the non-zero-pid panes (not %10 which has pid 0).
-	if pane.PaneID == "%10" {
-		t.Errorf("PaneBySession (nil ps): got pane %%10 (pid=0), want a non-zero-pid pane")
+	// Candidates are sorted by (window index, pane id); %11 has the lowest
+	// pane id among non-zero-pid panes, so it is the deterministic winner.
+	if pane.PaneID != "%11" {
+		t.Errorf("PaneBySession (nil ps): got pane %q, want %%11 (lowest pane id, non-zero pid)", pane.PaneID)
 	}
 	if pane.CurrentPid == nil || *pane.CurrentPid == 0 {
 		t.Errorf("PaneBySession (nil ps): got pane with zero/nil CurrentPid, want non-zero")

--- a/internal/cli/daemon/claudeinstance_wiring_test.go
+++ b/internal/cli/daemon/claudeinstance_wiring_test.go
@@ -122,10 +122,12 @@ func TestTmuxInputAdapter_PaneBySession_NoPanes_ReturnsNil(t *testing.T) {
 	}
 }
 
-// TestTmuxInputAdapter_PaneBySession_NoClaudeProcess_ReturnsNil verifies that
-// when a session has [vim, vim] panes (no claude process), PaneBySession
-// returns nil, false.
-func TestTmuxInputAdapter_PaneBySession_NoClaudeProcess_ReturnsNil(t *testing.T) {
+// TestTmuxInputAdapter_PaneBySession_NoClaudeMatch_ReturnsFallback verifies the
+// issue #580 fallback: when ps cross-check finds no claude-named pane, the
+// first pane with a non-zero pid in the session is returned with CurrentPid
+// stripped. The composer needs the pane.window.session edge for self-
+// suppression even when ps can't confirm a claude basename.
+func TestTmuxInputAdapter_PaneBySession_NoClaudeMatch_ReturnsFallback(t *testing.T) {
 	snap := snapshotWithPanes(
 		makePane("%10", "no-claude", 1000), // vim
 		makePane("%12", "no-claude", 1001), // also vim
@@ -141,11 +143,68 @@ func TestTmuxInputAdapter_PaneBySession_NoClaudeProcess_ReturnsNil(t *testing.T)
 	}
 
 	pane, ok := a.PaneBySession(context.Background(), "local", "no-claude")
+	if !ok {
+		t.Fatal("PaneBySession (no claude match): expected ok=true (fallback), got false")
+	}
+	if pane == nil {
+		t.Fatal("PaneBySession (no claude match): expected non-nil fallback pane, got nil")
+	}
+	if pane.CurrentPid != nil {
+		t.Errorf("PaneBySession (no claude match): expected stripped CurrentPid (nil), got %v", *pane.CurrentPid)
+	}
+}
+
+// TestTmuxInputAdapter_PaneBySession_PsCacheMiss_ReturnsFallback covers the
+// real-world issue #580 trigger: ps cross-check returns ok=false (pid not in
+// ps cache, ps provider stale, or ps unavailable). The fallback pane must be
+// returned with CurrentPid stripped so downstream liveness stays unknown but
+// pane.window.session edges are populated.
+func TestTmuxInputAdapter_PaneBySession_PsCacheMiss_ReturnsFallback(t *testing.T) {
+	snap := snapshotWithPanes(
+		makePane("%21", "orchardist", 95507),
+	)
+	ps := &staticPsGetter{commands: map[int]string{}} // pid 95507 absent — cache miss
+
+	a := &tmuxInputAdapter{
+		p:  &staticSnapshotter{snap: snap},
+		ps: ps,
+	}
+
+	pane, ok := a.PaneBySession(context.Background(), "local", "orchardist")
+	if !ok {
+		t.Fatal("PaneBySession (ps cache miss): expected ok=true (fallback), got false")
+	}
+	if pane == nil {
+		t.Fatal("PaneBySession (ps cache miss): expected non-nil fallback pane, got nil")
+	}
+	if pane.PaneID != "%21" {
+		t.Errorf("PaneBySession (ps cache miss): got pane %q, want %%21", pane.PaneID)
+	}
+	if pane.CurrentPid != nil {
+		t.Errorf("PaneBySession (ps cache miss): expected stripped CurrentPid (nil), got %v", *pane.CurrentPid)
+	}
+}
+
+// TestTmuxInputAdapter_PaneBySession_NoSessionPanes_ReturnsNil verifies that
+// when the named session genuinely has no panes (heartbeat references a
+// session that doesn't exist in tmux), PaneBySession returns nil, false.
+func TestTmuxInputAdapter_PaneBySession_NoSessionPanes_ReturnsNil(t *testing.T) {
+	snap := snapshotWithPanes(
+		makePane("%30", "other-session", 1234),
+	)
+	ps := &staticPsGetter{commands: map[int]string{1234: "claude"}}
+
+	a := &tmuxInputAdapter{
+		p:  &staticSnapshotter{snap: snap},
+		ps: ps,
+	}
+
+	pane, ok := a.PaneBySession(context.Background(), "local", "missing-session")
 	if ok {
-		t.Error("PaneBySession (no claude): expected ok=false, got true")
+		t.Error("PaneBySession (no session panes): expected ok=false, got true")
 	}
 	if pane != nil {
-		t.Errorf("PaneBySession (no claude): expected nil pane, got %v", pane)
+		t.Errorf("PaneBySession (no session panes): expected nil pane, got %v", pane)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds fallback in `tmuxInputAdapter.PaneBySession`: when ps cross-check finds no claude-named pane in a session that has a heartbeat, return the first pane in that session with `CurrentPid` stripped.
- Preserves the #468 multi-pane fix (claude-basename match still wins when found).
- Stripping `CurrentPid` keeps composer's `aliveSignal` at `alivenessUnknown`, so a stale heartbeat for a repurposed session still resolves to `no_claude` past its freshness window.

## Why
`attend.sh` self-suppression depends on `pane.window.session.name` matching `^(orchardist|boxd_orchardist|ubuntu_orchardist)$`. When the orchardist's own heartbeat exists but `PaneBySession`'s ps cross-check fails (cache miss, wrapper process), the daemon returns `pane: null` and self-suppression breaks — orchardist sees its own input/working flap in the attention feed.

## Live verify (Mac)
Before fix, the orchardist's pane resolution depended on luck (the ps cache happened to contain the right pid). After fix, the fallback path covers the gap deterministically. See live response below — `local:95507` (orchardist's instance) now shows `pane.window.session.name == "orchardist"`, and `attend.sh` regex would correctly match.

```
ClaudeInstance:local:95507  state=input  sname=orchardist  SUPPRESS
```

## Test plan
- [x] Unit: `TestTmuxInputAdapter_PaneBySession_ClaudeProcessWins` — claude pane still wins over vim (preserves #468)
- [x] Unit: `TestTmuxInputAdapter_PaneBySession_NoClaudeMatch_ReturnsFallback` — fallback returns pane with stripped pid
- [x] Unit: `TestTmuxInputAdapter_PaneBySession_PsCacheMiss_ReturnsFallback` — ps cache miss → fallback
- [x] Unit: `TestTmuxInputAdapter_PaneBySession_NoSessionPanes_ReturnsNil` — genuinely missing session → null
- [x] `go test ./internal/...` green
- [x] Live verify: daemon rebuilt, restarted, `claudeInstances { pane { window { session { name } } } }` returns non-null pane for orchardist's instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #580

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux session pane selection: deterministic pane choice in multi-pane sessions, and a safer fallback that preserves session/window info while clearing unavailable process IDs.
* **Tests**
  * Expanded and added tests to cover deterministic selection, fallback behavior when process info is missing, cache-miss scenarios, and empty-session handling; tightened existing assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/598)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #580

# Related issue

- #580

# Related issue

- #580