### PR TITLE
fix(daemon): correct S15b extend-type placement for Worktree fields

### DIFF
--- a/daemon/claude-instance/schema.graphql
+++ b/daemon/claude-instance/schema.graphql
@@ -10,6 +10,9 @@
 # Output: when all three line up, emit a ClaudeInstance node.
 #
 # Most jsonls have no instance. Some have 2+ (rare /resume case).
+#
+# Cross-domain `extend type Worktree` (S15b: claude-instance is the data producer):
+#   Worktree.claudeInstances — Claude REPLs whose cwd lies under the worktree path
 
 extend type Query {
   "All live Claude instances the daemon is tracking — JSONLs with live process + pane matches."
@@ -98,4 +101,23 @@ enum InstanceState {
   dead
   "No Claude session has ever been observed for this pane/process."
   no_claude
+}
+
+# ---------------------------------------------------------------------
+# S15b: cross-domain `extend type Worktree` — claude-instance produces REPL data.
+# The resolver lives in daemon/claude-instance/ and calls the claude-instance service.
+# ---------------------------------------------------------------------
+
+extend type Worktree {
+  """
+  Claude REPLs whose resolved process cwd lies under this worktree's `path`.
+  Server-side join over the claude-jsonls + ps domains. Ordered deterministically
+  by `id` ascending.
+
+  Note: a ClaudeInstance is a *running REPL* identified by sessionUuid — distinct
+  from a TmuxSession (tmux's server grouping of windows/panes). A worktree can carry
+  zero or many of each.
+  Resolver calls the claude-instance service (S15b: producer domain owns the field).
+  """
+  claudeInstances: [ClaudeInstance!]!
 }

--- a/daemon/gh/schema.graphql
+++ b/daemon/gh/schema.graphql
@@ -11,6 +11,10 @@
 # (`pullRequests`, `issue`, `workflowRuns`, etc.). The pass-through escape
 # hatch is `Query.gh(query, variables): JSON` — opaque, uncached, returns
 # whatever GitHub returns.
+#
+# Cross-domain `extend type Worktree` (S15b: gh is the data producer):
+#   Worktree.pr    — PR whose headRef matches the worktree branch
+#   Worktree.issue — Issue linked from the worktree branch name
 
 extend type Query {
   """
@@ -259,4 +263,33 @@ type WorkflowRun implements Node {
   url: String!
   createdAt: String!
   updatedAt: String!
+}
+
+# ---------------------------------------------------------------------
+# S15b: cross-domain `extend type Worktree` — gh produces PR/issue data.
+# The resolver lives in daemon/gh/ and calls the gh service.
+# ---------------------------------------------------------------------
+
+extend type Worktree {
+  """
+  PR whose headRef matches this worktree's branch.
+
+  Selection precedence (#489): an OPEN PR is returned when one exists;
+  otherwise the most-recent CLOSED/MERGED PR with the matching headRef is
+  returned so the TUI stale-fade UX can render the post-merge cleanup
+  affordance. The `state` field on the returned PullRequest disambiguates
+  between live and post-merge.
+
+  Null when no PR has ever existed for this branch in any state, when the
+  branch is detached, or when the branch is the project's default branch.
+  Resolver calls the gh service (S15b: producer domain owns the field).
+  """
+  pr: PullRequest
+
+  """
+  Issue linked from the worktree's branch (issue<N>/... convention).
+  Null when the branch name does not match the convention.
+  Resolver calls the gh service (S15b: producer domain owns the field).
+  """
+  issue: Issue
 }

--- a/daemon/git/README.md
+++ b/daemon/git/README.md
@@ -16,20 +16,20 @@ Local git: repos, worktrees, branches, refs, status, ahead/behind, remote heads.
 
 Walking the watched-projects list + known dirs to find git repos is a **startup routine** inside this domain — not its own domain. The data it populates (the set of `Repo` nodes) belongs to `git`.
 
-## Cross-domain fields on Worktree (resolved here)
+## Cross-domain fields on Worktree (S15b: declared in the producing domain)
 
-These fields are declared in this domain's partial; the resolver lives here and calls the owning domain's service:
+Per [S15b](../../RULES.md), cross-domain `extend type` blocks and their resolvers live in the domain that **produces** the data — NOT in the type owner (`git`). Worktree is owned here; the cross-domain fields live elsewhere:
 
-| Field | Owning domain |
+| Field | Producing domain (schema + resolver) |
 |---|---|
 | `Worktree.processes` | [`ps`](../ps/) |
 | `Worktree.tmuxPanes` | [`tmux`](../tmux/) |
 | `Worktree.tmuxSession` | [`tmux`](../tmux/) |
-| `Worktree.claudeInstances` | [`claude-jsonls`](../claude-jsonls/) |
+| `Worktree.claudeInstances` | [`claude-instance`](../claude-instance/) |
 | `Worktree.pr` | [`gh`](../gh/) |
 | `Worktree.issue` | [`gh`](../gh/) |
 
-The cross-domain join IS the GraphQL graph; per [R5](../../RULES.md), the resolver here imports the consumer's service interface and does not reach into another domain's provider.
+Each producing domain imports only a narrow service interface from `git` (per [R4, R5](../../RULES.md)) to look up the Worktree's `path` and `branch` — never the `git` provider directly.
 
 ## Current source location (pre-refactor)
 

--- a/daemon/git/schema.graphql
+++ b/daemon/git/schema.graphql
@@ -5,13 +5,13 @@
 # Mutations (to be added in #613): worktreeCreate, worktreeRemove, worktreeMove,
 #                                  fetch, pull, push. All exec `scripts/<op>`.
 #
-# Cross-domain fields on Worktree (resolved here, types owned elsewhere):
-#   processes      → ps
-#   tmuxPanes      → tmux
-#   tmuxSession    → tmux
-#   claudeInstances → claude-jsonls
-#   pr             → gh
-#   issue          → gh
+# Cross-domain fields on Worktree live in the PRODUCING domain's partial (S15b):
+#   processes       → daemon/ps/schema.graphql
+#   tmuxPanes       → daemon/tmux/schema.graphql
+#   tmuxSession     → daemon/tmux/schema.graphql
+#   claudeInstances → daemon/claude-instance/schema.graphql
+#   pr              → daemon/gh/schema.graphql
+#   issue           → daemon/gh/schema.graphql
 
 extend type Query {
   "All repos declared in ~/.orchard/config.json. Read-only — repos are added with `orchard config add-repo`."
@@ -78,52 +78,6 @@ type Worktree implements Node {
 
   "owner/repo slug derived from origin remote. Null when origin is not a GitHub URL."
   repo: String
-
-  """
-  PR whose headRef matches this worktree's branch.
-
-  Selection precedence (#489): an OPEN PR is returned when one exists;
-  otherwise the most-recent CLOSED/MERGED PR with the matching headRef is
-  returned so the TUI stale-fade UX can render the post-merge cleanup
-  affordance. The `state` field on the returned PullRequest disambiguates
-  between live and post-merge.
-
-  Null when no PR has ever existed for this branch in any state, when the
-  branch is detached, or when the branch is the project's default branch.
-  Cross-domain field; resolver here calls the `gh` service.
-  """
-  pr: PullRequest
-
-  "Issue linked from the worktree's branch (issue<N>/... convention). Cross-domain field; resolver here calls the `gh` service."
-  issue: Issue
-
-  "Processes whose cwd lies under `path`. Cross-domain field; resolver here calls the `ps` service."
-  processes: [Process!]!
-
-  """
-  Tmux panes whose foreground-process cwd equals `path` exactly OR has `path + '/'` as a prefix (#511).
-  Returns the matching pane list for every worktree, derived from a server-side join of pane.process.cwd
-  against the worktree path. Ordered deterministically by paneId ascending.
-  Cross-domain field; resolver here calls the `tmux` service.
-  """
-  tmuxPanes: [TmuxPane!]!
-
-  """
-  The most-recently-active tmux session among the panes returned by `tmuxPanes` (#511).
-  When two sessions tie on lastActivityAt, the session with the lexicographically-first name wins.
-  Cross-domain field; resolver here calls the `tmux` service.
-  """
-  tmuxSession: TmuxSession
-
-  """
-  Claude REPLs whose resolved process cwd lies under this worktree's `path`.
-  Server-side join over the claude-jsonls + ps domains. Ordered deterministically by `id` ascending.
-
-  Note: a ClaudeInstance is a *running REPL* identified by sessionUuid — distinct from
-  a TmuxSession (tmux's server grouping of windows/panes). A worktree can carry zero or
-  many of each. Cross-domain field; resolver here calls the `claude-jsonls` service.
-  """
-  claudeInstances: [ClaudeInstance!]!
 
   """
   Number of commits the worktree's branch is AHEAD of its upstream tracking

--- a/daemon/ps/schema.graphql
+++ b/daemon/ps/schema.graphql
@@ -4,6 +4,9 @@
 # Cross-domain: extend Host with processes(filter), extend Subscription with processes.
 # Note: Process.{worktree, claudeInstance} are cross-domain back-edges; declared here,
 #       resolved here by calling into git's and claude-jsonls' services respectively.
+#
+# Cross-domain `extend type Worktree` (S15b: ps is the data producer):
+#   Worktree.processes — processes whose cwd lies under the worktree path
 
 extend type Query {
   """
@@ -100,4 +103,17 @@ input ProcessFilter {
 
   "Match processes by pid."
   pidIn: [Int!]
+}
+
+# ---------------------------------------------------------------------
+# S15b: cross-domain `extend type Worktree` — ps produces process data.
+# The resolver lives in daemon/ps/ and calls the ps service.
+# ---------------------------------------------------------------------
+
+extend type Worktree {
+  """
+  Processes whose cwd lies under `path`.
+  Resolver calls the ps service (S15b: producer domain owns the field).
+  """
+  processes: [Process!]!
 }

--- a/daemon/tmux/schema.graphql
+++ b/daemon/tmux/schema.graphql
@@ -6,6 +6,10 @@
 # Owns: Subscription.tmuxSessionsChanged.
 # Owns: Mutation.sendTextToPane (L5: execs `scripts/tmux-send-text.sh`).
 #
+# Cross-domain `extend type Worktree` (S15b: tmux is the data producer):
+#   Worktree.tmuxPanes    — panes whose cwd matches the worktree path
+#   Worktree.tmuxSession  — most-recently-active session among those panes
+#
 # Cross-domain consumers (per dependency-graph north star):
 #   ps             → TmuxPane.process needs the Process node.
 #   claude-jsonls  → TmuxPane.claudeInstance is derived from a Claude jsonl matching
@@ -375,4 +379,27 @@ input TmuxPaneFilter {
   PanesByCommand.
   """
   command: String
+}
+
+# ---------------------------------------------------------------------
+# S15b: cross-domain `extend type Worktree` — tmux produces pane data.
+# The resolver lives in daemon/tmux/ and calls the tmux service.
+# ---------------------------------------------------------------------
+
+extend type Worktree {
+  """
+  Tmux panes whose foreground-process cwd equals `path` exactly OR has `path + '/'`
+  as a prefix (#511). Derived from a server-side join of pane.process.cwd against
+  the worktree path. Ordered deterministically by paneId ascending.
+  Resolver calls the tmux service (S15b: producer domain owns the field).
+  """
+  tmuxPanes: [TmuxPane!]!
+
+  """
+  The most-recently-active tmux session among the panes returned by `tmuxPanes` (#511).
+  When two sessions tie on lastActivityAt, the session with the lexicographically-first
+  name wins. Null when no panes match the worktree path.
+  Resolver calls the tmux service (S15b: producer domain owns the field).
+  """
+  tmuxSession: TmuxSession
 }


### PR DESCRIPTION
## Summary

RULES.md S15b states: *"When domain A adds a field to a type owned by domain B, the `extend type` block lives in A's partial and the resolver lives in A."* (A = producer of data, B = type owner.)

The swarm refactor (PR #634 audit) flagged that `Worktree.tmuxPanes`, `Worktree.tmuxSession`, `Worktree.claudeInstances`, `Worktree.pr`, `Worktree.issue`, and `Worktree.processes` were all declared inside the `type Worktree` block in `daemon/git/schema.graphql`. `git` owns the `Worktree` type — it is not the data producer for any of those fields.

### What moved

| Field | From | To |
|---|---|---|
| `Worktree.tmuxPanes` | `daemon/git/schema.graphql` | `daemon/tmux/schema.graphql` |
| `Worktree.tmuxSession` | `daemon/git/schema.graphql` | `daemon/tmux/schema.graphql` |
| `Worktree.claudeInstances` | `daemon/git/schema.graphql` | `daemon/claude-instance/schema.graphql` |
| `Worktree.pr` | `daemon/git/schema.graphql` | `daemon/gh/schema.graphql` |
| `Worktree.issue` | `daemon/git/schema.graphql` | `daemon/gh/schema.graphql` |
| `Worktree.processes` | `daemon/git/schema.graphql` | `daemon/ps/schema.graphql` |

Each field is now an `extend type Worktree` block in the domain that **produces** the data. `daemon/git/schema.graphql` declares only the core git-owned fields (`id`, `path`, `branch`, `head`, `bare`, `host`, `repo`, `ahead`, `behind`).

`daemon/git/README.md` updated to correct the cross-domain ownership table.

## Constraint notes

- Does NOT touch `daemon/features/` (another agent's lane)
- Does NOT modify RULES.md (S15b rule text is already correct — only the implementation violated it)
- Does NOT touch `internal/server/*` (legacy code, unmodified)
- No Go resolver files existed in `daemon/` on this branch (schema-only constitution) — resolver placement will be enforced naturally when swarm agents implement them

## Test plan

- [x] `go test ./...` — all 24 packages pass (schema files are not compiled by Go)
- [x] Each `extend type Worktree` block is in the domain that produces the data (verified against S15b)
- [x] `daemon/git/schema.graphql` contains no cross-domain fields in its `type Worktree` declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #15