### PR TITLE
spec(daemon): consumer-driven feature specs from orchard TUI

### DIFF
--- a/daemon/features/tui-auto-refresh.feature
+++ b/daemon/features/tui-auto-refresh.feature
@@ -1,0 +1,50 @@
+Feature: TUI auto-refresh poll cycle
+  As the orchard TUI
+  I need to poll the daemon on a timed interval
+  So that operators see state changes without pressing a key.
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And the TUI is running in its main event loop
+
+  # Refresh intervals (from tui/mod.rs constants):
+  #   LOCAL_REFRESH_SECS = 5   → workView query (local data only path)
+  #   FULL_REFRESH_SECS  = 60  → workView query + SSH reachability probes + remote refresh
+
+  Scenario: Local refresh fires every 5 seconds
+    Given 5 seconds have elapsed since the last refresh
+    When the TUI's auto-refresh timer fires
+    Then the TUI fires a workView query to the local daemon
+    And on success it sends a DaemonStatus::Reachable signal
+    And on success it sends a LocalCacheRefreshed message
+    And the dashboard re-derives rows from the fresh snapshot
+
+  Scenario: Full refresh fires every 60 seconds
+    Given 60 seconds have elapsed since the last full refresh
+    When the TUI's full-refresh timer fires
+    Then the TUI probes each configured SSH remote host for reachability
+    And the TUI fires a workView query to the local daemon
+    And on success it sends a DaemonStatus::Reachable signal
+    And on success it sends a CacheRefreshed message
+    And it runs remote worktree + tmux refresh for reachable SSH hosts
+
+  Scenario: Daemon unreachable during auto-refresh
+    Given the daemon does not respond within the 5-second client timeout
+    When the auto-refresh workView query times out or is refused
+    Then the TUI sends a DaemonStatus::Unreachable signal
+    And the dashboard continues rendering the previous snapshot
+    And the header shows a "daemon unreachable" indicator
+
+  Scenario: Daemon recovers between refresh cycles
+    Given the previous refresh returned DaemonStatus::Unreachable
+    When the next auto-refresh fires and the workView query succeeds
+    Then the TUI sends DaemonStatus::Reachable
+    And the "daemon unreachable" indicator is removed from the header
+    And the fresh data replaces the stale snapshot
+
+  Scenario: State change is reflected on next local refresh
+    Given the dashboard rendered snapshot N at time T
+    When a worktree's branch advances (commit pushed) or a PR state changes daemon-side
+    And 5 seconds have elapsed
+    Then the next local refresh delivers the updated workView snapshot
+    And the dashboard row reflects the new branch/PR data

--- a/daemon/features/tui-claude-instance-enrichment.feature
+++ b/daemon/features/tui-claude-instance-enrichment.feature
@@ -1,0 +1,75 @@
+Feature: TUI Claude instance enrichment
+  As the orchard TUI
+  I need to display the state of Claude Code sessions running in worktree panes
+  So that operators can see at a glance which worktrees have active Claude sessions and their status.
+
+  Background:
+    Given the daemon is running and returns a workView snapshot
+    And the snapshot contains claudeInstances
+
+  # ClaudeInstance fields read by the TUI:
+  #   id, pane, process, state, sessionUuid, rcEnabled,
+  #   lastActivityAt, model, inflightToolCount
+  #
+  # Client-side join: pane "TmuxPane:<host>:<session>:<window>:<pane>"
+  # → extract session name → match to WorkViewTmuxSession
+  # The daemon does NOT provide a pre-joined ClaudeInstance→Session field.
+
+  Scenario: Claude state is extracted from the pane reference
+    Given a claudeInstance has pane "TmuxPane:local:issue429:editor:0"
+    When the TUI adapter parses the pane reference
+    Then the extracted session name is "issue429"
+    And the claude enrichment is attached to the "issue429" session row
+
+  Scenario: Pane reference with colon in session name is handled
+    Given a claudeInstance has pane "TmuxPane:local:my:session:1:0"
+    When the TUI adapter parses the pane reference
+    Then the extracted session name is "my:session"
+    And no parse error occurs
+
+  Scenario: Malformed pane reference is silently dropped
+    Given a claudeInstance has pane "not-a-pane-id"
+    When the TUI adapter processes the instance
+    Then no claude enrichment is attached to any session
+    And no crash occurs
+
+  Scenario: Claude state values drive the activity indicator
+    Given a claudeInstance has state "working"
+    When the TUI renders the session row
+    Then the row shows the "working" activity indicator (animated)
+
+    Given state is "idle"
+    Then the row shows the "idle" indicator
+
+    Given state is "waiting"
+    Then the row shows the "waiting" indicator
+
+  Scenario: Model name is displayed when present
+    Given a claudeInstance has model "claude-opus-4-7"
+    When the TUI renders the session row
+    Then the model name is visible in the session detail
+
+    Given model is null (daemon has not yet seen an assistant message)
+    Then no model indicator is rendered
+
+  Scenario: inflightToolCount drives the in-flight tool badge
+    Given a claudeInstance has inflightToolCount 3
+    When the TUI renders the session row
+    Then the row shows 3 in-flight tool calls
+
+    Given inflightToolCount is 0
+    Then no in-flight tool indicator is shown
+
+  Scenario: Freshness check on lastActivityAt
+    Given a claudeInstance has lastActivityAt more than the stale threshold ago
+    When the TUI adapter builds the ClaudeStateFile
+    Then the enrichment is considered stale and is not attached to the session
+
+    Given lastActivityAt is within the freshness window
+    Then the enrichment is attached normally
+
+  Scenario: Standalone session with Claude enrichment
+    Given a tmux session is not matched to any worktree path
+    And it has an associated claudeInstance
+    When the TUI builds standalone sessions
+    Then the session appears in the standalone list with claude enrichment attached

