### PR TITLE
chore(contracts): bump conversation-contracts to 0.9.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "author": {
         "name": "drewdrewthis"
       },
-      "version": "0.9.0",
+      "version": "0.9.1",
       "source": "./plugins/conversation-contracts",
       "homepage": "https://github.com/drewdrewthis/git-orchard-rs/tree/main/plugins/conversation-contracts"
     }

--- a/plugins/conversation-contracts/.claude-plugin/plugin.json
+++ b/plugins/conversation-contracts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conversation-contracts",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on the first user message; /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon, no per-id files — the session jsonl is the durable store.",
   "author": {
     "name": "drewdrewthis",

--- a/plugins/conversation-contracts/scaffold.bats
+++ b/plugins/conversation-contracts/scaffold.bats
@@ -51,11 +51,11 @@ _jq() {
 
 # ---- plugin.json ------------------------------------------------------------
 
-@test "plugin.json is valid JSON with name, description, version 0.9.0, author" {
+@test "plugin.json is valid JSON with name, description, version 0.9.1, author" {
   local f=plugins/conversation-contracts/.claude-plugin/plugin.json
   [ -n "$(_jq "$f" '.name')" ]
   [ -n "$(_jq "$f" '.description')" ]
-  [ "$(_jq "$f" '.version')" = "0.9.0" ]
+  [ "$(_jq "$f" '.version')" = "0.9.1" ]
   [ -n "$(_jq "$f" '.author.name')" ]
 }
 


### PR DESCRIPTION
## Why

PRs [#669](https://github.com/drewdrewthis/git-orchard-rs/pull/669), [#670](https://github.com/drewdrewthis/git-orchard-rs/pull/670), and [#671](https://github.com/drewdrewthis/git-orchard-rs/pull/671) shipped three rounds of fixes to v0.9.0 without bumping the plugin manifest version. That means `claude plugin update conversation-contracts@orchard` reports `"already at the latest version (0.9.0)"` and **does not** refresh the on-disk files — fleet hosts already on v0.9.0 don't pick up:

- the silent-Stop-block fix (#671, Bug 3)
- the `$CLAUDE_PLUGIN_ROOT` recipe fallback (#671, Bug 4)
- the `/private/var` symlink + trailing-text fold tolerance (#670)
- the `--auto` mode for SDK/--print sessions (#669)

Concretely: today on this host I had to `claude plugin uninstall` + `claude plugin install` to pick the fixes up. After this bump, `claude plugin update` works.

## Change

`0.9.0` → `0.9.1` in:
- `plugins/conversation-contracts/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json` (the plugin entry)
- `scaffold.bats` version assertion + test name

40 plugin bats green. No code changes; just metadata + the test that pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #0