### PR TITLE
feat(daemon): git provider RemoveProject + hot-reload (closes #571)

### DIFF
--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -168,6 +168,14 @@ func runStart(parentCtx context.Context, addr string, version string) error {
 		return fmt.Errorf("build git provider: %w", err)
 	}
 
+	// Hot-reload: when ~/.orchard/config.json changes, re-list repos and
+	// converge the git provider via ApplyProjects (issue #571). Failures
+	// to subscribe are non-fatal — the daemon still serves the boot-time
+	// project set.
+	gitHotReload := newGitConfigSubscriber(repoDiscoverer, gitProvider, logger)
+	gitHotReload.start(ctx, configProvider.Subscribe(ctx))
+	defer gitHotReload.close()
+
 	claudeAccountProvider := claudeaccount.New("local", logger)
 
 	psAdapter := &psInputAdapter{p: psProvider}

--- a/internal/cli/daemon/git_hot_reload.go
+++ b/internal/cli/daemon/git_hot_reload.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
+)
+
+// gitConfigSubscriber bridges configprovider.Provider invalidations to
+// gitprovider.Provider.ApplyProjects so adds/removes of repos in
+// ~/.orchard/config.json apply without a daemon restart (issue #571).
+//
+// The wire shape mirrors peerproxy.ConfigWatcher: a tiny goroutine
+// listens on a Subscribe channel and re-runs the lister + diff each
+// time the file changes. Coalescing comes "for free" from the underlying
+// configprovider.Provider.run loop, which calls reload + emits one event
+// per fsnotify burst.
+type gitConfigSubscriber struct {
+	lister      gitProjectLister
+	gitProvider *gitprovider.Provider
+	logger      *slog.Logger
+	doneCh      chan struct{}
+
+	// applyCount is incremented immediately before each ApplyProjects
+	// call. Exposed via ApplyCount() as a test seam.
+	applyCount atomic.Int64
+}
+
+func newGitConfigSubscriber(lister gitProjectLister, gitProvider *gitprovider.Provider, logger *slog.Logger) *gitConfigSubscriber {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &gitConfigSubscriber{
+		lister:      lister,
+		gitProvider: gitProvider,
+		logger:      logger,
+		doneCh:      make(chan struct{}),
+	}
+}
+
+// start spawns a goroutine that reads invalidations from events and
+// calls ApplyProjects with the latest List result. Returns when ctx is
+// cancelled or the events channel closes.
+//
+// start is not idempotent — call it once per subscriber.
+func (s *gitConfigSubscriber) start(ctx context.Context, events <-chan configprovider.InvalidationEvent) {
+	go s.run(ctx, events)
+}
+
+func (s *gitConfigSubscriber) run(ctx context.Context, events <-chan configprovider.InvalidationEvent) {
+	defer close(s.doneCh)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-events:
+			if !ok {
+				return
+			}
+			projs, err := s.snapshotProjects(ctx)
+			if err != nil {
+				s.logger.Warn("git hot-reload: lister failed; keeping existing projects",
+					"err", err)
+				continue
+			}
+			s.applyCount.Add(1)
+			if err := s.gitProvider.ApplyProjects(projs); err != nil {
+				s.logger.Warn("git hot-reload: ApplyProjects error after config reload",
+					"err", err)
+			}
+		}
+	}
+}
+
+// snapshotProjects calls the lister and converts the result into the
+// git provider's Project shape.
+func (s *gitConfigSubscriber) snapshotProjects(ctx context.Context) ([]gitprovider.Project, error) {
+	repos, err := s.lister.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]gitprovider.Project, 0, len(repos))
+	for _, r := range repos {
+		out = append(out, gitprovider.Project{ID: string(r.ID), Dir: r.Path})
+	}
+	return out, nil
+}
+
+// ApplyCount returns the number of times ApplyProjects has been called.
+// Tests rely on this to assert hot-reload fired exactly once per edit.
+func (s *gitConfigSubscriber) ApplyCount() int {
+	return int(s.applyCount.Load())
+}
+
+// close waits for the run goroutine to exit. Callers must cancel the
+// context they passed to start before calling close — start exits when
+// the context is cancelled OR the events channel closes.
+func (s *gitConfigSubscriber) close() {
+	<-s.doneCh
+}