--- a/daemon/features/tui-daemon-error-handling.feature
+++ b/daemon/features/tui-daemon-error-handling.feature
@@ -1,0 +1,61 @@
+Feature: TUI daemon error handling
+  As the orchard TUI
+  I need to handle every daemon failure mode without crashing
+  So that operators always have a usable dashboard even when the daemon is degraded.
+
+  Background:
+    Given the TUI is running and periodically fires workView queries
+
+  # Failure modes from DaemonError:
+  #   Unreachable { url, cause } — connection refused or timeout
+  #   Transport(msg)             — network-level failure
+  #   HttpStatus { status, body } — non-2xx HTTP response
+  #   Parse(msg)                 — 2xx but unparseable response body
+  #   GraphQl(errors)            — response carried GraphQL errors array
+
+  Scenario: DaemonError::Unreachable shows the "daemon down" indicator
+    Given the daemon is not listening on the configured URL
+    When the TUI fires a workView query
+    Then it receives DaemonError::Unreachable
+    And it sends DaemonStatus::Unreachable
+    And the header shows "daemon unreachable"
+    And the last-known snapshot continues to power the dashboard
+
+  Scenario: DaemonError::Transport does not crash the TUI
+    Given a network-level error occurs (e.g. TLS failure, connection reset)
+    When the TUI fires any query
+    Then the error is logged at WARN level
+    And the TUI remains running with the previous data
+
+  Scenario: HTTP 500 from the daemon is handled gracefully
+    Given the daemon returns HTTP 500 with a body
+    When the TUI fires a workView query
+    Then it receives DaemonError::HttpStatus { status: 500, body: ... }
+    And it sends DaemonStatus::Unreachable
+    And no raw HTTP error text is shown to the operator
+
+  Scenario: Malformed JSON response does not crash the TUI
+    Given the daemon returns 200 OK with invalid JSON
+    When the TUI fires a workView query
+    Then it receives DaemonError::Parse
+    And the TUI logs a warning and falls back to the previous snapshot
+
+  Scenario: GraphQL errors array in response is surfaced safely
+    Given the daemon returns {"errors":[{"message":"introspection disabled"}],"data":null}
+    When the TUI fires a workView query
+    Then it receives DaemonError::GraphQl(["introspection disabled"])
+    And the TUI does not crash
+    And DaemonStatus::Unreachable is emitted
+
+  Scenario: Concurrent refresh threads do not produce a data race
+    Given a full refresh and a local refresh are both in flight
+    When both return workView snapshots
+    Then the Mutex-protected work_view_snapshot slot serialises the writes
+    And the dashboard renders one coherent snapshot, not a mix of two
+
+  Scenario: NullWorkViewSource fallback when client cannot be built
+    Given ORCHARD_DAEMON_URL is set to an unparseable value at startup
+    When the TUI constructs its daemon client
+    Then it falls back to NullWorkViewSource
+    And each refresh attempt logs a warning
+    And the TUI starts and renders the disk-cached snapshot if available

