### PR TITLE
fix(contracts): skills lose $CLAUDE_SESSION_ID under --print — use --auto

### DIFF
--- a/plugins/conversation-contracts/scripts/fold-contracts.bats
+++ b/plugins/conversation-contracts/scripts/fold-contracts.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# Tests for fold-contracts.sh — specifically the --auto mode the skills use.
+#
+# --auto exists because real Claude Code does NOT export CLAUDE_SESSION_ID to
+# skill subprocesses (SDK/--print in particular), so the older `--session
+# "$CLAUDE_SESSION_ID"` recipe ran blind in production. --auto resolves the
+# session jsonl from $PWD's encoding + the newest jsonl in that directory.
+# (Explicit-path and --session modes are exercised transitively by on-stop.bats.)
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/fold-contracts.sh"
+  TMP_HOME="$(mktemp -d)"
+  CWD="$TMP_HOME/work"
+  mkdir -p "$CWD"
+  ENCODED_CWD=$(printf '%s' "$CWD" | tr '/.' '--')
+  PROJECTS_DIR="$TMP_HOME/.claude/projects/$ENCODED_CWD"
+  mkdir -p "$PROJECTS_DIR"
+}
+
+teardown() {
+  rm -rf "$TMP_HOME"
+}
+
+# _open_line / _close_line — sentinel embedded in a tool_result content string
+# (the shape the harness writes when a skill echoes via emit-sentinel.sh).
+_open_line() {
+  local inner="{\\\"orchard_contract\\\":\\\"open\\\",\\\"id\\\":\\\"$1\\\",\\\"statement\\\":\\\"$2\\\",\\\"ts\\\":\\\"2026-05-28T10:00:00Z\\\"}"
+  printf '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"%s"}]}}' "$inner"
+}
+
+_run_auto() {
+  # Invoke the script with $PWD=$CWD and $HOME overridden so the encoded-cwd
+  # lookup resolves to $PROJECTS_DIR — mirroring how a skill would call it.
+  run env HOME="$TMP_HOME" \
+      bash -c "cd '$CWD' && bash '$SCRIPT' --auto"
+}
+
+@test "--auto picks the newest jsonl under encoded-cwd and folds it" {
+  printf '%s\n' "$(_open_line "C-AUTO-1" "the only session")" > "$PROJECTS_DIR/s-1.jsonl"
+  _run_auto
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"C-AUTO-1"* ]]
+  [[ "$output" == *"the only session"* ]]
+}
+
+@test "--auto chooses the most recently modified jsonl when multiple sessions exist" {
+  # Older session (closed open).
+  printf '%s\n%s\n' \
+    "$(_open_line "C-OLD" "older — should be ignored")" \
+    "{\"type\":\"user\",\"message\":{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"content\":\"{\\\"orchard_contract\\\":\\\"close\\\",\\\"id\\\":\\\"C-OLD\\\",\\\"reason\\\":\\\"d\\\",\\\"ts\\\":\\\"t\\\"}\"}]}}" \
+    > "$PROJECTS_DIR/s-old.jsonl"
+  # Bump older's mtime back; current session is newer.
+  touch -t 202001010000 "$PROJECTS_DIR/s-old.jsonl"
+  printf '%s\n' "$(_open_line "C-CURRENT" "this session's open")" > "$PROJECTS_DIR/s-current.jsonl"
+
+  _run_auto
+  [[ "$output" == *"C-CURRENT"* ]]
+  [[ "$output" != *"C-OLD"* ]]
+}
+
+@test "--auto gracefully degrades when no jsonl exists for this cwd" {
+  # No jsonl was written.
+  _run_auto
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "--auto picks up an explicit cwd argument when given" {
+  printf '%s\n' "$(_open_line "C-ELSEWHERE" "named-cwd path")" > "$PROJECTS_DIR/s-elsewhere.jsonl"
+  # Call from a DIFFERENT cwd but pass $CWD explicitly.
+  other=$(mktemp -d)
+  run env HOME="$TMP_HOME" \
+      bash -c "cd '$other' && bash '$SCRIPT' --auto '$CWD'"
+  rm -rf "$other"
+  [[ "$output" == *"C-ELSEWHERE"* ]]
+}

--- a/plugins/conversation-contracts/scripts/fold-contracts.sh
+++ b/plugins/conversation-contracts/scripts/fold-contracts.sh
@@ -13,9 +13,30 @@
 # Usage:
 #   fold-contracts.sh <session-jsonl-path>     # explicit path
 #   fold-contracts.sh --session <id> [<cwd>]   # resolve path from session id
+#   fold-contracts.sh --auto [<cwd>]           # newest jsonl under encoded-cwd
 # Output: one line per open contract; empty if none. Exit 0 always.
+#
+# Prefer --auto in skills: real Claude Code does NOT export CLAUDE_SESSION_ID
+# to user-driven skill subprocesses (SDK/--print mode in particular leaves it
+# unset), so any skill that calls `--session "$CLAUDE_SESSION_ID"` is blind to
+# the current session. --auto resolves the path from $PWD's encoding and picks
+# the newest jsonl in that directory — the current session by definition,
+# because we are running inside it as it writes to it.
 
 set -uo pipefail
+
+_resolve_session_jsonl() {
+  # Given a cwd, print the newest .jsonl in the corresponding projects subdir.
+  # Empty if no match. Cwd encoding mirrors Claude Code's: / and . → -.
+  local cwd="$1"
+  [ -n "$cwd" ] || return 0
+  local root="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
+  local enc; enc=$(printf '%s' "$cwd" | tr '/.' '--')
+  local dir="$root/$enc"
+  [ -d "$dir" ] || return 0
+  # ls -t sorts by mtime descending; ignore failures if no jsonls match.
+  ls -t "$dir"/*.jsonl 2>/dev/null | head -1
+}
 
 if [ "${1:-}" = "--session" ]; then
   sid="${2:-}"
@@ -24,6 +45,9 @@ if [ "${1:-}" = "--session" ]; then
   root="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
   enc=$(printf '%s' "$cwd" | tr '/.' '--')
   jsonl="$root/$enc/$sid.jsonl"
+elif [ "${1:-}" = "--auto" ]; then
+  cwd="${2:-${PWD:-}}"
+  jsonl=$(_resolve_session_jsonl "$cwd")
 else
   jsonl="${1:-}"
 fi

--- a/plugins/conversation-contracts/skills/close-conversation/SKILL.md
+++ b/plugins/conversation-contracts/skills/close-conversation/SKILL.md
@@ -11,11 +11,13 @@ Contracts are `orchard_contract` sentinels in the session jsonl (open minus clos
 
 ## Flow
 
-1. **Fold the open contracts.** Run `scripts/fold-contracts.sh` against this session's jsonl to list every open contract:
+1. **Fold the open contracts.** Run `scripts/fold-contracts.sh` in `--auto` mode to list every open contract for this session (it picks the newest jsonl under this cwd's projects dir):
 
    ```bash
-   bash "$CLAUDE_PLUGIN_ROOT/scripts/fold-contracts.sh" --session "$CLAUDE_SESSION_ID"
+   bash "$CLAUDE_PLUGIN_ROOT/scripts/fold-contracts.sh" --auto
    ```
+
+   Use `--auto`, not `--session "$CLAUDE_SESSION_ID"` — the env var is unset in SDK/--print contexts and the fold would silently return empty.
 
 2. **Identify the conversation contract** by its fixed statement: `user agrees conversation has come to a close and there are no loose ends`. Any other open contract is a **child** contract.
 

--- a/plugins/conversation-contracts/skills/my-contracts/SKILL.md
+++ b/plugins/conversation-contracts/skills/my-contracts/SKILL.md
@@ -9,13 +9,13 @@ List the contracts currently OPEN for this session — the deliverables that wil
 
 ## Flow
 
-1. Run the shared fold script with a single `Bash` call — it resolves this session's jsonl from the session id itself:
+1. Run the shared fold script in `--auto` mode — it picks the newest jsonl under this cwd's projects dir (which IS the current session, by definition, because we are running inside it as it writes to itself):
 
    ```bash
-   bash "$CLAUDE_PLUGIN_ROOT/scripts/fold-contracts.sh" --session "$CLAUDE_SESSION_ID"
+   bash "$CLAUDE_PLUGIN_ROOT/scripts/fold-contracts.sh" --auto
    ```
 
-   It prints one line per open contract: `- <id>: <statement>`. Empty output means no open contracts. (`--session <id> [<cwd>]` resolves `<projects_root>/<encoded-cwd>/<id>.jsonl`; pass an explicit jsonl path instead if you have one.)
+   It prints one line per open contract: `- <id>: <statement>`. Empty output means no open contracts. `--auto` does not need `$CLAUDE_SESSION_ID` — that env var is unset in SDK/--print contexts, so prefer `--auto` over `--session "$CLAUDE_SESSION_ID"` here.
 
 3. Report the result to the user:
    - Open contracts → list them and note each is closed with `/close-contract <id>`.
@@ -25,4 +25,4 @@ List the contracts currently OPEN for this session — the deliverables that wil
 
 - This is read-only: it never writes a sentinel. Opening/closing is `/open-contract` and `/close-contract`.
 - It calls the SAME `scripts/fold-contracts.sh` the Stop hook uses, so what it lists is exactly what would block Stop. One fold, no drift.
-- If `$CLAUDE_SESSION_ID` isn't set in your environment, the path can't be resolved — fall back to telling the user the Stop hook will surface open contracts when they try to end the session.
+- `--auto` is the production-correct mode. The earlier `--session "$CLAUDE_SESSION_ID"` recipe was an i-am-done canonical anti-pattern: `CLAUDE_SESSION_ID` is not exported to skill subprocesses in SDK/--print runs, so the fold ran blind. `--auto` resolves the path from `$PWD` and picks the newest jsonl, which is the running session.


### PR DESCRIPTION
## What

Post-merge install verification of v0.9.0 (PR #666) exposed that real Claude Code does NOT export `$CLAUDE_SESSION_ID` to skill subprocesses in SDK/`--print` runs. `/my-contracts` and the inventory step of `/close-conversation` were calling:

```bash
bash "$CLAUDE_PLUGIN_ROOT/scripts/fold-contracts.sh" --session "$CLAUDE_SESSION_ID"
```

which silently returned empty when the env var was unset — the skill ran blind, with the user none the wiser.

This is the canonical [test-mock-as-runtime-proof anti-pattern](https://github.com/drewdrewthis/git-orchard-rs/blob/main/AGENTS.md) replayed: bats tests passed because the harness sets `$CLAUDE_SESSION_ID`; production doesn't.

## Real-runtime evidence (the trigger)

Drove `claude --plugin-dir <v0.9-cache> --print` and asked the model to open / list / close a contract. The model itself surfaced the bug in its own response, with the corresponding jsonl confirming:

> The fold returns empty (`$CLAUDE_SESSION_ID` is unset in this environment, so it can't resolve a jsonl). Per the skill's idempotency note: "if the fold shows no open conversation contract, report success immediately — nothing to close." No conversation contract is visible to close.

So `/close-conversation` would silently report success against an open contract. Critical.

## Fix

Add `--auto` mode to `fold-contracts.sh`:

```
fold-contracts.sh --auto [<cwd>]   # newest jsonl under encoded-cwd
```

The newest jsonl under the encoded `$PWD` IS the current session, by definition — the session is writing to that file as we read it. No env var needed.

Switch `/my-contracts` and `/close-conversation` to call `--auto`. The Stop hook still uses `--session` (it gets `session_id` from the Stop payload via stdin, which IS reliable).

## Tests

New `fold-contracts.bats` with 4 cases targeting `--auto`:
- picks the newest jsonl under encoded-cwd
- prefers the most recently modified when multiple sessions exist
- degrades to empty output (exit 0) when no jsonl matches
- honours an explicit cwd argument

Plugin bats: 31 → 35. All 35 green locally.

## Related

- Discovered while verifying PR #666 (https://github.com/drewdrewthis/git-orchard-rs/pull/666) post-merge. That PR's design is correct end-to-end; this is a runtime-contract gap the install verification surfaced.
- Same anti-pattern as #650: `internal/server/providers/contracts` originally read `$CLAUDE_SESSION_ID` (the canonical i-am-done case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic session detection that identifies the most recently used session without requiring explicit session ID configuration.

* **Documentation**
  * Updated skill documentation to reflect automatic session detection capability across relevant features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->