--- a/internal/cli/daemon/git_hot_reload_test.go
+++ b/internal/cli/daemon/git_hot_reload_test.go
@@ -1,0 +1,193 @@
+package daemon
+
+// Integration test for git provider hot-reload via the daemon-side
+// subscriber (issue #571). The wiring exercised here is identical to
+// runStart: a real configprovider.JSONFileAdapter + Provider + Subscribe,
+// the gitConfigSubscriber bridge, and a real gitprovider.Provider.
+//
+// We rewrite the config file on disk, expect the subscriber to fire
+// ApplyProjects, and assert the git provider's HasProject set converged.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	configprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/config"
+	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
+)
+
+const hotReloadDeadline = 5 * time.Second
+
+// TestGitHotReload_RemovesProjectOnConfigEdit walks the full chain:
+//
+//  1. Write config.json containing two repos (alpha + beta).
+//  2. Start configprovider.Provider; build git provider against List();
+//     AddProject for each.
+//  3. Spin up gitConfigSubscriber on configProvider.Subscribe(ctx).
+//  4. Rewrite config.json without beta. Expect:
+//     - applyCount grows to >= 1
+//     - HasProject(beta) flips to false within the deadline
+//     - HasProject(alpha) remains true (and SpawnCount stays 1 — the
+//     watcher was NOT restarted on the survivor).
+//  5. Rewrite config.json adding gamma. Expect HasProject(gamma) flips
+//     to true and HasProject(alpha) is still unchanged.
+func TestGitHotReload_RemovesProjectOnConfigEdit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; hot-reload test needs real git repos")
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+
+	alphaRepo := setupHotReloadRepo(t)
+	betaRepo := setupHotReloadRepo(t)
+	gammaRepo := setupHotReloadRepo(t)
+
+	writeHotReloadConfig(t, cfgPath, []configprovider.RepoRow{
+		{Slug: "team/alpha", Path: alphaRepo},
+		{Slug: "team/beta", Path: betaRepo},
+	})
+
+	logger := slog.Default()
+	adapter := configprovider.NewJSONFileAdapter(cfgPath, logger)
+	cfgProvider := configprovider.NewProvider(adapter, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if err := cfgProvider.Start(ctx); err != nil {
+		t.Fatalf("config provider start: %v", err)
+	}
+	t.Cleanup(func() { _ = cfgProvider.Stop() })
+
+	repos, err := cfgProvider.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("initial List len = %d; want 2", len(repos))
+	}
+
+	gp := gitprovider.NewProvider(logger)
+	t.Cleanup(gp.Stop)
+	for _, r := range repos {
+		if err := gp.AddProject(gitprovider.Project{ID: string(r.ID), Dir: r.Path}); err != nil {
+			t.Fatalf("AddProject %q: %v", r.ID, err)
+		}
+	}
+	if !gp.HasProject("team/alpha") || !gp.HasProject("team/beta") {
+		t.Fatalf("initial git provider state missing projects; alpha=%v beta=%v",
+			gp.HasProject("team/alpha"), gp.HasProject("team/beta"))
+	}
+
+	subscriber := newGitConfigSubscriber(cfgProvider, gp, logger)
+	subscriber.start(ctx, cfgProvider.Subscribe(ctx))
+	t.Cleanup(func() {
+		cancel()
+		subscriber.close()
+	})
+
+	// Step 4: drop beta.
+	startApply := subscriber.ApplyCount()
+	writeHotReloadConfig(t, cfgPath, []configprovider.RepoRow{
+		{Slug: "team/alpha", Path: alphaRepo},
+	})
+
+	waitUntil(t, "beta removed", func() bool {
+		return !gp.HasProject("team/beta") && gp.HasProject("team/alpha")
+	})
+
+	if got := subscriber.ApplyCount(); got <= startApply {
+		t.Fatalf("ApplyCount did not grow after first edit: before=%d after=%d",
+			startApply, got)
+	}
+	if got := gp.SpawnCount("team/alpha"); got != 1 {
+		t.Fatalf("SpawnCount(alpha) = %d after first edit; want 1 (survivor not respawned)", got)
+	}
+
+	// Step 5: add gamma.
+	writeHotReloadConfig(t, cfgPath, []configprovider.RepoRow{
+		{Slug: "team/alpha", Path: alphaRepo},
+		{Slug: "team/gamma", Path: gammaRepo},
+	})
+
+	waitUntil(t, "gamma added", func() bool {
+		return gp.HasProject("team/gamma") && gp.HasProject("team/alpha") && !gp.HasProject("team/beta")
+	})
+	if got := gp.SpawnCount("team/alpha"); got != 1 {
+		t.Fatalf("SpawnCount(alpha) = %d after second edit; want 1 (survivor not respawned)", got)
+	}
+}
+
+// writeHotReloadConfig writes f atomically via rename so the fsnotify
+// event semantics match production (orchard config add-repo also
+// rename-replaces). Empty Slug → ID derived inside the provider; we
+// pass an explicit Slug per row to keep IDs predictable.
+func writeHotReloadConfig(t *testing.T, path string, repos []configprovider.RepoRow) {
+	t.Helper()
+	f := configprovider.File{Version: 1, Repos: repos}
+	data, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		t.Fatalf("write tmp: %v", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+}
+
+// setupHotReloadRepo creates a minimal git repo with one commit. We
+// need real .git dirs so the git provider's per-project watcher can
+// install fsnotify on `.git/HEAD`.
+func setupHotReloadRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-b", "main"},
+		{"config", "user.email", "hot-reload@example.com"},
+		{"config", "user.name", "hot-reload"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# fixture\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	for _, args := range [][]string{
+		{"add", "README.md"},
+		{"commit", "-m", "initial"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	return repo
+}
+
+// waitUntil polls cond until it returns true or the deadline elapses.
+// Used to bridge "config rewrite → fsnotify burst → debounce →
+// ApplyProjects" without a hard sleep.
+func waitUntil(t *testing.T, label string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(hotReloadDeadline)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("waitUntil(%s) timed out after %s", label, hotReloadDeadline)
+}

--- a/internal/server/providers/git/provider.go
+++ b/internal/server/providers/git/provider.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -17,23 +18,29 @@ import (
 // Concurrency model:
 //   - projects is guarded by mu.
 //   - store mirrors the freshest known state; reads + writes go through mu.
-//   - Each project owns one watcher goroutine; its invalidation channel
-//     is fanned out to provider subscribers.
+//   - Each project owns one watcher goroutine + one consumer goroutine,
+//     both bound to a per-project context derived from rootCtx. The
+//     per-project cancel is stored in projectCancels so RemoveProject can
+//     tear a single project down without affecting the others.
+//   - Watcher invalidation channels are fanned out to provider subscribers.
 //
 // The provider owns its goroutines: Stop() returns once every watcher
 // goroutine has exited.
 type Provider struct {
-	mu         sync.RWMutex
-	projects   []Project
-	store      map[WorktreeID]storeEntry
-	watchers   map[string]*watcher // keyed by project id
-	subs       map[chan adapter.InvalidationEvent[WorktreeID]]struct{}
-	subsMu     sync.Mutex
-	adapterImp *GitWorktreeAdapter
-	logger     *slog.Logger
-	wg         sync.WaitGroup
-	rootCtx    context.Context
-	rootCancel context.CancelFunc
+	mu             sync.RWMutex
+	projects       []Project
+	store          map[WorktreeID]storeEntry
+	watchers       map[string]*watcher           // keyed by project id
+	projectCancels map[string]context.CancelFunc // keyed by project id
+	projectDoneChs map[string]chan struct{}      // closes when both per-project goroutines exit
+	subs           map[chan adapter.InvalidationEvent[WorktreeID]]struct{}
+	subsMu         sync.Mutex
+	adapterImp     *GitWorktreeAdapter
+	logger         *slog.Logger
+	wg             sync.WaitGroup
+	rootCtx        context.Context
+	rootCancel     context.CancelFunc
+	spawnCounts    map[string]int // test seam: incremented each time AddProject starts watcher goroutines
 }
 
 type storeEntry struct {
@@ -50,12 +57,15 @@ func NewProvider(logger *slog.Logger) *Provider {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	p := &Provider{
-		store:      map[WorktreeID]storeEntry{},
-		watchers:   map[string]*watcher{},
-		subs:       map[chan adapter.InvalidationEvent[WorktreeID]]struct{}{},
-		logger:     logger,
-		rootCtx:    ctx,
-		rootCancel: cancel,
+		store:          map[WorktreeID]storeEntry{},
+		watchers:       map[string]*watcher{},
+		projectCancels: map[string]context.CancelFunc{},
+		projectDoneChs: map[string]chan struct{}{},
+		subs:           map[chan adapter.InvalidationEvent[WorktreeID]]struct{}{},
+		logger:         logger,
+		rootCtx:        ctx,
+		rootCancel:     cancel,
+		spawnCounts:    map[string]int{},
 	}
 	p.adapterImp = NewGitWorktreeAdapter(p.snapshotProjects)
 	return p
@@ -77,7 +87,7 @@ func (p *Provider) Adapter() *GitWorktreeAdapter { return p.adapterImp }
 
 // AddProject registers a project for scanning and starts a watcher for
 // it. Returns nil for duplicate IDs (idempotent re-add). The watcher
-// runs until Stop() is called.
+// runs until RemoveProject(id) or Stop() is called.
 func (p *Provider) AddProject(proj Project) error {
 	if proj.ID == "" {
 		return fmt.Errorf("git: project id cannot be empty")
@@ -98,29 +108,196 @@ func (p *Provider) AddProject(proj Project) error {
 
 	w, err := newWatcher(proj, p.logger)
 	if err != nil {
+		// Undo the projects append so an AddProject failure doesn't leave a
+		// half-registered project behind.
+		p.mu.Lock()
+		p.projects = removeProjectFromSlice(p.projects, proj.ID)
+		p.mu.Unlock()
 		return fmt.Errorf("watcher for %q: %w", proj.ID, err)
 	}
 
+	projCtx, projCancel := context.WithCancel(p.rootCtx)
+	done := make(chan struct{})
+
 	p.mu.Lock()
 	p.watchers[proj.ID] = w
+	p.projectCancels[proj.ID] = projCancel
+	p.projectDoneChs[proj.ID] = done
+	p.spawnCounts[proj.ID]++
 	p.mu.Unlock()
 
+	var inner sync.WaitGroup
+	inner.Add(2)
 	p.wg.Add(2)
 	go func() {
 		defer p.wg.Done()
-		w.run(p.rootCtx)
+		defer inner.Done()
+		w.run(projCtx)
 	}()
 	go func() {
 		defer p.wg.Done()
+		defer inner.Done()
 		p.consumeInvalidations(w)
+	}()
+	go func() {
+		inner.Wait()
+		close(done)
 	}()
 
 	// Cold-load the project's worktrees so subscribers querying right
 	// after registration see something.
-	if err := p.refreshProject(p.rootCtx, proj); err != nil {
+	if err := p.refreshProject(projCtx, proj); err != nil {
 		p.logger.Warn("git initial refresh failed", "project", proj.ID, "err", err)
 	}
 	return nil
+}
+
+// RemoveProject cancels the per-project context, closes the watcher,
+// drains the consumer goroutine, drops the project's entries from the
+// store, and unregisters it from the projects slice. Idempotent: a call
+// for an unknown id is a no-op (returns nil), matching how callers
+// expect "best-effort convergence" diffs (ApplyProjects) to behave.
+//
+// Safe to call concurrently with AddProject / RemoveProject.
+func (p *Provider) RemoveProject(id string) error {
+	if id == "" {
+		return fmt.Errorf("git: project id cannot be empty")
+	}
+
+	p.mu.Lock()
+	cancel, hasCancel := p.projectCancels[id]
+	done, hasDone := p.projectDoneChs[id]
+	_, hasWatcher := p.watchers[id]
+	if !hasCancel && !hasWatcher {
+		// Unknown id — no-op. The projects slice is the source of
+		// truth for what's registered, but absence from both the cancel
+		// map and the watchers map means there's nothing to tear down.
+		p.mu.Unlock()
+		return nil
+	}
+	delete(p.watchers, id)
+	delete(p.projectCancels, id)
+	delete(p.projectDoneChs, id)
+	p.projects = removeProjectFromSlice(p.projects, id)
+	// Drop cached worktrees for this project — once it's gone, callers
+	// must not see stale entries.
+	for k := range p.store {
+		pid, _, ok := splitID(k)
+		if ok && pid == id {
+			delete(p.store, k)
+		}
+	}
+	p.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	// Wait for the per-project watcher + consumer goroutines to exit so
+	// callers can rely on no further events from this project after the
+	// call returns. Watcher.run cancels the underlying fsnotify watcher
+	// and closes its invalidation channel; consumeInvalidations exits as
+	// soon as the channel drains.
+	if hasDone {
+		<-done
+	}
+	return nil
+}
+
+// removeProjectFromSlice returns projects with any entry whose ID
+// matches id removed. Order-preserving.
+func removeProjectFromSlice(projects []Project, id string) []Project {
+	out := projects[:0]
+	for _, proj := range projects {
+		if proj.ID != id {
+			out = append(out, proj)
+		}
+	}
+	return out
+}
+
+// projectsEqual reports whether two Projects are equivalent for the
+// purposes of the ApplyProjects diff. A change in Dir triggers a
+// remove + add so the watcher re-seeds against the new directory.
+func projectsEqual(a, b Project) bool {
+	return a.ID == b.ID && a.Dir == b.Dir
+}
+
+// ApplyProjects diffs the current project set against projs and issues
+// the minimum AddProject / RemoveProject calls needed to converge on
+// the new set.
+//
+// Algorithm:
+//   - Projects in projs but not in the current set → AddProject.
+//   - Projects in the current set but not in projs → RemoveProject.
+//   - Projects present in both with an unchanged Dir → left untouched
+//     (watcher goroutine is NOT restarted).
+//   - Projects present in both whose Dir changed → RemoveProject then
+//     AddProject so the watcher rebinds.
+//
+// Error policy: best-effort. Errors from individual Add/Remove calls
+// are collected; the rest of the diff is still applied. All errors are
+// joined and returned at the end so a single misbehaving project does
+// not block convergence for the others.
+//
+// Safe to call concurrently with AddProject / RemoveProject.
+func (p *Provider) ApplyProjects(projs []Project) error {
+	p.mu.RLock()
+	current := make(map[string]Project, len(p.projects))
+	for _, proj := range p.projects {
+		current[proj.ID] = proj
+	}
+	p.mu.RUnlock()
+
+	next := make(map[string]Project, len(projs))
+	for _, proj := range projs {
+		next[proj.ID] = proj
+	}
+
+	var errs []error
+	for _, proj := range projs {
+		cur, exists := current[proj.ID]
+		if !exists {
+			if err := p.AddProject(proj); err != nil {
+				errs = append(errs, err)
+			}
+			continue
+		}
+		if !projectsEqual(cur, proj) {
+			if err := p.RemoveProject(proj.ID); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			if err := p.AddProject(proj); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	for id := range current {
+		if _, exists := next[id]; !exists {
+			if err := p.RemoveProject(id); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// SpawnCount returns the number of times AddProject has launched the
+// watcher goroutines for id. Intended for tests that verify ApplyProjects
+// did NOT restart a project's goroutines — a count of 1 means the
+// project was added exactly once and left untouched.
+func (p *Provider) SpawnCount(id string) int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.spawnCounts[id]
+}
+
+// HasProject returns true when id is currently registered.
+func (p *Provider) HasProject(id string) bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	_, ok := p.watchers[id]
+	return ok
 }
 
 // Stop cancels watchers and waits for them to exit. Safe to call at

--- a/internal/server/providers/git/provider_lifecycle_test.go
+++ b/internal/server/providers/git/provider_lifecycle_test.go
@@ -1,0 +1,290 @@
+package git_test
+
+// Tests for the per-project lifecycle of the git provider (issue #571):
+// RemoveProject + ApplyProjects diff. Mirrors the shape of the peerproxy
+// AddPeer/RemovePeer/ApplyPeers tests so the patterns stay symmetric.
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	gitprovider "github.com/drewdrewthis/git-orchard-rs/internal/server/providers/git"
+)
+
+// TestRemoveProject_CancelsAndDrops verifies that RemoveProject cancels
+// the per-project watcher, removes its entries from the provider's
+// internal state, and stops emitting invalidations for the project.
+//
+// Steps:
+//  1. NewProvider, AddProject for a real git repo on disk.
+//  2. Subscribe; drain the cold-load invalidation if any.
+//  3. RemoveProject — must return nil.
+//  4. HasProject must be false; ListByProject must be empty/nil.
+//  5. Mutate the repo's HEAD; subscriber must NOT receive any event
+//     within a generous wait window (watcher goroutine was cancelled).
+//  6. RemoveProject again — idempotent, must return nil.
+func TestRemoveProject_CancelsAndDrops(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; provider lifecycle tests need real git")
+	}
+
+	repo := setupRepoForLifecycle(t)
+	const projectID = "demo"
+
+	p := gitprovider.NewProvider(slog.Default())
+	t.Cleanup(p.Stop)
+
+	if err := p.AddProject(gitprovider.Project{ID: projectID, Dir: repo}); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	events := p.Subscribe(ctx)
+
+	// Drain the cold-load invalidation(s), if any are produced. We only
+	// care that the channel is empty before we test "RemoveProject stops
+	// future events".
+	drainFor(events, 150*time.Millisecond)
+
+	if !p.HasProject(projectID) {
+		t.Fatalf("HasProject(%q) before RemoveProject = false; want true", projectID)
+	}
+
+	if err := p.RemoveProject(projectID); err != nil {
+		t.Fatalf("RemoveProject: %v", err)
+	}
+
+	if p.HasProject(projectID) {
+		t.Fatalf("HasProject(%q) after RemoveProject = true; want false", projectID)
+	}
+	if got, _ := p.ListByProject(ctx, projectID); len(got) != 0 {
+		t.Fatalf("ListByProject(%q) after RemoveProject returned %d entries; want 0",
+			projectID, len(got))
+	}
+
+	// Mutate the repo's HEAD. With the watcher gone, no invalidation
+	// should arrive within a generous wait window.
+	runGitLifecycle(t, repo, "checkout", "-b", "post-remove")
+
+	select {
+	case ev, ok := <-events:
+		if ok {
+			t.Fatalf("received invalidation %v after RemoveProject (watcher still alive)", ev)
+		}
+		// Channel closed — also acceptable; cancel() in cleanup may have
+		// fired between RemoveProject and the select. Either way we got
+		// no spurious event for the removed project.
+	case <-time.After(300 * time.Millisecond):
+		// Expected path: silence.
+	}
+
+	// Idempotent second call.
+	if err := p.RemoveProject(projectID); err != nil {
+		t.Fatalf("RemoveProject (second call) = %v; want nil (idempotent)", err)
+	}
+	// RemoveProject for an unknown id is also a no-op.
+	if err := p.RemoveProject("never-existed"); err != nil {
+		t.Fatalf("RemoveProject(unknown) = %v; want nil", err)
+	}
+}
+
+// TestApplyProjects_BasicDiff verifies the diff algorithm: a project
+// in both old and new sets with unchanged Dir is left alone (no respawn);
+// a new id is added; a removed id is dropped.
+//
+// Steps:
+//  1. NewProvider with no projects.
+//  2. AddProject("keep") and AddProject("drop").
+//  3. SpawnCount("keep") must be 1.
+//  4. ApplyProjects([keep, add]) — keep unchanged, drop removed, add new.
+//  5. Verify HasProject for keep (true), drop (false), add (true).
+//  6. SpawnCount("keep") must still be 1 (goroutine NOT restarted).
+//  7. SpawnCount("add") must be 1.
+func TestApplyProjects_BasicDiff(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; provider lifecycle tests need real git")
+	}
+
+	keepRepo := setupRepoForLifecycle(t)
+	dropRepo := setupRepoForLifecycle(t)
+	addRepo := setupRepoForLifecycle(t)
+
+	p := gitprovider.NewProvider(slog.Default())
+	t.Cleanup(p.Stop)
+
+	if err := p.AddProject(gitprovider.Project{ID: "keep", Dir: keepRepo}); err != nil {
+		t.Fatalf("AddProject keep: %v", err)
+	}
+	if err := p.AddProject(gitprovider.Project{ID: "drop", Dir: dropRepo}); err != nil {
+		t.Fatalf("AddProject drop: %v", err)
+	}
+
+	if got := p.SpawnCount("keep"); got != 1 {
+		t.Fatalf("SpawnCount(keep) before ApplyProjects = %d; want 1", got)
+	}
+
+	err := p.ApplyProjects([]gitprovider.Project{
+		{ID: "keep", Dir: keepRepo},
+		{ID: "add", Dir: addRepo},
+	})
+	if err != nil {
+		t.Fatalf("ApplyProjects: %v", err)
+	}
+
+	if !p.HasProject("keep") {
+		t.Fatal("HasProject(keep) = false after ApplyProjects; want true")
+	}
+	if p.HasProject("drop") {
+		t.Fatal("HasProject(drop) = true after ApplyProjects; want false (removed)")
+	}
+	if !p.HasProject("add") {
+		t.Fatal("HasProject(add) = false after ApplyProjects; want true (added)")
+	}
+
+	if got := p.SpawnCount("keep"); got != 1 {
+		t.Fatalf("SpawnCount(keep) after ApplyProjects = %d; want 1 (goroutine restarted)", got)
+	}
+	if got := p.SpawnCount("add"); got != 1 {
+		t.Fatalf("SpawnCount(add) after ApplyProjects = %d; want 1", got)
+	}
+}
+
+// TestApplyProjects_DirChangeRemoveAdd verifies that changing a
+// project's Dir is treated as remove + add (the watcher rebinds).
+//
+// Steps:
+//  1. AddProject id="lw" pointing at repoA.
+//  2. SpawnCount must be 1.
+//  3. ApplyProjects with same id but Dir=repoB.
+//  4. SpawnCount must be 2 (re-spawned against the new Dir).
+//  5. HasProject must still be true.
+func TestApplyProjects_DirChangeRemoveAdd(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; provider lifecycle tests need real git")
+	}
+
+	repoA := setupRepoForLifecycle(t)
+	repoB := setupRepoForLifecycle(t)
+
+	p := gitprovider.NewProvider(slog.Default())
+	t.Cleanup(p.Stop)
+
+	if err := p.AddProject(gitprovider.Project{ID: "lw", Dir: repoA}); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	if got := p.SpawnCount("lw"); got != 1 {
+		t.Fatalf("SpawnCount before = %d; want 1", got)
+	}
+
+	if err := p.ApplyProjects([]gitprovider.Project{
+		{ID: "lw", Dir: repoB},
+	}); err != nil {
+		t.Fatalf("ApplyProjects: %v", err)
+	}
+
+	if got := p.SpawnCount("lw"); got != 2 {
+		t.Fatalf("SpawnCount after Dir change = %d; want 2 (remove+add)", got)
+	}
+	if !p.HasProject("lw") {
+		t.Fatal("HasProject(lw) = false after Dir change; want true")
+	}
+}
+
+// TestRemoveProject_GoroutineLeak verifies that RemoveProject brings the
+// goroutine count back to baseline. Add → check growth → Remove → check
+// drain.
+//
+// The exact baseline depends on the test runtime, so we compare
+// post-remove against the pre-add baseline, allowing a small slack for
+// goroutines the runtime spawns asynchronously.
+func TestRemoveProject_GoroutineLeak(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH; provider lifecycle tests need real git")
+	}
+
+	p := gitprovider.NewProvider(slog.Default())
+	t.Cleanup(p.Stop)
+
+	baseline := runtime.NumGoroutine()
+
+	repo := setupRepoForLifecycle(t)
+	if err := p.AddProject(gitprovider.Project{ID: "leak-check", Dir: repo}); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	// Wait briefly for the watcher + consumer goroutines to actually start.
+	time.Sleep(50 * time.Millisecond)
+
+	added := runtime.NumGoroutine()
+	if added <= baseline {
+		t.Fatalf("goroutine count did not grow after AddProject: baseline=%d after_add=%d",
+			baseline, added)
+	}
+
+	if err := p.RemoveProject("leak-check"); err != nil {
+		t.Fatalf("RemoveProject: %v", err)
+	}
+	// Give the runtime a moment to schedule the goroutines' exit, then
+	// poll back to baseline with a deadline. We tolerate up to 2 extra
+	// goroutines for runtime-internal scheduling noise.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= baseline+2 {
+			return // success
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("goroutines did not drain after RemoveProject: baseline=%d, now=%d",
+		baseline, runtime.NumGoroutine())
+}
+
+// setupRepoForLifecycle creates a minimal git repo with one commit so
+// HEAD resolves and fsnotify has something to watch. Distinct from the
+// e2e setup helper to keep package-local tests self-contained.
+func setupRepoForLifecycle(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	runGitLifecycle(t, repo, "init", "-b", "main")
+	runGitLifecycle(t, repo, "config", "user.email", "issue571@example.com")
+	runGitLifecycle(t, repo, "config", "user.name", "issue571")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("# fixture\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGitLifecycle(t, repo, "add", "README.md")
+	runGitLifecycle(t, repo, "commit", "-m", "initial")
+	return repo
+}
+
+func runGitLifecycle(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, stderr.String())
+	}
+}
+
+// drainFor reads any pending invalidations off ch for d, discarding
+// them. Used to clear cold-load events before asserting silence.
+func drainFor[T any](ch <-chan T, d time.Duration) {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ch:
+		case <-time.After(20 * time.Millisecond):
+			if time.Now().After(deadline) {
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Mirror the peerproxy `AddPeer/RemovePeer/ApplyPeers` shape on the git
provider so repos removed from `~/.orchard/config.json` no longer leak
goroutines until daemon restart. Hot-reload wires
`configprovider.Provider.Subscribe` into a new `ApplyProjects` diff.

- **`gitprovider.Provider.RemoveProject(id)`** — cancels the
  per-project context, drains the watcher + consumer goroutines, drops
  cached worktrees, deletes registry entries. Idempotent for unknown
  ids.
- **`gitprovider.Provider.ApplyProjects([]Project)`** — diffs current
  vs new and issues the minimum `AddProject` / `RemoveProject` calls.
  `Dir` changes are remove+add so the fsnotify watcher rebinds;
  survivors are not respawned.
- **`AddProject`** now derives a per-project context from `rootCtx`
  and records its cancel + done channel so `RemoveProject` can tear a
  single project down without affecting the others. `SpawnCount()`
  exposes the startup tally as a test seam.
- **daemon** — `gitConfigSubscriber` bridges
  `configprovider.Provider.Subscribe` into `ApplyProjects`, so config
  edits apply without a daemon restart.

## Test plan

- [x] `go test -count=1 -race ./internal/server/providers/git/... ./internal/cli/daemon/...`
- [x] `go test -count=1 -race -p 1 ./internal/...` (serial) — clean
- [x] `cargo build --release`
- [x] **Live verify**: sandbox daemon on `:7778` with HOME pointed at a
      tempdir; added two repos, removed one via config rewrite without
      daemon restart, confirmed the repodiscovery cache (30s TTL) then
      reflects the convergence. The git provider's per-project watcher
      goroutines drain in-process.

New tests:
- `TestRemoveProject_CancelsAndDrops` — silence on the subscriber
  channel after RemoveProject + repo mutation, idempotency on second
  call and unknown ids.
- `TestRemoveProject_GoroutineLeak` — `runtime.NumGoroutine` returns
  to baseline after RemoveProject.
- `TestApplyProjects_BasicDiff` / `TestApplyProjects_DirChangeRemoveAdd`
  — converge-by-diff cases including the no-respawn invariant for
  unchanged survivors.
- `TestGitHotReload_RemovesProjectOnConfigEdit` — full chain
  integration: real `JSONFileAdapter` watching a real `config.json`,
  `provider.Subscribe` feeding the new subscriber, git provider state
  converges across two edits without restart.

Closes #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daemon now automatically re-lists git projects when the configuration file changes, reflecting updates without requiring a restart
  * Enhanced project lifecycle management with proper resource cleanup when projects are removed

* **Testing**
  * Added comprehensive test coverage for project lifecycle and configuration hot-reload behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/599)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #571