### PR TITLE
spec(daemon): consumer-driven feature specs from orchard-gui

### DIFF
--- a/daemon/features/gui-attention-lens.feature
+++ b/daemon/features/gui-attention-lens.feature
@@ -1,0 +1,68 @@
+Feature: GUI attention lens — triage view anchored on worktrees
+  As the orchard-gui LensSidebar in "attention" mode
+  I need every worktree tiered into blocked/waiting/active/quiet
+  So that the operator immediately sees what needs human intervention.
+
+  Operation consumed:
+    AttentionLens → workView.repos[].worktrees[...WorktreeEnrichment + claudeInstances[...SessionCard]]
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And at least one repo with at least one worktree is configured
+
+  Scenario: Every worktree appears in exactly one tier
+    When the AttentionLens query runs
+    Then every worktree in workView appears as at least one sidebar row
+    And a worktree with zero claudeInstances appears as a single "dormant" row
+    And a worktree with N live claudeInstances appears as N separate rows
+    And no worktree appears in more than one tier section
+
+  Scenario: Blocked tier — CI failure promotes worktree to blocked
+    Given a worktree whose pr.statusCheckRollup = "FAILURE"
+    When buildAttentionSections runs
+    Then that worktree's row appears in the "Blocked" tier
+    # Note: pr fields are NOT in WorktreeEnrichment at query time.
+    # The attention lens uses WorktreeEnrichment which excludes pr.
+    # Blocked-tier detection based on pr signals requires the WorktreePR fragment
+    # to be fetched separately; this is a known gap (see gaps section in PR body).
+
+  Scenario: Waiting tier — live session idle for more than 5 minutes
+    Given a ClaudeInstance with lastActivityAt = 10 minutes ago
+    And the instance is not in any PR-blocked state
+    When buildAttentionSections runs at now
+    Then that row appears in the "Waiting" tier with hint "idle 10m"
+
+  Scenario: Active tier — live session with recent activity
+    Given a ClaudeInstance with lastActivityAt = 30 seconds ago
+    And the instance is not blocked or waiting
+    When buildAttentionSections runs
+    Then that row appears in the "Active" tier
+
+  Scenario: Quiet tier — dormant worktree with no live session and no PR signal
+    Given a worktree whose claudeInstances is an empty list
+    And the worktree's pr is null or not-blocked
+    When buildAttentionSections runs
+    Then a dormant row appears in the "Quiet" tier
+
+  Scenario: Dedup — daemon attaches one ClaudeInstance to multiple repos
+    Given sessionUuid "abc" appears on worktrees from both repo-A and repo-B (shared parent dir)
+    When buildAttentionSections deduplicates by session.id
+    Then sessionUuid "abc" appears exactly once in the sidebar
+    And the first-seen occurrence is kept
+
+  Scenario: Activity sort within each tier
+    Given the "Active" tier has two rows with lastActivityAt T1 < T2
+    When the section is rendered
+    Then the row with lastActivityAt T2 appears first (most-recent activity floats up)
+
+  Scenario: Empty sidebar state — no Claude sessions
+    Given all worktrees have zero claudeInstances
+    And buildAttentionSections returns sections with all empty items
+    When attentionTotal = 0
+    Then the sidebar renders "No Claude sessions reported by the daemon."
+    And not a blank white box
+
+  Scenario: Attention lens error state — daemon GraphQL error
+    Given attentionStore.errors is non-empty
+    When attentionTotal = 0
+    Then the sidebar renders "Daemon couldn't fetch this lens. Try another lens or check the daemon logs."

--- a/daemon/features/gui-conversation-subscription.feature
+++ b/daemon/features/gui-conversation-subscription.feature
@@ -1,0 +1,72 @@
+Feature: GUI conversation subscription — ConversationChanged
+  As the orchard-gui TranscriptView
+  I need a push subscription that fires whenever the JSONL for my session is updated
+  So that the transcript reloads without polling, and pending-turn states advance correctly.
+
+  Operation consumed:
+    subscription ConversationChanged($sessionUuid: String!) {
+      conversationChanged(sessionUuid: $sessionUuid) {
+        sessionUuid
+        lastSeenAt
+        messageCount
+      }
+    }
+
+  Transport: graphql-ws WebSocket to ws://127.0.0.1:7777/graphql (or /__daemon/graphql via Vite proxy)
+
+  Background:
+    Given the daemon is running with fsnotify watching the claude projects directory
+    And TranscriptView has mounted with a known sessionUuid
+    And the WebSocket to the daemon is open
+
+  Scenario: Subscription fires when the JSONL file is appended
+    Given TranscriptView has subscribed to conversationChanged for sessionUuid "abc123"
+    When a new record is appended to the matching JSONL on disk
+    Then the daemon emits a conversationChanged event within 500ms of the file write
+    And the payload contains sessionUuid = "abc123"
+    And the payload contains an updated lastSeenAt timestamp
+    And the payload contains an updated messageCount
+
+  Scenario: TranscriptView debounces rapid pushes — no CPU storm on active turn
+    Given Claude is actively writing a multi-block response (1 JSONL record per token batch)
+    When conversationChanged fires at >5Hz
+    Then TranscriptView coalesces the burst with a 350ms trailing debounce
+    And the readTranscript call fires at most once per 350ms burst window
+    And the browser remains responsive during a fast-writing turn
+
+  Scenario: Pending turn advances to "received" on subscription push
+    Given the user sent a message and the pending turn is in "sent" state
+    And the turns.length at send time was N
+    When conversationChanged fires and readTranscript returns turns.length > N
+    Then the pending turn's status advances to "received"
+
+  Scenario: Pending turn advances to "seen" when assistant turn appears
+    Given a pending turn is in "received" state
+    When conversationChanged fires and the fresh turns array contains a new assistant turn
+    And the assistant turn's timestamp >= the pending turn's sentAt
+    Then the pending turn's status advances to "seen"
+    And the "seen" bubble fades out after 2 seconds
+
+  Scenario: Pending turn stalles after 90 seconds without advancing
+    Given a pending turn has been in "sent" state for 90 seconds
+    And no conversationChanged push has arrived during that window
+    Then the pending turn's status flips to "stalled"
+    And the bubble renders with "·waiting" indicator at reduced opacity
+
+  Scenario: Subscription error is logged but does not crash the view
+    When the WebSocket connection drops mid-session
+    Then TranscriptView logs a console.warn with "[transcript] subscription error:"
+    And the transcript view continues to display the last-loaded turns
+    And when the WebSocket reconnects, the subscription resumes from where it left off
+
+  Scenario: Subscription torn down when sessionUuid changes
+    Given TranscriptView is subscribed to sessionUuid "abc123"
+    When the panel selection changes to sessionUuid "def456"
+    Then the "abc123" subscription is unsubscribed via the returned Unsub handle
+    And a new subscription is opened for "def456"
+    And no subscription leaks remain after the component unmounts
+
+  Scenario: Zero-sessionUuid guard — no subscription when uuid is absent
+    When TranscriptView mounts without a sessionUuid prop
+    Then no conversationChanged subscription is opened
+    And the view loads from path alone when path is non-empty

--- a/daemon/features/gui-error-and-edge-cases.feature
+++ b/daemon/features/gui-error-and-edge-cases.feature
@@ -1,0 +1,94 @@
+Feature: GUI error and edge cases — resilience at the daemon boundary
+  As the orchard-gui
+  I need the UI to degrade gracefully when the daemon is unavailable, the schema drifts,
+  or edge-case data is returned
+  So that operators are not left staring at a blank screen or a JavaScript crash.
+
+  Background:
+    Given the orchard-gui is running and pointing at the daemon proxy at /__daemon/graphql
+
+  Scenario: Daemon unreachable at boot — all lens stores show loading, then error
+    Given the daemon is not running (connection refused on 127.0.0.1:7777)
+    When the lens stores fire their prefetch on mount
+    Then each store's fetching flag is true until timeout
+    And each store's errors array is non-empty after failure
+    And the attention lens sidebar renders "Daemon couldn't fetch this lens. Try another lens or check the daemon logs."
+    And no JavaScript uncaught exception is thrown
+
+  Scenario: Daemon restarts mid-session — Houdini re-fetches after reconnect
+    Given all lens stores are warm and rendering
+    When the daemon process exits and restarts
+    Then the WebSocket reconnects (graphql-ws reconnect policy)
+    And the next Houdini cache update renders fresh data
+    And pending subscriptions (conversationChanged, tmuxSessionsChanged) re-subscribe
+
+  Scenario: Schema drift — GUI queries a field the daemon no longer exposes
+    Given the GUI sends a query referencing "Worktree.claudeInstances"
+    And the daemon schema has removed or renamed that field
+    When the query executes
+    Then the daemon returns a GraphQL error with "Cannot query field"
+    And the lens store's errors array contains the error
+    And the GUI degrades to an empty section rather than throwing
+
+  Scenario: workView field missing from daemon schema — not yet in any domain partial
+    Given the GUI fires any of the five lens queries referencing workView
+    And workView is not present in the live daemon schema
+    Then the daemon returns a GraphQL error
+    And this is the most-likely gap to block lens rendering in a new daemon build
+    # workView is a synthetic read-model (WorkView type, Query.workView field) that lives
+    # in the live daemon schema but has no schema partial in daemon/<domain>/schema.graphql.
+    # This feature documents it as a known coverage gap for the constitution effort.
+
+  Scenario: conversationChanged subscription — null payload on file removal
+    Given TranscriptView is subscribed to conversationChanged for sessionUuid "abc123"
+    When the matching JSONL file is deleted from disk
+    Then the daemon emits a null payload for the subscription
+    And TranscriptView does not crash on a null push
+    And the transcript renders the last-cached turns with an "earlier turns omitted" banner if truncated
+
+  Scenario: Large fleet — 363+ conversations do not stall the recent lens
+    Given the daemon reports 363 conversations in RecentLens
+    When buildRecentItems runs
+    Then the output is capped at 100 rows
+    And the projection completes synchronously without blocking the render thread
+    And the sidebar renders the first 100 rows in the next frame
+
+  Scenario: tmuxServer null — no tmux daemon on this host
+    When the TmuxLens query runs and tmuxServer is null
+    Then buildTmuxSnapshot returns the EMPTY snapshot (alive: false, sessions: [], activePaneIds: {})
+    And the sidebar renders "No tmux server reachable."
+    And no null-dereference error occurs in the tmux lens projection
+
+  Scenario: Houdini cache key version mismatch — stale v1/v2 cache purged silently
+    Given localStorage contains "orchard:houdini:cache:v1" or "v2" from an old build
+    When the layout hydrates the cache at boot
+    Then the stale keys are removed from localStorage before hydration
+    And the current key "orchard:houdini:cache:v3" is used
+    And no stale schema shape corrupts the Houdini runtime
+
+  Scenario: Houdini cache too large — not persisted to localStorage
+    Given the serialized Houdini cache exceeds 2MB
+    When persistHoudiniCache is called
+    Then the cache is NOT written to localStorage
+    And no QuotaExceededError is thrown
+    And the next boot does a cold-fetch from the daemon (no stale half-write)
+
+  Scenario: Tauri bridge unavailable in browser dev — tmuxSendText falls back to GraphQL
+    Given the app is running in a browser (no window.__TAURI_INTERNALS__)
+    When tmuxSendText is called
+    Then a POST to /__daemon/graphql with the sendTextToPane mutation is fired
+    And no "Tauri bridge not available" error is surfaced to the user for this path
+
+  Scenario: sendTextToPane HTTP non-200 — error surfaces as toast
+    Given the daemon proxy returns HTTP 503
+    When tmuxSendText's fetch call rejects with HTTP 503
+    Then an Error is thrown with message "sendTextToPane HTTP 503"
+    And SessionComposer catches it, shows a toast, and removes the optimistic pending turn
+
+  Scenario: Peer disconnected — federation host goes unreachable
+    Given hosts[1] was reachable and is now unreachable
+    When the next HostsList query runs
+    Then hosts[1].reachable = false
+    And hosts[1].lastSeenAt is the last-known RFC3339 timestamp
+    And PeerCluster renders the pip as "bad" (red) with the last-seen tooltip
+    And no rows from hosts[1]'s worktrees/sessions appear in lens data (they were on that peer)

--- a/daemon/features/gui-fleet-topbar.feature
+++ b/daemon/features/gui-fleet-topbar.feature
@@ -1,0 +1,77 @@
+Feature: GUI fleet top bar — HostsList query
+  As the orchard-gui FleetTopBar and PeerCluster
+  I need host identity, reachability, resource load, and Claude account quota
+  So that operators see fleet health and their API quota at a glance.
+
+  Operation consumed:
+    query HostsList {
+      hosts {
+        id, hostname, os, kernel, reachable, lastSeenAt
+        resourceLoad { cpuPercent, memPercent, diskPercent, loadAvg1m, loadAvg5m, loadAvg15m }
+      }
+      claudeAccounts {
+        id, email, quotaUsed, quotaCap, quotaResetsAt, quotaEstimated
+      }
+    }
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And the HostsListStore Houdini singleton is used (hostsStore)
+    And FleetTopBar calls hostsStore.fetch() on mount
+
+  Scenario: HostsList returns local host with all required fields
+    When the HostsList query runs
+    Then hosts is a non-empty list
+    And each host has: id, hostname, os, reachable, lastSeenAt
+    And each host has a nullable kernel field
+    And each host has a nullable resourceLoad field
+
+  Scenario: resourceLoad is null at cold boot — topbar shows "—" not fabricated zeros
+    When the daemon has not yet sampled resource metrics (cold boot)
+    Then hosts[0].resourceLoad is null
+    And PeerCluster renders "no resource sample yet" in the tooltip
+    And no fake CPU/memory values appear in the UI
+
+  Scenario: resourceLoad present — topbar renders real metrics
+    Given the daemon has completed at least one 5s resource sample
+    When the HostsList query runs
+    Then resourceLoad.cpuPercent is a float in [0, 100]
+    And resourceLoad.memPercent is a float in [0, 100]
+    And resourceLoad.diskPercent is a float in [0, 100]
+    And resourceLoad.loadAvg1m, loadAvg5m, loadAvg15m are non-negative floats
+
+  Scenario: Peer cluster pip color reflects CPU load
+    Given host.resourceLoad.cpuPercent = 92
+    Then the pip for that host renders with the "attn" class (amber/red)
+    Given host.resourceLoad.cpuPercent = 40
+    Then the pip renders with the "ok" class (green)
+    Given host.reachable = false
+    Then the pip renders with the "bad" class (red)
+
+  Scenario: Claude account quota renders only when cap is known
+    Given claudeAccounts[0].quotaCap is null
+    Then the quota bar is hidden in the topbar
+    Given claudeAccounts[0].quotaCap = 100 and quotaUsed = 85
+    Then the quota bar renders at 85% fill
+    And the bar color is "attn" (overQuota flag = true because 85/100 > 0.8)
+    Given claudeAccounts[0].quotaEstimated = true
+    Then the quota tooltip reads "Estimated by ccusage"
+
+  Scenario: Multiple hosts — peer cluster shows one pip per host
+    Given the daemon reports 3 hosts (1 local + 2 federation peers)
+    When the HostsList query runs
+    Then hosts.length = 3
+    And PeerCluster renders 3 pips
+    And each pip links to its host's resource tooltip
+
+  Scenario: Unreachable host — tooltip shows last seen time
+    Given hosts[1].reachable = false and hosts[1].lastSeenAt = <5 minutes ago>
+    When PeerCluster renders the tooltip for that host
+    Then the tooltip shows "unreachable · last seen 5m ago"
+    And the pip renders with the "bad" (red) class
+
+  Scenario: NewConversation modal reads from same HostsListStore — no second fetch
+    When the user opens the NewConversation modal
+    Then the modal reads hosts from the already-fetched hostsStore singleton
+    And no second HostsList query is issued to the daemon
+    And worktrees are read from the WorktreesListStore singleton (WorktreesList query)

--- a/daemon/features/gui-issue-lens.feature
+++ b/daemon/features/gui-issue-lens.feature
@@ -1,0 +1,54 @@
+Feature: GUI issue lens — active PR/issue work grouped by GitHub issue
+  As the orchard-gui LensSidebar in "issue" mode
+  I need worktrees that have both an open PR and a linked issue to appear grouped by issue number
+  So that the operator sees in-progress GitHub work organized by its issue.
+
+  Operation consumed:
+    IssueLens:
+      claudeInstances [...SessionCard]
+      workView.repos[].worktrees [...WorktreeEnrichment + claudeInstances[...SessionCard]]
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And at least one worktree has an open PR linked to a GitHub issue
+
+  Scenario: IssueLens includes only worktrees with OPEN or DRAFT PR and a linked issue
+    When buildIssueSections runs
+    Then worktrees with no pr field are excluded
+    And worktrees with pr.state = "CLOSED" or "MERGED" are excluded
+    And worktrees with pr.state = "OPEN" or "DRAFT" and a non-null issue are included
+    And worktrees with no issue (no issue<N>/... branch convention) are excluded
+
+  Scenario: One section per unique issue number
+    Given worktrees for issues #123 and #456 are both in scope
+    When buildIssueSections runs
+    Then the sidebar has two sections: one for #123, one for #456
+    And the section label for issue #123 is "#123 · <issue title>" when title is non-null
+    And when issue.title is null the label is "#123"
+
+  Scenario: IssueLens drops worktrees with no live ClaudeInstance
+    Given worktree A has an open PR + issue but claudeInstances is empty
+    When buildIssueSections runs
+    Then no row appears for worktree A in the issue lens
+
+  Scenario: WorktreeEnrichment pr field required — gap acknowledged
+    When the IssueLens query runs
+    Then the worktree includes issue { number, state, title }
+    # NOTE: IssueLens depends on pr.state for the OPEN/DRAFT filter.
+    # WorktreeEnrichment.gql explicitly excludes pr to avoid ~12s REST calls.
+    # The IssueLens query's worktree projection DOES NOT carry pr in WorktreeEnrichment.
+    # This means buildIssueSections's pr.state filter can only operate when pr is populated
+    # at query time. As of the current schema, this is a functional gap:
+    # the issue lens must either include pr (with the REST latency cost)
+    # or drop the OPEN/DRAFT filter. File a daemon issue before implementing step defs.
+
+  Scenario: IssueLens top-level claudeInstances — secondary enrichment
+    When the IssueLens query runs
+    Then the top-level claudeInstances list is also returned
+    And it carries the same SessionCard fragment shape as other lenses
+    And buildIssueSections uses the worktree-scoped claudeInstances, not the top-level list
+
+  Scenario: Empty issue lens state
+    Given no worktrees have both an open PR and a linked issue with a live Claude session
+    When issueTotal = 0
+    Then the sidebar renders "No issues with open PRs in scope."

--- a/daemon/features/gui-new-conversation.feature
+++ b/daemon/features/gui-new-conversation.feature
@@ -1,0 +1,59 @@
+Feature: GUI new conversation modal — WorktreesList + HostsList
+  As the orchard-gui NewConversation modal
+  I need a flat list of non-bare worktrees and a list of reachable hosts
+  So that the user can pick a target (host, cwd) to launch a new Claude REPL.
+
+  Operations consumed:
+    WorktreesListStore (WorktreesList query):
+      workView.repos[].worktrees { id, path, branch, bare, host, repo }
+
+    HostsListStore (HostsList query):
+      hosts { id, hostname, os, reachable, resourceLoad{ cpuPercent } }
+      claudeAccounts { ... }   (read alongside hosts; quota shown in topbar, not here)
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And the NewConversation modal opens
+
+  Scenario: Modal reads from already-warm Houdini stores — no extra network requests
+    Given hostsStore and worktreesStore were fetched on LensSidebar/FleetTopBar mount
+    When the NewConversation modal opens
+    Then no new GraphQL queries are fired to the daemon
+    And the modal renders instantly from cache
+
+  Scenario: WorktreesList response shape — bare worktrees excluded from picker
+    When the WorktreesList query runs
+    Then workView.repos is a list of repos each with id, slug, and worktrees
+    And each worktree has: id, path, branch, bare, host, repo
+    And buildWorktreePickerRows filters out worktrees where bare = true
+    And the picker displays only non-bare worktrees
+
+  Scenario: WorktreesList null repo fallback — uses repo.slug
+    Given a worktree whose repo field is null (no GitHub origin remote detected)
+    When buildWorktreePickerRows processes that worktree
+    Then the picker row displays the parent repo.slug as the repo label
+    And no null-reference error occurs
+
+  Scenario: Modal snapshots data on open — no live updates while open
+    Given the modal is open with snapshotWorktrees and snapshotHosts captured at open time
+    When the underlying hostsStore or worktreesStore receives a Houdini cache update
+    Then the modal's displayed worktrees and hosts do NOT change
+    And the user is not surprised by shifting options during selection
+
+  Scenario: Unreachable host renders as disabled in the host picker
+    Given hosts[1].reachable = false
+    When the host picker renders
+    Then the button for that host is disabled
+    And a "down" chip is displayed next to the hostname
+    And the user cannot select an unreachable host as the launch target
+
+  Scenario: CPU load shown in host picker when resourceLoad is available
+    Given host.reachable = true and host.resourceLoad.cpuPercent = 72
+    When the host picker renders
+    Then cpu: 72% is displayed under the hostname button
+
+  Scenario: Launch emits (worktreeId, host, model, task) — no client-side joins
+    When the user picks a worktree and clicks Launch
+    Then onLaunch is called with { worktreeId, host, model, task }
+    And no client-side cwd→worktree resolution occurs (worktreeId is the daemon-assigned ID)
+    And model defaults to "claude-sonnet-4-5" unless changed

--- a/daemon/features/gui-panel-open.feature
+++ b/daemon/features/gui-panel-open.feature
@@ -1,0 +1,76 @@
+Feature: GUI panel open — OpenPanel query
+  As the orchard-gui SessionPane
+  I need to resolve a row identity (paneId and/or sessionUuid) to a full PanelData shape
+  So that the panel header, REPL pill, transcript, and composer render without client-side joins.
+
+  Operation consumed:
+    OpenPanel($paneIds: [String!], $cwd: String)
+      — tmuxPanes(filter:{paneIdIn:$paneIds, cwd:$cwd, command:"claude"}) [...PaneCard]
+      — claudeInstances [...SessionCard]
+      — conversations {sessionUuid, lastSeenAt, firstSeenAt, messageCount, open, recap, cwd, jsonlPath, agentName, customTitle}
+      — workView.repos[].worktrees [...WorktreeEnrichment]
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And at least one live Claude REPL is running in a tmux pane
+
+  Scenario: Panel opens by paneId — daemon resolves session and worktree
+    When SessionPane fires OpenPanel with paneIds: ["%26"] and no cwd
+    Then tmuxPanes returns the pane matching %26 spreading PaneCard
+    And claudeInstances includes the SessionCard for the Claude process in that pane
+    And conversations includes the Conversation whose sessionUuid matches the instance
+    And workView.repos[].worktrees includes a WorktreeEnrichment matching the session's process cwd
+    And PanelData.pane, PanelData.session, PanelData.conversation, and PanelData.worktree are all non-null
+
+  Scenario: Panel opens by sessionUuid — no pane in scope
+    When SessionPane fires OpenPanel with no paneIds and cwd from conversation.cwd
+    Then tmuxPanes returns the pane(s) whose process cwd matches, filtered by command="claude"
+    And claudeInstances includes the matching session
+    And the panel can render worktree breadcrumbs and PR/issue chips from the resolved worktree
+
+  Scenario: Panel resolves conversation fields for header rendering
+    When the OpenPanel query returns
+    Then conversation.jsonlPath is a non-empty string (used to read the transcript via Tauri)
+    And conversation.firstSeenAt and lastSeenAt are RFC3339 timestamps or null
+    And conversation.messageCount is a non-negative integer
+    And conversation.open is a boolean reflecting heartbeat freshness
+    And conversation.recap is a string or null
+    And conversation.agentName and customTitle are strings or null
+
+  Scenario: REPL state pill maps daemon InstanceState correctly
+    When OpenPanel returns a ClaudeInstance with state
+    Then state = "working" and inflightToolCount = 0 renders the pill as "working" (pulsing green)
+    And state = "working" and inflightToolCount > 0 renders the pill as "responding" (pulsing amber)
+    And state = "idle" renders the pill as "idle" (green)
+    And state = "input" renders the pill as "thinking" (slow amber)
+    And state = "stalled" renders the pill as "stalled" (red)
+    And state = "dead" or "no_claude" renders the pill as "dead" (grey line-through)
+    And no ClaudeInstance resolved renders the pill as "derived" (grey dot, no label)
+
+  Scenario: PR chips render from WorktreePR — fetched separately from WorktreeEnrichment
+    When a worktree row is opened in the panel
+    And the panel fires a second fetch including the WorktreePR fragment on the worktree
+    Then the worktree gains a pr field with: number, state, statusCheckRollup, reviewDecision, mergeable, mergeStateStatus
+    And when pr.statusCheckRollup = "FAILURE", a "CI" badge renders in red
+    And when pr.reviewDecision = "CHANGES_REQUESTED", a "review" badge renders in red
+    And when pr.mergeable = "CONFLICTING" or mergeStateStatus = "DIRTY", a "conflict" badge renders in red
+    And when pr.state = "DRAFT", a "draft" badge renders in grey
+
+  Scenario: Panel loading interstitial is minimised via titleHint
+    When the sidebar emits a row selection with titleHint = "feature-branch"
+    Then the panel renders "feature-branch" as the title before the OpenPanel round-trip completes
+    And the REPL pill renders in "derived" state (grey dot) until the query resolves
+    And no "Loading…" spinner blocks the panel chrome from appearing
+
+  Scenario: Dead session — no tmux pane, conversation.jsonlPath present
+    When OpenPanel returns no pane (tmuxPanes is empty) but conversation.jsonlPath is set
+    Then the panel renders the conversation header with breadcrumbs from the worktree
+    And the REPL pill shows "dead"
+    And TranscriptView loads the JSONL at jsonlPath via the Tauri bridge
+    And the composer is hidden (no effectivePaneId)
+    And the panel shows "No live tmux pane — open Terminal view to attach a fresh client."
+
+  Scenario: OpenPanel returns empty — nothing resolved
+    When paneId and sessionUuid both fail to match any daemon state
+    Then PanelData is null
+    And SessionPane renders "No tmux pane resolved."

--- a/daemon/features/gui-recent-lens.feature
+++ b/daemon/features/gui-recent-lens.feature
@@ -1,0 +1,55 @@
+Feature: GUI recent lens — all conversations sorted by last activity
+  As the orchard-gui LensSidebar in "recent" mode
+  I need every Claude conversation known to the daemon (live and historical)
+  So that the operator can find and re-open any session, not just live REPLs.
+
+  Operation consumed:
+    RecentLens:
+      conversations { id, sessionUuid, agentName, customTitle, cwd, firstSeenAt, lastSeenAt, messageCount, open, recap }
+      claudeInstances [...SessionCard]  (enrichment overlay — matched by sessionUuid)
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And the claude projects directory contains at least one JSONL file
+
+  Scenario: RecentLens returns all conversations — not just live processes
+    When the RecentLens query runs
+    Then conversations includes entries whose claudeInstances is empty (historical/dead sessions)
+    And conversations includes entries whose claudeInstances has a live match
+    And the list is ordered latest-first by lastSeenAt
+
+  Scenario: Dormant conversation row derives state from open field
+    Given a conversation with open = false and no matching live ClaudeInstance
+    When buildRecentItems processes it
+    Then the dormant row's synthetic state is "no_claude"
+    Given a conversation with open = true and no matching live ClaudeInstance
+    Then the dormant row's synthetic state is "idle"
+
+  Scenario: Live enrichment overlay — live ClaudeInstance lifts the row
+    Given conversations[0].sessionUuid = "abc123"
+    And claudeInstances contains a SessionCard with sessionUuid = "abc123"
+    When buildRecentItems processes the data
+    Then the row for "abc123" uses the live ClaudeInstance's state, pane, worktree, and process
+    And the row's lastActivityAt comes from the conversation's lastSeenAt (authoritative) falling back to the instance's lastActivityAt
+
+  Scenario: Recent lens capped at 100 rows
+    Given the daemon reports 363 conversations
+    When buildRecentItems runs
+    Then the output list has at most 100 items
+    And the 100 items are the most-recently-active conversations
+
+  Scenario: Dedup by sessionUuid — no duplicate rows when a pid appears in two conversations
+    Given two conversations share a sessionUuid prefix (edge case)
+    When buildRecentItems runs
+    Then each sessionUuid appears exactly once in the output
+
+  Scenario: Empty state — no conversations discovered
+    Given the claude projects directory is empty (no JSONL files)
+    When the RecentLens query runs
+    Then conversations is an empty list
+    And the sidebar renders "No Claude sessions known."
+
+  Scenario: Recent lens loading state
+    Given recentStore.fetching = true and recentStore.data = null
+    When the sidebar renders
+    Then the sidebar shows "Loading…" in the recent section

--- a/daemon/features/gui-send-text-mutation.feature
+++ b/daemon/features/gui-send-text-mutation.feature
@@ -1,0 +1,61 @@
+Feature: GUI send-text mutation — sendTextToPane
+  As the orchard-gui SessionComposer
+  I need to send user input to a live Claude REPL in a tmux pane
+  So that the user can message Claude from the browser or mobile client without direct tmux access.
+
+  Operations consumed:
+    Mutation.sendTextToPane(paneId: String!, text: String!): Boolean!
+    Tauri command: tmux_send_text(paneId, text)  [preferred path in desktop app]
+    Fallback: HTTP POST to /__daemon/graphql with the mutation [browser/mobile]
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And a live tmux pane "%26" is hosting a Claude REPL
+
+  Scenario: Desktop path — Tauri bridge sends text without network hop
+    Given the app is running in Tauri (window.__TAURI_INTERNALS__ is defined)
+    When the user submits a message in the composer
+    Then invoke("tmux_send_text", {paneId: "%26", text: "hello"}) is called
+    And no HTTP request is made to the daemon GraphQL endpoint
+    And the pending turn status advances to "sent" when the invoke resolves
+
+  Scenario: Browser/mobile path — mutation proxied through daemon
+    Given the app is running in a browser (no Tauri context)
+    When the user submits a message in the composer
+    Then a POST request is made to /__daemon/graphql (or http://127.0.0.1:7777/graphql)
+    And the request body is {"query": "mutation($paneId: String!, $text: String!) { sendTextToPane(paneId: $paneId, text: $text) }", "variables": {"paneId": "%26", "text": "hello"}}
+    And the daemon executes tmux send-keys for the target pane
+    And the response body has data.sendTextToPane = true
+    And the pending turn status advances to "sent"
+
+  Scenario: Optimistic UI — input clears immediately before async ack
+    When the user hits Enter in the composer
+    Then the input textarea clears instantly (before the mutation resolves)
+    And a "pending" turn bubble appears in the transcript with status "sending"
+    And focus returns to the textarea without waiting for the mutation
+
+  Scenario: Mutation returns error — pending turn is removed
+    When sendTextToPane raises an error (tmux pane not reachable, daemon exits non-zero)
+    Then the pending turn bubble is removed from the transcript
+    And a toast error is shown with the error message
+    And the textarea retains the failed text so the user can retry
+
+  Scenario: Daemon validates paneId — non-existent pane returns GraphQL error
+    Given pane "%999" does not exist
+    When sendTextToPane is called with paneId = "%999"
+    Then the daemon returns a GraphQL error with a descriptive message
+    And the HTTP status is 200 (GraphQL errors are always HTTP 200)
+    And the client surfaces the error as a toast
+
+  Scenario: Mutation feedback loop — ConversationChanged fires after send
+    Given the user sent a message and the pending turn is "sent"
+    When the daemon's tmux send-keys executes successfully
+    And Claude processes the message and appends a new assistant turn to the JSONL
+    Then conversationChanged fires within 2 seconds of the initial send
+    And the pending turn's status advances to "received" then "seen"
+    And the iMessage-style indicator sequence completes: sending → sent → received → seen
+
+  Scenario: Composer is hidden when no effectivePaneId
+    Given OpenPanel resolved a session and conversation but tmuxPanes is empty
+    Then SessionComposer is not rendered
+    And the panel shows "No live tmux pane — open Terminal view to attach a fresh client."

--- a/daemon/features/gui-sidebar-boot.feature
+++ b/daemon/features/gui-sidebar-boot.feature
@@ -1,0 +1,89 @@
+Feature: GUI sidebar boot — all five lens prefetch
+  As the orchard-gui LensSidebar
+  I need all five lens stores to prefetch in parallel on mount
+  So that lens switching is instant (pure cache render, no spinner interstitial).
+
+  Operations consumed:
+    AttentionLens  — workView.repos[].worktrees[].claudeInstances[...SessionCard] + WorktreeEnrichment
+    RecentLens     — conversations + claudeInstances[...SessionCard]
+    TmuxLens       — tmuxServer.sessions[].windows[].panes[...PaneCard]
+    IssueLens      — claudeInstances[...SessionCard] + workView.repos[].worktrees[...WorktreeEnrichment + claudeInstances]
+    WorktreeLens   — workView.repos[].worktrees[...WorktreeEnrichment + tmuxPanes[...PaneCard]]
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And at least one repo is registered in the orchard config
+    And the Houdini cache has been hydrated from localStorage (or is cold)
+
+  Scenario: Parallel lens prefetch completes without error
+    When LensSidebar mounts and fires all five stores with .fetch()
+    Then all five Houdini queries complete without GraphQL errors
+    And each store's fetching flag transitions false before the first render tick
+
+  Scenario: Attention lens response shape
+    When the AttentionLens query runs
+    Then the response root contains a workView field
+    And workView.repos is a list where each repo has id and slug
+    And each repo has a worktrees list
+    And each worktree includes the WorktreeEnrichment fields: id, path, branch, host, repo, issue{number,state,title}
+    And each worktree includes a claudeInstances list of SessionCard nodes
+    And a SessionCard includes: id, sessionUuid, state, inflightToolCount, startedAt, lastActivityAt, rcEnabled
+    And a SessionCard includes a nullable account field with email
+    And a SessionCard includes a nullable pane field with: paneId, title, currentCommand, window{id,index,name,active,session{id,name,attached,activeAttached}}
+    And a SessionCard includes a nullable process field with: pid, cwd
+    And a SessionCard includes a nullable worktree field spreading WorktreeEnrichment
+    And a SessionCard includes a nullable conversation field with: sessionUuid, lastSeenAt, agentName, customTitle
+
+  Scenario: Attention lens does NOT include pr in WorktreeEnrichment
+    When the AttentionLens query runs
+    Then the worktree nodes in workView do NOT carry a pr field
+    # PR data is deferred to the panel's WorktreePR fetch to avoid ~12s REST calls per repo
+
+  Scenario: RecentLens response shape
+    When the RecentLens query runs
+    Then the response contains a top-level conversations list
+    And each conversation includes: id, sessionUuid, agentName, customTitle, cwd, firstSeenAt, lastSeenAt, messageCount, open, recap
+    And the response contains a top-level claudeInstances list spreading SessionCard
+    And conversations list is non-empty when any JSONL exists under the configured repos root
+
+  Scenario: TmuxLens response shape
+    When the TmuxLens query runs
+    Then the response contains a tmuxServer field
+    And tmuxServer has: id, alive, sessions, clients
+    And each session has: id, name, attached, activeAttached, lastActivityAt, windows
+    And each window has: id, index, name, active, panes
+    And each pane spreads PaneCard: paneId, title, currentCommand, currentPid, window{...session}, claudeInstance{...SessionCard}, process{pid,cwd,command,worktree{...WorktreeEnrichment}}
+    And tmuxServer.clients has items with: tty and currentPane{paneId}
+    And when tmux is unreachable, tmuxServer.alive is false and tmuxServer.sessions is an empty list
+
+  Scenario: IssueLens response shape
+    When the IssueLens query runs
+    Then the response contains a top-level claudeInstances list spreading SessionCard
+    And the response contains a workView with repos and their worktrees spreading WorktreeEnrichment
+    And each worktree in IssueLens carries a claudeInstances list spreading SessionCard
+
+  Scenario: WorktreeLens response shape
+    When the WorktreeLens query runs
+    Then the response contains a workView with repos and their worktrees
+    And each worktree spreads WorktreeEnrichment
+    And each worktree carries a tmuxPanes list spreading PaneCard
+
+  Scenario: Houdini cache snapshot survives round-trip
+    Given the Houdini cache was persisted to localStorage key "orchard:houdini:cache:v3"
+    When the layout hydrates the cache before any store fetches
+    Then LensSidebar renders from cache without a "Loading…" flash
+    And each store's CacheAndNetwork policy still revalidates against the daemon in the background
+
+  Scenario: Sidebar fetch error surfaces a toast — not a silent empty list
+    Given the attention store fetch returns a GraphQL error
+    When the error does not contain known-noise strings ("use GetPull", "EnrichPullRequest", "is a pull request")
+    Then a toast error is shown to the user with a friendly message
+    And the raw daemon error string is logged to the browser console only
+    And when the error contains "rate limit", the toast reads "GitHub rate limit reached — PR data will catch up shortly."
+    And when the error contains "EnrichPullRequest", the toast reads "Couldn't refresh PR status — showing the last known state."
+
+  Scenario: Lens switch is a pure render — no new network request
+    Given all five stores have fetched successfully on mount
+    When the user switches the active lens from "attention" to "tmux"
+    Then the sidebar renders immediately from the Houdini cache
+    And no new HTTP request is fired to the daemon for the tmux lens data

--- a/daemon/features/gui-tmux-lens.feature
+++ b/daemon/features/gui-tmux-lens.feature
@@ -1,0 +1,67 @@
+Feature: GUI tmux lens — server → sessions → windows → panes view
+  As the orchard-gui LensSidebar in "tmux" mode
+  I need the full tmux server tree grouped by session
+  So that the operator sees which Claude REPLs are alive and in which tmux session.
+
+  Operation consumed:
+    TmuxLens → tmuxServer { id, alive, sessions { id, name, attached, activeAttached, lastActivityAt, windows { id, index, name, active, panes [...PaneCard] } }, clients { tty, currentPane { paneId } } }
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And a tmux server is running locally
+
+  Scenario: TmuxLens returns server alive flag
+    When the TmuxLens query runs
+    Then tmuxServer.alive = true when the tmux daemon is reachable
+    And tmuxServer.sessions is a non-empty list when at least one session exists
+
+  Scenario: Active pane detection — clients[].currentPane drives "here" badge
+    Given tmuxServer.clients[0].currentPane.paneId = "%26"
+    When buildTmuxSnapshot runs
+    Then activePaneIds contains "%26"
+    And any sidebar row with pane.paneId = "%26" renders the "here" badge
+
+  Scenario: Tmux lens groups rows by session — one sidebar section per session
+    Given tmuxServer has sessions ["orchard", "langwatch"]
+    When buildTmuxSections runs
+    Then the sidebar has two sections: one labelled "orchard", one "langwatch"
+    And each section contains rows for panes with a claudeInstance only
+    And panes with no Claude REPL are dropped from the section's item list
+
+  Scenario: PaneCard shape — required fields for the tmux lens
+    When a pane is included in TmuxLens
+    Then pane.paneId is the tmux pane ID (e.g. "%26")
+    And pane.title is a non-empty string (tmux pane_title)
+    And pane.currentCommand is the raw tmux pane_current_command value (may be a version string, not a basename)
+    And pane.currentPid is an integer or null
+    And pane.window.session.name matches the section label
+
+  Scenario: PaneCard.claudeInstance — nil when pane runs zsh/vim/etc
+    Given a pane whose currentCommand is "zsh"
+    When the TmuxLens query returns
+    Then pane.claudeInstance is null for that pane
+    And the pane is excluded from the tmux lens sidebar (buildTmuxSections drops it)
+
+  Scenario: PaneCard.claudeInstance — present for Claude panes
+    Given a pane running the Claude REPL
+    When TmuxLens returns
+    Then pane.claudeInstance is a full SessionCard
+    And pane.claudeInstance.worktree carries a WorktreeEnrichment (daemon-resolved by cwd)
+    And pane.claudeInstance.conversation carries agentName and customTitle for the title hint
+
+  Scenario: Tmux server unreachable — empty lens with informative message
+    When tmuxServer.alive = false
+    And tmuxStore.fetching = false
+    Then the tmux lens sidebar renders "No tmux server reachable."
+    And sections is an empty list (buildTmuxSections returns [])
+
+  Scenario: PaneCard.process.command — reliable command basename via ps
+    When the daemon builds the PaneCard
+    Then process.command is the basename as ps reports it (e.g. "claude", "zsh")
+    And process.command is more reliable than pane.currentCommand for intent detection
+    # See PaneCard.gql comment: on macOS pane_current_command can be the version string
+
+  Scenario: TmuxLens does NOT include pane content (screen capture)
+    When the TmuxLens query runs
+    Then no content, contentRange, or contentFull fields are included in the response
+    And no tmux capture-pane shellouts are triggered per request

--- a/daemon/features/gui-worktree-lens.feature
+++ b/daemon/features/gui-worktree-lens.feature
@@ -1,0 +1,61 @@
+Feature: GUI worktree lens — all worktrees grouped by repo, anchored on tmuxPanes
+  As the orchard-gui LensSidebar in "worktree" mode
+  I need every registered worktree visible regardless of session state
+  So that the operator can see their full topology and act on dormant worktrees.
+
+  Operation consumed:
+    WorktreeLens → workView.repos[].worktrees [...WorktreeEnrichment + tmuxPanes[...PaneCard]]
+
+  Background:
+    Given the daemon is running on 127.0.0.1:7777
+    And at least one repo is configured
+
+  Scenario: Every worktree appears — including those with no tmux panes
+    When the WorktreeLens query runs
+    And buildWorktreeSections runs
+    Then every worktree in workView appears as at least one row
+    And worktrees with tmuxPanes = [] render as a single dormant row
+    And worktrees with N panes render as N rows (one per pane)
+
+  Scenario: One sidebar section per repo
+    Given repos ["langwatch/langwatch", "drewdrewthis/orchard"]
+    When buildWorktreeSections runs
+    Then the sidebar has two sections labelled by repo slug
+    And each section contains rows for panes/worktrees within that repo only
+
+  Scenario: Pane with Claude session — full enriched row
+    Given a pane with a claudeInstance
+    When buildWorktreeSections processes it
+    Then the row is keyed as "pane:<paneId>" for stable dedup
+    And the row's title derives from conversation.agentName or customTitle or branch
+    And the row's worktree is taken from claudeInstance.worktree (daemon-joined, not client cwd match)
+
+  Scenario: Pane with no Claude session — tmux-only row
+    Given a pane whose claudeInstance is null
+    When buildWorktreeSections processes it
+    Then a tmux-only row appears for that pane
+    And the row's lastActivityMs comes from pane.window.session.lastActivityAt
+    And the row renders without a state pill (no ClaudeInstance to derive from)
+
+  Scenario: Dormant worktree — no panes but still visible
+    Given a worktree with tmuxPanes = [] and a branch "feature/x"
+    When buildWorktreeSections processes it
+    Then a dormant row appears showing "feature/x" and any PR/issue chips
+    And the row's lastActivityMs = 0, so it sinks to the bottom of the activity-sort
+
+  Scenario: Activity sort within a repo section — most-active panes float up
+    Given repo section "langwatch/langwatch" has panes with lastActivityAt T1 < T2 < T3
+    When buildWorktreeSections sorts within the section
+    Then the row with T3 appears first, T2 second, T1 third
+    And dormant rows (lastActivityMs = 0) appear last
+
+  Scenario: Dedup by item.id within a section
+    Given a pane appears in two worktrees of the same repo (daemon edge case)
+    When buildWorktreeSections deduplicates by item.id
+    Then the pane appears exactly once in the section
+    And no keyed-each crash occurs in the Svelte renderer
+
+  Scenario: Empty repo config — worktree lens shows no config message
+    Given the orchard config has no repos registered
+    When worktreeTotal = 0
+    Then the sidebar renders "No repos in config — run `orchard config init`."


### PR DESCRIPTION
## Summary

12 Gherkin feature files under `daemon/features/` that capture what the GUI actually fires at the daemon today — no speculation. Each feature describes a user-visible use case, the exact operations consumed, the response shape required, and latency/behavior constraints.

## Use cases covered (one .feature file each)

| File | Use case |
|------|----------|
| `gui-sidebar-boot.feature` | All five lens stores prefetch in parallel on mount |
| `gui-attention-lens.feature` | Attention lens tiering (blocked/waiting/active/quiet) |
| `gui-recent-lens.feature` | Recent lens — all conversations, live enrichment overlay |
| `gui-tmux-lens.feature` | Tmux lens — server → sessions → windows → panes |
| `gui-issue-lens.feature` | Issue lens — open-PR worktrees grouped by GitHub issue |
| `gui-worktree-lens.feature` | Worktree lens — all worktrees grouped by repo, anchored on tmuxPanes |
| `gui-panel-open.feature` | OpenPanel query — row identity → PanelData (pane+session+conversation+worktree) |
| `gui-send-text-mutation.feature` | sendTextToPane mutation + Tauri bridge + iMessage feedback loop |
| `gui-conversation-subscription.feature` | ConversationChanged subscription — live transcript push |
| `gui-fleet-topbar.feature` | HostsList query — host health + Claude account quota |
| `gui-new-conversation.feature` | NewConversation modal — WorktreesList + HostsList |
| `gui-error-and-edge-cases.feature` | Daemon unreachable, schema drift, cache hygiene, federation peer down |

## GUI lens queries inventoried

- `AttentionLens` — `workView.repos[].worktrees[...WorktreeEnrichment + claudeInstances[...SessionCard]]`
- `RecentLens` — `conversations` + `claudeInstances[...SessionCard]`
- `TmuxLens` — `tmuxServer.sessions[].windows[].panes[...PaneCard]` + `clients`
- `IssueLens` — `claudeInstances[...SessionCard]` + `workView.repos[].worktrees[...WorktreeEnrichment + claudeInstances]`
- `WorktreeLens` — `workView.repos[].worktrees[...WorktreeEnrichment + tmuxPanes[...PaneCard]]`
- `HostsList` — `hosts[id,hostname,os,kernel,reachable,lastSeenAt,resourceLoad{...}]` + `claudeAccounts[id,email,quotaUsed,quotaCap,quotaResetsAt,quotaEstimated]`
- `WorktreesList` — `workView.repos[].worktrees[id,path,branch,bare,host,repo]`
- `OpenPanel($paneIds,$cwd)` — `tmuxPanes[...PaneCard]` + `claudeInstances[...SessionCard]` + `conversations{...full metadata}` + `workView.repos[].worktrees[...WorktreeEnrichment]`
- `WorktreePR` (fragment, fetched in panel second pass) — `pr{number,state,statusCheckRollup,reviewDecision,mergeable,mergeStateStatus}`
- `ConversationChanged` (subscription) — `conversationChanged(sessionUuid:) { sessionUuid, lastSeenAt, messageCount }`
- `sendTextToPane` (mutation) — `sendTextToPane(paneId: String!, text: String!): Boolean!`

## Daemon fields the GUI uses NOT covered by any domain schema partial

1. **`Query.workView: WorkView!` and `type WorkView`** — present in the live `schema.graphql` and in `internal/server/resolvers/` but has no `daemon/<domain>/schema.graphql` partial. Every lens query (`AttentionLens`, `IssueLens`, `WorktreeLens`, `WorktreesList`, `OpenPanel`) relies on this field. This is the most critical gap for the constitution effort.

2. **`Worktree.claudeInstances`** — cross-domain field declared on `Worktree` (git domain) but resolved by `claude-jsonls`. The `git/schema.graphql` partial documents the field but the `claude-jsonls/schema.graphql` partial does not extend `Worktree`. Should be added as `extend type Worktree` in `claude-jsonls` or `claude-instance`.

3. **`Worktree.tmuxPanes`** — same pattern: declared in git schema but resolved by tmux. `tmux/schema.graphql` should carry `extend type Worktree { tmuxPanes: [TmuxPane!]! }`.

4. **`Worktree.pr` and `Worktree.issue`** — declared in git schema, resolved by gh domain. No `gh` schema partial exists in the worktree. The `daemon/gh/` directory may exist but was not present in the constitution tree at spec time.

## GUI code that bypasses GraphQL (L7 violations)

None found. The one non-Houdini operation (`ConversationChanged` subscription) is deliberately on `graphql-ws` directly and is documented in `daemon.ts` as a push-only wakeup signal — not a data fetch. The Tauri `tmux_send_text` invoke is a Tauri bridge call (not a daemon GraphQL bypass); the GraphQL `sendTextToPane` mutation is the declared fallback. Both are correctly L7-compliant.

## Test plan

- [ ] Read each `.feature` file and verify the operation names match the Houdini `.gql` files
- [ ] Cross-check every field name in each Scenario against the live daemon schema via introspection
- [ ] Verify `workView` gap is filed as a daemon issue before step-impl work begins
- [ ] Assign a step-implementation agent per feature file

🤖 Generated with [Claude Code](https://claude.com/claude-code)