### PR TITLE
feat(orchard-gui): sidebar v1 hardening + error visibility (#548)

### DIFF
--- a/crates/orchard-gui/package.json
+++ b/crates/orchard-gui/package.json
@@ -20,6 +20,7 @@
     "graphql": "^16.14.0",
     "graphql-request": "^7.4.0",
     "graphql-ws": "^6.0.8",
+    "svelte-sonner": "^1.1.1",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
     "xterm-addon-web-links": "^0.9.0"

--- a/crates/orchard-gui/pnpm-lock.yaml
+++ b/crates/orchard-gui/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       graphql-ws:
         specifier: ^6.0.8
         version: 6.0.8(graphql@16.14.0)
+      svelte-sonner:
+        specifier: ^1.1.1
+        version: 1.1.1(svelte@5.55.2)
       xterm:
         specifier: ^5.3.0
         version: 5.3.0
@@ -1238,6 +1241,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  runed@0.28.0:
+    resolution: {integrity: sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==}
+    peerDependencies:
+      svelte: ^5.7.0
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -1295,6 +1303,11 @@ packages:
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
+
+  svelte-sonner@1.1.1:
+    resolution: {integrity: sha512-5cd3p7wa4cq0NsqslMwdlPb7x1JglEZ/GKrLePWNr5bCxR1nagAVrY01FRFrXfUGs41miLt3C327+8XJo5BzZw==}
+    peerDependencies:
+      svelte: ^5.0.0
 
   svelte@5.55.2:
     resolution: {integrity: sha512-z41M/hi0ZPTzrwVKLvB/R1/Oo08gL1uIib8HZ+FncqxxtY9MLb01emg2fqk+WLZ/lNrrtNDFh7BZLDxAHvMgLw==}
@@ -2449,6 +2462,11 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  runed@0.28.0(svelte@5.55.2):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.55.2
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -2494,6 +2512,11 @@ snapshots:
       typescript: 5.6.3
     transitivePeerDependencies:
       - picomatch
+
+  svelte-sonner@1.1.1(svelte@5.55.2):
+    dependencies:
+      runed: 0.28.0(svelte@5.55.2)
+      svelte: 5.55.2
 
   svelte@5.55.2:
     dependencies:

--- a/crates/orchard-gui/src/lib/components/ChatMessage.svelte
+++ b/crates/orchard-gui/src/lib/components/ChatMessage.svelte
@@ -44,7 +44,9 @@
 		if (msg.text) {
 			try {
 				await navigator.clipboard.writeText(msg.text);
-			} catch {}
+			} catch {
+				// intentional swallow: clipboard write denied (no user gesture or permission blocked); copy action silently no-ops
+			}
 		}
 		copied = true;
 		setTimeout(() => (copied = false), 1100);

--- a/crates/orchard-gui/src/lib/components/ChatMessage.svelte
+++ b/crates/orchard-gui/src/lib/components/ChatMessage.svelte
@@ -41,12 +41,12 @@
 	const showActions = $derived(!msg.typing);
 
 	async function doCopy() {
-		if (msg.text) {
-			try {
-				await navigator.clipboard.writeText(msg.text);
-			} catch {
-				// intentional swallow: clipboard write denied (no user gesture or permission blocked); copy action silently no-ops
-			}
+		if (!msg.text) return;
+		try {
+			await navigator.clipboard.writeText(msg.text);
+		} catch {
+			// intentional swallow: clipboard write denied (no user gesture or permission blocked); copy action silently no-ops
+			return;
 		}
 		copied = true;
 		setTimeout(() => (copied = false), 1100);

--- a/crates/orchard-gui/src/lib/components/LensSelector.svelte
+++ b/crates/orchard-gui/src/lib/components/LensSelector.svelte
@@ -1,4 +1,8 @@
 <!-- Icon-only segmented control for the fleet's lens (attention/host/tmux/etc). -->
+<!--
+  Note: issue #600 referred to the attention lens as "activity lens" — the live Lens enum has
+  no `activity` member; any reference to "activity lens" maps to the attention lens.
+-->
 <script lang="ts">
 	import Icon from "$lib/icons/Icon.svelte";
 	import type { Lens } from "$lib/data/types";

--- a/crates/orchard-gui/src/lib/components/LensSidebar.svelte
+++ b/crates/orchard-gui/src/lib/components/LensSidebar.svelte
@@ -113,42 +113,180 @@
 	// Channels (chat rooms from chat-core) live across all lenses at the
 	// top — their relevance is independent of the lens filter.
 	const channelRooms = $derived(store.chatRooms);
+
+	// ── Collapsible sections ────────────────────────────────────────────
+	// Single localStorage key stores all collapsed states as a JSON object.
+	// Key schema: "<lens>:<section-id>", e.g. "attention:blocked".
+	// Special singles: "recent:recent", "channels:channels".
+	// Tauri SPA — no SSR, so localStorage is always available synchronously.
+	const LS_KEY = "orchard:sidebar:collapsed";
+
+	function hydrateCollapsed(): Record<string, boolean> {
+		try {
+			const raw = localStorage.getItem(LS_KEY);
+			if (raw) return JSON.parse(raw) as Record<string, boolean>;
+		} catch {
+			// Malformed JSON — start fresh.
+		}
+		return {};
+	}
+
+	let collapsed: Record<string, boolean> = $state(hydrateCollapsed());
+
+	$effect(() => {
+		// Write the current collapsed map back to localStorage whenever it changes.
+		localStorage.setItem(LS_KEY, JSON.stringify(collapsed));
+	});
+
+	function toggleCollapse(key: string): void {
+		collapsed = { ...collapsed, [key]: !collapsed[key] };
+	}
 </script>
 
 <div class="fleet-list">
 	{#if channelRooms.length > 0}
+		{@const channelsKey = "channels:channels"}
 		<div class="fleet-group" data-kind="channels">
-			<div class="group-header">
+			<button
+				class="group-header group-header--btn"
+				aria-expanded={!collapsed[channelsKey]}
+				onclick={() => toggleCollapse(channelsKey)}
+			>
 				<span style="display: inline-flex; align-items: center; gap: 6px;">
 					<Icon name="message" size={11} />
 					<span>Channels</span>
 				</span>
-				<span class="count">{channelRooms.length}</span>
-			</div>
-			{#each channelRooms as ch (ch.id)}
-				<ChannelRow
-					roomId={ch.id}
-					memberCount={ch.memberCount}
-					selected={rowSelected({ channelId: ch.id })}
-					{density}
-					{surface}
-					onSelect={(ev) => onSelect({ kind: "channel", roomId: ch.id }, ev)}
-				/>
-			{/each}
+				<span style="display: inline-flex; align-items: center; gap: 4px;">
+					<span class="count">{channelRooms.length}</span>
+					<Icon name={collapsed[channelsKey] ? "chevron-right" : "chevron-down"} size={11} />
+				</span>
+			</button>
+			{#if !collapsed[channelsKey]}
+				{#each channelRooms as ch (ch.id)}
+					<ChannelRow
+						roomId={ch.id}
+						memberCount={ch.memberCount}
+						selected={rowSelected({ channelId: ch.id })}
+						{density}
+						{surface}
+						onSelect={(ev) => onSelect({ kind: "channel", roomId: ch.id }, ev)}
+					/>
+				{/each}
+			{/if}
 		</div>
 	{/if}
 
 	{#if lens === "attention"}
 		{#each attentionSections as section (section.id)}
 			{#if section.items.length > 0}
+				{@const attnKey = "attention:" + section.id}
 				<div class="fleet-group" data-kind={section.id}>
-					<div class="group-header" class:attn={section.id === "blocked"}>
+					<button
+						class="group-header group-header--btn"
+						class:attn={section.id === "blocked"}
+						aria-expanded={!collapsed[attnKey]}
+						onclick={() => toggleCollapse(attnKey)}
+					>
 						<span style="display: inline-flex; align-items: center; gap: 6px;">
 							<Icon name={section.id === "blocked" ? "alert" : section.id === "waiting" ? "clock" : "spark"} size={11} />
 							<span>{section.label}</span>
 						</span>
+						<span style="display: inline-flex; align-items: center; gap: 4px;">
+							<span class="count">{section.items.length}</span>
+							<Icon name={collapsed[attnKey] ? "chevron-right" : "chevron-down"} size={11} />
+						</span>
+					</button>
+					{#if !collapsed[attnKey]}
+						{#each section.items as item (item.id)}
+							<SidebarItem
+								{item}
+								{now}
+								{density}
+								{surface}
+								here={isHere(item.session.pane?.paneId)}
+								selected={rowSelected({
+									paneId: item.session.pane?.paneId,
+									sessionUuid: item.session.sessionUuid,
+								})}
+								onSelect={(_id, ev) => onSelect({
+									kind: "session",
+									paneId: item.session.pane?.paneId,
+									sessionUuid: item.session.sessionUuid,
+								}, ev)}
+							/>
+						{/each}
+					{/if}
+				</div>
+			{/if}
+		{/each}
+		{#if attentionTotal === 0}
+			<div class="empty-lens">
+				<span class="dimer">{attentionLoading ? "Loading…" : "No Claude sessions reported by the daemon."}</span>
+			</div>
+		{/if}
+	{:else if lens === "recent"}
+		<!-- Recent activity is the only flat lens — no grouping axis (#540 B0). -->
+		{@const recentKey = "recent:recent"}
+		<div class="fleet-group" data-kind="recent">
+			<button
+				class="group-header group-header--btn"
+				aria-expanded={!collapsed[recentKey]}
+				onclick={() => toggleCollapse(recentKey)}
+			>
+				<span style="display: inline-flex; align-items: center; gap: 6px;">
+					<Icon name="clock" size={11} />
+					<span>Recent</span>
+				</span>
+				<span style="display: inline-flex; align-items: center; gap: 4px;">
+					<span class="count">{recentItems.length}</span>
+					<Icon name={collapsed[recentKey] ? "chevron-right" : "chevron-down"} size={11} />
+				</span>
+			</button>
+			{#if !collapsed[recentKey]}
+				{#each recentItems as item (item.id)}
+					<SidebarItem
+						{item}
+						{now}
+						{density}
+						{surface}
+						here={isHere(item.session.pane?.paneId)}
+						selected={rowSelected({
+							paneId: item.session.pane?.paneId,
+							sessionUuid: item.session.sessionUuid,
+						})}
+						onSelect={(_id, ev) => onSelect({
+							kind: "session",
+							paneId: item.session.pane?.paneId,
+							sessionUuid: item.session.sessionUuid,
+						}, ev)}
+					/>
+				{/each}
+			{/if}
+		</div>
+		{#if recentItems.length === 0}
+			<div class="empty-lens">
+				<span class="dimer">{recentLoading ? "Loading…" : "No Claude sessions known."}</span>
+			</div>
+		{/if}
+	{:else if lens === "tmux"}
+		{#each tmuxSections as section (section.id)}
+			{@const tmuxKey = "tmux:" + section.id}
+			<div class="fleet-group" data-kind={section.id}>
+				<button
+					class="group-header group-header--btn"
+					aria-expanded={!collapsed[tmuxKey]}
+					onclick={() => toggleCollapse(tmuxKey)}
+				>
+					<span style="display: inline-flex; align-items: center; gap: 6px;">
+						<Icon name="terminal" size={11} />
+						<span>{section.label}</span>
+					</span>
+					<span style="display: inline-flex; align-items: center; gap: 4px;">
 						<span class="count">{section.items.length}</span>
-					</div>
+						<Icon name={collapsed[tmuxKey] ? "chevron-right" : "chevron-down"} size={11} />
+					</span>
+				</button>
+				{#if !collapsed[tmuxKey]}
 					{#each section.items as item (item.id)}
 						<SidebarItem
 							{item}
@@ -167,76 +305,7 @@
 							}, ev)}
 						/>
 					{/each}
-				</div>
-			{/if}
-		{/each}
-		{#if attentionTotal === 0}
-			<div class="empty-lens">
-				<span class="dimer">{attentionLoading ? "Loading…" : "No Claude sessions reported by the daemon."}</span>
-			</div>
-		{/if}
-	{:else if lens === "recent"}
-		<!-- Recent activity is the only flat lens — no grouping axis (#540 B0). -->
-		<div class="fleet-group" data-kind="recent">
-			<div class="group-header">
-				<span style="display: inline-flex; align-items: center; gap: 6px;">
-					<Icon name="clock" size={11} />
-					<span>Recent</span>
-				</span>
-				<span class="count">{recentItems.length}</span>
-			</div>
-			{#each recentItems as item (item.id)}
-				<SidebarItem
-					{item}
-					{now}
-					{density}
-					{surface}
-					here={isHere(item.session.pane?.paneId)}
-					selected={rowSelected({
-						paneId: item.session.pane?.paneId,
-						sessionUuid: item.session.sessionUuid,
-					})}
-					onSelect={(_id, ev) => onSelect({
-						kind: "session",
-						paneId: item.session.pane?.paneId,
-						sessionUuid: item.session.sessionUuid,
-					}, ev)}
-				/>
-			{/each}
-		</div>
-		{#if recentItems.length === 0}
-			<div class="empty-lens">
-				<span class="dimer">{recentLoading ? "Loading…" : "No Claude sessions known."}</span>
-			</div>
-		{/if}
-	{:else if lens === "tmux"}
-		{#each tmuxSections as section (section.id)}
-			<div class="fleet-group" data-kind={section.id}>
-				<div class="group-header">
-					<span style="display: inline-flex; align-items: center; gap: 6px;">
-						<Icon name="terminal" size={11} />
-						<span>{section.label}</span>
-					</span>
-					<span class="count">{section.items.length}</span>
-				</div>
-				{#each section.items as item (item.id)}
-					<SidebarItem
-						{item}
-						{now}
-						{density}
-						{surface}
-						here={isHere(item.session.pane?.paneId)}
-						selected={rowSelected({
-							paneId: item.session.pane?.paneId,
-							sessionUuid: item.session.sessionUuid,
-						})}
-						onSelect={(_id, ev) => onSelect({
-							kind: "session",
-							paneId: item.session.pane?.paneId,
-							sessionUuid: item.session.sessionUuid,
-						}, ev)}
-					/>
-				{/each}
+				{/if}
 			</div>
 		{/each}
 		{#if tmuxSections.length === 0}
@@ -254,56 +323,23 @@
 		{/if}
 	{:else if lens === "issue"}
 		{#each issueSections as section (section.id)}
+			{@const issueKey = "issue:" + section.id}
 			<div class="fleet-group" data-kind={section.id}>
-				<div class="group-header">
+				<button
+					class="group-header group-header--btn"
+					aria-expanded={!collapsed[issueKey]}
+					onclick={() => toggleCollapse(issueKey)}
+				>
 					<span style="display: inline-flex; align-items: center; gap: 6px;">
 						<Icon name="issue" size={11} />
 						<span>{section.label}</span>
 					</span>
-					<span class="count">{section.items.length}</span>
-				</div>
-				{#each section.items as item (item.id)}
-					<SidebarItem
-						{item}
-						{now}
-						{density}
-						{surface}
-						here={isHere(item.session.pane?.paneId)}
-						selected={rowSelected({
-							paneId: item.session.pane?.paneId,
-							sessionUuid: item.session.sessionUuid,
-						})}
-						onSelect={(_id, ev) => onSelect({
-							kind: "session",
-							paneId: item.session.pane?.paneId,
-							sessionUuid: item.session.sessionUuid,
-						}, ev)}
-					/>
-				{/each}
-			</div>
-		{/each}
-		{#if issueTotal === 0}
-			<div class="empty-lens">
-				<span class="dimer">
-					{issueLoading ? "Loading…" : "No issues with open PRs in scope."}
-				</span>
-			</div>
-		{/if}
-	{:else if lens === "worktree"}
-		{#each worktreeSections as section (section.id)}
-			<div class="fleet-group" data-kind={section.id}>
-				<div class="group-header">
-					<span style="display: inline-flex; align-items: center; gap: 6px;">
-						<Icon name="git-branch" size={11} />
-						<span>{section.label}</span>
+					<span style="display: inline-flex; align-items: center; gap: 4px;">
+						<span class="count">{section.items.length}</span>
+						<Icon name={collapsed[issueKey] ? "chevron-right" : "chevron-down"} size={11} />
 					</span>
-					<span class="count">{section.items.length}</span>
-				</div>
-				{#if section.items.length === 0}
-					<div class="empty-section">
-						<span class="dimer">No active sessions in this repo.</span>
-					</div>
-				{:else}
+				</button>
+				{#if !collapsed[issueKey]}
 					{#each section.items as item (item.id)}
 						<SidebarItem
 							{item}
@@ -322,6 +358,59 @@
 							}, ev)}
 						/>
 					{/each}
+				{/if}
+			</div>
+		{/each}
+		{#if issueTotal === 0}
+			<div class="empty-lens">
+				<span class="dimer">
+					{issueLoading ? "Loading…" : "No issues with open PRs in scope."}
+				</span>
+			</div>
+		{/if}
+	{:else if lens === "worktree"}
+		{#each worktreeSections as section (section.id)}
+			{@const worktreeKey = "worktree:" + section.id}
+			<div class="fleet-group" data-kind={section.id}>
+				<button
+					class="group-header group-header--btn"
+					aria-expanded={!collapsed[worktreeKey]}
+					onclick={() => toggleCollapse(worktreeKey)}
+				>
+					<span style="display: inline-flex; align-items: center; gap: 6px;">
+						<Icon name="git-branch" size={11} />
+						<span>{section.label}</span>
+					</span>
+					<span style="display: inline-flex; align-items: center; gap: 4px;">
+						<span class="count">{section.items.length}</span>
+						<Icon name={collapsed[worktreeKey] ? "chevron-right" : "chevron-down"} size={11} />
+					</span>
+				</button>
+				{#if !collapsed[worktreeKey]}
+					{#if section.items.length === 0}
+						<div class="empty-section">
+							<span class="dimer">No active sessions in this repo.</span>
+						</div>
+					{:else}
+						{#each section.items as item (item.id)}
+							<SidebarItem
+								{item}
+								{now}
+								{density}
+								{surface}
+								here={isHere(item.session.pane?.paneId)}
+								selected={rowSelected({
+									paneId: item.session.pane?.paneId,
+									sessionUuid: item.session.sessionUuid,
+								})}
+								onSelect={(_id, ev) => onSelect({
+									kind: "session",
+									paneId: item.session.pane?.paneId,
+									sessionUuid: item.session.sessionUuid,
+								}, ev)}
+							/>
+						{/each}
+					{/if}
 				{/if}
 			</div>
 		{/each}
@@ -344,5 +433,25 @@
 	.empty-section {
 		padding: 8px 16px;
 		font-size: 11.5px;
+	}
+	/* Section headers are now <button> elements for a11y (click + Enter/Space). */
+	.group-header--btn {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
+		background: none;
+		border: none;
+		padding: 0;
+		margin: 0;
+		font: inherit;
+		color: inherit;
+		cursor: pointer;
+		text-align: left;
+	}
+	.group-header--btn:focus-visible {
+		outline: 2px solid var(--color-accent, #6366f1);
+		outline-offset: -2px;
+		border-radius: 2px;
 	}
 </style>

--- a/crates/orchard-gui/src/lib/components/LensSidebar.svelte
+++ b/crates/orchard-gui/src/lib/components/LensSidebar.svelte
@@ -4,7 +4,6 @@
   Channels (chat rooms from chat-core) are rendered above the lens content.
 -->
 <script lang="ts">
-	import { onMount } from "svelte";
 	import Icon from "$lib/icons/Icon.svelte";
 	import SidebarItem from "./SidebarItem.svelte";
 	import ChannelRow from "./ChannelRow.svelte";
@@ -39,17 +38,13 @@
 	const store = getStore();
 	const lens = $derived(store.lens);
 
-	// Houdini stores: kick off CacheAndNetwork fetches on mount; the
-	// component subscribes via the `$<storeName>` reactive contract.
-	// Subsequent push events into the daemon (subscribeAll → cache patch)
-	// re-render the sidebar without an explicit re-fetch.
-	onMount(() => {
-		attentionStore.fetch();
-		recentStore.fetch();
-		tmuxStore.fetch();
-		issueStore.fetch();
-		worktreeStore.fetch();
-	});
+	// Per-lens $effect: re-fetches the active lens store on every lens entry.
+	// CacheAndNetwork policy (houdini.config.js) serves cache instantly then revalidates.
+	$effect(() => { if (lens === "attention") attentionStore.fetch(); });
+	$effect(() => { if (lens === "recent") recentStore.fetch(); });
+	$effect(() => { if (lens === "tmux") tmuxStore.fetch(); });
+	$effect(() => { if (lens === "issue") issueStore.fetch(); });
+	$effect(() => { if (lens === "worktree") worktreeStore.fetch(); });
 
 	// All four lenses produce the same shape per #540 B0/B1: sections
 	// of `SidebarItem[]`. The lens decides the grouping axis; the item

--- a/crates/orchard-gui/src/lib/components/LensSidebar.svelte
+++ b/crates/orchard-gui/src/lib/components/LensSidebar.svelte
@@ -58,10 +58,19 @@
 	const attentionLoading = $derived($attentionStore.fetching);
 
 	// Surface attention-lens fetch errors via toast so the user isn't left
-	// with a silently empty sidebar (Scenario L208 / #600).
+	// with a silently empty sidebar (Scenario L208 / #600). Track the
+	// last-shown message so the effect doesn't re-fire the same toast every
+	// time another reactive read in scope changes.
+	let lastAttentionError: string | null = null;
 	$effect(() => {
-		const errs = $attentionStore.errors;
-		if (errs && errs.length > 0) toast.error(errs[0].message);
+		const msg = $attentionStore.errors?.[0]?.message?.trim() ?? "";
+		if (!msg) {
+			lastAttentionError = null;
+			return;
+		}
+		if (msg === lastAttentionError) return;
+		lastAttentionError = msg;
+		toast.error(msg);
 	});
 
 	const recentItems = $derived(buildRecentItems($recentStore.data));

--- a/crates/orchard-gui/src/lib/components/LensSidebar.svelte
+++ b/crates/orchard-gui/src/lib/components/LensSidebar.svelte
@@ -9,6 +9,7 @@
 	import SidebarItem from "./SidebarItem.svelte";
 	import ChannelRow from "./ChannelRow.svelte";
 	import { getStore } from "$lib/store.svelte";
+	import { toast } from "$lib/util/toast";
 	import {
 		attentionStore,
 		buildAttentionSections,
@@ -60,6 +61,13 @@
 		attentionSections.reduce((n, s) => n + s.items.length, 0),
 	);
 	const attentionLoading = $derived($attentionStore.fetching);
+
+	// Surface attention-lens fetch errors via toast so the user isn't left
+	// with a silently empty sidebar (Scenario L208 / #600).
+	$effect(() => {
+		const errs = $attentionStore.errors;
+		if (errs && errs.length > 0) toast.error(errs[0].message);
+	});
 
 	const recentItems = $derived(buildRecentItems($recentStore.data));
 	const recentLoading = $derived($recentStore.fetching);

--- a/crates/orchard-gui/src/lib/components/SessionComposer.svelte
+++ b/crates/orchard-gui/src/lib/components/SessionComposer.svelte
@@ -11,6 +11,7 @@
 <script lang="ts">
 	import Icon from "$lib/icons/Icon.svelte";
 	import { tmuxSendText } from "$lib/tauri";
+	import { toast } from "$lib/util/toast";
 
 	type Props = {
 		paneId: string;
@@ -35,6 +36,7 @@
 			autosize();
 		} catch (err) {
 			error = (err as Error)?.message ?? String(err);
+			toast.error(err);
 		} finally {
 			sending = false;
 			queueMicrotask(() => textarea?.focus());

--- a/crates/orchard-gui/src/lib/components/SidebarItem.svelte
+++ b/crates/orchard-gui/src/lib/components/SidebarItem.svelte
@@ -79,6 +79,13 @@
 	const cwdBase = $derived(
 		cwdFull ? cwdFull.split("/").filter(Boolean).pop() || cwdFull : null,
 	);
+
+	// Repo chip (#550): last path segment of "owner/repo" form, or the value
+	// as-is when no slash. Null when the worktree carries no repo metadata.
+	const repo = $derived(item.worktree?.repo ?? null);
+	const repoSlug = $derived(
+		repo ? (repo.includes("/") ? repo.split("/").pop()! : repo) : null,
+	);
 </script>
 
 <div
@@ -97,10 +104,17 @@
 	tabindex="0"
 >
 	<div class="fleet-item-main">
-		<span
-			class="pip {item.state === 'working' ? 'ok' : 'idle'}"
-			title={stateLabel}
-		></span>
+		{#if item.state !== 'no_claude'}
+			<span class="state-pill state-pill--{item.state}" title={stateLabel}>
+				{#if item.state === 'working'}● working
+				{:else if item.state === 'idle'}· idle
+				{:else if item.state === 'input'}→ input
+				{:else if item.state === 'stalled'}⚠ stalled
+				{:else if item.state === 'dead'}✕ dead
+				{:else}{item.state}
+				{/if}
+			</span>
+		{/if}
 		<div class="fleet-item-body">
 			<div class="fleet-item-title-row">
 				<span class="fleet-item-title">{item.title}</span>
@@ -135,6 +149,12 @@
 						<span>{item.worktree.branch}</span>
 					</span>
 				{/if}
+				{#if repoSlug}
+					<span class="meta-chip mono dimer" title={repo ?? undefined}>
+						<Icon name="git-fork" size={11} />
+						<span>{repoSlug}</span>
+					</span>
+				{/if}
 				{#if item.worktree?.pr}
 					<span class="mono dimer">PR #{item.worktree.pr.number}</span>
 					<span class="dimest">·</span>
@@ -156,7 +176,6 @@
 					<span class="mono dimest" style:font-size="10.5px" title="claude pid">{item.pid}</span>
 					<span class="dimest">·</span>
 				{/if}
-				<span class="dimer mono" style:font-size="11px">{stateLabel}</span>
 				{#if item.lastActivityMs > 0}
 					<span class="dimest">·</span>
 					<span class="dimer mono" style:font-size="11px">{relTime(item.lastActivityMs, now)}</span>
@@ -187,6 +206,52 @@
 </div>
 
 <style>
+	/* State pill (#553) — replaces the binary pip. 6-way visual distinction. */
+	.state-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 2px;
+		font-size: 10px;
+		padding: 1px 5px;
+		border-radius: 3px;
+		white-space: nowrap;
+		font-family: var(--font-mono, monospace);
+		flex: none;
+		align-self: center;
+	}
+	/* working — green */
+	.state-pill--working {
+		background: rgba(110, 211, 145, 0.14);
+		color: #6fd391;
+		border: 0.5px solid rgba(110, 211, 145, 0.32);
+	}
+	/* idle — muted grey */
+	.state-pill--idle {
+		background: rgba(160, 160, 160, 0.10);
+		color: #888;
+		border: 0.5px solid rgba(160, 160, 160, 0.22);
+	}
+	/* input — high-contrast amber/orange; bold per #553 L160 */
+	.state-pill--input {
+		background: rgba(255, 160, 50, 0.20);
+		color: #ffaa33;
+		border: 0.5px solid rgba(255, 160, 50, 0.50);
+		font-weight: 700;
+	}
+	/* stalled — red/warning */
+	.state-pill--stalled {
+		background: rgba(255, 100, 100, 0.14);
+		color: #ff7272;
+		border: 0.5px solid rgba(255, 100, 100, 0.32);
+	}
+	/* dead — dark muted */
+	.state-pill--dead {
+		background: rgba(100, 100, 100, 0.10);
+		color: #666;
+		border: 0.5px solid rgba(100, 100, 100, 0.22);
+		text-decoration: line-through;
+	}
+
 	.meta-chip {
 		display: inline-flex;
 		align-items: center;

--- a/crates/orchard-gui/src/lib/components/TerminalAttach.svelte
+++ b/crates/orchard-gui/src/lib/components/TerminalAttach.svelte
@@ -24,6 +24,7 @@
 		PTY_UNSUPPORTED,
 	} from "$lib/data/pty";
 	import type { UnlistenFn } from "@tauri-apps/api/event";
+	import { toast } from "$lib/util/toast";
 
 	type Props = {
 		argv: string[];
@@ -139,7 +140,42 @@
 				});
 				fitAddon = new fit.FitAddon();
 				term.loadAddon(fitAddon);
-				term.loadAddon(new links.WebLinksAddon());
+				try {
+					// Detect macOS: cmd-click is the platform convention; other
+					// platforms use a plain click.
+					const isMac =
+						typeof navigator !== "undefined" &&
+						navigator.platform.toUpperCase().includes("MAC");
+
+					/**
+					 * Open a URL using the Tauri shell opener when running inside
+					 * the desktop app, falling back to window.open for browser dev.
+					 */
+					async function openUrl(uri: string): Promise<void> {
+						if (inTauri) {
+							const { openUrl: tauriOpen } = await import(
+								"@tauri-apps/plugin-opener"
+							);
+							await tauriOpen(uri);
+						} else {
+							window.open(uri, "_blank", "noopener,noreferrer");
+						}
+					}
+
+					/**
+					 * activateCallback for WebLinksAddon.
+					 * On macOS, only activate on cmd-click (metaKey).
+					 * On other platforms, activate on a plain click.
+					 */
+					function handleLink(event: MouseEvent, uri: string): void {
+						if (isMac && !event.metaKey) return;
+						openUrl(uri).catch(toast.error);
+					}
+
+					term.loadAddon(new links.WebLinksAddon(handleLink));
+				} catch (err) {
+					toast.error(err);
+				}
 				term.open(host);
 				fitAddon.fit();
 

--- a/crates/orchard-gui/src/lib/components/TerminalAttach.svelte
+++ b/crates/orchard-gui/src/lib/components/TerminalAttach.svelte
@@ -188,7 +188,7 @@
 				const enc = new TextEncoder();
 				term.onData((data) => {
 					// intentional swallow: keystrokes may arrive after PTY exits; drop silently
-				if (ptyId != null) writePty(ptyId, enc.encode(data)).catch(() => {});
+					if (ptyId != null) writePty(ptyId, enc.encode(data)).catch(() => {});
 				});
 
 				resizeObserver = new ResizeObserver(() => {

--- a/crates/orchard-gui/src/lib/components/TerminalAttach.svelte
+++ b/crates/orchard-gui/src/lib/components/TerminalAttach.svelte
@@ -60,15 +60,20 @@
 	async function killCurrentPty() {
 		try {
 			unsubData?.();
-		} catch {}
+		} catch {
+			// intentional swallow: pty already dead during cleanup; unsub throws harmlessly
+		}
 		try {
 			unsubExit?.();
-		} catch {}
+		} catch {
+			// intentional swallow: pty already dead during cleanup; unsub throws harmlessly
+		}
 		unsubData = null;
 		unsubExit = null;
 		if (ptyId != null) {
 			const old = ptyId;
 			ptyId = null;
+			// intentional swallow: pty already dead during cleanup
 			killPty(old).catch(() => {});
 		}
 	}
@@ -91,6 +96,7 @@
 		try {
 			const handle = await spawnPty(currentArgv, { cwd, cols, rows });
 			if (cancelled || lastArgvKey !== argvKey(currentArgv)) {
+				// intentional swallow: stale PTY spawned after argv changed; kill is best-effort
 				killPty(handle.id).catch(() => {});
 				return;
 			}
@@ -181,12 +187,14 @@
 
 				const enc = new TextEncoder();
 				term.onData((data) => {
-					if (ptyId != null) writePty(ptyId, enc.encode(data)).catch(() => {});
+					// intentional swallow: keystrokes may arrive after PTY exits; drop silently
+				if (ptyId != null) writePty(ptyId, enc.encode(data)).catch(() => {});
 				});
 
 				resizeObserver = new ResizeObserver(() => {
 					try {
 						fitAddon?.fit();
+						// intentional swallow: PTY may have exited between resize check and IPC call
 						if (ptyId != null && term) resizePty(ptyId, term.cols, term.rows).catch(() => {});
 					} catch {
 						// Window not visible / 0-sized — skip silently.

--- a/crates/orchard-gui/src/lib/components/TranscriptView.svelte
+++ b/crates/orchard-gui/src/lib/components/TranscriptView.svelte
@@ -125,6 +125,7 @@
 		if (!stickToBottom || len === 0 || len === lastScrolledLen) return;
 		lastScrolledLen = len;
 		setTimeout(() => {
+			// intentional swallow: virtualizer may not be mounted yet during fast turn bursts; scroll retried on next tick
 			try { $virtualizer.scrollToIndex(len - 1, { align: "end" }); } catch {}
 		}, 0);
 	});

--- a/crates/orchard-gui/src/lib/data/chat.ts
+++ b/crates/orchard-gui/src/lib/data/chat.ts
@@ -85,6 +85,7 @@ class TauriBackend implements ChatBackend {
 				memberCount: r.member_count,
 			}));
 		} catch {
+			// intentional swallow: chat-core IPC unavailable (daemon not running or non-Tauri env); caller degrades to empty list
 			return [];
 		}
 	}
@@ -114,6 +115,7 @@ class TauriBackend implements ChatBackend {
 			await invoke("chat_list_rooms");
 			return true;
 		} catch {
+			// intentional swallow: reachability probe — failure means unreachable, callers receive false
 			return false;
 		}
 	}
@@ -175,6 +177,7 @@ export async function getSelfHandle(): Promise<string | null> {
 		if (!inTauri) return null;
 		_selfHandle = await invoke<string>("chat_self_handle");
 	} catch {
+		// intentional swallow: handle discovery is best-effort; null means messages render without a self-attribution
 		_selfHandle = null;
 	}
 	return _selfHandle;

--- a/crates/orchard-gui/src/lib/data/lenses/houdini/WorktreeLens.gql
+++ b/crates/orchard-gui/src/lib/data/lenses/houdini/WorktreeLens.gql
@@ -5,8 +5,8 @@ query WorktreeLens {
 			slug
 			worktrees {
 				...WorktreeEnrichment
-				claudeInstances {
-					...SessionCard
+				tmuxPanes {
+					...PaneCard
 				}
 			}
 		}

--- a/crates/orchard-gui/src/lib/data/lenses/worktree.ts
+++ b/crates/orchard-gui/src/lib/data/lenses/worktree.ts
@@ -1,17 +1,23 @@
 /**
  * Worktree lens — anchor: workView.repos[].worktrees[]. One section per
- * repo (label = "owner/repo"); within each, one item per Claude session
+ * repo (label = "owner/repo"); within each, one item per tmux pane
  * attached to a worktree in that repo.
  *
- * Daemon owns the join (Worktree.claudeInstances). Empty worktrees still
- * surface so the user sees their topology. Drew (2026-05-10): "I want a
- * worktree lens to be back."
+ * Iterates Worktree.tmuxPanes (not claudeInstances). Each pane gets a
+ * row: panes with a Claude instance use the full SessionCard shape;
+ * panes without use a tmux-only row (state="no_claude"). Worktrees with
+ * zero panes still surface as dormant rows so the user sees their
+ * topology. Drew (2026-05-10): "I want a worktree lens to be back."
  */
 import { WorktreeLensStore, type WorktreeLens$result } from "$houdini";
 import { parseTime } from "./client";
-import type { SessionCardT, WorktreeEnrichment } from "./fragments";
+import type { PaneCardT, SessionCardT, WorktreeEnrichment } from "./fragments";
 import type { SidebarItem, SidebarSection } from "$lib/data/sidebar-item";
-import { buildSidebarItem, buildDormantWorktreeItem } from "$lib/data/sidebar-item";
+import {
+	buildSidebarItem,
+	buildDormantWorktreeItem,
+	buildTmuxOnlyPaneItem,
+} from "$lib/data/sidebar-item";
 
 /** Singleton store for the worktree lens. */
 export const worktreeStore = new WorktreeLensStore();
@@ -21,6 +27,10 @@ type Data = NonNullable<WorktreeLens$result>;
 /**
  * Project into one section per repo, items sorted by activity desc so
  * the busiest worktrees float to the top.
+ *
+ * Iteration anchor is Worktree.tmuxPanes — one sidebar item per pane.
+ * Panes with a Claude instance render the full Claude row; panes without
+ * render a tmux-only row. Worktrees with no panes render a dormant row.
  */
 export function buildWorktreeSections(
 	data: Data | null | undefined,
@@ -30,11 +40,11 @@ export function buildWorktreeSections(
 	for (const repo of data.workView.repos) {
 		const items: SidebarItem[] = [];
 		for (const w of repo.worktrees as unknown as Array<
-			WorktreeEnrichment & { claudeInstances?: SessionCardT[] | null }
+			WorktreeEnrichment & { tmuxPanes?: PaneCardT[] | null }
 		>) {
-			const sessions = (w.claudeInstances ?? []) as SessionCardT[];
-			if (sessions.length === 0) {
-				// Dormant worktree — no live Claude session. Drew (2026-05-10):
+			const panes = (w.tmuxPanes ?? []) as PaneCardT[];
+			if (panes.length === 0) {
+				// Dormant worktree — no live tmux panes. Drew (2026-05-10):
 				// "if there is a live worktree, that means it should be visible."
 				// Render a row anyway so the user can see + act on it (open a
 				// session, destroy, etc.). Branch / PR / issue chips still
@@ -42,13 +52,28 @@ export function buildWorktreeSections(
 				items.push(buildDormantWorktreeItem(w));
 				continue;
 			}
-			for (const s of sessions) {
-				const conv = s.conversation;
-				const lastActivityMs = parseTime(conv?.lastSeenAt) || parseTime(s.lastActivityAt);
-				const hints = conv
-					? { agentName: conv.agentName ?? null, customTitle: conv.customTitle ?? null }
-					: null;
-				items.push(buildSidebarItem(s, w, lastActivityMs, [], hints));
+			for (const pane of panes) {
+				const ci = pane.claudeInstance as SessionCardT | null;
+				if (ci) {
+					// Pane has a Claude session — build the full enriched row.
+					const worktree = (ci.worktree ?? w) as WorktreeEnrichment;
+					const conv = ci.conversation;
+					const lastActivityMs =
+						parseTime(conv?.lastSeenAt) || parseTime(ci.lastActivityAt);
+					const hints = conv
+						? { agentName: conv.agentName ?? null, customTitle: conv.customTitle ?? null }
+						: null;
+					// Key the item by paneId (not by ci.id) so that two panes sharing
+					// the same ClaudeInstance (edge case) each get their own row.
+					const item = buildSidebarItem(ci, worktree, lastActivityMs, [], hints);
+					items.push({ ...item, id: `pane:${pane.paneId}` });
+				} else {
+					// Pane has no Claude session — tmux-only row keyed by paneId.
+					const paneWorktree = (pane.process?.worktree ?? w) as WorktreeEnrichment;
+					const lastActivityMs =
+						parseTime(pane.window?.session?.lastActivityAt) ?? 0;
+					items.push(buildTmuxOnlyPaneItem(pane, paneWorktree, lastActivityMs));
+				}
 			}
 		}
 		// Dormant rows have lastActivityMs=0 and naturally sink to the bottom

--- a/crates/orchard-gui/src/lib/data/pty.ts
+++ b/crates/orchard-gui/src/lib/data/pty.ts
@@ -79,6 +79,7 @@ export async function listenData(
 		try {
 			onChunk(decodeBase64(e.payload.b64));
 		} catch (err) {
+			// intentional swallow: malformed PTY data chunk; warn to console but don't interrupt the terminal stream
 			console.warn("[pty] decode failed:", err);
 		}
 	});

--- a/crates/orchard-gui/src/lib/data/sidebar-item.ts
+++ b/crates/orchard-gui/src/lib/data/sidebar-item.ts
@@ -16,7 +16,7 @@
  * No more pane-id-as-title in the tmux lens; no more lens-specific
  * label divergence.
  */
-import type { SessionCardT, WorktreeEnrichment } from "./lenses/fragments";
+import type { PaneCardT, SessionCardT, WorktreeEnrichment } from "./lenses/fragments";
 
 /**
  * One sidebar section — a label plus the items that belong to it.
@@ -183,6 +183,60 @@ export function buildSidebarItem(
 		state: session.state,
 		lastActivityMs,
 		reasons,
+	};
+}
+
+/**
+ * Build a sidebar row for a tmux pane that has no attached Claude session.
+ * Keyed by the pane's `paneId` so that two panes on the same worktree each
+ * get their own row. Title comes from pane.title → pane.currentCommand →
+ * pane.paneId. `state="no_claude"` drives the renderer (no state pill).
+ *
+ * @param pane - the tmux pane (PaneCard shape)
+ * @param worktree - resolved worktree for the pane's process, if any
+ * @param lastActivityMs - activity timestamp; 0 when not known
+ */
+export function buildTmuxOnlyPaneItem(
+	pane: PaneCardT,
+	worktree: WorktreeEnrichment | null,
+	lastActivityMs: number = 0,
+): SidebarItem {
+	const title = pane.title || pane.currentCommand || pane.paneId;
+	return {
+		id: `pane:${pane.paneId}`,
+		// Synthetic placeholder so the existing SidebarItem component renders
+		// the row uniformly; no live Claude session exists for this pane.
+		session: {
+			id: `pane:${pane.paneId}`,
+			sessionUuid: "",
+			state: "no_claude",
+			startedAt: null,
+			lastActivityAt: null,
+			rcEnabled: false,
+			account: null,
+			pane: {
+				paneId: pane.paneId,
+				title: pane.title,
+				currentCommand: pane.currentCommand,
+				window: pane.window,
+			},
+			process: pane.process ? { pid: pane.process.pid, cwd: pane.process.cwd } : null,
+			worktree: worktree ?? null,
+			conversation: null,
+		} as unknown as SessionCardT,
+		title,
+		worktree,
+		tmuxAddress: (() => {
+			const w = pane.window;
+			const sessionName = w?.session?.name;
+			const windowIndex = w?.index;
+			if (sessionName == null || windowIndex == null) return pane.paneId;
+			return `${sessionName}:${windowIndex}.${pane.paneId.replace("%", "")}`;
+		})(),
+		pid: pane.process?.pid ?? null,
+		state: "no_claude",
+		lastActivityMs,
+		reasons: [],
 	};
 }
 

--- a/crates/orchard-gui/src/lib/data/transcript.ts
+++ b/crates/orchard-gui/src/lib/data/transcript.ts
@@ -145,6 +145,7 @@ export function parseTranscript(text: string): TranscriptTurn[] {
 		try {
 			row = JSON.parse(line);
 		} catch {
+			// intentional swallow: malformed JSONL line (truncated write or non-JSON footer); skip to next line
 			continue;
 		}
 		if (row.type && SKIP_TYPES.has(row.type)) continue;

--- a/crates/orchard-gui/src/lib/store.svelte.ts
+++ b/crates/orchard-gui/src/lib/store.svelte.ts
@@ -17,6 +17,7 @@ import {
 	getSelfHandle,
 	type ChatBackend,
 } from "./data/chat";
+import { toast } from "./util/toast";
 import type {
 	Conversation,
 	ConvView,
@@ -412,7 +413,7 @@ export class AppStore {
 				this.sending = null;
 			})
 			.catch((err) => {
-				console.warn("[orchard-gui] chat send failed:", err);
+				toast.error(err);
 				this.sending = null;
 			});
 	};
@@ -422,6 +423,7 @@ export class AppStore {
 		try {
 			this.chatRooms = await b.listRooms();
 		} catch {
+			// intentional swallow: chat-core may not be running; sidebar degrades to empty rooms list silently on startup
 			this.chatRooms = [];
 		}
 	};
@@ -447,6 +449,7 @@ export class AppStore {
 		if (this.chatRoomCache[roomId] || this._chatRoomLoading.has(roomId)) return;
 		this._chatRoomLoading.add(roomId);
 		this.loadChatRoom(roomId)
+			// intentional swallow: lazy background room load; failure leaves the room absent from cache, user can re-select to retry
 			.catch(() => {})
 			.finally(() => this._chatRoomLoading.delete(roomId));
 	};

--- a/crates/orchard-gui/src/lib/util/toast.ts
+++ b/crates/orchard-gui/src/lib/util/toast.ts
@@ -1,0 +1,31 @@
+/**
+ * Thin wrapper over svelte-sonner's `toast` that:
+ *   - Extracts a human-readable message from any thrown value
+ *   - Logs the full error (with stack) to the dev-tools console so engineers
+ *     can trace the cause even after the toast auto-dismisses
+ */
+import { toast as _toast } from "svelte-sonner";
+
+function extractMessage(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	if (typeof err === "string") return err;
+	try {
+		return JSON.stringify(err);
+	} catch {
+		return String(err);
+	}
+}
+
+export const toast = {
+	/**
+	 * Surface an error as a visible toast and emit the full error to the
+	 * dev-tools console so the stack trace is preserved.
+	 */
+	error(err: unknown): void {
+		console.error(err);
+		_toast.error(extractMessage(err));
+	},
+	/** Convenience pass-throughs kept thin — add only what's needed (YAGNI). */
+	success: _toast.success.bind(_toast),
+	info: _toast.info.bind(_toast),
+};

--- a/crates/orchard-gui/src/lib/util/toast.ts
+++ b/crates/orchard-gui/src/lib/util/toast.ts
@@ -12,6 +12,7 @@ function extractMessage(err: unknown): string {
 	try {
 		return JSON.stringify(err);
 	} catch {
+		// intentional swallow: circular-reference or non-serialisable object; fall back to String coercion
 		return String(err);
 	}
 }

--- a/crates/orchard-gui/src/lib/util/toast.ts
+++ b/crates/orchard-gui/src/lib/util/toast.ts
@@ -10,11 +10,19 @@ function extractMessage(err: unknown): string {
 	if (err instanceof Error) return err.message;
 	if (typeof err === "string") return err;
 	try {
-		return JSON.stringify(err);
+		const json = JSON.stringify(err);
+		// JSON.stringify returns "{}" for plain objects with only non-enumerable
+		// or symbol keys; fall through so the user sees something more useful.
+		if (json && json !== "{}") return json;
 	} catch {
-		// intentional swallow: circular-reference or non-serialisable object; fall back to String coercion
-		return String(err);
+		// intentional swallow: circular-reference or non-serialisable object; fall through to descriptor
 	}
+	if (err && typeof err === "object") {
+		const ctor = (err as { constructor?: { name?: string } }).constructor?.name;
+		const keys = Object.keys(err as object).slice(0, 5).join(",");
+		return `${ctor ?? "Object"}{${keys}}`;
+	}
+	return String(err);
 }
 
 export const toast = {

--- a/crates/orchard-gui/src/routes/+layout.svelte
+++ b/crates/orchard-gui/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import "$lib/styles/layout.css";
 	import { getStore } from "$lib/store.svelte";
 	import { onMount } from "svelte";
+	import { Toaster } from "svelte-sonner";
 
 	// Houdini's client at `src/client.ts` is wired by the houdini-svelte
 	// plugin (see `houdini.config.js:client`); it's lazy-imported the
@@ -34,4 +35,5 @@
 	});
 </script>
 
+<Toaster richColors />
 {@render children?.()}

--- a/crates/orchard-gui/src/routes/+layout.svelte
+++ b/crates/orchard-gui/src/routes/+layout.svelte
@@ -29,6 +29,7 @@
 
 		return () => {
 			stopTick();
+			// intentional swallow: cleanup-time unsubscribe; if the promise never resolved the subscription was never established
 			subPromise.then((u) => u()).catch(() => {});
 			store.teardown();
 		};

--- a/specs/features/sidebar-v1-hardening-error-visibility.feature
+++ b/specs/features/sidebar-v1-hardening-error-visibility.feature
@@ -128,7 +128,7 @@ Feature: orchard-gui sidebar v1 hardening + error visibility (parent #548)
   @integration
   Scenario: Collapse state is persisted in localStorage
     Given the user toggles a section's collapse state
-    Then a localStorage key (mirroring the "orchard:sidebarW" pattern) records the section's collapsed/expanded state per section identifier
+    Then a localStorage key "orchard:sidebar:collapsed" records each section's collapsed/expanded state by section identifier
 
   @unit
   Scenario: Each section toggles independently
@@ -154,7 +154,6 @@ Feature: orchard-gui sidebar v1 hardening + error visibility (parent #548)
       | input    |
       | stalled  |
       | dead     |
-      | no_claude|
 
   @e2e
   Scenario: "input" state is rendered prominently (blocked on user)

--- a/specs/features/sidebar-v1-hardening-error-visibility.feature
+++ b/specs/features/sidebar-v1-hardening-error-visibility.feature
@@ -1,0 +1,290 @@
+Feature: orchard-gui sidebar v1 hardening + error visibility (parent #548)
+  As an orchard-gui user juggling worktrees, tmux panes, and Claude sessions
+  I want the sidebar to render every pane reliably, refresh on lens re-entry, surface repo + Claude state, collapse, and never swallow errors silently — and terminal URLs to be clickable
+  So that the sidebar is trustworthy at-a-glance and failures are diagnosable
+
+  Background:
+    Given the orchard daemon is running at "127.0.0.1:7777"
+    And the daemon GraphQL exposes "Worktree.tmuxPanes", "Worktree.repo", "ClaudeInstance.state", "ClaudeInstance.pane", and "TmuxPane.{process,currentCommand,title,paneId,claudeInstance}"
+    And the active lens enum is "attention | recent | tmux | issue | worktree"
+
+  # ===================================================================
+  # AC1 (parent #548) — Worktree lens shows one item per tmux pane
+  # ===================================================================
+
+  @e2e
+  Scenario: Worktree lens shows one sidebar item per tmux pane on a multi-pane session
+    Given a worktree "feature/foo" has a tmux session with 3 panes
+    And only pane 1 has a Claude instance attached
+    When orchard-gui renders the worktree lens
+    Then the sidebar shows 3 sidebar items for that worktree
+    And the item for pane 1 renders Claude-state information
+    And the items for panes 2 and 3 render as tmux-only rows (no Claude pill)
+
+  @integration
+  Scenario: Pane without an attached Claude session still renders
+    Given a worktree has a single tmux pane with no Claude instance attached
+    When the worktree lens builds sidebar items
+    Then a sidebar item exists for that pane
+    And the item is keyed by the pane's "paneId"
+    And the item shows pane process / currentCommand / title rendered from "TmuxPane" fields
+
+  @integration
+  Scenario: Worktree lens iterates Worktree.tmuxPanes (not Worktree.claudeInstances)
+    Given the WorktreeLens GraphQL query
+    When the query is introspected
+    Then the selection set on "worktrees" includes "tmuxPanes { ...PaneCard, claudeInstance { ...SessionCard } }"
+    And the selection set on "worktrees" does NOT use "claudeInstances" as the iteration source for sidebar items
+
+  @unit
+  Scenario: buildWorktreeSections keys items by pane id, not by claude instance id
+    Given a Worktree with two panes, both with the same ClaudeInstance attached (edge case)
+    When buildWorktreeSections runs
+    Then it emits two sidebar items (one per pane)
+    And each item's key is derived from "pane.paneId"
+
+  @unit
+  Scenario: A worktree with zero panes still appears in the sidebar (dormant row)
+    Given a Worktree has no tmux panes and no Claude instances
+    When buildWorktreeSections runs
+    Then a single dormant worktree item is emitted (mirrors existing buildDormantWorktreeItem behavior)
+
+  # ===================================================================
+  # AC2 (parent #548) — Worktree lens refreshes on re-entry
+  # ===================================================================
+
+  @e2e
+  Scenario: Switching back to the worktree lens always refreshes the sidebar
+    Given orchard-gui is mounted on the worktree lens
+    And the user switches to the attention lens
+    And the daemon's worktree state changes (e.g. a new pane appears)
+    When the user switches back to the worktree lens
+    Then the sidebar reflects the daemon's current worktree state (not the snapshot from initial mount)
+
+  @integration
+  Scenario: Each lens fetches its store on re-entry
+    Given LensSidebar is mounted with active lens "worktree"
+    When the active lens changes from "worktree" to "attention" and back to "worktree"
+    Then "worktreeStore.fetch()" is invoked on each entry to the worktree lens
+    And the fetch policy is CacheAndNetwork (cache served instantly, network revalidates)
+
+  @integration
+  Scenario: Lens-switch does not re-fetch stores for inactive lenses
+    Given the active lens is "worktree"
+    When the lens switches to "attention"
+    Then only the attention store fetches
+    And the worktree store does not refetch until the user returns to the worktree lens
+
+  @unit
+  Scenario: LensSidebar uses $effect keyed on lens, not onMount, for store fetches
+    Given the LensSidebar component source
+    When the source is parsed
+    Then per-lens store fetches are inside a "$effect" block keyed on the active lens
+    And no per-lens store fetch is invoked from a one-shot "onMount" handler
+    And the stale comment claiming "subscribeAll → cache patch re-renders the sidebar" is removed or corrected
+
+  # ===================================================================
+  # Sub-issue #550 — Sidebar items show which repo they belong to
+  # ===================================================================
+
+  @e2e
+  Scenario: Sidebar item shows a repo chip alongside the branch
+    Given the user has worktrees across two repos: "git-orchard-rs" and "langwatch"
+    When orchard-gui renders the sidebar
+    Then each sidebar item visibly shows its repo (chip, label, or icon) alongside the branch
+    And two items on different repos but the same branch name are visually distinguishable without hovering or expanding
+
+  @integration
+  Scenario: Repo data is sourced from Worktree.repo via the existing fragment
+    Given the WorktreeEnrichment fragment
+    Then the fragment selects "repo" from "Worktree"
+    And SidebarItem.svelte renders "item.repo" without an additional query
+
+  @unit
+  Scenario: Items with no repo metadata fall back gracefully
+    Given a sidebar item whose "Worktree.repo" is null or empty
+    When SidebarItem.svelte renders
+    Then no broken/empty repo chip is rendered
+    And the item still renders the branch and host
+
+  # ===================================================================
+  # Sub-issue #551 — Sidebar sections are collapsible
+  # ===================================================================
+
+  @e2e
+  Scenario: User collapses a section
+    Given the sidebar shows multiple sections in any lens
+    When the user clicks a section header (or its chevron)
+    Then that section's items collapse from view
+    And the chevron flips to indicate collapsed state
+    And other sections are unaffected
+
+  @e2e
+  Scenario: Collapsed state persists across app restart
+    Given the user collapses a sidebar section
+    When orchard-gui is closed and reopened
+    Then the previously-collapsed section renders collapsed on startup
+
+  @integration
+  Scenario: Collapse state is persisted in localStorage
+    Given the user toggles a section's collapse state
+    Then a localStorage key (mirroring the "orchard:sidebarW" pattern) records the section's collapsed/expanded state per section identifier
+
+  @unit
+  Scenario: Each section toggles independently
+    Given two sections "A" and "B" are both expanded
+    When the user collapses section "A"
+    Then section "B" remains expanded
+
+  # ===================================================================
+  # Sub-issue #553 — Claude instance state pill (working/idle/input/stalled/dead/no_claude)
+  # ===================================================================
+
+  @e2e
+  Scenario Outline: Sidebar item visually distinguishes each Claude instance state
+    Given a sidebar item whose attached ClaudeInstance has state "<state>"
+    When SidebarItem.svelte renders
+    Then the state pill renders with a visual affordance distinct from every other state
+    And the rendering is not the binary working/idle pip that exists today
+
+    Examples:
+      | state    |
+      | working  |
+      | idle     |
+      | input    |
+      | stalled  |
+      | dead     |
+      | no_claude|
+
+  @e2e
+  Scenario: "input" state is rendered prominently (blocked on user)
+    Given a sidebar item whose ClaudeInstance state is "input"
+    When SidebarItem.svelte renders
+    Then the state pill is visually prominent (e.g. high-contrast color, glyph) compared to "idle" or "working"
+
+  @integration
+  Scenario: SidebarItem reads state from item.state (sourced from ClaudeInstance.state)
+    Given a Worktree's pane has a ClaudeInstance with state "stalled"
+    When the sidebar item is built
+    Then "item.state" is "stalled"
+    And SidebarItem.svelte renders the "stalled" pill
+
+  @unit
+  Scenario: Pane without a Claude instance renders no state pill
+    Given a sidebar item whose pane has no ClaudeInstance attached
+    When SidebarItem.svelte renders
+    Then no Claude state pill is rendered
+    And the item reads as a tmux-only / worktree-only row
+
+  # ===================================================================
+  # Sub-issue #600 — Error visibility (Toaster, catch audit, activity-lens disambiguation)
+  # ===================================================================
+
+  @e2e
+  Scenario: A failed mutation surfaces a user-visible toast
+    Given the global "<Toaster>" is wired into the app root layout
+    And the user triggers an action whose underlying mutation throws (e.g. daemon disconnected)
+    When the failure occurs
+    Then a toast is rendered with the error message
+    And the dev-tools console contains the stack trace
+
+  @integration
+  Scenario: A toast.error helper is provided and wired to Toaster
+    Given the orchard-gui codebase
+    Then a "toast.error(err)" helper exists
+    And the helper renders through the global "<Toaster>"
+
+  @integration
+  Scenario: Every catch block is annotated or wired through toast.error
+    Given the source tree under "crates/orchard-gui/src/"
+    When every "catch" block is audited
+    Then each catch block either:
+      | behavior                                                       |
+      | calls toast.error(...) (and rethrows or logs)                  |
+      | has a "// intentional swallow: <reason>" comment with rationale|
+    And no unannotated silent swallow remains
+
+  @e2e
+  Scenario: The lens previously called "activity" (the attention lens) renders items or shows a typed error
+    Given the user clicks the attention lens (referred to as "activity lens" in #600)
+    When the lens activates
+    Then either the lens renders sidebar items
+    Or a typed error is surfaced via the toast and console (no silent no-op)
+
+  @unit
+  Scenario: "activity lens" is treated as the existing attention lens (unless user confirms a new sixth lens)
+    Given the live Lens enum is "attention | recent | tmux | issue | worktree"
+    When this PR ships
+    Then no new "activity" lens is introduced
+    And any reference labeled "activity lens" maps to the attention lens
+
+  # ===================================================================
+  # Sub-issue #601 — Terminal URLs are clickable
+  # ===================================================================
+
+  @e2e
+  Scenario: A printed URL underlines on hover and opens in the default browser on click
+    Given a terminal pane prints "https://github.com/drewdrewthis/git-orchard-rs"
+    When the user hovers the URL
+    Then the URL underlines
+    When the user clicks the URL (cmd-click on macOS, plain click on platforms where that is conventional)
+    Then the URL opens in the system default browser
+
+  @integration
+  Scenario: WebLinksAddon is configured with an activateCallback
+    Given TerminalAttach.svelte loads "@xterm/addon-web-links" (WebLinksAddon)
+    Then WebLinksAddon is constructed with an "activateCallback" that opens URLs via the Tauri shell API (or window.open as a fallback)
+    And initialization errors are surfaced via toast.error (not silently caught)
+
+  @unit
+  Scenario: Click-to-open respects platform convention
+    Given orchard-gui is running on macOS
+    Then the URL activates on cmd-click (not plain click)
+    Given orchard-gui is running on a platform where plain click is conventional
+    Then the URL activates on plain click
+
+  @integration
+  Scenario: URL clickability does not regress text selection or copy/paste
+    Given a terminal pane contains a URL inline with surrounding text
+    When the user drags to select a region that includes the URL
+    Then the selection succeeds
+    And copy/paste of the selection works as before
+
+  # ===================================================================
+  # AC3 (parent #548) — PR closes all six issues
+  # ===================================================================
+
+  @integration
+  Scenario: The bundled PR closes the parent and all sub-issues
+    Given the PR landing this work
+    Then the PR description body contains:
+      | closes  |
+      | #548    |
+      | #550    |
+      | #551    |
+      | #553    |
+      | #600    |
+      | #601    |
+    And merging the PR auto-closes all six issues
+
+  # --- AC Coverage Map ---
+  # AC1 (panes): "Worktree lens shows one sidebar item per tmux pane attached to that worktree, not one per ClaudeInstance. Panes without a Claude session render too, sourced from Worktree.tmuxPanes."
+  #   → Scenario: Worktree lens shows one sidebar item per tmux pane on a multi-pane session
+  #   → Scenario: Pane without an attached Claude session still renders
+  #   → Scenario: Worktree lens iterates Worktree.tmuxPanes (not Worktree.claudeInstances)
+  #   → Scenario: buildWorktreeSections keys items by pane id, not by claude instance id
+  #   → Scenario: A worktree with zero panes still appears in the sidebar (dormant row)
+  #
+  # AC2 (worktree lens re-entry): "Switching to the worktree lens after visiting another lens always refreshes the sidebar — the data shown reflects the daemon's current state, not the snapshot taken on initial mount."
+  #   → Scenario: Switching back to the worktree lens always refreshes the sidebar
+  #   → Scenario: Each lens fetches its store on re-entry
+  #   → Scenario: Lens-switch does not re-fetch stores for inactive lenses
+  #   → Scenario: LensSidebar uses $effect keyed on lens, not onMount, for store fetches
+  #
+  # AC3 (sub-issues): "Each sub-issue (#550, #551, #553, #600, #601) has its own AC met by the bundled PR. PR auto-closes all six."
+  #   → #550 (repo): Sidebar item shows a repo chip alongside the branch / Repo data is sourced from Worktree.repo / Items with no repo metadata fall back gracefully
+  #   → #551 (collapsible): User collapses a section / Collapsed state persists across app restart / Collapse state is persisted in localStorage / Each section toggles independently
+  #   → #553 (state pill): Sidebar item visually distinguishes each Claude instance state (Outline) / "input" state is rendered prominently / SidebarItem reads state from item.state / Pane without a Claude instance renders no state pill
+  #   → #600 (error visibility): A failed mutation surfaces a user-visible toast / A toast.error helper is provided / Every catch block is annotated or wired through toast.error / The lens previously called "activity" renders items or shows a typed error / "activity lens" is treated as the existing attention lens
+  #   → #601 (clickable URLs): A printed URL underlines on hover and opens in the default browser on click / WebLinksAddon is configured with an activateCallback / Click-to-open respects platform convention / URL clickability does not regress text selection or copy/paste
+  #   → Closure: The bundled PR closes the parent and all sub-issues


### PR DESCRIPTION
## Why

Bundled fix landing six issues at once because their surfaces overlap (SidebarItem.svelte, LensSidebar.svelte) and splitting forces redundant context-loading across multiple PRs. The parent issue body explains the bundling rationale and the seven-phase sequencing.

Closes #548
Closes #550
Closes #551
Closes #553
Closes #600
Closes #601

## What changed

> **Status: in progress** — Phase 1 of 7 landed in `5901b6f`. Each phase ships as its own commit; this PR description updates as commits land.

- **Phase 1 (this commit) — Toaster foundation (#600a)**: chose `svelte-sonner` over `svelte-french-toast` for Svelte 5 runes compatibility and active maintenance. Mounts `<Toaster richColors />` once at the SPA root so every route inherits it. Adds `toast.error(unknown)` helper that always `console.error`s the value before toasting — preserves stack traces in dev-tools even after the toast auto-dismisses.

Subsequent phases (in plan order) will land as separate commits:
- Phase 2 — clickable terminal URLs (#601)
- Phase 3 — catch-block audit + activity-lens disambiguation (#600 cont.)
- Phase 4 — repo chip (#550) + Claude state pill (#553)
- Phase 5 — collapsible sidebar sections (#551)
- Phase 6 — sidebar lens fixes (AC1 per-pane items + AC2 lens-re-entry refresh)
- Phase 7 — cross-cutting verification + screenshots

See the parent issue (#548) for the full plan, investigation, and per-phase ACs.

## Test plan

- Spec lives at `specs/features/sidebar-v1-hardening-error-visibility.feature` (30 scenarios across 6 ACs).
- `pnpm -C crates/orchard-gui check` produces zero new errors versus baseline (9 errors / 9 warnings, all pre-existing `\$houdini` virtual-module gaps and one implicit-any).
- Per-phase verification will be captured in the Proof section below as commits land.

## How I can prove I was successful

- **Phase 1**: with `<Toaster>` mounted, calling `toast.error(new Error("x"))` from any component renders a visible red toast and logs the full Error to dev-tools. (No playable artifact yet — UI screenshots will land with Phases 4/5 once visible sidebar changes ship.)
- **Phases 2–7**: this section gets the seven before/after screenshots from the parent issue's Proof checklist as each phase lands.

## Anything surprising?

- **#600's "activity lens" wording**: the live `Lens` enum is `attention | recent | tmux | issue | worktree`. There is no `activity` lens. This PR treats "activity lens" as the **attention lens**. If a new sixth lens is wanted, that's a separate issue — call it out before merge.
- **Phase 6 hypothesis is read-from-code only**: AC1 (per-pane) and AC2 (lens re-entry) root causes were diagnosed from the code, not live-reproduced yet. Phase 6a explicitly verifies live before implementing the fix; the fix shape may pivot.

# Related issue

- #548

# Related issue

- #548

# Related issue

- #548

# Related issue

- #548

# Related issue

- #548

# Related issue

- #548

# Related issue

- #548

# Related issue

- #548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide toast notifications added for user-facing errors
  * Collapsible sidebar sections with persisted state
  * Clickable terminal URLs with platform-aware behavior

* **Improvements**
  * Sidebar now renders one row per tmux pane and shows repo metadata
  * More granular lifecycle state pills for processes
  * Clipboard, messaging, and terminal error handling refined

* **Tests / Specs**
  * New acceptance spec covering sidebar reliability and error visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/604)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #548

# Related issue

- #548

# Related issue

- #548