### PR TITLE
fix(contracts): --auto resolves symlinks; fold tolerates trailing text

### DIFF
--- a/plugins/conversation-contracts/scripts/fold-contracts.bats
+++ b/plugins/conversation-contracts/scripts/fold-contracts.bats
@@ -9,7 +9,10 @@
 
 setup() {
   SCRIPT="$BATS_TEST_DIRNAME/fold-contracts.sh"
-  TMP_HOME="$(mktemp -d)"
+  # Resolve to the physical path so tests see the same encoding the fold uses
+  # (macOS's /var → /private/var symlink would otherwise produce mismatching
+  # projects-dir lookups).
+  TMP_HOME="$(cd -P -- "$(mktemp -d)" && pwd -P)"
   CWD="$TMP_HOME/work"
   mkdir -p "$CWD"
   ENCODED_CWD=$(printf '%s' "$CWD" | tr '/.' '--')
@@ -63,6 +66,49 @@ _run_auto() {
   _run_auto
   [ "$status" -eq 0 ]
   [ -z "$output" ]
+}
+
+@test "--auto resolves symlinked cwd to its physical path before encoding" {
+  # The trigger: on macOS, /var is a symlink to /private/var. A session whose
+  # cwd reports /var/folders/... has its jsonl written under
+  # ~/.claude/projects/-private-var-folders-... — the encoded RESOLVED path.
+  # If --auto encodes $PWD directly (the symlinked /var/... form), it misses
+  # the projects dir entirely and returns empty. Bug 1 from PR #666 install
+  # verification.
+  printf '%s\n' "$(_open_line "C-RESOLVED" "resolved-path open")" > "$PROJECTS_DIR/s-resolved.jsonl"
+  # Symlink a /tmp/<rand> dir at the SAME real path as $CWD — so $PWD-as-string
+  # differs from `pwd -P` but they encode to the same projects dir.
+  symlink="$TMP_HOME/symlinked-cwd"
+  ln -s "$CWD" "$symlink"
+  run env HOME="$TMP_HOME" \
+      bash -c "cd '$symlink' && bash '$SCRIPT' --auto"
+  rm -f "$symlink"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"C-RESOLVED"* ]]
+}
+
+@test "fold tolerates trailing text after a sentinel in a tool_result.content string" {
+  # The trigger: a skill recipe wrote `bash emit-sentinel.sh open ... && echo
+  # "Opened contract $id"` which made tool_result.content the multi-line string
+  # `<sentinel>\nOpened contract C-...`. The fold's plain `fromjson?` failed
+  # on the trailing text and silently dropped the sentinel. Bug 2 from PR #666
+  # install verification.
+  #
+  # Python builds the jsonl fixture so the embedded newline in the content
+  # string is correctly JSON-escaped (a literal \n inside the JSON string,
+  # which decodes to a real newline — the production shape).
+  python3 - "$PROJECTS_DIR/s-trailing.jsonl" <<'PY'
+import json, sys
+sentinel = '{"orchard_contract":"open","id":"C-TRAIL","statement":"with trailing text","ts":"t"}'
+content = sentinel + "\nOpened contract C-TRAIL"
+line = {"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":content}]}}
+open(sys.argv[1], "w").write(json.dumps(line) + "\n")
+PY
+
+  _run_auto
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"C-TRAIL"* ]]
+  [[ "$output" == *"with trailing text"* ]]
 }
 
 @test "--auto picks up an explicit cwd argument when given" {

--- a/plugins/conversation-contracts/scripts/fold-contracts.sh
+++ b/plugins/conversation-contracts/scripts/fold-contracts.sh
@@ -28,10 +28,18 @@ set -uo pipefail
 _resolve_session_jsonl() {
   # Given a cwd, print the newest .jsonl in the corresponding projects subdir.
   # Empty if no match. Cwd encoding mirrors Claude Code's: / and . → -.
+  #
+  # The cwd must be the RESOLVED (physical) path, not the symlinked one Claude
+  # Code received via $PWD — on macOS, `/var` is a symlink to `/private/var`,
+  # and the harness encodes the resolved `/private/var/...` path into the
+  # projects dir name, while a script's $PWD may still report `/var/...`. We
+  # resolve via `cd -P` so the encoding matches what the harness wrote.
   local cwd="$1"
   [ -n "$cwd" ] || return 0
+  local resolved
+  resolved=$(cd -P -- "$cwd" 2>/dev/null && pwd -P) || resolved="$cwd"
   local root="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
-  local enc; enc=$(printf '%s' "$cwd" | tr '/.' '--')
+  local enc; enc=$(printf '%s' "$resolved" | tr '/.' '--')
   local dir="$root/$enc"
   [ -d "$dir" ] || return 0
   # ls -t sorts by mtime descending; ignore failures if no jsonls match.
@@ -61,10 +69,18 @@ grep -Fq 'orchard_contract' "$jsonl" 2>/dev/null || exit 0
 # and as the SessionStart hook's recorded stdout (a `hook_success` attachment).
 # Union both extraction paths, keep only well-formed open/close sentinels with
 # a non-empty string id, dedupe, then fold by id.
+#
+# For the strings path, split on \n and try fromjson on each line — tolerates
+# bash recipes that chained `&& echo "..."` after emit-sentinel.sh and ended
+# up writing `<sentinel>\nhuman text` into a single tool_result.content string.
+# The sentinel is always one line, so per-line fromjson recovers it.
 grep -F 'orchard_contract' "$jsonl" 2>/dev/null \
   | jq -c '
       ( [ .. | objects | select(.orchard_contract) ]
-      + [ .. | strings | (fromjson? // empty) | select(type == "object" and .orchard_contract) ]
+      + [ .. | strings
+            | split("\n") | .[]
+            | (fromjson? // empty)
+            | select(type == "object" and .orchard_contract) ]
       ) | .[]
     ' 2>/dev/null \
   | jq -sc '

--- a/plugins/conversation-contracts/skills/open-contract/SKILL.md
+++ b/plugins/conversation-contracts/skills/open-contract/SKILL.md
@@ -23,14 +23,13 @@ Contracts live as JSON **sentinels** in this session's own jsonl — there is no
 2. Generate an id and emit the open sentinel with a single `Bash` call to the shared `scripts/emit-sentinel.sh` — the single source of truth for the on-disk shape, shared with `/close-contract` and the SessionStart auto-open hook:
 
    ```bash
-   id="C-$(date -u +%Y-%m-%d)-$(openssl rand -hex 4)" \
-     && bash "$CLAUDE_PLUGIN_ROOT/scripts/emit-sentinel.sh" open "$id" "<one-line statement>" \
-     && echo "Opened contract $id"
+   id="C-$(date -u +%Y-%m-%d)-$(openssl rand -hex 4)" && \
+     bash "$CLAUDE_PLUGIN_ROOT/scripts/emit-sentinel.sh" open "$id" "<one-line statement>"
    ```
 
-   The emitted JSON lands in the jsonl (inside the tool_result), where the fold picks it up. The script JSON-escapes the statement, so double-quotes and backslashes in your text are safe — you do not need to escape them by hand.
+   The emitted JSON is the **only** line on stdout — that single string becomes the `tool_result.content` the fold parses. Do NOT chain `&& echo "Opened contract $id"` into the same Bash command: the trailing text would concatenate into the same `tool_result.content` string and break the fold's `fromjson?` extraction. The id is in the JSON output already (`"id":"C-..."`); read it from there. The script JSON-escapes the statement, so double-quotes and backslashes in your text are safe.
 
-3. Read the generated `id` from the script's output and **report it back** to the user: "Opened contract `<id>`: <statement>. Close it with `/close-contract <id>` when delivered." The user needs the id to close it later.
+3. Read the generated `id` from the script's JSON output and **report it back to the user as chat text** (not as another Bash echo): "Opened contract `<id>`: <statement>. Close it with `/close-contract <id>` when delivered." The user needs the id to close it later.
 
 ## Notes
 


### PR DESCRIPTION
## Why

Post-merge verification of v0.9.0 surfaced two silent bugs in the skill → tool_result fold path. Both fail the same way: skill runs, fold returns empty, user gets "no open contracts" against a genuinely open one. The Stop-hook block path was never affected (it parses the SessionStart hook's stdout, which has no trailing text).

## Bug 1 — `/var` → `/private/var` symlink on macOS

Real Claude Code encodes the **resolved** (physical) path into its projects dir name. On macOS, `$PWD` reports the `/var/folders/...` form while `pwd -P` returns `/private/var/folders/...`. `--auto` was encoding `$PWD` directly, missed the projects dir, returned empty.

Real-runtime evidence from the verifier session in #666 follow-up:

> `$PWD` reports `/var/folders/9h/.../tmp.UJF6QUlHMD` (symlink-aware). Claude Code encodes its projects dir from the **resolved** path: `-private-var-folders-9h-...-tmp-UJF6QUlHMD`. `fold-contracts.sh --auto` encodes `$PWD` directly → looks in `-var-...` (no such dir) → returns empty.

Fix: `cd -P "$cwd" && pwd -P` to resolve the physical path before encoding.

## Bug 2 — Trailing text breaks the fold's `fromjson`

The `/open-contract` SKILL.md recipe was:
```bash
bash emit-sentinel.sh open "$id" "..." && echo "Opened contract $id"
```

That made `tool_result.content` a multi-line string `<sentinel JSON>\nOpened contract C-...`. The fold's `.. | strings | fromjson?` required the whole string to be valid JSON; it failed and silently dropped the sentinel. Skill-opened contracts were invisible to the fold.

Two-part fix:
- **Recipe**: rewrite `/open-contract` to make `emit-sentinel.sh`'s stdout the only thing in the captured `tool_result.content`. The human-readable confirmation goes in chat text, not via a chained bash echo.
- **Defense in depth**: change the fold's strings path from `fromjson?` to `split("\n") | .[] | fromjson? // empty` so a future skill author who messes this up doesn't break the fold.

## Tests

Two new `fold-contracts.bats` cases:
- `--auto resolves symlinked cwd to its physical path before encoding`
- `fold tolerates trailing text after a sentinel in a tool_result.content string`

Also a `setup()` tweak: resolve `TMP_HOME` to its physical path so the bats fixtures land where the fold actually looks (otherwise the fix would have failed the older happy-path tests on macOS too — the install-verification bug repro itself).

**37 plugin bats green** (was 35). Scripts bats unchanged.

## Related

Follow-up from #669 (the original `--auto` fix). Both bugs were already present in #666's design but silent because the only bats fixture for the strings path used clean script output; the SKILL.md recipe's `&& echo` was added separately and never end-to-end tested against the fold. Real-runtime drive caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)