### PR TITLE
fix(tmux): daemon-side discovery blind on tmux 3.x (empty tmuxSessions/claudeInstances)

### DIFF
--- a/internal/server/providers/tmux/adapter.go
+++ b/internal/server/providers/tmux/adapter.go
@@ -1,9 +1,11 @@
 // Adapter wraps the tmux CLI. Per ADR-011 §3 it is stateless: cache,
 // watcher, and invalidation live in the surrounding Provider.
 //
-// All field separation in -F format strings uses U+0001 (`\x01`) — tmux
-// never emits that byte for the format-variables we read, so the parser
-// never needs to consider quoting or escaping.
+// All field separation in -F format strings uses a TAB (U+0009) — see
+// fieldSep for why a control byte (the previous U+0001 choice) cannot be
+// used: tmux 3.x's format engine renders raw control bytes in a -F string
+// as their octal escape text (e.g. `\001`) rather than emitting the byte,
+// which collapses every output row to a single un-splittable field.
 
 package tmux
 
@@ -21,10 +23,25 @@ import (
 	"time"
 )
 
-// Field separator in -F format strings. tmux format-variables we read
-// (names, indexes, integers, paths, terminal names) never contain this
-// byte, so splitting on it round-trips losslessly.
-const fieldSep = "\x01"
+// Field separator in -F format strings.
+//
+// MUST be a printable character that tmux's format engine emits verbatim.
+// The previous choice — U+0001 (SOH) — does NOT round-trip on tmux 3.x:
+// the engine renders a raw control byte in a -F template as its 4-char
+// octal escape (`\001`), so a row like `name\001id\001…` came back as the
+// literal text `name\001id\001…` with zero real separators. listAll then
+// saw field-count==1, failed its `!= listAllFieldCount` guard, and dropped
+// every row — surfacing as empty tmuxSessions / claudeInstances even though
+// `tmux list-panes -a` clearly returned data. (The old comment claimed this
+// was "verified against tmux 3.5+ on macOS"; the regression bites tmux 3.4
+// on Linux.)
+//
+// TAB is tmux's conventional scripting delimiter and round-trips faithfully.
+// The tmux metadata we read (session/window names, indexes, integers, pids,
+// dimensions, pane_current_command, pane_title) does not contain tabs in
+// practice — same risk posture the SOH choice assumed, with a separator that
+// actually works.
+const fieldSep = "\t"
 
 // CommandRunner is the test seam — production wires execRunner.
 type CommandRunner interface {
@@ -100,7 +117,7 @@ func signalName(sig syscall.Signal) string {
 
 // Adapter is the tmux CLI client. The alive-check result is cached for
 // aliveTTL (default = DefaultPollInterval) so consecutive FetchAll cycles
-// do not each pay for a separate `tmux info` exec.
+// do not each pay for a separate liveness-probe exec (see IsAlive).
 //
 // The cache lives behind a pointer so the With*-builder methods can do a
 // shallow value-copy of Adapter without copying the embedded mutex —
@@ -116,9 +133,9 @@ type Adapter struct {
 	alive    *aliveCache
 }
 
-// aliveCache memoises the result of `tmux info` for one TTL window. It
-// is heap-allocated and shared across With*-derived Adapter copies so the
-// mutex inside is not copied by value.
+// aliveCache memoises the result of the liveness probe (see IsAlive) for
+// one TTL window. It is heap-allocated and shared across With*-derived
+// Adapter copies so the mutex inside is not copied by value.
 type aliveCache struct {
 	mu          sync.Mutex
 	lastChecked time.Time
@@ -126,7 +143,7 @@ type aliveCache struct {
 }
 
 // defaultAliveTTL matches DefaultPollInterval so a single FetchAll within
-// one tick never calls `tmux info` twice.
+// one tick never runs the liveness probe twice.
 const defaultAliveTTL = DefaultPollInterval
 
 // NewAdapter constructs an Adapter targeting the default tmux socket on
@@ -201,10 +218,20 @@ func (a *Adapter) tmuxArgs(rest ...string) []string {
 	return out
 }
 
-// IsAlive shells out the cheapest possible command to detect a live tmux
-// server. Results are cached for aliveTTL (default = DefaultPollInterval) so
-// a single FetchAll cycle — which calls IsAlive before listAll — never pays
-// for two `tmux info` execs within the same tick.
+// IsAlive shells out the cheapest possible SERVER-scoped command to detect a
+// live tmux server. Results are cached for aliveTTL (default =
+// DefaultPollInterval) so a single FetchAll cycle — which calls IsAlive before
+// listAll — never pays for two probe execs within the same tick.
+//
+// Issue: the probe must be SERVER-scoped, not CLIENT-scoped. `tmux info` is a
+// client command: it exits non-zero with "no current client" when run from a
+// process that is not attached to a tmux client — which is exactly the daemon's
+// situation (a detached background process). Under that probe IsAlive returned
+// false even though the server was alive and `list-panes -a` returned data,
+// short-circuiting FetchAll to an empty snapshot. `tmux list-sessions` is
+// server-scoped: it exits 0 (and lists sessions) whenever a server is running,
+// regardless of client attachment, and exits non-zero ("no server running" /
+// "error connecting") when the server is dead — correct in both directions.
 //
 // Stale-true window: between server death and the next TTL expiry (≤TTL),
 // IsAlive may return true even though the server is dead. The next FetchAll
@@ -225,7 +252,9 @@ func (a *Adapter) IsAlive(ctx context.Context) bool {
 	}
 	a.alive.mu.Unlock()
 
-	_, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("info")...)
+	// `-F ''` suppresses the per-session output line — we only care about the
+	// exit code, not the session list (FetchAll's listAll does the real read).
+	_, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("list-sessions", "-F", "")...)
 	result := err == nil
 
 	a.alive.mu.Lock()
@@ -238,7 +267,9 @@ func (a *Adapter) IsAlive(ctx context.Context) bool {
 
 // FetchAll fetches a full Snapshot in at most 3 tmux execs per cycle:
 //
-//  1. `tmux info` — via IsAlive (cached for aliveTTL; 0 execs when warm).
+//  1. `tmux list-sessions` — via IsAlive (cached for aliveTTL; 0 execs when
+//     warm). Server-scoped liveness probe; see IsAlive for why `tmux info`
+//     (client-scoped) is wrong for a detached daemon.
 //  2. `tmux list-panes -a -F …` — via listAll, which synthesises session,
 //     window, and pane maps from a single output stream.
 //  3. `tmux list-clients -F …` — via listClients, which populates the Clients

--- a/internal/server/providers/tmux/adapter_test.go
+++ b/internal/server/providers/tmux/adapter_test.go
@@ -27,7 +27,14 @@ func (f fakeRunner) Run(ctx context.Context, name string, args ...string) ([]byt
 		return out, nil
 	}
 	// Match by leading verb when the caller supplies a partial key —
-	// keeps test data short.
+	// keeps test data short. Errors are matched by prefix too so a staged
+	// failure for e.g. "tmux list-sessions" fires even when the real call
+	// appends flags ("tmux list-sessions -F ").
+	for prefix, err := range f.errs {
+		if strings.HasPrefix(key, prefix) {
+			return f.out[prefix], err
+		}
+	}
 	for prefix, out := range f.out {
 		if strings.HasPrefix(key, prefix) {
 			return out, nil
@@ -37,10 +44,12 @@ func (f fakeRunner) Run(ctx context.Context, name string, args ...string) ([]byt
 }
 
 func TestListPanes_EmptyOnNoServer(t *testing.T) {
+	// IsAlive probes with `tmux list-sessions`; staging that as a
+	// "no server running" error drives FetchAll down the dead-server path.
 	a := NewAdapter("h").WithRunner(fakeRunner{out: map[string][]byte{
-		"tmux info": nil,
+		"tmux list-sessions": nil,
 	}, errs: map[string]error{
-		"tmux info": errFake("no server running"),
+		"tmux list-sessions": errFake("no server running"),
 	}})
 
 	snap, err := a.FetchAll(context.Background())

--- a/internal/server/providers/tmux/exec_count_test.go
+++ b/internal/server/providers/tmux/exec_count_test.go
@@ -120,10 +120,12 @@ func TestRegression_FetchAllExecCount_Issue464(t *testing.T) {
 			callSet[c] = true
 		}
 
-		// After the fix the alive probe should still be present.
-		hasAliveProbe := callSet["info"] || callSet["display-message"] || callSet["server-info"]
+		// After the fix the alive probe should still be present. The probe is
+		// `list-sessions` (server-scoped); `info` is client-scoped and returns
+		// "no current client" for a detached daemon — see Adapter.IsAlive.
+		hasAliveProbe := callSet["list-sessions"] || callSet["info"] || callSet["display-message"] || callSet["server-info"]
 		if !hasAliveProbe {
-			t.Logf("advisory: expected an alive-probe subcommand (info/display-message/server-info); got %v", runner.calls)
+			t.Logf("advisory: expected an alive-probe subcommand (list-sessions/info/display-message/server-info); got %v", runner.calls)
 		}
 
 		// After the fix pane data should still be fetched — it is the richest

--- a/internal/server/providers/tmux/list_all_test.go
+++ b/internal/server/providers/tmux/list_all_test.go
@@ -17,12 +17,14 @@ func buildListAllLine(
 	winIndex, winName, winActive, winPanes, winActivePaneID,
 	paneID, paneTitle, paneCmd, panePID, paneWidth, paneHeight, paneDead string,
 ) string {
-	const sep = "\x01"
+	// Use the production field separator so the test data round-trips through
+	// the same split the parser uses. (fieldSep moved from U+0001 to TAB once
+	// tmux 3.x was found to escape control bytes in -F templates.)
 	return strings.Join([]string{
 		sessName, sessCreated, sessAttached, sessActivity, sessWindows, sessWindowIndex,
 		winIndex, winName, winActive, winPanes, winActivePaneID,
 		paneID, paneTitle, paneCmd, panePID, paneWidth, paneHeight, paneDead,
-	}, sep)
+	}, fieldSep)
 }
 
 // TestListAll_OnePaneOneWindowOneSession verifies the simplest happy path.
@@ -276,11 +278,15 @@ func TestFetchAll_TotalExecCount(t *testing.T) {
 	}
 }
 
-// staleAliveRunner returns success for `info` but "no server running" for
-// list-* — simulating tmux dying between the IsAlive cache hit and the
-// list call. Used by TestFetchAll_StaleAliveCache_RecoversToDeadServer.
+// staleAliveRunner returns success for the alive probe (`list-sessions`) but
+// "no server running" for the data list-* calls — simulating tmux dying
+// between the IsAlive cache hit and the list call. Used by
+// TestFetchAll_StaleAliveCache_RecoversToDeadServer.
+//
+// Arg-matching note: the alive probe is `list-sessions`, distinct from the
+// data-fetch `list-panes`; an exact per-arg switch keeps them separate.
 type staleAliveRunner struct {
-	infoCalls       int
+	aliveCalls      int
 	listPanesCalls  int
 	listClientCalls int
 }
@@ -288,8 +294,8 @@ type staleAliveRunner struct {
 func (r *staleAliveRunner) Run(_ context.Context, _ string, args ...string) ([]byte, error) {
 	for _, arg := range args {
 		switch arg {
-		case "info":
-			r.infoCalls++
+		case "list-sessions":
+			r.aliveCalls++
 			return []byte("ok"), nil
 		case "list-panes":
 			r.listPanesCalls++
@@ -312,12 +318,12 @@ func TestFetchAll_StaleAliveCache_RecoversToDeadServer(t *testing.T) {
 	a := NewAdapter("h").WithRunner(r).WithAliveTTL(10 * time.Second)
 	ctx := context.Background()
 
-	// Warm the alive cache: info succeeds, IsAlive returns true.
+	// Warm the alive cache: list-sessions succeeds, IsAlive returns true.
 	if !a.IsAlive(ctx) {
-		t.Fatalf("warm-up: IsAlive should be true with succeeding info call")
+		t.Fatalf("warm-up: IsAlive should be true with succeeding list-sessions probe")
 	}
 
-	// FetchAll: IsAlive uses the cache (no info call), list-panes returns
+	// FetchAll: IsAlive uses the cache (no probe call), list-panes returns
 	// errNoServer → adapter should invalidate the cache and ship Alive=false.
 	snap, err := a.FetchAll(ctx)
 	if err != nil {
@@ -333,7 +339,7 @@ func TestFetchAll_StaleAliveCache_RecoversToDeadServer(t *testing.T) {
 
 	// Cache should now be invalidated — next IsAlive should re-probe.
 	_ = a.IsAlive(ctx)
-	if r.infoCalls != 2 {
-		t.Errorf("after invalidation, IsAlive should re-probe; want 2 info calls, got %d", r.infoCalls)
+	if r.aliveCalls != 2 {
+		t.Errorf("after invalidation, IsAlive should re-probe; want 2 list-sessions probe calls, got %d", r.aliveCalls)
 	}
 }


### PR DESCRIPTION
## Problem

On a live host with a running tmux session, the daemon's GraphQL resolvers `tmuxSessions` and `claudeInstances` both returned `[]` — the daemon was **blind** to local sessions. The daemon process had the correct env (`TMUX` set, default socket reachable) and `tmux list-panes -a` from a shell returned data, so this was a **server-side discovery bug**, not an env/socket problem.

Root-caused to **two independent bugs in the tmux adapter** (`internal/server/providers/tmux/adapter.go`), each sufficient on its own to blank the snapshot. Both bite **tmux 3.x on Linux** (the box ran tmux 3.4); the code was written/verified against tmux 3.5+ on macOS.

## Bug 1 — client-scoped liveness probe

`FetchAll` calls `IsAlive` before `listAll`, and `IsAlive` probed `tmux info`. `tmux info` is a **client** command: it exits non-zero with `no current client` when run from a process not attached to a tmux client — exactly the daemon's situation (a detached background process). So `IsAlive` returned `false`, `FetchAll` short-circuited to `EmptySnapshot` with `Alive:false`, and `listAll` never ran.

**Fix:** probe with `tmux list-sessions -F ''` — server-scoped, exit 0 whenever a server is running regardless of client attachment, non-zero (`no server running` / `error connecting`) when dead. Correct in both directions.

## Bug 2 — control-byte field separator

`listAll` / `listClients` built their `-F` format strings with `fieldSep = U+0001` (SOH). tmux 3.x's format engine renders a raw control byte in a `-F` template as its **4-char octal escape text** (`\001`) rather than emitting the byte. Every output row therefore came back as one un-splittable field; `listAll`'s `len(fields) != listAllFieldCount` guard then dropped every row.

**Fix:** `fieldSep = "\t"` (TAB) — tmux's conventional scripting delimiter, emitted verbatim. Same risk posture the SOH choice assumed (tmux metadata fields don't contain the separator in practice), with a separator that actually round-trips.

## Verification

- Against a sandbox tmux, the adapter now returns 1 session / 1 window / 1 pane (was 0/0/0).
- Live daemon after rebuild + restart:
  ```
  $ curl -s http://127.0.0.1:7777/graphql -X POST -H 'Content-Type: application/json' \
      --data '{"query":"{ tmuxSessions { name } claudeInstances { sessionUuid } }"}'
  {"data":{"tmuxSessions":[{"name":"boxd_orchardist"}],"claudeInstances":[{"sessionUuid":null}]}}
  ```
- `go test ./internal/server/providers/tmux/` is green, including two E2E tests that were **already red on `main`** because they exercise a detached sandbox tmux and tripped both bugs: `TestEndToEnd_SessionAppearsAndDisappears` and `TestRegression_FetchAllSurvivesFastPolls_Issue464_Linux`.

## Test changes

Mechanical only: fake-runner probe arg `info` → `list-sessions`; `buildListAllLine` and the exec-count advisory updated to the new `fieldSep` / probe name. No behavioral test was weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tmux session liveness detection and parsing for better compatibility with tmux 3.x behavior.
  * Fixed field separator handling in tmux command output parsing to ensure reliable session data retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #3