### PR TITLE
feat(orchard-gui): live create+chat, BDD-green (AC2 renders durably, AC3 create→send→reply 11/11)

### DIFF
--- a/crates/orchard-gui/features/gui-create-chat.feature
+++ b/crates/orchard-gui/features/gui-create-chat.feature
@@ -1,0 +1,57 @@
+Feature: GUI create + chat from the browser — launchSession + sendTextToPane
+  As a user on the live HTTPS GUI (no Tauri desktop app)
+  I want to create a Claude session and chat with it entirely from the browser
+  So that I can drive a fresh REPL and see its replies without terminal access.
+
+  Operations consumed:
+    Mutation.launchSession(input: LaunchSessionInput!): LaunchSessionResult!
+    Mutation.sendTextToPane(paneId: String!, text: String!): Boolean!
+    Subscription.conversationChanged(sessionUuid: String!): Conversation
+    GET /v1/conversations/<sessionUuid>/jsonl   (transcript body)
+
+  These scenarios are driven end-to-end against the LIVE HTTPS endpoint by the
+  companion driver `tests/create-chat.drive.mjs` (a plain Playwright script — no
+  Gherkin runner). Every Then/And line below maps 1:1 to one logged assertion in
+  that driver, so a green driver run proves this file scenario-for-scenario.
+
+  Background:
+    Given the daemon is running and reachable through the GUI's /__daemon proxy
+    And the GUI is loaded in a desktop-width browser (surface = desktop, not Tauri)
+
+  @live
+  Scenario: Create a real Claude session from the New Conversation modal
+    When the user clicks New and the Launch button in the modal
+    Then a success toast "Launched <sessionName>" is shown
+    And a new tmux session appears that was not present before the click
+    And that session's pane is running the claude command
+
+  @live
+  Scenario: A browser-created session opens a usable chat composer
+    When the launched session opens in the deep view
+    Then the message composer textarea (placeholder "Message…") is visible
+    And no "No tmux pane resolved" or "desktop app required" placeholder is shown
+    # The composer renders on the raw paneId before the daemon indexes the pane,
+    # because browser desktop now defaults to chat view (inTauri() gate).
+
+  @live
+  Scenario: Sending a message submits it to the pane (sendTextToPane)
+    When the user types a message and presses Enter in the composer
+    Then the textarea clears instantly (optimistic, before the mutation resolves)
+    And the message text reaches the target tmux pane and is submitted to Claude
+    # Submit needs the two-step send-keys + gap fix; a fresh REPL otherwise leaves
+    # the text unsent at the prompt (Enter absorbed by paste-coalesce).
+
+  @live
+  Scenario: Claude's reply streams into the transcript without a manual refresh
+    Given the user has sent a message to the session
+    When Claude appends its reply to the JSONL on disk
+    Then conversationChanged fires over the WebSocket and the transcript re-fetches
+    And an assistant turn ([data-role="assistant"]) containing the reply renders in the GUI
+    # Live WS requires the daemon started with ORCHARD_ALLOWED_ORIGINS = the boxd
+    # HTTPS origin, else the subscription handshake is refused (403).
+
+  @live
+  Scenario: End-to-end create → chat → reply entirely on the live HTTPS URL
+    When the user creates a session, sends a message, and waits for the reply
+    Then the whole flow completes from https://orchard-gui.drewdrewthis.boxd.sh
+    And there are no uncaught page errors during the flow

--- a/crates/orchard-gui/features/gui-new-conversation.feature
+++ b/crates/orchard-gui/features/gui-new-conversation.feature
@@ -59,8 +59,10 @@ Feature: GUI new conversation modal — WorktreesList + HostsList
     Then cpu: 72% is displayed under the hostname button
 
   @integration
-  Scenario: Launch emits (worktreeId, host, model, task) — no client-side joins
+  Scenario: Launch emits (worktreeId, cwd, host, model, task) and calls launchSession
     When the user picks a worktree and clicks Launch
-    Then onLaunch is called with { worktreeId, host, model, task }
-    And no client-side cwd→worktree resolution occurs (worktreeId is the daemon-assigned ID)
+    Then onLaunch is called with { worktreeId, cwd, host, model, task }
+    And cwd is the picked worktree's path read from the already-loaded picker row (no fresh query)
+    And the page calls the daemon launchSession mutation with { cwd, model, prompt }
     And model defaults to "claude-sonnet-4-5" unless changed
+    And Launch is disabled until a worktree is selected (host and cur both required)

--- a/crates/orchard-gui/features/gui-render-no-regression.feature
+++ b/crates/orchard-gui/features/gui-render-no-regression.feature
@@ -1,0 +1,26 @@
+Feature: GUI renders without regression on the live HTTPS endpoint
+  As a user who can open https://orchard-gui.drewdrewthis.boxd.sh at any time
+  I want the page to always render a real UI after a server bring-up or change
+  So that the create+chat work never lands the GUI on a blank/white screen.
+
+  This is the "never let the page go blank again" gate. Every Then/And line
+  below maps 1:1 to one logged check in the companion driver
+  `tests/render-gate.mjs` (a plain Playwright script — no Gherkin runner), so a
+  green run proves this file line-for-line. Run it after every change that
+  touches the served bundle, and as the no-regression tail of the create+chat
+  suite.
+
+  Background:
+    Given the gui-servers tmux session is up (daemon :7777 + vite preview :4173)
+    And a desktop-width browser loads the live HTTPS URL
+
+  @live
+  Scenario: The live GUI renders a real UI, not a blank screen
+    When the browser navigates to https://orchard-gui.drewdrewthis.boxd.sh
+    Then the endpoint answers 200
+    And the body is not blank (rendered text present)
+    And the app shell mounted (hydration root populated)
+    And the "Orchard" brand chrome rendered
+    And the "New" conversation entrypoint is visible
+    And the sidebar/main rendered from live daemon state
+    And there are no uncaught page errors during load

--- a/crates/orchard-gui/pnpm-workspace.yaml
+++ b/crates/orchard-gui/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# pnpm 11+ build-script approval. esbuild ships a native binary and needs its
+# install script to run; without this, `pnpm install`/`pnpm build` abort with
+# ERR_PNPM_IGNORED_BUILDS. esbuild is a trusted, widely-used build dependency.
+allowBuilds:
+  esbuild: true

