### PR TITLE
fix(daemon): verify pidfile PID is the daemon before refusing to start (#665)

### DIFF
--- a/internal/cli/daemon/daemon.go
+++ b/internal/cli/daemon/daemon.go
@@ -102,8 +102,20 @@ func runStart(parentCtx context.Context, addr string, version string) error {
 	if err := ensureParentDir(pidPath); err != nil {
 		return err
 	}
-	if pid, err := readPid(pidPath); err == nil && processAlive(pid) {
-		return fmt.Errorf("orchard daemon already running (pid %d, pidfile %s)", pid, pidPath)
+	if pid, err := readPid(pidPath); err == nil {
+		// The pidfile names a process. Only honour it as "already running"
+		// when that PID is alive AND genuinely an orchard-daemon. After a
+		// crash that skipped `defer os.Remove(pidPath)`, the OS may have
+		// recycled the PID to an unrelated process — a bare liveness probe
+		// then falsely reports "already running" and refuses to start
+		// (issue #665, a P0 outage). When the live PID is NOT the daemon,
+		// the pidfile is stale: warn, reclaim it, and proceed to start.
+		if !shouldTreatPidfileAsStale(pid, processAlive, processIsDaemon) {
+			return fmt.Errorf("orchard daemon already running (pid %d, pidfile %s)", pid, pidPath)
+		}
+		if processAlive(pid) {
+			fmt.Fprintf(os.Stderr, "orchard: stale pidfile %s names live non-daemon pid %d; reclaiming\n", pidPath, pid)
+		}
 	}
 	if err := writePid(pidPath, os.Getpid()); err != nil {
 		return fmt.Errorf("write pidfile: %w", err)
@@ -456,4 +468,71 @@ func processAlive(pid int) bool {
 		return false
 	}
 	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+// daemonProcessName is the executable basename of the daemon binary
+// (see cmd/orchard-daemon). It is what /proc/<pid>/comm reports and what
+// /proc/<pid>/cmdline starts with for a running daemon.
+const daemonProcessName = "orchard-daemon"
+
+// procNameReader returns a best-effort identifier for the process at pid
+// — on Linux the contents of /proc/<pid>/comm and /proc/<pid>/cmdline.
+// ok is false when the platform offers no introspection (no /proc), so
+// callers can fall back conservatively. It is a package var so tests can
+// inject a fake without depending on the real /proc.
+var procNameReader = readProcName
+
+// processIsDaemon reports whether the (assumed-alive) process at pid is
+// genuinely an orchard-daemon. On Linux this inspects /proc; where the
+// process name cannot be determined (non-Linux, or /proc unreadable) it
+// falls back to the old liveness-only behaviour — assuming the PID is the
+// daemon — so we never silently double-start on platforms we cannot
+// introspect.
+func processIsDaemon(pid int) bool {
+	name, ok := procNameReader(pid)
+	if !ok {
+		// Conservative fallback: cannot introspect, so treat a live PID as
+		// the daemon (preserves the pre-#665 double-start guard).
+		return true
+	}
+	return strings.Contains(name, daemonProcessName)
+}
+
+// shouldTreatPidfileAsStale decides what runStart's pidfile gate should
+// do, factored out of runStart so the three-way decision is unit-testable
+// without a pidfile, a signal trap, or an addr binding. It composes the
+// liveness probe (alive) with the daemon-identity probe (isDaemon):
+//
+//   - dead PID                  → stale (proceed to start)
+//   - live PID, not the daemon  → stale (PID reuse; reclaim and start) — issue #665
+//   - live PID, is the daemon   → NOT stale (genuine "already running")
+//
+// alive and isDaemon are injected so tests can drive every branch
+// deterministically.
+func shouldTreatPidfileAsStale(pid int, alive func(int) bool, isDaemon func(int) bool) bool {
+	if !alive(pid) {
+		return true
+	}
+	return !isDaemon(pid)
+}
+
+// readProcName reads the Linux /proc entries that identify a process.
+// It concatenates /proc/<pid>/comm and a space-joined /proc/<pid>/cmdline
+// so a substring match against daemonProcessName catches both the
+// (15-char-truncated) comm name and a path-prefixed argv[0]. ok is false
+// when neither file can be read — including on platforms without /proc,
+// where the open simply fails.
+func readProcName(pid int) (name string, ok bool) {
+	var parts []string
+	if comm, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid)); err == nil {
+		parts = append(parts, strings.TrimSpace(string(comm)))
+	}
+	if cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid)); err == nil {
+		// cmdline args are NUL-separated; join with spaces for matching.
+		parts = append(parts, strings.ReplaceAll(strings.TrimRight(string(cmdline), "\x00"), "\x00", " "))
+	}
+	if len(parts) == 0 {
+		return "", false
+	}
+	return strings.Join(parts, " "), true
 }

