### PR TITLE
fix(contracts): --session scans projects subdirs by sid; SKILL.md PLUGIN_ROOT fallback

### DIFF
--- a/plugins/conversation-contracts/scripts/fold-contracts.bats
+++ b/plugins/conversation-contracts/scripts/fold-contracts.bats
@@ -120,3 +120,55 @@ PY
   rm -rf "$other"
   [[ "$output" == *"C-ELSEWHERE"* ]]
 }
+
+# ---- --session scan-by-sid (Bug 3) -----------------------------------------
+#
+# Bug 3, surfaced post-merge of PR #666: Stop hook blocks were silently failing
+# in any session where the user `cd`'d after startup, because the fold's
+# `--session "$sid" "$PWD"` encoded $PWD to find the jsonl — but Claude Code
+# encodes the SESSION'S STARTUP cwd into the projects dir name, not $PWD. Fix:
+# scan every projects subdir for <sid>.jsonl; the session id is globally
+# unique so the scan is correct regardless of where the user cd'd.
+
+@test "--session finds the jsonl by sid even when stored under a different cwd-encoded dir" {
+  # The session jsonl lives under the encoding of the SESSION'S startup cwd —
+  # which here we simulate as a *different* dir than the calling $PWD.
+  local sid="S-SCAN-BY-SID"
+  local startup_encoded="-startup-cwd"
+  local startup_dir="$TMP_HOME/.claude/projects/$startup_encoded"
+  mkdir -p "$startup_dir"
+  printf '%s\n' "$(_open_line "C-SCANNED" "from startup-encoded dir")" \
+    > "$startup_dir/$sid.jsonl"
+
+  # Now invoke --session from a DIFFERENT $PWD whose encoding doesn't match
+  # the projects subdir at all. Pre-fix this returned empty (encoded $PWD,
+  # missed the jsonl). Post-fix it scans and finds.
+  run env HOME="$TMP_HOME" \
+      bash -c "cd '$CWD' && bash '$SCRIPT' --session '$sid'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"C-SCANNED"* ]]
+  [[ "$output" == *"from startup-encoded dir"* ]]
+}
+
+@test "--session ignores its optional cwd argument (backcompat with old callers)" {
+  # The old (pre-fix) signature was `--session <sid> [<cwd>]`. Callers in the
+  # wild may still pass a cwd argument; accept and ignore it.
+  local sid="S-IGNORES-CWD"
+  local startup_dir="$TMP_HOME/.claude/projects/-some-startup-cwd"
+  mkdir -p "$startup_dir"
+  printf '%s\n' "$(_open_line "C-BACKCOMPAT" "ignored-cwd-arg")" \
+    > "$startup_dir/$sid.jsonl"
+
+  # Pass a totally wrong cwd as the third arg; the scan should still find it.
+  run env HOME="$TMP_HOME" \
+      bash -c "bash '$SCRIPT' --session '$sid' /nonexistent/wrong/cwd"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"C-BACKCOMPAT"* ]]
+}
+
+@test "--session degrades to empty when no jsonl with that sid exists" {
+  run env HOME="$TMP_HOME" \
+      bash -c "bash '$SCRIPT' --session 'S-DOES-NOT-EXIST'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/plugins/conversation-contracts/scripts/fold-contracts.sh
+++ b/plugins/conversation-contracts/scripts/fold-contracts.sh
@@ -11,17 +11,24 @@
 # intended — a close for an unknown id is a harmless no-op.
 #
 # Usage:
-#   fold-contracts.sh <session-jsonl-path>     # explicit path
-#   fold-contracts.sh --session <id> [<cwd>]   # resolve path from session id
-#   fold-contracts.sh --auto [<cwd>]           # newest jsonl under encoded-cwd
+#   fold-contracts.sh <session-jsonl-path>   # explicit path
+#   fold-contracts.sh --session <id> [<cwd>] # scan projects dirs for <id>.jsonl
+#                                            # (cwd arg accepted for backcompat
+#                                            #  but ignored — see Bug 3 below)
+#   fold-contracts.sh --auto [<cwd>]         # newest jsonl under encoded-cwd
 # Output: one line per open contract; empty if none. Exit 0 always.
 #
-# Prefer --auto in skills: real Claude Code does NOT export CLAUDE_SESSION_ID
-# to user-driven skill subprocesses (SDK/--print mode in particular leaves it
-# unset), so any skill that calls `--session "$CLAUDE_SESSION_ID"` is blind to
-# the current session. --auto resolves the path from $PWD's encoding and picks
-# the newest jsonl in that directory — the current session by definition,
-# because we are running inside it as it writes to it.
+# Path resolution: Claude Code encodes the SESSION'S STARTUP cwd into the
+# projects dir name, not the current $PWD. If the user `cd`s after the session
+# starts (which is the common case in worktree-driven workflows), $PWD diverges
+# from the encoded path. Prior fold versions encoded $PWD and missed the jsonl
+# entirely — Stop blocks fired and silently allowed because the fold returned
+# empty (Bug 3, surfaced in PR #666 live verification).
+#
+# Fix: --session scans every projects subdir for <id>.jsonl rather than
+# encoding $PWD. The session id is globally unique, so the scan is correct
+# regardless of where the user has cd'd. The optional <cwd> argument is still
+# accepted for backward compatibility with old callers but is now ignored.
 
 set -uo pipefail
 
@@ -46,13 +53,24 @@ _resolve_session_jsonl() {
   ls -t "$dir"/*.jsonl 2>/dev/null | head -1
 }
 
+_find_jsonl_by_sid() {
+  # Scan every projects subdir for <sid>.jsonl. Print the first match's
+  # absolute path; empty if not found. Session ids are globally unique, so
+  # at most one match exists across all projects subdirs.
+  local sid="$1"
+  [ -n "$sid" ] || return 0
+  local root="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
+  [ -d "$root" ] || return 0
+  # find ... -path is portable across macOS and Linux; -quit on first match.
+  # Using -name keeps the scan cheap (one stat per subdir's <sid>.jsonl).
+  find "$root" -maxdepth 2 -type f -name "$sid.jsonl" -print -quit 2>/dev/null
+}
+
 if [ "${1:-}" = "--session" ]; then
   sid="${2:-}"
-  cwd="${3:-${PWD:-}}"
-  [ -n "$sid" ] && [ -n "$cwd" ] || exit 0
-  root="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
-  enc=$(printf '%s' "$cwd" | tr '/.' '--')
-  jsonl="$root/$enc/$sid.jsonl"
+  [ -n "$sid" ] || exit 0
+  # The third arg (cwd) is accepted for backcompat but unused — see Bug 3 fix.
+  jsonl=$(_find_jsonl_by_sid "$sid")
 elif [ "${1:-}" = "--auto" ]; then
   cwd="${2:-${PWD:-}}"
   jsonl=$(_resolve_session_jsonl "$cwd")

--- a/plugins/conversation-contracts/skills/close-contract/SKILL.md
+++ b/plugins/conversation-contracts/skills/close-contract/SKILL.md
@@ -22,10 +22,11 @@ A close is one of two things:
 3. Emit the close sentinel with a single `Bash` call to the shared `scripts/emit-sentinel.sh` — the same script `/open-contract` and the SessionStart auto-open hook use, so the on-disk shape stays consistent:
 
    ```bash
-   bash "$CLAUDE_PLUGIN_ROOT/scripts/emit-sentinel.sh" close "<id>" "<reason>"
+   PR="${CLAUDE_PLUGIN_ROOT:-$(find ~/.claude/plugins/cache -path '*/conversation-contracts/*/scripts/emit-sentinel.sh' -print -quit 2>/dev/null | sed 's|/scripts/emit-sentinel.sh$||')}" \
+     && bash "$PR/scripts/emit-sentinel.sh" close "<id>" "<reason>"
    ```
 
-   The script JSON-escapes the reason, so double-quotes and backslashes in your evidence text are safe — you do not need to escape them by hand.
+   The first line is a `$CLAUDE_PLUGIN_ROOT` fallback — the harness sets it when invoking hooks, but interactive `Bash` tool calls in skill subprocesses often don't have it. The script JSON-escapes the reason, so double-quotes and backslashes in your evidence text are safe — you do not need to escape them by hand.
 
 4. Report: "Closed `<id>` (<delivered|abandoned>): <reason>."
 

--- a/plugins/conversation-contracts/skills/close-conversation/SKILL.md
+++ b/plugins/conversation-contracts/skills/close-conversation/SKILL.md
@@ -11,13 +11,16 @@ Contracts are `orchard_contract` sentinels in the session jsonl (open minus clos
 
 ## Flow
 
-1. **Fold the open contracts.** Run `scripts/fold-contracts.sh` in `--auto` mode to list every open contract for this session (it picks the newest jsonl under this cwd's projects dir):
+1. **Fold the open contracts.** Run `scripts/fold-contracts.sh` — prefer `--session` (scans projects subdirs for the matching jsonl by id), fall back to `--auto` (encoded `$PWD`) when `$CLAUDE_SESSION_ID` is unset:
 
    ```bash
-   bash "$CLAUDE_PLUGIN_ROOT/scripts/fold-contracts.sh" --auto
+   PR="${CLAUDE_PLUGIN_ROOT:-$(find ~/.claude/plugins/cache -path '*/conversation-contracts/*/scripts/fold-contracts.sh' -print -quit 2>/dev/null | sed 's|/scripts/fold-contracts.sh$||')}" \
+     && if [ -n "${CLAUDE_SESSION_ID:-}" ]; then \
+          bash "$PR/scripts/fold-contracts.sh" --session "$CLAUDE_SESSION_ID"; \
+        else \
+          bash "$PR/scripts/fold-contracts.sh" --auto; \
+        fi
    ```
-
-   Use `--auto`, not `--session "$CLAUDE_SESSION_ID"` — the env var is unset in SDK/--print contexts and the fold would silently return empty.
 
 2. **Identify the conversation contract** by its fixed statement: `user agrees conversation has come to a close and there are no loose ends`. Any other open contract is a **child** contract.
 

--- a/plugins/conversation-contracts/skills/my-contracts/SKILL.md
+++ b/plugins/conversation-contracts/skills/my-contracts/SKILL.md
@@ -9,13 +9,18 @@ List the contracts currently OPEN for this session — the deliverables that wil
 
 ## Flow
 
-1. Run the shared fold script in `--auto` mode — it picks the newest jsonl under this cwd's projects dir (which IS the current session, by definition, because we are running inside it as it writes to itself):
+1. Run the shared fold script. Prefer `--session "$CLAUDE_SESSION_ID"` when the env var is set (the most-robust path — scans all projects subdirs for the matching jsonl, so a post-startup `cd` doesn't break it). Fall back to `--auto` (newest jsonl under the cwd's encoded projects dir) when it isn't:
 
    ```bash
-   bash "$CLAUDE_PLUGIN_ROOT/scripts/fold-contracts.sh" --auto
+   PR="${CLAUDE_PLUGIN_ROOT:-$(find ~/.claude/plugins/cache -path '*/conversation-contracts/*/scripts/fold-contracts.sh' -print -quit 2>/dev/null | sed 's|/scripts/fold-contracts.sh$||')}" \
+     && if [ -n "${CLAUDE_SESSION_ID:-}" ]; then \
+          bash "$PR/scripts/fold-contracts.sh" --session "$CLAUDE_SESSION_ID"; \
+        else \
+          bash "$PR/scripts/fold-contracts.sh" --auto; \
+        fi
    ```
 
-   It prints one line per open contract: `- <id>: <statement>`. Empty output means no open contracts. `--auto` does not need `$CLAUDE_SESSION_ID` — that env var is unset in SDK/--print contexts, so prefer `--auto` over `--session "$CLAUDE_SESSION_ID"` here.
+   It prints one line per open contract: `- <id>: <statement>`. Empty output means no open contracts. The first line is a `$CLAUDE_PLUGIN_ROOT` fallback — the harness sets it when invoking hooks, but interactive `Bash` tool calls in skill subprocesses often don't have it.
 
 3. Report the result to the user:
    - Open contracts → list them and note each is closed with `/close-contract <id>`.
@@ -25,4 +30,5 @@ List the contracts currently OPEN for this session — the deliverables that wil
 
 - This is read-only: it never writes a sentinel. Opening/closing is `/open-contract` and `/close-contract`.
 - It calls the SAME `scripts/fold-contracts.sh` the Stop hook uses, so what it lists is exactly what would block Stop. One fold, no drift.
-- `--auto` is the production-correct mode. The earlier `--session "$CLAUDE_SESSION_ID"` recipe was an i-am-done canonical anti-pattern: `CLAUDE_SESSION_ID` is not exported to skill subprocesses in SDK/--print runs, so the fold ran blind. `--auto` resolves the path from `$PWD` and picks the newest jsonl, which is the running session.
+- `--session` is preferred when `$CLAUDE_SESSION_ID` is set (interactive Claude Code typically exports it). It scans every projects subdir for the matching jsonl by session id, so the session's startup cwd vs. current `$PWD` doesn't matter.
+- `--auto` is the fallback when `$CLAUDE_SESSION_ID` is unset (SDK/--print contexts). It encodes `$PWD` and picks the newest jsonl there — correct as long as the session was started in the current cwd, which is the common case for `--print`.

--- a/plugins/conversation-contracts/skills/open-contract/SKILL.md
+++ b/plugins/conversation-contracts/skills/open-contract/SKILL.md
@@ -23,9 +23,12 @@ Contracts live as JSON **sentinels** in this session's own jsonl — there is no
 2. Generate an id and emit the open sentinel with a single `Bash` call to the shared `scripts/emit-sentinel.sh` — the single source of truth for the on-disk shape, shared with `/close-contract` and the SessionStart auto-open hook:
 
    ```bash
-   id="C-$(date -u +%Y-%m-%d)-$(openssl rand -hex 4)" && \
-     bash "$CLAUDE_PLUGIN_ROOT/scripts/emit-sentinel.sh" open "$id" "<one-line statement>"
+   PR="${CLAUDE_PLUGIN_ROOT:-$(find ~/.claude/plugins/cache -path '*/conversation-contracts/*/scripts/emit-sentinel.sh' -print -quit 2>/dev/null | sed 's|/scripts/emit-sentinel.sh$||')}" \
+     && id="C-$(date -u +%Y-%m-%d)-$(openssl rand -hex 4)" \
+     && bash "$PR/scripts/emit-sentinel.sh" open "$id" "<one-line statement>"
    ```
+
+   The first line is a fallback for `$CLAUDE_PLUGIN_ROOT` — the harness sets it when invoking hooks, but interactive `Bash` tool calls in skill subprocesses often don't have it. The `find` resolves the install cache; if neither path works, the recipe fails loud with a "No such file or directory" rather than running blind.
 
    The emitted JSON is the **only** line on stdout — that single string becomes the `tool_result.content` the fold parses. Do NOT chain `&& echo "Opened contract $id"` into the same Bash command: the trailing text would concatenate into the same `tool_result.content` string and break the fold's `fromjson?` extraction. The id is in the JSON output already (`"id":"C-..."`); read it from there. The script JSON-escapes the statement, so double-quotes and backslashes in your text are safe.
 


### PR DESCRIPTION
## Why

Live interactive verification of v0.9.0 (after PR #670 merged) surfaced two more silent bugs that the previous test suite missed.

## Bug 3 — Stop hook fold silently fails after a post-startup `cd`

The Stop hook (and `/my-contracts` and `/close-conversation`) called `fold-contracts.sh --session "$sid" "$PWD"`, which encoded `$PWD` to find the projects subdir. But Claude Code encodes the **session's startup cwd** into the projects dir name — not the current `$PWD`. In any session where the user `cd`'d after startup (the common case for worktree-driven work), the fold encoded the wrong dir, found nothing, and returned empty. **The Stop hook then released silently, even though the `orchard_contract` sentinel was correctly in the jsonl.**

Live proof from the trigger session:
- 186 `orchard_contract` mentions in the jsonl
- Fold against the explicit jsonl path returned 7 open contracts
- All 205 Stop events recorded `preventedContinuation: false` because the in-hook fold (`--session "$sid" "$PWD"`) returned empty

**Fix:** `--session` scans every projects subdir for `<sid>.jsonl` using `find -maxdepth 2 -name "$sid.jsonl" -print -quit`. Session ids are globally unique, so the scan returns exactly one match (or none). The optional `<cwd>` third arg is still accepted (backcompat with old callers) but ignored.

## Bug 4 — `$CLAUDE_PLUGIN_ROOT` unset in skill subprocess Bash calls

The harness sets `$CLAUDE_PLUGIN_ROOT` when invoking hooks, but interactive Bash tool calls in skill subprocesses often don't have it. The documented recipe `bash "$CLAUDE_PLUGIN_ROOT/scripts/emit-sentinel.sh" ...` failed with `bash: /scripts/emit-sentinel.sh: No such file or directory` when the env var was empty.

**Fix:** all four SKILL.md recipes now derive a `PLUGIN_ROOT` with a `find` fallback that resolves the install cache. Works whether or not the harness exported the env var; fails loud if neither path resolves.

## Tests

Three new `fold-contracts.bats` cases targeting Bug 3:
- `--session finds the jsonl by sid even when stored under a different cwd-encoded dir`
- `--session ignores its optional cwd argument (backcompat with old callers)`
- `--session degrades to empty when no jsonl with that sid exists`

40 plugin bats green (was 37). Scripts bats unchanged.

## Related

Bundled in contract `C-2026-05-28-baacd163` (open in the v0.9 orchestrator session). Follow-up issue [#668](https://github.com/drewdrewthis/git-orchard-rs/issues/668) (ClaudeSession enrichment) is still deferred and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)