--- a/crates/orchard-gui/schema.graphql
+++ b/crates/orchard-gui/schema.graphql
@@ -182,9 +182,15 @@ type Contract implements Node {
 
 """Filter for `Query.contracts`. All fields are optional."""
 input ContractFilter {
-  """Match closed contracts whose closedReason is in this list. Ignored for SIGNED contracts."""
+  """
+  Match closed contracts whose closedReason is in this list. Ignored for SIGNED contracts.
+  """
   closedReasons: [ContractReason!]
+
+  """Match contracts owned by this Claude session UUID."""
   ownerSessionId: String
+
+  """Match contracts whose folded status is in this list."""
   statuses: [ContractStatus!]
 }
 
@@ -260,7 +266,9 @@ type Conversation implements Node {
   """
   open: Boolean!
 
-  """Daemon-derived recap from the most recent `/recap` slash-command invocation in this session. Null when no `/recap` has been invoked."""
+  """
+  Daemon-derived recap from the most recent `/recap` slash-command invocation in this session. Null when no `/recap` has been invoked.
+  """
   recap: String
 
   """
@@ -549,6 +557,53 @@ type Label {
 }
 
 """
+Input for launchSession. Anchored to (host, cwd) semantics (ADR-009);
+v1 is local-host only, so host is implicit.
+"""
+input LaunchSessionInput {
+  """
+  Absolute working directory the session runs in — typically a worktree path. A leading ~ is expanded daemon-side.
+  """
+  cwd: String!
+
+  """
+  Optional model alias or full name (e.g. "opus", "claude-sonnet-4-6"). Passed to `claude --model` when present.
+  """
+  model: String
+
+  """
+  Optional tmux session name. When omitted the daemon derives one from the cwd basename plus a short unique suffix; collisions are de-duplicated.
+  """
+  name: String
+
+  """
+  Optional first prompt. When present it is passed to Claude as the initial task so the agent starts working immediately.
+  """
+  prompt: String
+}
+
+"""
+Result of launchSession: the freshly created tmux session, the Claude REPL pane to target for chat sends, and the pre-assigned session UUID.
+"""
+type LaunchSessionResult {
+  """The working directory the session was launched in (after ~ expansion)."""
+  cwd: String!
+
+  """
+  The tmux pane id running the Claude REPL (e.g. "%73"). Target this with sendTextToPane.
+  """
+  paneId: String!
+
+  """The tmux session name that was created (after de-duplication)."""
+  sessionName: String!
+
+  """
+  The pre-assigned Claude session UUID. Subscribe to conversationChanged(sessionUuid:) to stream the transcript as it grows.
+  """
+  sessionUuid: String!
+}
+
+"""
 Whether GitHub considers the PR mergeable. UNKNOWN means GitHub is still computing.
 """
 enum MergeableState {
@@ -599,6 +654,27 @@ Every mutation MUST:
   - Be reversible or idempotent where reasonable
 """
 type Mutation {
+  """
+  Launch a new Claude REPL inside a fresh detached tmux session at the
+  given working directory.
+  
+  The daemon creates the tmux session (`tmux new-session -d -s <name>
+  -c <cwd>`), resolves the new pane, then types
+  `claude --session-id <uuid> --dangerously-skip-permissions --effort max`
+  (plus `--model` and an initial prompt when supplied) into the pane and
+  submits it — mirroring sendTextToPane's literal-write + Enter so the
+  REPL boots in the user's login shell with full env.
+  
+  The session UUID is pre-assigned (`claude --session-id`) so the caller
+  can `conversationChanged(sessionUuid:)`-subscribe and target the pane
+  with `sendTextToPane` immediately, without waiting for the JSONL to
+  first appear under an unknown id.
+  
+  Use case: browser / mobile clients creating a new working session on a
+  host where they have no shell access.
+  """
+  launchSession(input: LaunchSessionInput!): LaunchSessionResult!
+
   """
   Send literal text to a tmux pane, followed by an Enter keypress.
   
@@ -1194,7 +1270,11 @@ type TmuxPane implements Node {
 """Filter for `Query.tmuxPanes`. AND-combined when multiple are set."""
 input TmuxPaneFilter {
   """
-  Only include panes whose foreground-process command basename contains this substring, case-insensitive (ADR-022 PanesByCommand axis).
+  Only include panes whose foreground-process command basename contains this
+  substring (case-insensitive). Uses the ps provider for the real command name
+  so node-wrapped CLIs (e.g. `node /usr/local/bin/claude`) resolve correctly;
+  falls back to `currentCommand` when ps is unavailable. ADR-022 axis:
+  PanesByCommand.
   """
   command: String
 
@@ -1211,7 +1291,10 @@ input TmuxPaneFilter {
   currentCommandIn: [String!]
 
   """
-  Only include panes whose foreground-process cwd matches (ADR-022 PanesByCwd axis).
+  Only include panes whose foreground-process cwd equals `cwd` exactly or has
+  `cwd + '/'` as a prefix (server-side join via the ps provider, same path as
+  Worktree.tmuxPanes). Requires ps provider to be wired; panes whose cwd cannot
+  be resolved are silently skipped. ADR-022 axis: PanesByCwd.
   """
   cwd: String
 

--- a/crates/orchard-gui/src/lib/components/NewConversation.svelte
+++ b/crates/orchard-gui/src/lib/components/NewConversation.svelte
@@ -21,7 +21,7 @@
 		open: boolean;
 		surface: "desktop" | "mobile";
 		onClose: () => void;
-		onLaunch: (spec: { worktreeId: string; host: string; model: string; task: string }) => void;
+		onLaunch: (spec: { worktreeId: string; cwd: string; host: string; model: string; task: string }) => void;
 	};
 	let { open, surface, onClose, onLaunch }: Props = $props();
 
@@ -253,8 +253,8 @@
 					<button
 						class="btn-primary"
 						style="display: inline-flex; align-items: center; gap: 6px;"
-						onclick={() => onLaunch({ worktreeId, host, model, task })}
-						disabled={!host}
+						onclick={() => onLaunch({ worktreeId, cwd, host, model, task })}
+						disabled={!host || !cur}
 					>
 						<Icon name="sparkle" size={13} />
 						<span>Launch</span>

--- a/crates/orchard-gui/src/lib/data/daemon.ts
+++ b/crates/orchard-gui/src/lib/data/daemon.ts
@@ -123,5 +123,9 @@ export async function launchSession(input: LaunchSessionInput): Promise<LaunchSe
 	if (body.errors && body.errors.length > 0) {
 		throw new Error(body.errors[0].message ?? "launchSession failed");
 	}
-	return body.data.launchSession as LaunchSessionResult;
+	const launched = body.data?.launchSession;
+	if (!launched) {
+		throw new Error("launchSession returned no data");
+	}
+	return launched as LaunchSessionResult;
 }

--- a/crates/orchard-gui/src/lib/data/daemon.ts
+++ b/crates/orchard-gui/src/lib/data/daemon.ts
@@ -22,6 +22,14 @@ function endpoints(): { ws: string } {
 	return { ws: `${wsProto}//${window.location.host}/__daemon/graphql` };
 }
 
+/** Same-origin daemon GraphQL HTTP endpoint (via the Vite/boxd `/__daemon` proxy). */
+function httpEndpoint(): string {
+	if (typeof window === "undefined" || !window.location) {
+		return "http://127.0.0.1:7777/graphql";
+	}
+	return `${window.location.origin}/__daemon/graphql`;
+}
+
 let _ws: WsClient | null = null;
 function ws(): WsClient {
 	if (!_ws) _ws = createWsClient({ url: endpoints().ws, lazy: true });
@@ -60,4 +68,60 @@ export function subscribeConversation(
 			complete: () => {},
 		},
 	);
+}
+
+export interface LaunchSessionInput {
+	/** Absolute working directory (a worktree path) to launch the session in. */
+	cwd: string;
+	/** Optional tmux session name; daemon derives + de-dupes one when absent. */
+	name?: string;
+	/** Optional model alias/full name passed to `claude --model`. */
+	model?: string;
+	/** Optional first prompt — Claude starts on it immediately. */
+	prompt?: string;
+}
+
+export interface LaunchSessionResult {
+	sessionName: string;
+	paneId: string;
+	sessionUuid: string;
+	cwd: string;
+}
+
+const LAUNCH_SESSION = `
+	mutation LaunchSession($input: LaunchSessionInput!) {
+		launchSession(input: $input) {
+			sessionName
+			paneId
+			sessionUuid
+			cwd
+		}
+	}
+`;
+
+/**
+ * Create a new Claude REPL via the daemon's `launchSession` mutation —
+ * the "create" counterpart to sendTextToPane (chat). The daemon creates a
+ * detached tmux session at `cwd` and boots `claude` inside it with a
+ * pre-assigned session UUID, returned here so the caller can open the
+ * session (paneId for chat sends, sessionUuid for the transcript
+ * subscription) without waiting for the daemon's next poll.
+ *
+ * Plain fetch (not Houdini): this is an imperative action, not cached
+ * read state — same rationale as sendTextToPane in $lib/tauri.ts.
+ */
+export async function launchSession(input: LaunchSessionInput): Promise<LaunchSessionResult> {
+	const res = await fetch(httpEndpoint(), {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ query: LAUNCH_SESSION, variables: { input } }),
+	});
+	if (!res.ok) {
+		throw new Error(`launchSession HTTP ${res.status}`);
+	}
+	const body = await res.json();
+	if (body.errors && body.errors.length > 0) {
+		throw new Error(body.errors[0].message ?? "launchSession failed");
+	}
+	return body.data.launchSession as LaunchSessionResult;
 }

--- a/crates/orchard-gui/src/lib/store.svelte.ts
+++ b/crates/orchard-gui/src/lib/store.svelte.ts
@@ -18,6 +18,7 @@ import {
 	type ChatBackend,
 } from "./data/chat";
 import { toast } from "./util/toast";
+import { inTauri } from "./tauri";
 import type {
 	Conversation,
 	ConvView,
@@ -271,12 +272,15 @@ export class AppStore {
 		// Default view rule:
 		//   - mobile: always chat (browser can't host a PTY, terminal view
 		//     would just show "desktop app required").
-		//   - desktop + live pane: terminal (the substrate when attached).
-		//   - desktop + no pane: chat (the jsonl is the only thing to show).
+		//   - browser desktop: also chat — only the Tauri desktop app can
+		//     attach a PTY, so terminal view is dead weight in a plain browser
+		//     (the GUI is now served over HTTPS for browser create+chat).
+		//   - Tauri desktop + live pane: terminal (the substrate when attached).
+		//   - any + no pane: chat (the jsonl is the only thing to show).
 		// Drew (2026-05-10): "if no tmux sessions still okay, right, we have
 		// the jsonl."
 		const defaultView: ConvView =
-			this.surface === "mobile" ? "chat" : key.paneId ? "terminal" : "chat";
+			inTauri() && this.surface === "desktop" && key.paneId ? "terminal" : "chat";
 
 		// Mobile: always single-tab.
 		if (this.surface === "mobile") {

--- a/crates/orchard-gui/src/lib/tauri.ts
+++ b/crates/orchard-gui/src/lib/tauri.ts
@@ -18,7 +18,7 @@ import { invoke } from "@tauri-apps/api/core";
  * The GUI deliberately keeps these proxies thin — callers handle the
  * "browser dev, no Tauri" case at the call site.
  */
-function inTauri(): boolean {
+export function inTauri(): boolean {
 	return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 }
 function requireTauri(op: string): void {

--- a/crates/orchard-gui/src/routes/+page.svelte
+++ b/crates/orchard-gui/src/routes/+page.svelte
@@ -16,6 +16,8 @@
 		buildWorktreePickerRows,
 	} from "$lib/data/daemon-stores";
 	import { buildPaletteEntries, PALETTE_ACTIONS } from "$lib/data/palette";
+	import { launchSession } from "$lib/data/daemon";
+	import { toast } from "$lib/util/toast";
 	import type { Lens, PaletteEntry } from "$lib/data/types";
 
 	const store = getStore();
@@ -144,11 +146,24 @@
 	open={store.newConvOpen}
 	surface={store.surface}
 	onClose={() => store.closeNewConv()}
-	onLaunch={async (_spec) => {
+	onLaunch={async (spec) => {
 		store.closeNewConv();
-		// NewConversation only emits an existing worktreeId from the picker,
-		// so the worktree is already on disk — no createWorktree needed.
-		// The session itself is started outside this flow (user clicks the
-		// row in the sidebar; future: launch a Claude REPL into the pane).
+		// NewConversation emits an existing worktreeId from the picker, so the
+		// worktree is already on disk (its path is `spec.cwd`). The daemon's
+		// launchSession mutation creates the tmux session + boots Claude there
+		// and returns the pane + pre-assigned session UUID, which we open
+		// straight into the deep view — the composer targets the pane and the
+		// transcript subscribes by uuid, both before the daemon's next poll.
+		try {
+			const result = await launchSession({
+				cwd: spec.cwd,
+				model: spec.model,
+				prompt: spec.task?.trim() ? spec.task : undefined,
+			});
+			store.openSession({ paneId: result.paneId, sessionUuid: result.sessionUuid });
+			toast.success(`Launched ${result.sessionName}`);
+		} catch (err) {
+			toast.error(err);
+		}
 	}}
 />

--- a/crates/orchard-gui/src/routes/+page.svelte
+++ b/crates/orchard-gui/src/routes/+page.svelte
@@ -147,7 +147,6 @@
 	surface={store.surface}
 	onClose={() => store.closeNewConv()}
 	onLaunch={async (spec) => {
-		store.closeNewConv();
 		// NewConversation emits an existing worktreeId from the picker, so the
 		// worktree is already on disk (its path is `spec.cwd`). The daemon's
 		// launchSession mutation creates the tmux session + boots Claude there
@@ -161,6 +160,9 @@
 				prompt: spec.task?.trim() ? spec.task : undefined,
 			});
 			store.openSession({ paneId: result.paneId, sessionUuid: result.sessionUuid });
+			// Close only on success — a failed launch keeps the modal open so the
+			// user's picked worktree / model / task aren't lost.
+			store.closeNewConv();
 			toast.success(`Launched ${result.sessionName}`);
 		} catch (err) {
 			toast.error(err);

--- a/crates/orchard-gui/tests/create-chat.drive.mjs
+++ b/crates/orchard-gui/tests/create-chat.drive.mjs
@@ -1,0 +1,119 @@
+// Companion driver for features/gui-create-chat.feature.
+//
+// Plain Playwright script (NO Gherkin runner). Each assert() call mirrors one
+// Then/And line in the feature, in order, so a green run proves the feature
+// scenario-for-scenario. Drives the LIVE HTTPS endpoint by default.
+//
+//   node tests/create-chat.drive.mjs [baseURL]
+//   ORCHARD_TEST_BASE=https://orchard-gui.drewdrewthis.boxd.sh node tests/create-chat.drive.mjs
+//
+// Spawns a REAL Claude session (named git-orchard-rs*) and kills it on exit —
+// that is why this is a .drive.mjs, not a **/*.spec.ts the rig auto-runs.
+//
+// playwright is resolved from this package's pnpm store (CommonJS default import).
+import pw from "../node_modules/.pnpm/playwright@1.59.1/node_modules/playwright/index.js";
+import { execSync } from "node:child_process";
+const { chromium } = pw;
+
+const BASE = process.argv[2] || process.env.ORCHARD_TEST_BASE || "https://orchard-gui.drewdrewthis.boxd.sh";
+const MARK = "PONGORCHARD";
+const MSG = `Reply with exactly this one word and nothing else: ${MARK}`;
+const tmux = (c) => { try { return execSync(c, { encoding: "utf8" }); } catch { return ""; } };
+
+let failures = 0;
+let scenario = "";
+const SCENARIO = (s) => { scenario = s; console.log(`\nScenario: ${s}`); };
+const assert = (then, ok) => {
+  console.log(`  ${ok ? "PASS" : "FAIL"}  Then ${then}`);
+  if (!ok) failures++;
+};
+
+const before = new Set(tmux("tmux ls -F '#{session_name}' 2>/dev/null").split("\n").filter(Boolean));
+const pageErrors = [];
+let createdSession = null;
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1280, height: 900 } });
+const page = await ctx.newPage();
+page.on("pageerror", (e) => pageErrors.push(String(e)));
+
+try {
+  await page.goto(BASE, { waitUntil: "networkidle", timeout: 30000 });
+  await page.waitForTimeout(1200);
+
+  // ── Scenario: Create a real Claude session ────────────────────────────────
+  SCENARIO("Create a real Claude session from the New Conversation modal");
+  await page.getByRole("button", { name: /^New/ }).first().click();
+  await page.getByText("Launch new conversation").waitFor({ timeout: 5000 });
+  await page.getByRole("button", { name: /Launch/ }).last().click();
+  await page.waitForFunction(() => /Launched/i.test(document.body.innerText), { timeout: 15000 }).catch(() => {});
+  const toast = await page.evaluate(() => (document.body.innerText.match(/Launched[^\n]*/i) || [""])[0]);
+  assert(`a success toast "Launched <sessionName>" is shown`, /^Launched\s+\S/.test(toast));
+  await page.waitForTimeout(1500);
+  const after = tmux("tmux ls -F '#{session_name}' 2>/dev/null").split("\n").filter(Boolean);
+  createdSession = after.find((s) => !before.has(s)) || null;
+  assert("a new tmux session appears that was not present before the click", !!createdSession);
+  const paneLine = createdSession ? tmux(`tmux list-panes -t ${createdSession} -F '#{pane_id} #{pane_current_command}'`).trim() : "";
+  const paneId = paneLine.split(" ")[0] || "";
+  // Claude may still be exec'ing at first capture; poll briefly.
+  let paneIsClaude = false;
+  for (let i = 0; i < 8 && !paneIsClaude; i++) {
+    if (tmux(`tmux list-panes -t '${createdSession}' -F '#{pane_current_command}'`).includes("claude")) paneIsClaude = true;
+    else await page.waitForTimeout(1000);
+  }
+  assert("that session's pane is running the claude command", paneIsClaude);
+
+  // ── Scenario: usable chat composer ────────────────────────────────────────
+  SCENARIO("A browser-created session opens a usable chat composer");
+  const composer = page.locator("textarea[placeholder^='Message']");
+  const composerVisible = await composer.isVisible().catch(() => false);
+  assert(`the message composer textarea (placeholder "Message…") is visible`, composerVisible);
+  const blocked = await page.getByText(/No tmux pane resolved|desktop app required/i).isVisible().catch(() => false);
+  assert(`no "No tmux pane resolved" or "desktop app required" placeholder is shown`, !blocked);
+
+  // ── Scenario: send submits to the pane ────────────────────────────────────
+  SCENARIO("Sending a message submits it to the pane (sendTextToPane)");
+  await page.waitForTimeout(8000); // let the fresh REPL finish booting
+  await composer.click();
+  await composer.fill(MSG);
+  await page.keyboard.press("Enter");
+  await page.waitForTimeout(800);
+  const cleared = (await composer.inputValue()) === "";
+  assert("the textarea clears instantly (optimistic, before the mutation resolves)", cleared);
+  let submitted = false;
+  for (let i = 0; i < 16 && !submitted; i++) {
+    const cap = tmux(`tmux capture-pane -t '${paneId}' -p 2>/dev/null`);
+    // Submitted = Claude started processing (message no longer just sitting at the ❯ prompt).
+    if (/(✻|✶|●|Crunch|Sauté|Churn|Discombobulat|Reply with exactly)/.test(cap) && (cap.match(/Reply with exactly/g) || []).length >= 1) {
+      // confirm submit by checking Claude moved past the bare prompt (reply token or thinking spinner)
+      if (/(●|✻|✶|tokens|thinking|esc to interrupt)/i.test(cap)) submitted = true;
+    }
+    if (!submitted) await page.waitForTimeout(1500);
+  }
+  assert("the message text reaches the target tmux pane and is submitted to Claude", submitted);
+
+  // ── Scenario: reply streams into transcript ───────────────────────────────
+  SCENARIO("Claude's reply streams into the transcript without a manual refresh");
+  let assistantRendered = false;
+  for (let i = 0; i < 40 && !assistantRendered; i++) {
+    assistantRendered = await page.evaluate((mark) =>
+      Array.from(document.querySelectorAll('[data-role="assistant"]')).some((t) => (t.innerText || "").includes(mark)),
+      MARK);
+    if (!assistantRendered) await page.waitForTimeout(1500);
+  }
+  assert(`an assistant turn ([data-role="assistant"]) containing the reply renders in the GUI`, assistantRendered);
+
+  // ── Scenario: end-to-end ──────────────────────────────────────────────────
+  SCENARIO("End-to-end create → chat → reply entirely on the live HTTPS URL");
+  assert(`the whole flow completes from ${BASE}`, !!createdSession && assistantRendered);
+  assert("there are no uncaught page errors during the flow", pageErrors.length === 0);
+  if (pageErrors.length) console.log("    pageErrors:", pageErrors.slice(0, 5));
+
+  await page.screenshot({ path: "/tmp/create-chat-drive.png" });
+} finally {
+  await browser.close();
+  if (createdSession) { tmux(`tmux kill-session -t '${createdSession}' 2>/dev/null`); console.log(`\n(cleaned up test session ${createdSession})`); }
+}
+
+console.log(`\n${failures === 0 ? "ALL GREEN" : failures + " FAILED"} — ${BASE}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/crates/orchard-gui/tests/create-chat.drive.mjs
+++ b/crates/orchard-gui/tests/create-chat.drive.mjs
@@ -36,6 +36,14 @@ const browser = await chromium.launch({ headless: true });
 const ctx = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1280, height: 900 } });
 const page = await ctx.newPage();
 page.on("pageerror", (e) => pageErrors.push(String(e)));
+// Capture live-update evidence: graphql-ws frames. The conversationChanged
+// subscription's "next" frames carry the field name in their JSON payload, so
+// a frame matching /conversationChanged/ proves the WS subscription delivered.
+// Listener attaches before goto so the handshake + every frame is observed.
+const wsFrames = [];
+page.on("websocket", (ws) => {
+  ws.on("framereceived", (f) => { try { wsFrames.push(String(f.payload)); } catch {} });
+});
 
 try {
   await page.goto(BASE, { waitUntil: "networkidle", timeout: 30000 });
@@ -101,6 +109,9 @@ try {
       MARK);
     if (!assistantRendered) await page.waitForTimeout(1500);
   }
+  const convChangedFrames = wsFrames.filter((f) => /conversationChanged/.test(f)).length;
+  console.log(`    (ws frames received: ${wsFrames.length}; conversationChanged frames: ${convChangedFrames})`);
+  assert("conversationChanged fires over the WebSocket and the transcript re-fetches", convChangedFrames > 0);
   assert(`an assistant turn ([data-role="assistant"]) containing the reply renders in the GUI`, assistantRendered);
 
   // ── Scenario: end-to-end ──────────────────────────────────────────────────

--- a/crates/orchard-gui/tests/create-chat.drive.mjs
+++ b/crates/orchard-gui/tests/create-chat.drive.mjs
@@ -10,8 +10,8 @@
 // Spawns a REAL Claude session (named git-orchard-rs*) and kills it on exit —
 // that is why this is a .drive.mjs, not a **/*.spec.ts the rig auto-runs.
 //
-// playwright is resolved from this package's pnpm store (CommonJS default import).
-import pw from "../node_modules/.pnpm/playwright@1.59.1/node_modules/playwright/index.js";
+// playwright's default export is its CJS module ({ chromium, firefox, … }).
+import pw from "playwright";
 import { execSync } from "node:child_process";
 const { chromium } = pw;
 

--- a/crates/orchard-gui/tests/create-chat.drive.mjs
+++ b/crates/orchard-gui/tests/create-chat.drive.mjs
@@ -57,9 +57,13 @@ try {
   await page.waitForFunction(() => /Launched/i.test(document.body.innerText), { timeout: 15000 }).catch(() => {});
   const toast = await page.evaluate(() => (document.body.innerText.match(/Launched[^\n]*/i) || [""])[0]);
   assert(`a success toast "Launched <sessionName>" is shown`, /^Launched\s+\S/.test(toast));
+  // Bind cleanup + the new-session check to the EXACT name from the toast — a
+  // generic before/after diff could pick up (and later kill) an unrelated
+  // session created concurrently by something else.
+  const launchedName = (toast.match(/^Launched\s+(\S+)/) || [])[1] || null;
   await page.waitForTimeout(1500);
-  const after = tmux("tmux ls -F '#{session_name}' 2>/dev/null").split("\n").filter(Boolean);
-  createdSession = after.find((s) => !before.has(s)) || null;
+  const after = new Set(tmux("tmux ls -F '#{session_name}' 2>/dev/null").split("\n").filter(Boolean));
+  createdSession = launchedName && after.has(launchedName) && !before.has(launchedName) ? launchedName : null;
   assert("a new tmux session appears that was not present before the click", !!createdSession);
   const paneLine = createdSession ? tmux(`tmux list-panes -t ${createdSession} -F '#{pane_id} #{pane_current_command}'`).trim() : "";
   const paneId = paneLine.split(" ")[0] || "";

--- a/crates/orchard-gui/tests/parity-check.mjs
+++ b/crates/orchard-gui/tests/parity-check.mjs
@@ -1,0 +1,91 @@
+// Parity check — the 1:1 feature-line ↔ test-assertion guarantee.
+//
+// The brief forbids a heavy Gherkin/cucumber runner; instead each create+chat
+// feature has a companion plain-Playwright driver whose assertion calls mirror
+// the feature's Then/And lines one-for-one, in order. This script MECHANICALLY
+// enforces that: it parses the assertion-bearing lines of each feature and the
+// assertion calls of its driver and fails if they don't line up 1:1.
+//
+//   node tests/parity-check.mjs
+//
+// A green run guarantees every feature assertion line is backed by exactly one
+// concrete driver assertion (no orphan lines, no extra asserts).
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+
+// Each pair: a feature and the driver whose `assertFn(...)` calls back it.
+const PAIRS = [
+  { feature: "features/gui-create-chat.feature", driver: "tests/create-chat.drive.mjs", assertFn: "assert" },
+  { feature: "features/gui-render-no-regression.feature", driver: "tests/render-gate.mjs", assertFn: "check" },
+];
+
+// Gherkin assertion lines = Then, plus And/But while in the Then phase.
+// Given/When (and And/But under them) are setup, not assertions.
+function featureAssertions(src) {
+  const out = [];
+  let phase = null;
+  for (const raw of src.split("\n")) {
+    const line = raw.trim();
+    if (/^(Feature|Background|Scenario(?: Outline)?):/.test(line)) { phase = null; continue; }
+    const m = line.match(/^(Given|When|Then|And|But)\s+(.*)$/);
+    if (!m) continue;
+    const [, kw, text] = m;
+    if (kw === "Given" || kw === "When" || kw === "Then") phase = kw;
+    if (phase === "Then") out.push(text);
+  }
+  return out;
+}
+
+// Driver assertions = first string-literal argument of each `assertFn(...)`
+// call. The arrow-fn definition (`const assert = (then, ok) =>`) is skipped
+// because the name there is followed by ` =`, not `(`.
+function driverAssertions(src, fn) {
+  const out = [];
+  const re = new RegExp(`\\b${fn}\\(\\s*(["'\`])((?:\\\\.|(?!\\1).)*)\\1`, "g");
+  let m;
+  while ((m = re.exec(src))) out.push(m[2]);
+  return out;
+}
+
+// Content words for comparison: drop ${...} interpolations and Gherkin/English
+// stopwords, keep the meaningful tokens. Two lines match when one's content
+// words are a subset of the other's — tolerant of paraphrase ("is visible" vs
+// "visible") and interpolation ("${BASE}" vs the literal URL), strict about
+// the actual subject of the assertion.
+const STOP = new Set(["the", "a", "an", "is", "are", "be", "of", "to", "in", "on", "that", "this", "was", "were", "and", "or", "no", "it", "its"]);
+const contentWords = (s) =>
+  new Set(
+    s.replace(/\$\{[^}]*\}/g, " ")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((w) => w && !STOP.has(w))
+  );
+const subset = (a, b) => [...a].every((w) => b.has(w));
+
+let failed = 0;
+for (const { feature, driver, assertFn } of PAIRS) {
+  console.log(`\n${feature}  ↔  ${driver}`);
+  const fLines = featureAssertions(readFileSync(resolve(root, feature), "utf8"));
+  const dCalls = driverAssertions(readFileSync(resolve(root, driver), "utf8"), assertFn);
+
+  if (fLines.length !== dCalls.length) {
+    console.log(`  FAIL  count mismatch: ${fLines.length} feature assertion lines vs ${dCalls.length} ${assertFn}() calls`);
+    failed++;
+  }
+  const n = Math.max(fLines.length, dCalls.length);
+  for (let i = 0; i < n; i++) {
+    const f = fLines[i] ?? "(missing feature line)";
+    const d = dCalls[i] ?? "(missing assertion)";
+    const wf = contentWords(f), wd = contentWords(d);
+    const ok = wf.size && wd.size && (subset(wf, wd) || subset(wd, wf));
+    console.log(`  ${ok ? "PASS" : "FAIL"}  [${i + 1}] ${f}`);
+    if (!ok) { console.log(`         ↳ driver: ${d}`); failed++; }
+  }
+}
+
+console.log(`\n${failed === 0 ? "PARITY OK — every feature line maps 1:1 to a driver assertion" : failed + " PARITY FAILURES"}`);
+process.exit(failed === 0 ? 0 : 1);

--- a/crates/orchard-gui/tests/parity-check.mjs
+++ b/crates/orchard-gui/tests/parity-check.mjs
@@ -56,7 +56,7 @@ function driverAssertions(src, fn) {
 // words are a subset of the other's — tolerant of paraphrase ("is visible" vs
 // "visible") and interpolation ("${BASE}" vs the literal URL), strict about
 // the actual subject of the assertion.
-const STOP = new Set(["the", "a", "an", "is", "are", "be", "of", "to", "in", "on", "that", "this", "was", "were", "and", "or", "no", "it", "its"]);
+const STOP = new Set(["the", "a", "an", "is", "are", "be", "of", "to", "in", "on", "that", "this", "was", "were", "and", "or", "it", "its"]);
 const contentWords = (s) =>
   new Set(
     s.replace(/\$\{[^}]*\}/g, " ")
@@ -65,6 +65,11 @@ const contentWords = (s) =>
       .filter((w) => w && !STOP.has(w))
   );
 const subset = (a, b) => [...a].every((w) => b.has(w));
+// Polarity guard: "no errors" must NOT match "errors". A negation word present
+// on one side but not the other is a polarity mismatch even when the content
+// words are otherwise a subset — this is why "no" was kept out of STOP above.
+const NEG = new Set(["no", "not", "never", "without", "none", "cannot"]);
+const isNegative = (s) => s.toLowerCase().split(/[^a-z0-9']+/).some((w) => NEG.has(w) || w.endsWith("n't"));
 
 let failed = 0;
 for (const { feature, driver, assertFn } of PAIRS) {
@@ -81,9 +86,10 @@ for (const { feature, driver, assertFn } of PAIRS) {
     const f = fLines[i] ?? "(missing feature line)";
     const d = dCalls[i] ?? "(missing assertion)";
     const wf = contentWords(f), wd = contentWords(d);
-    const ok = wf.size && wd.size && (subset(wf, wd) || subset(wd, wf));
+    const polarityOk = isNegative(f) === isNegative(d);
+    const ok = wf.size && wd.size && polarityOk && (subset(wf, wd) || subset(wd, wf));
     console.log(`  ${ok ? "PASS" : "FAIL"}  [${i + 1}] ${f}`);
-    if (!ok) { console.log(`         ↳ driver: ${d}`); failed++; }
+    if (!ok) { console.log(`         ↳ driver: ${d}${polarityOk ? "" : "  [negation-polarity mismatch]"}`); failed++; }
   }
 }
 

--- a/crates/orchard-gui/tests/render-gate.mjs
+++ b/crates/orchard-gui/tests/render-gate.mjs
@@ -1,0 +1,64 @@
+// Render gate — proves the LIVE https GUI renders a real UI, not a blank screen.
+//
+// Run after EVERY change that could affect the served bundle (the brief's
+// "never let the page go blank again" rule). Plain Playwright, no Gherkin
+// runner; drives the live HTTPS endpoint by default.
+//
+//   node tests/render-gate.mjs [baseURL]
+//   ORCHARD_TEST_BASE=https://orchard-gui.drewdrewthis.boxd.sh node tests/render-gate.mjs
+//
+// Asserts (each maps to a concrete check, exit 1 on any failure):
+//   1. the endpoint answers 200
+//   2. the body is not blank (rendered text present)
+//   3. the SvelteKit app shell mounted (hydration root populated)
+//   4. the "Orchard" brand chrome rendered
+//   5. the "New" conversation entrypoint is visible (create affordance live)
+//   6. the sidebar rendered real daemon state (a lens group or conversation)
+//   7. no uncaught page errors during load
+import pw from "../node_modules/.pnpm/playwright@1.59.1/node_modules/playwright/index.js";
+const { chromium } = pw;
+const BASE = process.argv[2] || process.env.ORCHARD_TEST_BASE || "https://orchard-gui.drewdrewthis.boxd.sh";
+
+let fail = 0;
+const check = (name, ok, extra = "") => { console.log(`  ${ok ? "PASS" : "FAIL"}  ${name}${extra ? "  — " + extra : ""}`); if (!ok) fail++; };
+
+const pageErrors = [];
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1280, height: 900 } });
+const page = await ctx.newPage();
+page.on("pageerror", (e) => pageErrors.push(String(e)));
+
+try {
+  const resp = await page.goto(BASE, { waitUntil: "networkidle", timeout: 30000 });
+  check("endpoint answers 200", resp && resp.status() === 200, resp ? String(resp.status()) : "no response");
+  await page.waitForTimeout(1500);
+
+  const bodyText = (await page.evaluate(() => document.body.innerText || "")).trim();
+  check("body is not blank", bodyText.length > 20, `${bodyText.length} chars`);
+
+  const mounted = await page.evaluate(() => {
+    const root = document.querySelector("body > div") || document.body;
+    return !!root && root.children.length > 0 && root.innerHTML.length > 200;
+  });
+  check("app shell mounted (hydration root populated)", mounted);
+
+  check('"Orchard" brand chrome rendered', /Orchard/.test(bodyText), bodyText.slice(0, 24).replace(/\n/g, " "));
+
+  const newBtn = await page.getByRole("button", { name: /^New/ }).first().isVisible().catch(() => false);
+  check('"New" conversation entrypoint visible', newBtn);
+
+  // Real daemon state: a lens group badge (QUIET/ACTIVE/…) or an open conversation,
+  // or the empty-state the GUI shows when no session is open. Any one proves the
+  // sidebar/main rendered from live data rather than a white screen.
+  const realState = /QUIET|ACTIVE|RECENT|No conversations open|Search/i.test(bodyText);
+  check("sidebar/main rendered from live daemon state", realState);
+
+  check("no uncaught page errors", pageErrors.length === 0, pageErrors.slice(0, 3).join(" | "));
+
+  await page.screenshot({ path: "/tmp/ac2-render.png", fullPage: false });
+  console.log("  screenshot -> /tmp/ac2-render.png");
+} finally {
+  await browser.close();
+}
+console.log(`\n${fail === 0 ? "RENDER OK" : fail + " RENDER GATE FAILURES"} — ${BASE}`);
+process.exit(fail === 0 ? 0 : 1);

--- a/crates/orchard-gui/tests/render-gate.mjs
+++ b/crates/orchard-gui/tests/render-gate.mjs
@@ -15,7 +15,7 @@
 //   5. the "New" conversation entrypoint is visible (create affordance live)
 //   6. the sidebar rendered real daemon state (a lens group or conversation)
 //   7. no uncaught page errors during load
-import pw from "../node_modules/.pnpm/playwright@1.59.1/node_modules/playwright/index.js";
+import pw from "playwright";
 const { chromium } = pw;
 const BASE = process.argv[2] || process.env.ORCHARD_TEST_BASE || "https://orchard-gui.drewdrewthis.boxd.sh";
 

--- a/crates/orchard-gui/tests/twa-acceptance.spec.ts
+++ b/crates/orchard-gui/tests/twa-acceptance.spec.ts
@@ -330,7 +330,12 @@ test.describe("orchard-gui TWA — phone acceptance", () => {
 		let graphqlPosts = 0;
 		page.on("request", (req) => {
 			const url = req.url();
-			if (url.includes(":7777/graphql") && req.method() === "POST") {
+			// The browser client always POSTs to the same-origin `/__daemon/graphql`
+			// proxy path (see src/client.ts); it only targets `:7777/graphql`
+			// directly in the SSR fallback, which never runs in a browser test.
+			// Count both so the storm guard is real against the dev rig, the
+			// `vite preview` build, and the boxd HTTPS URL alike.
+			if ((url.includes("/__daemon/graphql") || url.includes(":7777/graphql")) && req.method() === "POST") {
 				graphqlPosts++;
 			}
 		});

--- a/crates/orchard-gui/vite.config.js
+++ b/crates/orchard-gui/vite.config.js
@@ -19,10 +19,10 @@ export default defineConfig(async () => ({
     port: 1420,
     strictPort: true,
     host: host || false,
-    // Allow cloudflared / ngrok hostnames during browser-dev preview from
-    // a phone or other device. Tauri reaches Vite via 127.0.0.1 and doesn't
-    // hit this guard.
-    allowedHosts: [".trycloudflare.com", ".ngrok-free.app", ".ngrok.io", ".loca.lt"],
+    // Allow cloudflared / ngrok / boxd hostnames during browser-dev preview
+    // from a phone or other device. Tauri reaches Vite via 127.0.0.1 and
+    // doesn't hit this guard.
+    allowedHosts: [".trycloudflare.com", ".ngrok-free.app", ".ngrok.io", ".loca.lt", ".boxd.sh"],
     hmr: host
       ? {
           protocol: "ws",
@@ -49,6 +49,28 @@ export default defineConfig(async () => ({
     // smoke-tested in a regular browser without Tauri's CORS-bypass. In Tauri,
     // `127.0.0.1:7777` is reached directly (and `csp: null` lets fetch through),
     // so this proxy is only consulted in browser dev.
+    proxy: {
+      "/__daemon": {
+        target: "http://127.0.0.1:7777",
+        changeOrigin: true,
+        ws: true,
+        rewrite: (/** @type {string} */ p) => p.replace(/^\/__daemon/, ""),
+      },
+    },
+  },
+
+  // `vite preview` serves the production build (adapter-static output).
+  // Unlike `server`, the preview server does NOT inherit `server.proxy`,
+  // so the `/__daemon` GraphQL proxy (HTTP + WS) is redeclared here. This
+  // is the same-origin path that lets a remote browser — loaded from the
+  // boxd HTTPS proxy — reach the daemon without a localhost-only endpoint
+  // leaking to the client. `host: true` binds 0.0.0.0 so the boxd proxy
+  // can forward to it.
+  preview: {
+    port: 4173,
+    strictPort: true,
+    host: true,
+    allowedHosts: [".trycloudflare.com", ".ngrok-free.app", ".ngrok.io", ".loca.lt", ".boxd.sh"],
     proxy: {
       "/__daemon": {
         target: "http://127.0.0.1:7777",

--- a/daemon/tmux/adapter.go
+++ b/daemon/tmux/adapter.go
@@ -204,7 +204,7 @@ func (a *Adapter) tmuxArgs(rest ...string) []string {
 // IsAlive shells out the cheapest possible command to detect a live tmux
 // server. Results are cached for aliveTTL (default = DefaultPollInterval) so
 // a single FetchAll cycle — which calls IsAlive before listAll — never pays
-// for two `tmux info` execs within the same tick.
+// for two `tmux list-sessions` execs within the same tick.
 //
 // Stale-true window: between server death and the next TTL expiry (≤TTL),
 // IsAlive may return true even though the server is dead. The next FetchAll
@@ -225,7 +225,15 @@ func (a *Adapter) IsAlive(ctx context.Context) bool {
 	}
 	a.alive.mu.Unlock()
 
-	_, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("info")...)
+	// `tmux list-sessions` is the cheapest *client-independent* liveness
+	// probe: rc 0 when the server is up, "no server running" (rc 1) when
+	// it is down. `tmux info` was used here previously but it defaults its
+	// target to the *current client* and exits 1 with "no current client"
+	// whenever the caller isn't an attached tmux client — which a detached
+	// daemon (systemd / setsid) never is. That made IsAlive always false,
+	// so FetchAll shipped an EmptySnapshot and the whole tmux/claude
+	// subgraph reported zero. See daemon/tmux regression from #660.
+	_, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("list-sessions", "-F", "#{session_id}")...)
 	result := err == nil
 
 	a.alive.mu.Lock()
@@ -238,7 +246,7 @@ func (a *Adapter) IsAlive(ctx context.Context) bool {
 
 // FetchAll fetches a full Snapshot in at most 3 tmux execs per cycle:
 //
-//  1. `tmux info` — via IsAlive (cached for aliveTTL; 0 execs when warm).
+//  1. `tmux list-sessions` — via IsAlive (cached for aliveTTL; 0 execs when warm).
 //  2. `tmux list-panes -a -F …` — via listAll, which synthesises session,
 //     window, and pane maps from a single output stream.
 //  3. `tmux list-clients -F …` — via listClients, which populates the Clients

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/99designs/gqlgen v0.17.90
 	github.com/fsnotify/fsnotify v1.10.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/graph-gophers/dataloader/v7 v7.1.3
 	github.com/spf13/cobra v1.10.2
@@ -16,7 +17,6 @@ require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/sosodev/duration v1.4.0 // indirect

--- a/internal/server/graphql/generated.go
+++ b/internal/server/graphql/generated.go
@@ -175,6 +175,13 @@ type ComplexityRoot struct {
 		Name        func(childComplexity int) int
 	}
 
+	LaunchSessionResult struct {
+		Cwd         func(childComplexity int) int
+		PaneID      func(childComplexity int) int
+		SessionName func(childComplexity int) int
+		SessionUUID func(childComplexity int) int
+	}
+
 	Meta struct {
 		FailureReason         func(childComplexity int) int
 		LastSuccessfulFetchAt func(childComplexity int) int
@@ -182,6 +189,7 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
+		LaunchSession  func(childComplexity int, input LaunchSessionInput) int
 		SendTextToPane func(childComplexity int, paneID string, text string) int
 	}
 
@@ -423,6 +431,7 @@ type IssueResolver interface {
 }
 type MutationResolver interface {
 	SendTextToPane(ctx context.Context, paneID string, text string) (bool, error)
+	LaunchSession(ctx context.Context, input LaunchSessionInput) (*LaunchSessionResult, error)
 }
 type ProcessResolver interface {
 	Host(ctx context.Context, obj *Process) (*Host, error)
@@ -1134,6 +1143,31 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Label.Name(childComplexity), true
 
+	case "LaunchSessionResult.cwd":
+		if e.ComplexityRoot.LaunchSessionResult.Cwd == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LaunchSessionResult.Cwd(childComplexity), true
+	case "LaunchSessionResult.paneId":
+		if e.ComplexityRoot.LaunchSessionResult.PaneID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LaunchSessionResult.PaneID(childComplexity), true
+	case "LaunchSessionResult.sessionName":
+		if e.ComplexityRoot.LaunchSessionResult.SessionName == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LaunchSessionResult.SessionName(childComplexity), true
+	case "LaunchSessionResult.sessionUuid":
+		if e.ComplexityRoot.LaunchSessionResult.SessionUUID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.LaunchSessionResult.SessionUUID(childComplexity), true
+
 	case "Meta.failureReason":
 		if e.ComplexityRoot.Meta.FailureReason == nil {
 			break
@@ -1153,6 +1187,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Meta.Provider(childComplexity), true
 
+	case "Mutation.launchSession":
+		if e.ComplexityRoot.Mutation.LaunchSession == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_launchSession_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.LaunchSession(childComplexity, args["input"].(LaunchSessionInput)), true
 	case "Mutation.sendTextToPane":
 		if e.ComplexityRoot.Mutation.SendTextToPane == nil {
 			break
@@ -2338,6 +2383,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputContractFilter,
 		ec.unmarshalInputHostServiceFilter,
+		ec.unmarshalInputLaunchSessionInput,
 		ec.unmarshalInputProcessFilter,
 		ec.unmarshalInputTmuxPaneFilter,
 		ec.unmarshalInputTmuxSessionFilter,
@@ -3845,6 +3891,54 @@ type Mutation {
   clients prefer the Tauri command since it stays local.
   """
   sendTextToPane(paneId: String!, text: String!): Boolean!
+
+  """
+  Launch a new Claude REPL inside a fresh detached tmux session at the
+  given working directory.
+
+  The daemon creates the tmux session (` + "`" + `tmux new-session -d -s <name>
+  -c <cwd>` + "`" + `), resolves the new pane, then types
+  ` + "`" + `claude --session-id <uuid> --dangerously-skip-permissions --effort max` + "`" + `
+  (plus ` + "`" + `--model` + "`" + ` and an initial prompt when supplied) into the pane and
+  submits it — mirroring sendTextToPane's literal-write + Enter so the
+  REPL boots in the user's login shell with full env.
+
+  The session UUID is pre-assigned (` + "`" + `claude --session-id` + "`" + `) so the caller
+  can ` + "`" + `conversationChanged(sessionUuid:)` + "`" + `-subscribe and target the pane
+  with ` + "`" + `sendTextToPane` + "`" + ` immediately, without waiting for the JSONL to
+  first appear under an unknown id.
+
+  Use case: browser / mobile clients creating a new working session on a
+  host where they have no shell access.
+  """
+  launchSession(input: LaunchSessionInput!): LaunchSessionResult!
+}
+
+"""
+Input for launchSession. Anchored to (host, cwd) semantics (ADR-009);
+v1 is local-host only, so host is implicit.
+"""
+input LaunchSessionInput {
+  "Absolute working directory the session runs in — typically a worktree path. A leading ~ is expanded daemon-side."
+  cwd: String!
+  "Optional tmux session name. When omitted the daemon derives one from the cwd basename plus a short unique suffix; collisions are de-duplicated."
+  name: String
+  "Optional model alias or full name (e.g. \"opus\", \"claude-sonnet-4-6\"). Passed to ` + "`" + `claude --model` + "`" + ` when present."
+  model: String
+  "Optional first prompt. When present it is passed to Claude as the initial task so the agent starts working immediately."
+  prompt: String
+}
+
+"Result of launchSession: the freshly created tmux session, the Claude REPL pane to target for chat sends, and the pre-assigned session UUID."
+type LaunchSessionResult {
+  "The tmux session name that was created (after de-duplication)."
+  sessionName: String!
+  "The tmux pane id running the Claude REPL (e.g. \"%73\"). Target this with sendTextToPane."
+  paneId: String!
+  "The pre-assigned Claude session UUID. Subscribe to conversationChanged(sessionUuid:) to stream the transcript as it grows."
+  sessionUuid: String!
+  "The working directory the session was launched in (after ~ expansion)."
+  cwd: String!
 }
 `, BuiltIn: false},
 }
@@ -4104,6 +4198,20 @@ func (ec *executionContext) childFields_Label(ctx context.Context, field graphql
 		return ec.fieldContext_Label_description(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Label", field.Name)
+}
+
+func (ec *executionContext) childFields_LaunchSessionResult(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "sessionName":
+		return ec.fieldContext_LaunchSessionResult_sessionName(ctx, field)
+	case "paneId":
+		return ec.fieldContext_LaunchSessionResult_paneId(ctx, field)
+	case "sessionUuid":
+		return ec.fieldContext_LaunchSessionResult_sessionUuid(ctx, field)
+	case "cwd":
+		return ec.fieldContext_LaunchSessionResult_cwd(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type LaunchSessionResult", field.Name)
 }
 
 func (ec *executionContext) childFields_Meta(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -4601,6 +4709,20 @@ func (ec *executionContext) field_Host_processes_args(ctx context.Context, rawAr
 		return nil, err
 	}
 	args["filter"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_launchSession_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input",
+		func(ctx context.Context, v any) (LaunchSessionInput, error) {
+			return ec.unmarshalNLaunchSessionInput2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐLaunchSessionInput(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
 	return args, nil
 }
 
@@ -7450,6 +7572,98 @@ func (ec *executionContext) fieldContext_Label_description(_ context.Context, fi
 	return graphql.NewScalarFieldContext("Label", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
+func (ec *executionContext) _LaunchSessionResult_sessionName(ctx context.Context, field graphql.CollectedField, obj *LaunchSessionResult) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LaunchSessionResult_sessionName(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.SessionName, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LaunchSessionResult_sessionName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("LaunchSessionResult", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _LaunchSessionResult_paneId(ctx context.Context, field graphql.CollectedField, obj *LaunchSessionResult) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LaunchSessionResult_paneId(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.PaneID, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LaunchSessionResult_paneId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("LaunchSessionResult", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _LaunchSessionResult_sessionUuid(ctx context.Context, field graphql.CollectedField, obj *LaunchSessionResult) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LaunchSessionResult_sessionUuid(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.SessionUUID, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LaunchSessionResult_sessionUuid(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("LaunchSessionResult", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _LaunchSessionResult_cwd(ctx context.Context, field graphql.CollectedField, obj *LaunchSessionResult) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_LaunchSessionResult_cwd(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Cwd, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_LaunchSessionResult_cwd(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("LaunchSessionResult", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
 func (ec *executionContext) _Meta_provider(ctx context.Context, field graphql.CollectedField, obj *Meta) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -7557,6 +7771,50 @@ func (ec *executionContext) fieldContext_Mutation_sendTextToPane(ctx context.Con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_sendTextToPane_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_launchSession(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Mutation_launchSession(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().LaunchSession(ctx, fc.Args["input"].(LaunchSessionInput))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *LaunchSessionResult) graphql.Marshaler {
+			return ec.marshalNLaunchSessionResult2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐLaunchSessionResult(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Mutation_launchSession(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_LaunchSessionResult(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_launchSession_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -13643,6 +13901,57 @@ func (ec *executionContext) unmarshalInputHostServiceFilter(ctx context.Context,
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputLaunchSessionInput(ctx context.Context, obj any) (LaunchSessionInput, error) {
+	var it LaunchSessionInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"cwd", "name", "model", "prompt"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "cwd":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("cwd"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Cwd = data
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "model":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("model"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Model = data
+		case "prompt":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("prompt"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Prompt = data
+		}
+	}
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputProcessFilter(ctx context.Context, obj any) (ProcessFilter, error) {
 	var it ProcessFilter
 	if obj == nil {
@@ -15002,6 +15311,60 @@ func (ec *executionContext) _Label(ctx context.Context, sel ast.SelectionSet, ob
 	return out
 }
 
+var launchSessionResultImplementors = []string{"LaunchSessionResult"}
+
+func (ec *executionContext) _LaunchSessionResult(ctx context.Context, sel ast.SelectionSet, obj *LaunchSessionResult) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, launchSessionResultImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("LaunchSessionResult")
+		case "sessionName":
+			out.Values[i] = ec._LaunchSessionResult_sessionName(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "paneId":
+			out.Values[i] = ec._LaunchSessionResult_paneId(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "sessionUuid":
+			out.Values[i] = ec._LaunchSessionResult_sessionUuid(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "cwd":
+			out.Values[i] = ec._LaunchSessionResult_cwd(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var metaImplementors = []string{"Meta"}
 
 func (ec *executionContext) _Meta(ctx context.Context, sel ast.SelectionSet, obj *Meta) graphql.Marshaler {
@@ -15067,6 +15430,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "sendTextToPane":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_sendTextToPane(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "launchSession":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_launchSession(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
@@ -19356,6 +19726,25 @@ func (ec *executionContext) marshalNLabel2ᚖgithubᚗcomᚋdrewdrewthisᚋgit�
 		return graphql.Null
 	}
 	return ec._Label(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNLaunchSessionInput2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐLaunchSessionInput(ctx context.Context, v any) (LaunchSessionInput, error) {
+	res, err := ec.unmarshalInputLaunchSessionInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNLaunchSessionResult2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐLaunchSessionResult(ctx context.Context, sel ast.SelectionSet, v LaunchSessionResult) graphql.Marshaler {
+	return ec._LaunchSessionResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNLaunchSessionResult2ᚖgithubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐLaunchSessionResult(ctx context.Context, sel ast.SelectionSet, v *LaunchSessionResult) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._LaunchSessionResult(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNMergeableState2githubᚗcomᚋdrewdrewthisᚋgitᚑorchardᚑrsᚋinternalᚋserverᚋgraphqlᚐMergeableState(ctx context.Context, v any) (MergeableState, error) {

--- a/internal/server/graphql/models_gen.go
+++ b/internal/server/graphql/models_gen.go
@@ -362,6 +362,31 @@ type Label struct {
 	Description string `json:"description"`
 }
 
+// Input for launchSession. Anchored to (host, cwd) semantics (ADR-009);
+// v1 is local-host only, so host is implicit.
+type LaunchSessionInput struct {
+	// Absolute working directory the session runs in — typically a worktree path. A leading ~ is expanded daemon-side.
+	Cwd string `json:"cwd"`
+	// Optional tmux session name. When omitted the daemon derives one from the cwd basename plus a short unique suffix; collisions are de-duplicated.
+	Name *string `json:"name,omitempty"`
+	// Optional model alias or full name (e.g. "opus", "claude-sonnet-4-6"). Passed to `claude --model` when present.
+	Model *string `json:"model,omitempty"`
+	// Optional first prompt. When present it is passed to Claude as the initial task so the agent starts working immediately.
+	Prompt *string `json:"prompt,omitempty"`
+}
+
+// Result of launchSession: the freshly created tmux session, the Claude REPL pane to target for chat sends, and the pre-assigned session UUID.
+type LaunchSessionResult struct {
+	// The tmux session name that was created (after de-duplication).
+	SessionName string `json:"sessionName"`
+	// The tmux pane id running the Claude REPL (e.g. "%73"). Target this with sendTextToPane.
+	PaneID string `json:"paneId"`
+	// The pre-assigned Claude session UUID. Subscribe to conversationChanged(sessionUuid:) to stream the transcript as it grows.
+	SessionUUID string `json:"sessionUuid"`
+	// The working directory the session was launched in (after ~ expansion).
+	Cwd string `json:"cwd"`
+}
+
 // Provenance and freshness envelope used to disambiguate "valid empty"
 // from "data unavailable" (#469 F1). Returned alongside list/composite
 // fields whose underlying providers can fail or be uninitialised.

--- a/internal/server/providers/tmux/adapter.go
+++ b/internal/server/providers/tmux/adapter.go
@@ -100,7 +100,7 @@ func signalName(sig syscall.Signal) string {
 
 // Adapter is the tmux CLI client. The alive-check result is cached for
 // aliveTTL (default = DefaultPollInterval) so consecutive FetchAll cycles
-// do not each pay for a separate `tmux info` exec.
+// do not each pay for a separate `tmux list-sessions` exec.
 //
 // The cache lives behind a pointer so the With*-builder methods can do a
 // shallow value-copy of Adapter without copying the embedded mutex —
@@ -116,7 +116,7 @@ type Adapter struct {
 	alive    *aliveCache
 }
 
-// aliveCache memoises the result of `tmux info` for one TTL window. It
+// aliveCache memoises the result of `tmux list-sessions` for one TTL window. It
 // is heap-allocated and shared across With*-derived Adapter copies so the
 // mutex inside is not copied by value.
 type aliveCache struct {
@@ -126,7 +126,7 @@ type aliveCache struct {
 }
 
 // defaultAliveTTL matches DefaultPollInterval so a single FetchAll within
-// one tick never calls `tmux info` twice.
+// one tick never calls `tmux list-sessions` twice.
 const defaultAliveTTL = DefaultPollInterval
 
 // NewAdapter constructs an Adapter targeting the default tmux socket on
@@ -204,7 +204,7 @@ func (a *Adapter) tmuxArgs(rest ...string) []string {
 // IsAlive shells out the cheapest possible command to detect a live tmux
 // server. Results are cached for aliveTTL (default = DefaultPollInterval) so
 // a single FetchAll cycle — which calls IsAlive before listAll — never pays
-// for two `tmux info` execs within the same tick.
+// for two `tmux list-sessions` execs within the same tick.
 //
 // Stale-true window: between server death and the next TTL expiry (≤TTL),
 // IsAlive may return true even though the server is dead. The next FetchAll
@@ -225,7 +225,15 @@ func (a *Adapter) IsAlive(ctx context.Context) bool {
 	}
 	a.alive.mu.Unlock()
 
-	_, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("info")...)
+	// `tmux list-sessions` is the cheapest *client-independent* liveness
+	// probe: rc 0 when the server is up, "no server running" (rc 1) when
+	// it is down. `tmux info` was used here previously but it defaults its
+	// target to the *current client* and exits 1 with "no current client"
+	// whenever the caller isn't an attached tmux client — which a detached
+	// daemon (systemd / setsid) never is. That made IsAlive always false,
+	// so FetchAll shipped an EmptySnapshot and the whole tmux/claude
+	// subgraph reported zero.
+	_, err := a.runner.Run(ctx, "tmux", a.tmuxArgs("list-sessions", "-F", "#{session_id}")...)
 	result := err == nil
 
 	a.alive.mu.Lock()
@@ -238,7 +246,7 @@ func (a *Adapter) IsAlive(ctx context.Context) bool {
 
 // FetchAll fetches a full Snapshot in at most 3 tmux execs per cycle:
 //
-//  1. `tmux info` — via IsAlive (cached for aliveTTL; 0 execs when warm).
+//  1. `tmux list-sessions` — via IsAlive (cached for aliveTTL; 0 execs when warm).
 //  2. `tmux list-panes -a -F …` — via listAll, which synthesises session,
 //     window, and pane maps from a single output stream.
 //  3. `tmux list-clients -F …` — via listClients, which populates the Clients
@@ -473,7 +481,7 @@ func (a *Adapter) listAll(ctx context.Context) (
 	}
 
 	for _, line := range bytes.Split(out, []byte{'\n'}) {
-		fields := strings.Split(string(line), fieldSep)
+		fields := splitFields(string(line))
 		if len(fields) != listAllFieldCount {
 			continue
 		}
@@ -524,6 +532,21 @@ func (a *Adapter) listAll(ctx context.Context) (
 	return sessions, windows, panes, nil
 }
 
+// splitFields splits a tmux `-F` output line on the field separator.
+//
+// tmux escapes control bytes in format output rather than emitting them raw:
+// tmux 3.4 (Linux) turns a 0x01 in the format string into the literal 4-char
+// sequence `\001`, while tmux 3.5+ (macOS) passes the raw byte through.
+// Normalizing the octal-escaped form back to the raw separator makes the
+// split behave identically across tmux versions — without it the whole line
+// stays a single field and every session/pane/client is silently dropped
+// (#660 regression: the format was verified only against tmux 3.5 on macOS).
+// A 0x01 separator stays collision-proof because no tmux field value contains
+// a raw control byte.
+func splitFields(line string) []string {
+	return strings.Split(strings.ReplaceAll(line, `\001`, fieldSep), fieldSep)
+}
+
 // In `list-clients -F` context, the per-client format vars
 // `#{client_window_index}` and `#{client_active_pane}` are silently
 // empty in current tmux releases. The format engine instead resolves
@@ -557,7 +580,7 @@ func (a *Adapter) listClients(ctx context.Context) (map[ClientKey]Client, error)
 	}
 	clients := make(map[ClientKey]Client)
 	for _, line := range bytes.Split(out, []byte{'\n'}) {
-		fields := strings.Split(string(line), fieldSep)
+		fields := splitFields(string(line))
 		if len(fields) != 9 {
 			continue
 		}

--- a/internal/server/resolvers/launch.go
+++ b/internal/server/resolvers/launch.go
@@ -1,0 +1,170 @@
+package resolvers
+
+// launchClaudeSession backs Mutation.launchSession. It shells out directly
+// to tmux (the same pattern as SendTextToPane) instead of going through the
+// read-only tmux snapshot adapter: create a detached session rooted at cwd,
+// resolve its pane, then type the `claude` launch line into the pane's login
+// shell and submit it with a separate Enter. The Claude session UUID is
+// pre-assigned via `claude --session-id` so the caller can immediately
+// subscribe to conversationChanged(sessionUuid:) and target the pane with
+// sendTextToPane — no waiting for the JSONL to first appear under an
+// unknown id.
+//
+// Lives outside *.resolvers.go so gqlgen never rewrites it.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
+)
+
+func launchClaudeSession(ctx context.Context, input graphql1.LaunchSessionInput) (*graphql1.LaunchSessionResult, error) {
+	cwd, err := resolveLaunchDir(input.Cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	base := sanitizeTmuxName(derefString(input.Name))
+	if base == "" {
+		base = sanitizeTmuxName(filepath.Base(cwd))
+	}
+	sessionName := uniqueTmuxName(ctx, base)
+	sessionUUID := uuid.NewString()
+
+	// 1. Create the detached tmux session rooted at cwd.
+	if out, err := exec.CommandContext(ctx, "tmux", "new-session", "-d", "-s", sessionName, "-c", cwd).CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("tmux new-session: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	// 2. Resolve the pane id of the freshly created session.
+	paneOut, err := exec.CommandContext(ctx, "tmux", "list-panes", "-t", sessionName, "-F", "#{pane_id}").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("tmux list-panes: %w: %s", err, strings.TrimSpace(string(paneOut)))
+	}
+	paneID := strings.TrimSpace(strings.SplitN(string(paneOut), "\n", 2)[0])
+	if paneID == "" {
+		return nil, fmt.Errorf("could not resolve pane id for new session %q", sessionName)
+	}
+
+	// 3. Type the claude launch line into the pane, then submit with Enter.
+	//    Two-step literal-write + Enter mirrors SendTextToPane and runs the
+	//    command in the pane's login shell (full PATH/env, e.g. ~/.local/bin).
+	launchCmd := buildClaudeLaunch(sessionUUID, sessionName, derefString(input.Model), derefString(input.Prompt))
+	if out, err := exec.CommandContext(ctx, "tmux", "send-keys", "-t", paneID, "-l", launchCmd).CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("tmux send-keys (launch): %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	if out, err := exec.CommandContext(ctx, "tmux", "send-keys", "-t", paneID, "Enter").CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("tmux send-keys (enter): %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	return &graphql1.LaunchSessionResult{
+		SessionName: sessionName,
+		PaneID:      paneID,
+		SessionUUID: sessionUUID,
+		Cwd:         cwd,
+	}, nil
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// resolveLaunchDir validates and normalizes the launch working directory:
+// trim, expand a leading ~, and confirm it is an existing directory.
+func resolveLaunchDir(raw string) (string, error) {
+	cwd := strings.TrimSpace(raw)
+	if cwd == "" {
+		return "", fmt.Errorf("cwd is empty")
+	}
+	if cwd == "~" || strings.HasPrefix(cwd, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("expand ~: %w", err)
+		}
+		cwd = filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(cwd, "~"), "/"))
+	}
+	info, err := os.Stat(cwd)
+	if err != nil {
+		return "", fmt.Errorf("cwd not accessible: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("cwd is not a directory: %s", cwd)
+	}
+	return cwd, nil
+}
+
+// sanitizeTmuxName reduces a string to a tmux-safe session name. tmux
+// forbids '.' and ':' in session names and chokes on whitespace; map any
+// non [A-Za-z0-9_-] rune to '-', collapse runs, and trim. Empty in → "".
+func sanitizeTmuxName(s string) string {
+	mapped := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, strings.TrimSpace(s))
+	for strings.Contains(mapped, "--") {
+		mapped = strings.ReplaceAll(mapped, "--", "-")
+	}
+	return strings.Trim(mapped, "-")
+}
+
+// uniqueTmuxName returns base when no live tmux session has that exact name,
+// else base with a short suffix that doesn't collide. `tmux has-session -t
+// =<name>` uses the `=` exact-match anchor (not the default prefix match).
+func uniqueTmuxName(ctx context.Context, base string) string {
+	if base == "" {
+		base = "session"
+	}
+	exists := func(n string) bool {
+		return exec.CommandContext(ctx, "tmux", "has-session", "-t", "="+n).Run() == nil
+	}
+	if !exists(base) {
+		return base
+	}
+	for i := 0; i < 50; i++ {
+		if cand := base + "-" + uuid.NewString()[:4]; !exists(cand) {
+			return cand
+		}
+	}
+	return fmt.Sprintf("%s-%d", base, time.Now().UnixNano())
+}
+
+// buildClaudeLaunch assembles the shell command line that boots an
+// interactive Claude REPL with a pre-assigned session id. Values that can
+// carry shell metacharacters (name, model, prompt) are single-quoted; the
+// UUID is hex+dashes and needs no quoting.
+func buildClaudeLaunch(sessionUUID, name, model, prompt string) string {
+	parts := []string{
+		"claude",
+		"--session-id", sessionUUID,
+		"--dangerously-skip-permissions",
+		"--effort", "max",
+		"--name", shellSingleQuote(name),
+	}
+	if m := strings.TrimSpace(model); m != "" {
+		parts = append(parts, "--model", shellSingleQuote(m))
+	}
+	if p := strings.TrimSpace(prompt); p != "" {
+		parts = append(parts, shellSingleQuote(p))
+	}
+	return strings.Join(parts, " ")
+}
+
+// shellSingleQuote wraps s in single quotes for /bin/sh, escaping embedded
+// single quotes with the standard '\'' idiom.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/server/resolvers/launch.go
+++ b/internal/server/resolvers/launch.go
@@ -19,7 +19,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	graphql1 "github.com/drewdrewthis/git-orchard-rs/internal/server/graphql"
@@ -35,16 +34,29 @@ func launchClaudeSession(ctx context.Context, input graphql1.LaunchSessionInput)
 	if base == "" {
 		base = sanitizeTmuxName(filepath.Base(cwd))
 	}
-	sessionName := uniqueTmuxName(ctx, base)
 	sessionUUID := uuid.NewString()
 
-	// 1. Create the detached tmux session rooted at cwd.
-	if out, err := exec.CommandContext(ctx, "tmux", "new-session", "-d", "-s", sessionName, "-c", cwd).CombinedOutput(); err != nil {
-		return nil, fmt.Errorf("tmux new-session: %w: %s", err, strings.TrimSpace(string(out)))
+	// 1. Create the detached tmux session rooted at cwd, retrying with a fresh
+	//    suffix on a name collision. Letting new-session arbitrate is atomic;
+	//    a has-session pre-check would race a concurrent create between the
+	//    check and the create.
+	sessionName, err := createUniqueSession(ctx, base, cwd)
+	if err != nil {
+		return nil, err
 	}
 
+	// Tear the session down if launch fails before it becomes a usable REPL,
+	// so a half-created detached session can't leak into the list. Uses
+	// exec.Command (not ctx) so cleanup still runs when ctx was cancelled.
+	launched := false
+	defer func() {
+		if !launched {
+			_ = exec.Command("tmux", "kill-session", "-t", "="+sessionName).Run()
+		}
+	}()
+
 	// 2. Resolve the pane id of the freshly created session.
-	paneOut, err := exec.CommandContext(ctx, "tmux", "list-panes", "-t", sessionName, "-F", "#{pane_id}").CombinedOutput()
+	paneOut, err := exec.CommandContext(ctx, "tmux", "list-panes", "-t", "="+sessionName, "-F", "#{pane_id}").CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("tmux list-panes: %w: %s", err, strings.TrimSpace(string(paneOut)))
 	}
@@ -64,6 +76,7 @@ func launchClaudeSession(ctx context.Context, input graphql1.LaunchSessionInput)
 		return nil, fmt.Errorf("tmux send-keys (enter): %w: %s", err, strings.TrimSpace(string(out)))
 	}
 
+	launched = true
 	return &graphql1.LaunchSessionResult{
 		SessionName: sessionName,
 		PaneID:      paneID,
@@ -121,25 +134,28 @@ func sanitizeTmuxName(s string) string {
 	return strings.Trim(mapped, "-")
 }
 
-// uniqueTmuxName returns base when no live tmux session has that exact name,
-// else base with a short suffix that doesn't collide. `tmux has-session -t
-// =<name>` uses the `=` exact-match anchor (not the default prefix match).
-func uniqueTmuxName(ctx context.Context, base string) string {
+// createUniqueSession creates a detached tmux session rooted at cwd, named
+// base (or "session" when empty), retrying with a short random suffix on a
+// name collision. tmux rejects a duplicate name with a non-zero exit and
+// "duplicate session" on stderr; letting new-session arbitrate is atomic,
+// unlike a has-session pre-check which races a concurrent create between the
+// check and the create. Returns the name actually created.
+func createUniqueSession(ctx context.Context, base, cwd string) (string, error) {
 	if base == "" {
 		base = "session"
 	}
-	exists := func(n string) bool {
-		return exec.CommandContext(ctx, "tmux", "has-session", "-t", "="+n).Run() == nil
-	}
-	if !exists(base) {
-		return base
-	}
+	name := base
 	for i := 0; i < 50; i++ {
-		if cand := base + "-" + uuid.NewString()[:4]; !exists(cand) {
-			return cand
+		out, err := exec.CommandContext(ctx, "tmux", "new-session", "-d", "-s", name, "-c", cwd).CombinedOutput()
+		if err == nil {
+			return name, nil
 		}
+		if !strings.Contains(string(out), "duplicate session") {
+			return "", fmt.Errorf("tmux new-session: %w: %s", err, strings.TrimSpace(string(out)))
+		}
+		name = base + "-" + uuid.NewString()[:4]
 	}
-	return fmt.Sprintf("%s-%d", base, time.Now().UnixNano())
+	return "", fmt.Errorf("tmux new-session: no unique name for %q after 50 attempts", base)
 }
 
 // buildClaudeLaunch assembles the shell command line that boots an

--- a/internal/server/resolvers/launch_test.go
+++ b/internal/server/resolvers/launch_test.go
@@ -1,0 +1,123 @@
+package resolvers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeTmuxName(t *testing.T) {
+	cases := map[string]string{
+		"git-orchard-rs":     "git-orchard-rs",
+		"new session 1":      "new-session-1",
+		"feat/foo.bar:baz":   "feat-foo-bar-baz",
+		"  padded  ":         "padded",
+		"--leading-trailing-": "leading-trailing",
+		"a..b__c":            "a-b__c",
+		"":                   "",
+		"...":                "",
+	}
+	for in, want := range cases {
+		if got := sanitizeTmuxName(in); got != want {
+			t.Errorf("sanitizeTmuxName(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestShellSingleQuote(t *testing.T) {
+	cases := map[string]string{
+		"plain":          "'plain'",
+		"with space":     "'with space'",
+		"it's a trap":    `'it'\''s a trap'`,
+		"a 'b' c":        `'a '\''b'\'' c'`,
+		"$(rm -rf /)":    "'$(rm -rf /)'", // metachars stay literal inside single quotes
+	}
+	for in, want := range cases {
+		if got := shellSingleQuote(in); got != want {
+			t.Errorf("shellSingleQuote(%q) = %q; want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildClaudeLaunch(t *testing.T) {
+	uuid := "11111111-2222-3333-4444-555555555555"
+
+	got := buildClaudeLaunch(uuid, "my-sess", "", "")
+	for _, want := range []string{
+		"claude",
+		"--session-id " + uuid,
+		"--dangerously-skip-permissions",
+		"--effort max",
+		"--name 'my-sess'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("buildClaudeLaunch base missing %q in %q", want, got)
+		}
+	}
+	if strings.Contains(got, "--model") {
+		t.Errorf("buildClaudeLaunch should omit --model when empty: %q", got)
+	}
+
+	withAll := buildClaudeLaunch(uuid, "s", "claude-sonnet-4-6", "do the thing")
+	if !strings.Contains(withAll, "--model 'claude-sonnet-4-6'") {
+		t.Errorf("expected --model in %q", withAll)
+	}
+	// Prompt is the trailing positional, single-quoted.
+	if !strings.HasSuffix(withAll, "'do the thing'") {
+		t.Errorf("expected prompt as trailing positional in %q", withAll)
+	}
+
+	// A prompt with a single quote must stay shell-safe.
+	tricky := buildClaudeLaunch(uuid, "s", "", "don't break")
+	if !strings.HasSuffix(tricky, `'don'\''t break'`) {
+		t.Errorf("prompt single-quote not escaped: %q", tricky)
+	}
+}
+
+func TestResolveLaunchDir(t *testing.T) {
+	if _, err := resolveLaunchDir(""); err == nil {
+		t.Error("expected error for empty cwd")
+	}
+	if _, err := resolveLaunchDir("/no/such/dir/orchard-xyz"); err == nil {
+		t.Error("expected error for missing dir")
+	}
+
+	// A real file is not a directory.
+	f, err := os.CreateTemp(t.TempDir(), "notadir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveLaunchDir(f.Name()); err == nil {
+		t.Errorf("expected error for non-directory %q", f.Name())
+	}
+
+	// A real dir resolves and round-trips.
+	dir := t.TempDir()
+	got, err := resolveLaunchDir("  " + dir + "  ")
+	if err != nil {
+		t.Fatalf("resolveLaunchDir(%q) err: %v", dir, err)
+	}
+	if got != dir {
+		t.Errorf("resolveLaunchDir trimmed = %q; want %q", got, dir)
+	}
+
+	// ~ expansion lands under $HOME.
+	home, err := os.UserHomeDir()
+	if err == nil {
+		got, err := resolveLaunchDir("~")
+		if err != nil {
+			t.Fatalf("resolveLaunchDir(\"~\") err: %v", err)
+		}
+		if got != home {
+			t.Errorf("resolveLaunchDir(\"~\") = %q; want %q", got, home)
+		}
+		// ~/sub expands too (use an existing subdir).
+		sub := filepath.Join(home, ".claude")
+		if fi, statErr := os.Stat(sub); statErr == nil && fi.IsDir() {
+			if got, err := resolveLaunchDir("~/.claude"); err != nil || got != sub {
+				t.Errorf("resolveLaunchDir(\"~/.claude\") = %q, %v; want %q", got, err, sub)
+			}
+		}
+	}
+}

--- a/internal/server/resolvers/schema.graphql
+++ b/internal/server/resolvers/schema.graphql
@@ -1410,4 +1410,52 @@ type Mutation {
   clients prefer the Tauri command since it stays local.
   """
   sendTextToPane(paneId: String!, text: String!): Boolean!
+
+  """
+  Launch a new Claude REPL inside a fresh detached tmux session at the
+  given working directory.
+
+  The daemon creates the tmux session (`tmux new-session -d -s <name>
+  -c <cwd>`), resolves the new pane, then types
+  `claude --session-id <uuid> --dangerously-skip-permissions --effort max`
+  (plus `--model` and an initial prompt when supplied) into the pane and
+  submits it — mirroring sendTextToPane's literal-write + Enter so the
+  REPL boots in the user's login shell with full env.
+
+  The session UUID is pre-assigned (`claude --session-id`) so the caller
+  can `conversationChanged(sessionUuid:)`-subscribe and target the pane
+  with `sendTextToPane` immediately, without waiting for the JSONL to
+  first appear under an unknown id.
+
+  Use case: browser / mobile clients creating a new working session on a
+  host where they have no shell access.
+  """
+  launchSession(input: LaunchSessionInput!): LaunchSessionResult!
+}
+
+"""
+Input for launchSession. Anchored to (host, cwd) semantics (ADR-009);
+v1 is local-host only, so host is implicit.
+"""
+input LaunchSessionInput {
+  "Absolute working directory the session runs in — typically a worktree path. A leading ~ is expanded daemon-side."
+  cwd: String!
+  "Optional tmux session name. When omitted the daemon derives one from the cwd basename plus a short unique suffix; collisions are de-duplicated."
+  name: String
+  "Optional model alias or full name (e.g. \"opus\", \"claude-sonnet-4-6\"). Passed to `claude --model` when present."
+  model: String
+  "Optional first prompt. When present it is passed to Claude as the initial task so the agent starts working immediately."
+  prompt: String
+}
+
+"Result of launchSession: the freshly created tmux session, the Claude REPL pane to target for chat sends, and the pre-assigned session UUID."
+type LaunchSessionResult {
+  "The tmux session name that was created (after de-duplication)."
+  sessionName: String!
+  "The tmux pane id running the Claude REPL (e.g. \"%73\"). Target this with sendTextToPane."
+  paneId: String!
+  "The pre-assigned Claude session UUID. Subscribe to conversationChanged(sessionUuid:) to stream the transcript as it grows."
+  sessionUuid: String!
+  "The working directory the session was launched in (after ~ expansion)."
+  cwd: String!
 }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -214,6 +214,13 @@ func (r *mutationResolver) SendTextToPane(ctx context.Context, paneID string, te
 	return true, nil
 }
 
+// LaunchSession is the resolver for the launchSession field. The tmux +
+// claude-launch logic lives in launch.go (launchClaudeSession) so this
+// gqlgen-managed file stays a thin projection.
+func (r *mutationResolver) LaunchSession(ctx context.Context, input graphql1.LaunchSessionInput) (*graphql1.LaunchSessionResult, error) {
+	return launchClaudeSession(ctx, input)
+}
+
 // Host is the resolver for the process.host field.
 func (r *processResolver) Host(ctx context.Context, obj *graphql1.Process) (*graphql1.Host, error) {
 	hostID, _ := splitProcessNodeID(obj.ID)

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -192,7 +192,8 @@ func (r *issueResolver) ParentIssue(ctx context.Context, obj *graphql1.Issue) (*
 // literally (no shell interpretation, safe with backticks / magic
 // strings); then a separate `Enter` keypress submits. Mirrors the
 // desktop app's Tauri command in crates/orchard-gui/src-tauri/src/commands.rs.
-// A 50ms gap between the two keeps long messages from racing Enter.
+// A short gap between the two keeps the Enter from racing the text into the
+// same input batch (which Claude's TUI swallows as a pasted newline).
 func (r *mutationResolver) SendTextToPane(ctx context.Context, paneID string, text string) (bool, error) {
 	if paneID == "" {
 		return false, fmt.Errorf("paneId is empty")
@@ -200,16 +201,25 @@ func (r *mutationResolver) SendTextToPane(ctx context.Context, paneID string, te
 	if text == "" {
 		return false, fmt.Errorf("text is empty")
 	}
-	// Single shellout: `-l <text>` literal write, then `Enter` keypress.
-	// Combining them into one send-keys invocation removes a fork+exec
-	// and the 50ms inter-key sleep the desktop Tauri command used (the
-	// sleep was belt+suspenders for very long messages; even 1KB texts
-	// don't race in practice). Round-trip drops from ~80ms+ to ~3ms
-	// inside the daemon; phone-side latency is dominated by the
-	// tunnel hop, not this.
-	cmd := exec.CommandContext(ctx, "tmux", "send-keys", "-t", paneID, "-l", text, ";", "send-keys", "-t", paneID, "Enter")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return false, fmt.Errorf("tmux send-keys: %w: %s", err, strings.TrimSpace(string(out)))
+	// Two separate send-keys with a short gap. First `-l <text>` writes the
+	// message literally (no shell interpretation, safe with backticks); a
+	// brief sleep lets Claude's TUI flush the paste-like input; then a
+	// discrete `Enter` keypress submits. Collapsing these into one
+	// invocation (or firing them back-to-back with no gap) makes the Enter
+	// race the text into the same input batch — Claude's TUI then treats it
+	// as a pasted newline rather than a submit, so the message lands in the
+	// composer box but is never sent. Observed on a freshly-booted REPL: the
+	// text appeared at the `❯` prompt but Claude never processed it until a
+	// manual Enter arrived. Mirrors the desktop Tauri command's gap.
+	if out, err := exec.CommandContext(ctx, "tmux", "send-keys", "-t", paneID, "-l", text).CombinedOutput(); err != nil {
+		return false, fmt.Errorf("tmux send-keys (text): %w: %s", err, strings.TrimSpace(string(out)))
+	}
+	// 250ms clears Claude Code's paste-coalesce window. A shorter gap
+	// (tested at 75ms) intermittently lets the Enter get absorbed into the
+	// paste burst on a freshly-booted REPL, leaving the message unsent.
+	time.Sleep(250 * time.Millisecond)
+	if out, err := exec.CommandContext(ctx, "tmux", "send-keys", "-t", paneID, "Enter").CombinedOutput(); err != nil {
+		return false, fmt.Errorf("tmux send-keys (enter): %w: %s", err, strings.TrimSpace(string(out)))
 	}
 	return true, nil
 }

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -217,7 +217,13 @@ func (r *mutationResolver) SendTextToPane(ctx context.Context, paneID string, te
 	// 250ms clears Claude Code's paste-coalesce window. A shorter gap
 	// (tested at 75ms) intermittently lets the Enter get absorbed into the
 	// paste burst on a freshly-booted REPL, leaving the message unsent.
-	time.Sleep(250 * time.Millisecond)
+	// select (not a bare time.Sleep) so a cancelled request returns promptly
+	// instead of blocking the goroutine for the full window.
+	select {
+	case <-time.After(250 * time.Millisecond):
+	case <-ctx.Done():
+		return false, ctx.Err()
+	}
 	if out, err := exec.CommandContext(ctx, "tmux", "send-keys", "-t", paneID, "Enter").CombinedOutput(); err != nil {
 		return false, fmt.Errorf("tmux send-keys (enter): %w: %s", err, strings.TrimSpace(string(out)))
 	}

--- a/schema.graphql
+++ b/schema.graphql
@@ -1410,4 +1410,52 @@ type Mutation {
   clients prefer the Tauri command since it stays local.
   """
   sendTextToPane(paneId: String!, text: String!): Boolean!
+
+  """
+  Launch a new Claude REPL inside a fresh detached tmux session at the
+  given working directory.
+
+  The daemon creates the tmux session (`tmux new-session -d -s <name>
+  -c <cwd>`), resolves the new pane, then types
+  `claude --session-id <uuid> --dangerously-skip-permissions --effort max`
+  (plus `--model` and an initial prompt when supplied) into the pane and
+  submits it — mirroring sendTextToPane's literal-write + Enter so the
+  REPL boots in the user's login shell with full env.
+
+  The session UUID is pre-assigned (`claude --session-id`) so the caller
+  can `conversationChanged(sessionUuid:)`-subscribe and target the pane
+  with `sendTextToPane` immediately, without waiting for the JSONL to
+  first appear under an unknown id.
+
+  Use case: browser / mobile clients creating a new working session on a
+  host where they have no shell access.
+  """
+  launchSession(input: LaunchSessionInput!): LaunchSessionResult!
+}
+
+"""
+Input for launchSession. Anchored to (host, cwd) semantics (ADR-009);
+v1 is local-host only, so host is implicit.
+"""
+input LaunchSessionInput {
+  "Absolute working directory the session runs in — typically a worktree path. A leading ~ is expanded daemon-side."
+  cwd: String!
+  "Optional tmux session name. When omitted the daemon derives one from the cwd basename plus a short unique suffix; collisions are de-duplicated."
+  name: String
+  "Optional model alias or full name (e.g. \"opus\", \"claude-sonnet-4-6\"). Passed to `claude --model` when present."
+  model: String
+  "Optional first prompt. When present it is passed to Claude as the initial task so the agent starts working immediately."
+  prompt: String
+}
+
+"Result of launchSession: the freshly created tmux session, the Claude REPL pane to target for chat sends, and the pre-assigned session UUID."
+type LaunchSessionResult {
+  "The tmux session name that was created (after de-duplication)."
+  sessionName: String!
+  "The tmux pane id running the Claude REPL (e.g. \"%73\"). Target this with sendTextToPane."
+  paneId: String!
+  "The pre-assigned Claude session UUID. Subscribe to conversationChanged(sessionUuid:) to stream the transcript as it grows."
+  sessionUuid: String!
+  "The working directory the session was launched in (after ~ expansion)."
+  cwd: String!
 }

--- a/scripts/host-services/gui-servers-up.sh
+++ b/scripts/host-services/gui-servers-up.sh
@@ -22,6 +22,12 @@ PUBLIC_URL="https://orchard-gui.drewdrewthis.boxd.sh"
 # The browser loads the GUI from the boxd HTTPS origin; the daemon's WS
 # CheckOrigin must allowlist it or conversationChanged subscriptions 403.
 ORIGIN="$PUBLIC_URL"
+# Introspection is OFF by default on the public daemon — serving the full
+# schema to anyone who can reach the boxd URL is an info-disclosure surface.
+# Opt in for debugging with `ORCHARD_INTROSPECTION=1 gui-servers-up.sh`. The
+# live suites (create-chat / render-gate) drive the UI, not __schema queries,
+# so they pass with it off.
+INTROSPECTION="${ORCHARD_INTROSPECTION:-0}"
 BUILD=true
 [[ "${1:-}" == "--no-build" ]] && BUILD=false
 
@@ -38,7 +44,7 @@ echo "[gui-servers] (re)creating detached tmux session '$SESSION'…"
 tmux kill-session -t "$SESSION" 2>/dev/null || true
 tmux new-session -d -s "$SESSION" -n daemon -c "$REPO"
 tmux send-keys -t "$SESSION:daemon" \
-  "ORCHARD_INTROSPECTION=1 ORCHARD_ALLOWED_ORIGINS=$ORIGIN ./bin/orchard-daemon daemon start 2>&1 | tee /tmp/orchard-daemon.log" Enter
+  "ORCHARD_INTROSPECTION=$INTROSPECTION ORCHARD_ALLOWED_ORIGINS=$ORIGIN ./bin/orchard-daemon daemon start 2>&1 | tee /tmp/orchard-daemon.log" Enter
 tmux new-window -t "$SESSION" -n vite -c "$GUI"
 tmux send-keys -t "$SESSION:vite" \
   "corepack pnpm preview --port 4173 2>&1 | tee /tmp/vite-preview.log" Enter

--- a/scripts/host-services/gui-servers-up.sh
+++ b/scripts/host-services/gui-servers-up.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# gui-servers-up.sh — bring the live browser GUI up DURABLY.
+#
+# Root cause this fixes: the orchard daemon (:7777) and the vite preview
+# server (:4173) used to run inside a Claude worker session. When that
+# session died (burnout / reboot) the servers died with it and the public
+# URL went 502/blank. This script runs them in a detached tmux session
+# `gui-servers` (windows `daemon` + `vite`) that is independent of any
+# Claude session, so they survive it dying. Idempotent: safe to re-run.
+#
+#   scripts/host-services/gui-servers-up.sh            # build + (re)launch + verify
+#   scripts/host-services/gui-servers-up.sh --no-build # relaunch existing builds
+#
+# Verifies at the end: daemon /health 200, vite 200, public URL 200, and a
+# real render (tests/render-gate.mjs). Exits non-zero if any gate fails.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+GUI="$REPO/crates/orchard-gui"
+SESSION="gui-servers"
+PUBLIC_URL="https://orchard-gui.drewdrewthis.boxd.sh"
+# The browser loads the GUI from the boxd HTTPS origin; the daemon's WS
+# CheckOrigin must allowlist it or conversationChanged subscriptions 403.
+ORIGIN="$PUBLIC_URL"
+BUILD=true
+[[ "${1:-}" == "--no-build" ]] && BUILD=false
+
+cd "$REPO"
+
+if $BUILD; then
+  echo "[gui-servers] building daemon from HEAD…"
+  go build -o bin/orchard-daemon ./cmd/orchard-daemon
+  echo "[gui-servers] building GUI bundle…"
+  ( cd "$GUI" && corepack pnpm build )
+fi
+
+echo "[gui-servers] (re)creating detached tmux session '$SESSION'…"
+tmux kill-session -t "$SESSION" 2>/dev/null || true
+tmux new-session -d -s "$SESSION" -n daemon -c "$REPO"
+tmux send-keys -t "$SESSION:daemon" \
+  "ORCHARD_INTROSPECTION=1 ORCHARD_ALLOWED_ORIGINS=$ORIGIN ./bin/orchard-daemon daemon start 2>&1 | tee /tmp/orchard-daemon.log" Enter
+tmux new-window -t "$SESSION" -n vite -c "$GUI"
+tmux send-keys -t "$SESSION:vite" \
+  "corepack pnpm preview --port 4173 2>&1 | tee /tmp/vite-preview.log" Enter
+
+wait_200() { # url, label
+  for _ in $(seq 1 40); do
+    code=$(curl -s -o /dev/null -w '%{http_code}' "$1" || true)
+    [[ "$code" == "200" ]] && { echo "[gui-servers] $2: 200"; return 0; }
+    sleep 0.5
+  done
+  echo "[gui-servers] $2: never reached 200 (last: ${code:-000})" >&2; return 1
+}
+
+wait_200 "http://127.0.0.1:7777/health" "daemon /health"
+wait_200 "http://127.0.0.1:4173" "vite preview"
+wait_200 "$PUBLIC_URL" "public URL"
+
+echo "[gui-servers] verifying real render…"
+( cd "$GUI" && node tests/render-gate.mjs "$PUBLIC_URL" )
+
+echo "[gui-servers] UP — $PUBLIC_URL"


### PR DESCRIPTION
GUI create+chat is live and behavior-locked against the **live HTTPS endpoint** (https://orchard-gui.drewdrewthis.boxd.sh).

## AC2 — GUI live + renders durably
- daemon `:7777` + vite `:4173` run in a detached `gui-servers` tmux session (independent of any Claude session — survives reboot/burnout).
- Reproducible via `scripts/host-services/gui-servers-up.sh` (rebuilds daemon from HEAD, builds GUI, relaunches, gates on health + render).
- `render-gate.mjs` **7/7 PASS** against live HTTPS — real UI renders, no blank screen.

## AC3 — create+chat BDD all-green
- `tests/create-chat.drive.mjs` **11/11 GREEN** against live HTTPS: real session created via `launchSession`, `sendTextToPane` submits, `conversationChanged` fires over the WS (5 frames / 4 events), reply renders, full e2e, no page errors.
- 1:1 feature-line↔assertion parity mechanically enforced by `tests/parity-check.mjs` (**PARITY OK, 18 assertions**) — no heavy Gherkin runner.

Commits: `6253bf0` (AC2), `823476d` (AC3). Delivers the GUI half of contract `C-2026-05-25-6751f2b9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to create Claude sessions directly from the GUI browser via "New Conversation" modal.
  * Integrated chat composer after launching a session, supporting message submission and streaming replies.

* **Tests**
  * Added comprehensive end-to-end test suite for create + chat workflow from the browser.
  * Added GUI rendering regression test to verify page loads and renders correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/663?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->