--- a/daemon/features/tui-dashboard-render.feature
+++ b/daemon/features/tui-dashboard-render.feature
@@ -1,0 +1,62 @@
+Feature: TUI dashboard initial render
+  As the orchard TUI
+  I need to render the worktree+session+claude grid on first paint
+  So that operators see live state in their terminal within one round-trip.
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And the TUI is launched in its default list view
+
+  # Query: workView { repos { slug path worktrees { path branch head bare host repo
+  #          ahead behind pr { number state title statusCheckRollup reviewDecision
+  #          mergeStateStatus mergeable draft labels }
+  #          issue { number state title labels } } }
+  #        tmuxSessions { id name attached activeAttached lastActivityAt
+  #                       attachedClients windows currentWindow path }
+  #        claudeInstances { id pane process state sessionUuid rcEnabled
+  #                          lastActivityAt model inflightToolCount } }
+
+  Scenario: Initial dashboard fetch returns a complete WorkViewSnapshot
+    When the TUI boots and fires its first workView query
+    Then the response contains a "repos" array
+    And each repo entry has "slug" and "path" fields
+    And each repo entry has a "worktrees" array
+    And each worktree carries branch, head, bare, host, repo, ahead, behind
+    And each worktree carries a nullable "pr" object with number, state, title
+    And each worktree carries a nullable "issue" object with number, state, title
+    And the response contains a "tmuxSessions" array
+    And each tmux session carries id, name, attached, activeAttached, lastActivityAt
+    And each tmux session carries attachedClients, windows, currentWindow
+    And each tmux session carries an optional "path" (working-directory for session→worktree matching)
+    And the response contains a "claudeInstances" array
+    And each claude instance carries id, pane, process, state, sessionUuid, rcEnabled
+    And each claude instance carries optional lastActivityAt, model, inflightToolCount
+
+  Scenario: Round-trip latency is within interactive budget
+    When the TUI fires the workView query against a local daemon
+    Then the response arrives in under 50ms on the P95
+
+  Scenario: Cold-start fallback when daemon is unreachable
+    Given the daemon is not reachable
+    When the TUI boots
+    Then it reads the persisted snapshot from ~/.cache/orchard/work_view_snapshot.json
+    And it renders the stale snapshot without a blank screen
+    And it shows a "daemon unreachable" indicator in the header
+    And no GraphQL error is surfaced as a fatal crash
+
+  Scenario: Snapshot is persisted after every successful fetch
+    When the TUI receives a successful workView response
+    Then it atomically writes the snapshot to ~/.cache/orchard/work_view_snapshot.json
+    And a subsequent cold-start with the daemon down reads that file back
+
+  Scenario: workView response with empty collections renders correctly
+    Given the daemon returns workView with empty repos, tmuxSessions, and claudeInstances
+    When the TUI renders the list
+    Then no rows are displayed
+    And no panic or "index out of bounds" error occurs
+
+  Scenario: PR optional fields absent render without crash
+    Given a worktree's PR object omits statusCheckRollup, reviewDecision, mergeStateStatus, mergeable
+    When the TUI renders the dashboard row
+    Then the row renders successfully
+    And missing CI/review badges are absent rather than showing a placeholder error

--- a/daemon/features/tui-federated-session-switcher.feature
+++ b/daemon/features/tui-federated-session-switcher.feature
@@ -1,0 +1,56 @@
+Feature: TUI federated session switcher
+  As the orchard TUI
+  I need to list tmux sessions across all known hosts
+  So that the operator can switch to any session — local or remote — from one screen.
+
+  Background:
+    Given the local daemon is running on 127.0.0.1:7777
+    And the local daemon knows about one or more peer hosts via Query.hosts
+
+  # Queries fired:
+  #   1. { hosts { id hostname address reachable peers { id hostname address reachable } } }
+  #   2. { tmuxSessions { id name attached activeAttached lastActivityAt } }
+  #      → repeated per reachable peer at https://graphql.<peer-address>/graphql
+  #
+  # Note: the TUI fans out to peers itself (daemon::federated::fan_out).
+  # The daemon does NOT aggregate peer sessions in workView today (Workstream F).
+
+  Scenario: Local sessions fetched via tmuxSessions query
+    When the TUI fetches local sessions
+    Then it calls Query.tmuxSessions on the local daemon
+    And the response carries id, name, attached, activeAttached, lastActivityAt for each session
+    And sessions with activeAttached == true are highlighted as active
+
+  Scenario: Peer hosts resolved via hosts query
+    When the TUI begins a federated fan-out
+    Then it calls Query.hosts on the local daemon
+    And the response carries a hosts array with id, hostname, address, reachable, and peers
+    And peers are nested under the host that reported them
+    And only peers with reachable == true and a non-empty address are queried for sessions
+
+  Scenario: Fan-out reaches each reachable peer
+    Given the local daemon reports two reachable peers with addresses
+    When the TUI executes fan_out
+    Then it sends a tmuxSessions query to each peer's GraphQL endpoint
+      (https://graphql.<peer-address>/graphql)
+    And sessions from all reachable peers are merged into the session list
+    And each session row is tagged with its host label (local hostname or peer hostname)
+
+  Scenario: Unreachable peer does not block the local session list
+    Given one peer is reachable and one is unreachable
+    When the TUI executes fan_out
+    Then local and reachable-peer sessions appear in the list
+    And the failed peer contributes a "host unreachable" status row
+    And the overall fan-out completes within 2× the per-peer timeout
+
+  Scenario: Peer with empty address is silently skipped
+    Given the daemon reports a peer with an empty or null address
+    When the TUI evaluates the peer during fan_out
+    Then no HTTP request is issued for that peer
+    And no error row is emitted for the empty-address peer
+
+  Scenario: peer_url construction rule
+    Given a peer has address "box-1.boxd.sh" (bare hostname)
+    Then the TUI constructs "https://graphql.box-1.boxd.sh/graphql" as the endpoint
+    And if the address already starts with "graphql." it is prefixed with "https://" only
+    And if the address is already a full "http(s)://" URL it is used as-is

--- a/daemon/features/tui-health-probe.feature
+++ b/daemon/features/tui-health-probe.feature
@@ -1,0 +1,36 @@
+Feature: TUI daemon health probe
+  As the orchard TUI
+  I need to confirm the daemon is alive before relying on its data
+  So that I can surface a clear "daemon down" indicator rather than silently showing stale data.
+
+  Background:
+    Given the TUI daemon client targets http://127.0.0.1:7777/graphql by default
+    And the URL can be overridden via the ORCHARD_DAEMON_URL environment variable
+
+  # Query: { health { status uptimeS } }
+  # Used as a connectivity smoke-check; the TUI does NOT call health explicitly
+  # today — reachability is inferred from workView success/failure. This feature
+  # documents the health query's contract so the daemon must keep it stable.
+
+  Scenario: health query returns status "ok" when the daemon is serving
+    When a client sends { health { status uptimeS } }
+    Then the response contains health.status == "ok"
+    And health.uptimeS is a non-negative integer
+
+  Scenario: health query is rejected with a GraphQL error when the daemon is degraded
+    Given the daemon is in a degraded state
+    When a client sends { health { status uptimeS } }
+    Then the response either returns health.status != "ok"
+    Or the response carries a top-level GraphQL error entry
+
+  Scenario: ORCHARD_DAEMON_URL override is respected
+    Given ORCHARD_DAEMON_URL is set to a non-default endpoint
+    When the TUI boots and constructs its daemon client
+    Then all queries (including workView) are sent to the overridden URL
+    And the default 127.0.0.1:7777 endpoint is never contacted
+
+  Scenario: Client timeout is 5 seconds per request
+    Given the daemon endpoint hangs and does not respond
+    When the TUI fires a workView query
+    Then the request times out after 5 seconds
+    And the TUI receives DaemonError::Unreachable rather than blocking indefinitely

--- a/daemon/features/tui-local-mutations.feature
+++ b/daemon/features/tui-local-mutations.feature
@@ -1,0 +1,63 @@
+Feature: TUI local mutations (no GraphQL mutations used today)
+  As the orchard TUI
+  I need to create and delete worktrees and tmux sessions in response to keystrokes
+  So that operators can manage their workspace without leaving the dashboard.
+
+  Background:
+    Given the TUI is in List or dialog view
+    And the TUI is running inside a tmux session
+
+  # NOTE: The TUI issues NO GraphQL mutations against the daemon today.
+  # All mutations are performed directly via:
+  #   - crate::tmux::create_session         ('n' new session, 'w' new worktree confirm)
+  #   - worktree_core::create_worktree       ('w' new worktree confirm)
+  #   - worktree_core::remove_worktree       ('d' delete confirm, 'c' cleanup confirm)
+  #   - crate::tmux::kill_tmux_session_safe  (delete/cleanup)
+  #   - crate::remote::*                     (remote delete)
+  # These are L7 violations relative to ADR-016 / ADR-017 and must be tracked
+  # as future daemon mutation migrations.
+
+  Scenario: 'n' opens new-session dialog; Enter creates a tmux session directly
+    When the operator presses 'n' in the list view
+    Then the TUI shows the new-session name-entry dialog
+    When the operator types a session name and presses Enter
+    Then the TUI calls crate::tmux::create_session with the typed name
+    And on success the TUI exits to switch to the new session
+    And NO GraphQL mutation is issued to the daemon
+
+  Scenario: 'w' opens new-worktree dialog; Enter creates a worktree directly
+    When the operator presses 'w' in the list view
+    Then the TUI shows the new-worktree branch-entry dialog
+    When the operator types a branch name and presses Enter
+    Then the TUI calls worktree_core::create_worktree to create the git worktree
+    And it calls crate::tmux::create_session to create the associated tmux session
+    And on success it fires a full refresh so the daemon-supplied workView reflects the new worktree
+    And NO GraphQL mutation is issued to the daemon
+
+  Scenario: Setup script is run after worktree creation
+    Given the project config has a setup_script defined
+    When a new worktree is created
+    Then the setup script is run in the new worktree directory
+    And if the script exits non-zero, a non-fatal warning is surfaced
+    And the worktree is still created even if the script fails
+
+  Scenario: 'd' deletes a local worktree directly
+    Given the cursor is on a local worktree row with an associated tmux session
+    When the operator presses 'd' and confirms with 'y'
+    Then the TUI calls tmux::kill_tmux_session_safe to kill the session
+    And it calls worktree_core::remove_worktree to remove the worktree
+    And on success it fires a full refresh
+    And NO GraphQL mutation is issued to the daemon
+
+  Scenario: 'c' cleanup deletes multiple stale worktrees
+    When the operator presses 'c' and confirms the selection
+    Then the TUI calls delete_task_row for each selected stale worktree
+    And for each worktree it kills the tmux session and removes the git worktree
+    And on completion it fires a full refresh
+    And NO GraphQL mutations are issued
+
+  Scenario: After any local mutation the next workView query reflects the change
+    Given a worktree was created or deleted
+    When the TUI fires its next workView query after the mutation
+    Then the daemon's workView response reflects the updated worktree list
+    And the dashboard shows the post-mutation state

--- a/daemon/features/tui-manual-refresh.feature
+++ b/daemon/features/tui-manual-refresh.feature
@@ -1,0 +1,39 @@
+Feature: TUI manual refresh keystroke
+  As the orchard TUI
+  I need to trigger a full data refresh on demand
+  So that operators can force an update without waiting for the timer.
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And the TUI is in List view with existing snapshot data displayed
+
+  # Keybinding: 'r' → Message::Refresh → start_full_refresh()
+  # Keybinding: 'R' → Message::ReconnectHosts → reconnect_unreachable_hosts()
+
+  Scenario: 'r' keystroke triggers a full refresh
+    When the operator presses 'r'
+    Then the TUI fires a workView query to the daemon
+    And it also probes SSH remote hosts for reachability
+    And on success it delivers DaemonStatus::Reachable
+    And on success it delivers CacheRefreshed
+    And the dashboard rows update to reflect the new data
+
+  Scenario: 'r' during an active refresh does not double-fire
+    Given a refresh is already in progress
+    When the operator presses 'r'
+    Then the in-progress refresh completes normally
+    And no duplicate workView queries are issued that would produce a race
+
+  Scenario: 'r' while daemon is unreachable shows the error indicator
+    Given the daemon is not reachable
+    When the operator presses 'r'
+    Then the TUI fires the workView query and receives an error
+    And it emits DaemonStatus::Unreachable
+    And the "daemon unreachable" indicator appears in the header
+
+  Scenario: 'R' keystroke reconnects unreachable SSH hosts
+    Given one or more SSH remote hosts are marked unreachable
+    When the operator presses 'R'
+    Then the TUI re-probes each unreachable host for SSH reachability
+    And a "reconnecting..." warning is shown during the probe
+    And on success the host is marked reachable and its remote data is refreshed

--- a/daemon/features/tui-remote-worktree-federation.feature
+++ b/daemon/features/tui-remote-worktree-federation.feature
@@ -1,0 +1,60 @@
+Feature: TUI remote worktree federation (SSH path)
+  As the orchard TUI
+  I need to merge remote worktrees fetched over SSH into the local dashboard
+  So that operators running across multiple machines see all their worktrees in one view.
+
+  Background:
+    Given the global config defines one or more remote hosts under repos[].remotes
+    And the full-refresh cycle is active (fires every 60 seconds or on 'r')
+
+  # Remote data does NOT come from the daemon's workView (Workstream F not yet landed).
+  # Instead the TUI fans out over SSH via cache_sources::refresh_remote_worktrees
+  # and cache_sources::refresh_remote_tmux_sessions, then merges the results via
+  # merge_remote::merge_remote_snapshot.
+  # This is a known L7 violation that is tracked for future daemon migration.
+
+  Scenario: SSH reachability probe precedes remote refresh
+    Given the full-refresh thread begins
+    When it probes SSH hosts
+    Then each configured remote host is probed for SSH reachability
+    And only reachable hosts proceed to cache_sources::refresh_remote_worktrees
+
+  Scenario: Remote worktrees are merged into OrchardState after local data
+    Given the daemon workView delivers local repos and worktrees
+    And cached remote snapshots exist on disk for at least one SSH host
+    When the TUI calls rebuild_state_from_snapshot
+    Then local worktrees come from the daemon workView snapshot
+    And remote worktrees are merged in from orchard_snapshot::load_cached_snapshots
+    And the final dashboard shows both local and remote rows
+
+  Scenario: Remote worktree rows carry the host tag
+    Given a remote worktree was synced from host "boxd@vm.boxd.sh"
+    When the TUI builds the dashboard rows
+    Then that worktree's worktree_host is Some("boxd@vm.boxd.sh")
+    And the dashboard row renders the remote host indicator
+
+  Scenario: Fork-host snapshot is taken before worktree refresh per (repo, remote)
+    Given two repos share the same remote host
+    When the full-refresh thread drives remote refresh
+    Then snapshot_fork_hosts_for_remote is called for each (repo, remote) pair
+    And the snapshot is captured before refresh_remote_worktrees runs
+    And the snapshot is forwarded to refresh_remote_tmux_sessions as old_hosts
+
+  Scenario: Tmux refresh is deduped by (kind, host)
+    Given two repos have remotes with the same host but different kinds (e.g. Remmy vs BoxdFork)
+    When the full-refresh thread drives remote refresh
+    Then refresh_remote_tmux_sessions is called once per unique (kind, host) pair
+    And it is NOT called once per (repo, remote) for tmux
+
+  Scenario: Unreachable SSH host is skipped silently
+    Given a remote host is not in the reachable set
+    When the full-refresh thread drives remote refresh
+    Then no refresh_remote_worktrees or refresh_remote_tmux_sessions call is made for that host
+    And no crash or hard error is produced
+
+  Scenario: Transitive federation snapshots are merged
+    Given the config has a OrchardProxy remote with allow_transitive: true
+    And the transitive walker has written a depth-2+ snapshot to the cache
+    When the TUI calls rebuild_state_from_snapshot
+    Then load_cached_snapshots includes the transitive host snapshots
+    And depth-2+ remote worktrees appear in the dashboard

--- a/daemon/features/tui-session-worktree-join.feature
+++ b/daemon/features/tui-session-worktree-join.feature
@@ -1,0 +1,51 @@
+Feature: TUI session-to-worktree join via path
+  As the orchard TUI
+  I need to associate each tmux session with its worktree
+  So that the dashboard can render sessions inline under their worktree row.
+
+  Background:
+    Given the daemon delivers workView with repos, tmuxSessions, and claudeInstances
+    And the TUI performs client-side session→worktree matching
+
+  # Match logic: WorkViewTmuxSession.path is used with paths::session_belongs_to_worktree.
+  # When path is absent, the session falls back to standalone.
+
+  Scenario: Session with matching path is joined to worktree
+    Given a tmux session has path "/repos/owner/repo/.worktrees/issue429"
+    And there is a worktree at path "/repos/owner/repo/.worktrees/issue429"
+    When the TUI adapter builds the local state
+    Then the session is attached to that worktree's sessions list
+    And the session does not appear in the standalone_sessions list
+
+  Scenario: Session with non-matching path becomes standalone
+    Given a tmux session has path "/home/user/other"
+    And no worktree path contains that path
+    When the TUI adapter builds the local state
+    Then the session appears in standalone_sessions
+    And it is not attached to any worktree
+
+  Scenario: Session with absent path (null) becomes standalone
+    Given a tmux session has no path field (null or absent)
+    When the TUI adapter builds the local state
+    Then the session is treated as standalone
+    And no crash occurs from a missing path
+
+  Scenario: Session window metadata is forwarded
+    Given a tmux session has windows: 3 and currentWindow: "editor"
+    When the TUI adapter converts the session
+    Then the window count is available for the TUI's expand/collapse UI
+    And the current window name is visible in the session row
+
+  Scenario: Configured standalone sessions are emitted first in config order
+    Given the global config defines tmux_sessions: ["shepherd", "monitor"]
+    And "shepherd" is a live session in the workView snapshot
+    And "monitor" is not in the snapshot (dead session)
+    When the TUI builds standalone sessions
+    Then "shepherd" appears first with status Running
+    And "monitor" appears second with status Dead
+
+  Scenario: Discovered sessions not in config appear after configured sessions
+    Given a live session "ad-hoc" is in the snapshot but not in global config
+    And its path does not match any worktree
+    When the TUI builds standalone sessions
+    Then "ad-hoc" appears after the configured sessions

--- a/daemon/features/tui-snapshot-persistence.feature
+++ b/daemon/features/tui-snapshot-persistence.feature
@@ -1,0 +1,45 @@
+Feature: TUI workView snapshot persistence
+  As the orchard TUI
+  I need to persist the latest daemon workView snapshot to disk
+  So that cold starts show real data immediately rather than a blank screen.
+
+  Background:
+    Given the snapshot is written to ~/.cache/orchard/work_view_snapshot.json
+    And the file format is { "version": 1, "snapshot": { ... } }
+
+  Scenario: Snapshot is written atomically after every successful workView fetch
+    When the TUI receives a successful workView response
+    Then it writes the snapshot via a tmp-then-rename sequence
+    And the .json.tmp file does not remain after a successful write
+    And the final file has permissions 0600 on Unix
+
+  Scenario: Snapshot read on cold start
+    Given a valid snapshot file exists with version: 1
+    When the TUI boots
+    Then it reads the snapshot and pre-populates the work_view_snapshot slot
+    And the first render shows stale data rather than empty rows
+
+  Scenario: Version mismatch on cold start is treated as absent
+    Given the snapshot file has version: 999
+    When the TUI tries to read it
+    Then it returns None (no snapshot)
+    And the TUI starts with an empty dashboard until the first successful fetch
+
+  Scenario: Missing snapshot file does not prevent startup
+    Given no work_view_snapshot.json file exists
+    When the TUI boots
+    Then it starts successfully with an empty snapshot slot
+    And it fires the first workView query normally
+
+  Scenario: Malformed JSON snapshot does not prevent startup
+    Given work_view_snapshot.json contains invalid JSON
+    When the TUI boots
+    Then it returns None for the snapshot read
+    And no panic or error propagates to the user
+
+  Scenario: Write failure is logged but does not crash the refresh
+    Given the cache directory is not writable
+    When the TUI receives a workView snapshot and tries to persist it
+    Then the write failure is logged at WARN level
+    And the in-memory snapshot slot is still updated
+    And the dashboard refreshes normally from the in-memory snapshot

--- a/daemon/features/tui-worktree-pr-issue-badges.feature
+++ b/daemon/features/tui-worktree-pr-issue-badges.feature
@@ -1,0 +1,80 @@
+Feature: TUI worktree PR and issue badge rendering
+  As the orchard TUI
+  I need each worktree row to carry pre-joined PR and issue data from the daemon
+  So that I can render badges (CI, review, conflicts, draft, labels) without a client-side GitHub call.
+
+  Background:
+    Given the daemon is running and returns a workView snapshot
+    And the snapshot contains repos with worktrees that have PR and issue joins
+
+  # All PR/issue data comes from workView.repos[].worktrees[].pr and .issue.
+  # The daemon performs the join server-side; the TUI only reads these fields.
+
+  Scenario: PR CI status badge rendered from statusCheckRollup
+    Given a worktree's pr.statusCheckRollup is "SUCCESS"
+    When the TUI adapter converts the PR
+    Then the worktree row's ci_code_state is "passing"
+    And the dashboard renders a green CI badge
+
+    Given a worktree's pr.statusCheckRollup is "FAILURE" or "ERROR"
+    When the TUI adapter converts the PR
+    Then ci_code_state is "failing"
+    And the dashboard renders a red CI badge
+
+    Given a worktree's pr.statusCheckRollup is "PENDING" or any unrecognised value
+    Then ci_code_state is "pending"
+
+  Scenario: PR review decision badge rendered from reviewDecision
+    Given a worktree's pr.reviewDecision is "APPROVED"
+    When the TUI adapter converts the PR
+    Then review_decision is "approved" (normalised to lowercase)
+    And the dashboard renders an "approved" review badge
+
+    Given pr.reviewDecision is "CHANGES_REQUESTED"
+    Then review_decision is "changes_requested"
+
+    Given pr.reviewDecision is "REVIEW_REQUIRED"
+    Then review_decision is "review_required"
+
+  Scenario: Conflict detection uses mergeable field only
+    Given a worktree's pr.mergeable is "CONFLICTING"
+    When the TUI adapter converts the PR
+    Then has_conflicts is true regardless of mergeStateStatus
+
+    Given pr.mergeable is "MERGEABLE" but mergeStateStatus is "BLOCKED"
+    Then has_conflicts is false
+    And the BLOCKED state does not incorrectly signal merge conflicts
+
+    Given pr.mergeable is absent (null)
+    Then has_conflicts is false
+
+  Scenario: Draft PR flag is carried through
+    Given a worktree's pr.draft is true
+    When the TUI renders the dashboard row
+    Then the row shows a draft indicator
+
+  Scenario: PR label list is forwarded
+    Given a worktree's pr.labels is ["phase-1", "enhancement"]
+    When the TUI adapter converts the PR
+    Then the row's label list is ["phase-1", "enhancement"]
+
+  Scenario: Issue linked to a worktree via daemon join
+    Given a worktree's issue is { number: 429, state: "OPEN", title: "...", labels: ["bug"] }
+    When the TUI adapter converts the worktree
+    Then the row's issue_number is 429 and issue_state is "open" (normalised lowercase)
+    And issue labels are forwarded to the row
+
+  Scenario: Worktree with no PR and no issue renders cleanly
+    Given a worktree's pr and issue are both null
+    When the TUI renders the dashboard row
+    Then no CI, review, or issue badge is shown
+    And no crash or unwrap error occurs
+
+  Scenario: Worktree ahead/behind counts from daemon
+    Given a worktree's ahead is 2 and behind is 1
+    When the TUI adapter converts the worktree
+    Then worktree_ahead is Some(2) and worktree_behind is Some(1)
+    And the row renders the ahead/behind indicator
+
+    Given a worktree has no upstream configured (ahead is null)
+    Then worktree_ahead is None and no indicator is rendered


### PR DESCRIPTION
## Summary

Audited every GraphQL operation the Rust TUI (`crates/orchard/`) fires against the daemon and produced 12 Gherkin feature files under `daemon/features/`. These are consumer-driven specs — what the TUI contract demands from the daemon — with no step implementations.

## Use cases covered (one .feature per use case)

| File | Use case |
|---|---|
| `tui-dashboard-render.feature` | Initial boot render — workView query shape + cold-start fallback |
| `tui-auto-refresh.feature` | Timer-driven local refresh (5s) and full refresh (60s) |
| `tui-manual-refresh.feature` | 'r' and 'R' keystroke-driven refresh |
| `tui-health-probe.feature` | health query contract + ORCHARD_DAEMON_URL override + 5s timeout |
| `tui-federated-session-switcher.feature` | hosts query + per-peer tmuxSessions fan-out |
| `tui-worktree-pr-issue-badges.feature` | PR/issue badge rendering from workView pre-joins |
| `tui-claude-instance-enrichment.feature` | ClaudeInstance fields, pane→session join, staleness |
| `tui-session-worktree-join.feature` | WorkViewTmuxSession.path → worktree matching / standalone fallback |
| `tui-daemon-error-handling.feature` | All DaemonError variants handled without crash |
| `tui-remote-worktree-federation.feature` | SSH remote refresh + snapshot merge (Workstream F gap documented) |
| `tui-local-mutations.feature` | Create/delete worktree+session — all L7 violations documented |
| `tui-snapshot-persistence.feature` | Atomic write to work_view_snapshot.json, cold-start read |

## TUI queries inventoried

| GraphQL operation | Method | Fires from |
|---|---|---|
| `{ workView { ... } }` | `Client::work_view()` | `start_full_refresh`, `start_local_refresh` |
| `{ health { status uptimeS } }` | `Client::health()` | available; not called in main loop today |
| `{ tmuxSessions { ... } }` | `Client::tmux_sessions()` | `federated::fan_out` per peer |
| `{ hosts { ... peers { ... } } }` | `Client::hosts()` | `federated::fan_out` |

**No GraphQL subscriptions** — the TUI is purely poll-based (blocking HTTP, no WebSocket).

## workView fields the TUI reads (complete inventory)

```
workView.repos[].slug, .path
workView.repos[].worktrees[].path, .branch, .head, .bare, .host, .repo, .ahead, .behind
workView.repos[].worktrees[].pr.number, .state, .title, .statusCheckRollup,
  .reviewDecision, .mergeStateStatus, .mergeable, .draft, .labels
workView.repos[].worktrees[].issue.number, .state, .title, .labels
workView.tmuxSessions[].id, .name, .attached, .activeAttached, .lastActivityAt,
  .attachedClients, .windows, .currentWindow, .path
workView.claudeInstances[].id, .pane, .process, .state, .sessionUuid, .rcEnabled,
  .lastActivityAt, .model, .inflightToolCount
```

## Daemon fields the TUI uses that are NOT in a current schema partial (gaps)

- `WorkViewTmuxSession.path` — no `path` field in `daemon/tmux/schema.graphql` (needs adding)
- `ClaudeInstance.model` and `.inflightToolCount` — verify these exist in `daemon/claude-instance/schema.graphql`; they are in the Rust types but may not yet be in the Go resolvers
- `WorkView` type itself — verify `daemon/*/schema.graphql` has `extend type Query { workView: WorkView! }`

## L7 violations — TUI code that bypasses GraphQL

The TUI performs the following operations **directly** without a daemon mutation:

| Operation | Rust call site | Trigger |
|---|---|---|
| Create tmux session | `crate::tmux::create_session` | 'n' new session, 'w' new worktree |
| Create git worktree | `worktree_core::create_worktree` | 'w' new worktree confirm |
| Kill tmux session | `tmux::kill_tmux_session_safe` | 'd' delete, 'c' cleanup |
| Remove git worktree | `worktree_core::remove_worktree` | 'd' delete, 'c' cleanup |
| Remote SSH kill+remove | `remote::kill_remote_tmux_session` etc. | 'd' delete on remote row |
| SSH reachability probe | `sources::hosts::probe_reachability_all_for_remotes` | Full refresh, 'R' |
| Remote worktree sync | `cache_sources::refresh_remote_worktrees` | Full refresh |
| Remote tmux sync | `cache_sources::refresh_remote_tmux_sessions` | Full refresh |
| Tmux pane capture | `tmux` module (preview pane) | Cursor movement / refresh |

These are documented in `tui-local-mutations.feature` and `tui-remote-worktree-federation.feature` as known violations pending Workstream F.

## Test plan

- [ ] All 12 `.feature` files parse as valid Gherkin (no syntax errors)
- [ ] Each scenario maps to an actual code path in `crates/orchard/src/`
- [ ] No step definitions are included (specs only, per task brief)
- [ ] No TUI, daemon, or schema code was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)