--- a/internal/cli/daemon/pidfile_stale_test.go
+++ b/internal/cli/daemon/pidfile_stale_test.go
@@ -1,0 +1,136 @@
+// Tests for the startup pidfile staleness decision — issue #665.
+//
+// The daemon's startup gate used to refuse to start whenever the pidfile
+// named ANY live PID, even after the OS recycled that PID to an unrelated
+// process. These tests pin the corrected three-way decision (dead /
+// live-non-daemon / live-daemon) via the pure, dependency-injected
+// helper `shouldTreatPidfileAsStale`, plus the `/proc`-backed
+// `processIsDaemon` identity probe and its conservative fallback.
+
+package daemon
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// alwaysAlive / neverAlive / asDaemon / notDaemon are tiny injectable
+// stand-ins so the decision table can be driven without real processes.
+func alwaysAlive(int) bool { return true }
+func neverAlive(int) bool  { return false }
+func asDaemon(int) bool    { return true }
+func notDaemon(int) bool   { return false }
+
+// TestShouldTreatPidfileAsStale_LiveDaemon is the genuine "already
+// running" case: the PID is alive AND is an orchard-daemon, so the
+// pidfile is authoritative (NOT stale) and runStart must refuse to start.
+func TestShouldTreatPidfileAsStale_LiveDaemon(t *testing.T) {
+	if got := shouldTreatPidfileAsStale(1234, alwaysAlive, asDaemon); got {
+		t.Errorf("live + is-daemon: shouldTreatPidfileAsStale = true, want false (honour pidfile, refuse start)")
+	}
+}
+
+// TestShouldTreatPidfileAsStale_LiveNonDaemon is the #665 regression:
+// the PID is alive but belongs to an unrelated process (PID reuse). The
+// pidfile MUST be treated as stale so the daemon reclaims it and starts.
+func TestShouldTreatPidfileAsStale_LiveNonDaemon(t *testing.T) {
+	if got := shouldTreatPidfileAsStale(79, alwaysAlive, notDaemon); !got {
+		t.Errorf("live + NOT daemon (PID reuse): shouldTreatPidfileAsStale = false, want true (reclaim, proceed) — issue #665 regression")
+	}
+}
+
+// TestShouldTreatPidfileAsStale_DeadPid is the existing-behaviour
+// regression guard: a dead PID means the pidfile is stale and start
+// proceeds. The daemon-identity probe must not even be consulted.
+func TestShouldTreatPidfileAsStale_DeadPid(t *testing.T) {
+	identityConsulted := false
+	isDaemon := func(int) bool { identityConsulted = true; return true }
+
+	if got := shouldTreatPidfileAsStale(99999, neverAlive, isDaemon); !got {
+		t.Errorf("dead PID: shouldTreatPidfileAsStale = false, want true (proceed to start)")
+	}
+	if identityConsulted {
+		t.Errorf("dead PID: daemon-identity probe was consulted; liveness should short-circuit")
+	}
+}
+
+// TestProcessIsDaemon_MatchesInjectedName verifies the identity probe
+// returns true only when the looked-up process name contains the daemon
+// binary basename. The name lookup is injected so the test does not
+// depend on a real /proc entry.
+func TestProcessIsDaemon_MatchesInjectedName(t *testing.T) {
+	orig := procNameReader
+	t.Cleanup(func() { procNameReader = orig })
+
+	cases := []struct {
+		name string
+		read func(int) (string, bool)
+		want bool
+	}{
+		{"bare comm", func(int) (string, bool) { return "orchard-daemon", true }, true},
+		{"path-prefixed cmdline", func(int) (string, bool) { return "/usr/local/bin/orchard-daemon daemon start", true }, true},
+		{"unrelated process", func(int) (string, bool) { return "boxd-orchardist-start.sh", true }, false},
+		{"empty name", func(int) (string, bool) { return "", true }, false},
+		{"no introspection falls back to true", func(int) (string, bool) { return "", false }, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			procNameReader = tc.read
+			if got := processIsDaemon(4321); got != tc.want {
+				t.Errorf("processIsDaemon = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProcessIsDaemon_ConservativeFallback isolates the platform we cannot
+// introspect: when the name reader reports ok=false, processIsDaemon must
+// assume the live PID is the daemon, preserving the pre-#665 double-start
+// guard rather than silently reclaiming an unknown live process.
+func TestProcessIsDaemon_ConservativeFallback(t *testing.T) {
+	orig := procNameReader
+	t.Cleanup(func() { procNameReader = orig })
+	procNameReader = func(int) (string, bool) { return "irrelevant", false }
+
+	if !processIsDaemon(4321) {
+		t.Errorf("ok=false fallback: processIsDaemon = false, want true (conservative, do not double-start)")
+	}
+}
+
+// TestReadProcName_CurrentProcess exercises the real Linux /proc reader
+// against this very test binary (a genuinely-live PID). The reported name
+// must be non-empty and must NOT name orchard-daemon — the test binary is
+// the live-non-daemon case from #665, end to end against real /proc.
+func TestReadProcName_CurrentProcess(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("readProcName reads /proc; Linux only")
+	}
+	name, ok := readProcName(os.Getpid())
+	if !ok {
+		t.Fatalf("readProcName(self) ok = false; want true on Linux")
+	}
+	if strings.TrimSpace(name) == "" {
+		t.Fatalf("readProcName(self) name empty; want the test binary name")
+	}
+	if strings.Contains(name, daemonProcessName) {
+		t.Fatalf("readProcName(self) = %q unexpectedly contains %q; the go-test binary is not the daemon", name, daemonProcessName)
+	}
+	// And the composed identity probe must agree this is not the daemon.
+	if processIsDaemon(os.Getpid()) {
+		t.Errorf("processIsDaemon(self) = true; the test binary is a live non-daemon process")
+	}
+}
+
+// TestReadProcName_DeadPid confirms the reader reports ok=false for a PID
+// with no /proc entry. PID 0x7FFFFFFF is effectively never live, so this
+// stays deterministic without spawning and reaping a child.
+func TestReadProcName_DeadPid(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("readProcName reads /proc; Linux only")
+	}
+	if _, ok := readProcName(0x7FFFFFFF); ok {
+		t.Errorf("readProcName(dead pid) ok = true; want false (no /proc entry)")
+	}
+}


### PR DESCRIPTION
## Summary

The daemon's startup pidfile gate refused to start whenever the pidfile named **any** live PID — it used a bare `Signal(0)` liveness probe (`processAlive`) that cannot tell `orchard-daemon` from an unrelated process. After a crash that skips `defer os.Remove(pidPath)` (SIGKILL/OOM/host reboot), the OS can recycle that PID to a different process; startup then falsely reports `orchard daemon already running` and exits non-zero, looping under systemd until a human removes the pidfile. This caused a **P0 outage** on `orchardist-backup`.

**Fix:** after confirming the PID is alive, verify it is genuinely an `orchard-daemon` before honouring the pidfile. On Linux this reads `/proc/<pid>/comm` and `/proc/<pid>/cmdline` (substring match on `orchard-daemon`, covering the 15-char `comm` truncation and a path-prefixed `argv[0]`). Where the process name can't be determined (no `/proc`), it falls back to the old liveness-only behaviour so we never silently double-start on platforms we can't introspect.

The three-way decision is factored into a pure `shouldTreatPidfileAsStale(pid, alive, isDaemon)` helper with both probes injected, and the `/proc` name lookup is a package var (`procNameReader`) — so the regression is unit-tested without a real `/proc`, a signal trap, or an addr binding. The genuine double-start guard is unchanged.

Closes #665

## Behaviour

| pidfile PID | before | after |
|---|---|---|
| live **and** is `orchard-daemon` | refuse: "already running" | refuse: "already running" (unchanged) |
| live but **not** the daemon (PID reuse) | **refuse (bug)** | stale: warn to stderr, reclaim pidfile, **start** |
| dead | start | start (unchanged) |

## Tests (`internal/cli/daemon/pidfile_stale_test.go`)

Covers all three acceptance-criteria cases plus the identity probe:

1. **live + is-daemon** → not stale, start is refused with the "already running" error.
2. **live + NOT daemon** (PID reuse) → treated as stale; start proceeds. This is the #665 regression — also verified end-to-end against real `/proc` using the test binary's own PID (a genuinely-live non-daemon process).
3. **dead PID** → stale; start proceeds (regression guard; identity probe is short-circuited).

Plus: `processIsDaemon` name-matching table (bare comm / path-prefixed cmdline / unrelated / empty), the conservative `ok=false` fallback, and `readProcName` against the live current process and a dead PID.

```
$ go test ./internal/cli/daemon/...
ok  	github.com/drewdrewthis/git-orchard-rs/internal/cli/daemon	0.255s
```
`go build ./...` and `go vet ./internal/cli/daemon/...` are clean. The change is scoped to `internal/cli/daemon/daemon.go` (+ the new test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #665