### PR TITLE
simplify(contracts): SKILL.md recipes use <this-skill-dir>/../../scripts/

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "author": {
         "name": "drewdrewthis"
       },
-      "version": "0.9.1",
+      "version": "0.9.2",
       "source": "./plugins/conversation-contracts",
       "homepage": "https://github.com/drewdrewthis/git-orchard-rs/tree/main/plugins/conversation-contracts"
     }

--- a/plugins/conversation-contracts/.claude-plugin/plugin.json
+++ b/plugins/conversation-contracts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conversation-contracts",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on the first user message; /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon, no per-id files — the session jsonl is the durable store.",
   "author": {
     "name": "drewdrewthis",

--- a/plugins/conversation-contracts/scaffold.bats
+++ b/plugins/conversation-contracts/scaffold.bats
@@ -51,11 +51,11 @@ _jq() {
 
 # ---- plugin.json ------------------------------------------------------------
 
-@test "plugin.json is valid JSON with name, description, version 0.9.1, author" {
+@test "plugin.json is valid JSON with name, description, version 0.9.2, author" {
   local f=plugins/conversation-contracts/.claude-plugin/plugin.json
   [ -n "$(_jq "$f" '.name')" ]
   [ -n "$(_jq "$f" '.description')" ]
-  [ "$(_jq "$f" '.version')" = "0.9.1" ]
+  [ "$(_jq "$f" '.version')" = "0.9.2" ]
   [ -n "$(_jq "$f" '.author.name')" ]
 }
 

--- a/plugins/conversation-contracts/skills/close-contract/SKILL.md
+++ b/plugins/conversation-contracts/skills/close-contract/SKILL.md
@@ -19,14 +19,15 @@ A close is one of two things:
    - delivered → `delivered: <one-line evidence>` (a command output, a PR link, a test result — what proves it).
    - abandoned → `abandoned: <why it's being dropped>`.
 
-3. Emit the close sentinel with a single `Bash` call to the shared `scripts/emit-sentinel.sh` — the same script `/open-contract` and the SessionStart auto-open hook use, so the on-disk shape stays consistent:
+3. Emit the close sentinel with a single `Bash` call to the shared `scripts/emit-sentinel.sh` — the same script `/open-contract` and the SessionStart auto-open hook use, so the on-disk shape stays consistent.
+
+   The script lives at `<this-skill-dir>/../../scripts/emit-sentinel.sh`. The "Base directory" line at the top of this SKILL.md gives you the absolute skill directory; substitute that literal path for `<this-skill-dir>` when you construct the Bash call. Do not use `$CLAUDE_PLUGIN_ROOT` — it's not set in skill subprocesses.
 
    ```bash
-   PR="${CLAUDE_PLUGIN_ROOT:-$(find ~/.claude/plugins/cache -path '*/conversation-contracts/*/scripts/emit-sentinel.sh' -print -quit 2>/dev/null | sed 's|/scripts/emit-sentinel.sh$||')}" \
-     && bash "$PR/scripts/emit-sentinel.sh" close "<id>" "<reason>"
+   bash "<this-skill-dir>/../../scripts/emit-sentinel.sh" close "<id>" "<reason>"
    ```
 
-   The first line is a `$CLAUDE_PLUGIN_ROOT` fallback — the harness sets it when invoking hooks, but interactive `Bash` tool calls in skill subprocesses often don't have it. The script JSON-escapes the reason, so double-quotes and backslashes in your evidence text are safe — you do not need to escape them by hand.
+   The script JSON-escapes the reason, so double-quotes and backslashes in your evidence text are safe — you do not need to escape them by hand.
 
 4. Report: "Closed `<id>` (<delivered|abandoned>): <reason>."
 

--- a/plugins/conversation-contracts/skills/close-conversation/SKILL.md
+++ b/plugins/conversation-contracts/skills/close-conversation/SKILL.md
@@ -11,15 +11,16 @@ Contracts are `orchard_contract` sentinels in the session jsonl (open minus clos
 
 ## Flow
 
-1. **Fold the open contracts.** Run `scripts/fold-contracts.sh` — prefer `--session` (scans projects subdirs for the matching jsonl by id), fall back to `--auto` (encoded `$PWD`) when `$CLAUDE_SESSION_ID` is unset:
+1. **Fold the open contracts.** Run `scripts/fold-contracts.sh` — prefer `--session` (scans projects subdirs for the matching jsonl by id), fall back to `--auto` (encoded `$PWD`) when `$CLAUDE_SESSION_ID` is unset.
+
+   The script lives at `<this-skill-dir>/../../scripts/fold-contracts.sh`. The "Base directory" line at the top of this SKILL.md gives you the absolute skill directory; substitute that literal path for `<this-skill-dir>` when you construct the Bash call. Do not use `$CLAUDE_PLUGIN_ROOT` — it's not set in skill subprocesses.
 
    ```bash
-   PR="${CLAUDE_PLUGIN_ROOT:-$(find ~/.claude/plugins/cache -path '*/conversation-contracts/*/scripts/fold-contracts.sh' -print -quit 2>/dev/null | sed 's|/scripts/fold-contracts.sh$||')}" \
-     && if [ -n "${CLAUDE_SESSION_ID:-}" ]; then \
-          bash "$PR/scripts/fold-contracts.sh" --session "$CLAUDE_SESSION_ID"; \
-        else \
-          bash "$PR/scripts/fold-contracts.sh" --auto; \
-        fi
+   if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+     bash "<this-skill-dir>/../../scripts/fold-contracts.sh" --session "$CLAUDE_SESSION_ID"
+   else
+     bash "<this-skill-dir>/../../scripts/fold-contracts.sh" --auto
+   fi
    ```
 
 2. **Identify the conversation contract** by its fixed statement: `user agrees conversation has come to a close and there are no loose ends`. Any other open contract is a **child** contract.
@@ -28,10 +29,10 @@ Contracts are `orchard_contract` sentinels in the session jsonl (open minus clos
    - Open child contracts: every open contract that is NOT the conversation contract.
    - Open TodoWrite items: scan the session jsonl for pending TodoWrite entries (best-effort).
 
-4. **If the inventory is empty** (only the conversation contract is open): close it as **delivered**. Emit a close sentinel for the conversation contract's id via the shared `scripts/emit-sentinel.sh` (the same script `/close-contract` uses), folding the session summary into the reason:
+4. **If the inventory is empty** (only the conversation contract is open): close it as **delivered**. Emit a close sentinel for the conversation contract's id via the shared `scripts/emit-sentinel.sh` (the same script `/close-contract` uses), folding the session summary into the reason. Same `<this-skill-dir>/../../scripts/...` shape as step 1 — substitute the "Base directory" path inline:
 
    ```bash
-   bash "$CLAUDE_PLUGIN_ROOT/scripts/emit-sentinel.sh" close "<conversation-contract-id>" "delivered: <inventory summary>"
+   bash "<this-skill-dir>/../../scripts/emit-sentinel.sh" close "<conversation-contract-id>" "delivered: <inventory summary>"
    ```
    Report: "Conversation contract closed as delivered."
 

--- a/plugins/conversation-contracts/skills/my-contracts/SKILL.md
+++ b/plugins/conversation-contracts/skills/my-contracts/SKILL.md
@@ -9,18 +9,19 @@ List the contracts currently OPEN for this session — the deliverables that wil
 
 ## Flow
 
-1. Run the shared fold script. Prefer `--session "$CLAUDE_SESSION_ID"` when the env var is set (the most-robust path — scans all projects subdirs for the matching jsonl, so a post-startup `cd` doesn't break it). Fall back to `--auto` (newest jsonl under the cwd's encoded projects dir) when it isn't:
+1. Run the shared fold script. Prefer `--session "$CLAUDE_SESSION_ID"` when the env var is set (the most-robust path — scans all projects subdirs for the matching jsonl, so a post-startup `cd` doesn't break it). Fall back to `--auto` (newest jsonl under the cwd's encoded projects dir) when it isn't.
+
+   The script lives at `<this-skill-dir>/../../scripts/fold-contracts.sh`. The "Base directory" line at the top of this SKILL.md gives you the absolute skill directory; substitute that literal path for `<this-skill-dir>` when you construct the Bash call. Do not use `$CLAUDE_PLUGIN_ROOT` — it's not set in skill subprocesses.
 
    ```bash
-   PR="${CLAUDE_PLUGIN_ROOT:-$(find ~/.claude/plugins/cache -path '*/conversation-contracts/*/scripts/fold-contracts.sh' -print -quit 2>/dev/null | sed 's|/scripts/fold-contracts.sh$||')}" \
-     && if [ -n "${CLAUDE_SESSION_ID:-}" ]; then \
-          bash "$PR/scripts/fold-contracts.sh" --session "$CLAUDE_SESSION_ID"; \
-        else \
-          bash "$PR/scripts/fold-contracts.sh" --auto; \
-        fi
+   if [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+     bash "<this-skill-dir>/../../scripts/fold-contracts.sh" --session "$CLAUDE_SESSION_ID"
+   else
+     bash "<this-skill-dir>/../../scripts/fold-contracts.sh" --auto
+   fi
    ```
 
-   It prints one line per open contract: `- <id>: <statement>`. Empty output means no open contracts. The first line is a `$CLAUDE_PLUGIN_ROOT` fallback — the harness sets it when invoking hooks, but interactive `Bash` tool calls in skill subprocesses often don't have it.
+   It prints one line per open contract: `- <id>: <statement>`. Empty output means no open contracts.
 
 3. Report the result to the user:
    - Open contracts → list them and note each is closed with `/close-contract <id>`.

--- a/plugins/conversation-contracts/skills/open-contract/SKILL.md
+++ b/plugins/conversation-contracts/skills/open-contract/SKILL.md
@@ -20,15 +20,14 @@ Contracts live as JSON **sentinels** in this session's own jsonl — there is no
 
 1. Get a one-line **statement** of the commitment from the user (or state your own). Keep it free of unescaped double-quotes — it is embedded in a JSON line.
 
-2. Generate an id and emit the open sentinel with a single `Bash` call to the shared `scripts/emit-sentinel.sh` — the single source of truth for the on-disk shape, shared with `/close-contract` and the SessionStart auto-open hook:
+2. Generate an id and emit the open sentinel with a single `Bash` call to the shared `scripts/emit-sentinel.sh` — the single source of truth for the on-disk shape, shared with `/close-contract` and the SessionStart auto-open hook.
+
+   The script lives at `<this-skill-dir>/../../scripts/emit-sentinel.sh`. The "Base directory" line at the top of this SKILL.md (injected by the Claude Code harness when this skill loads) gives you the absolute skill directory; substitute that literal path for `<this-skill-dir>` when you construct the Bash call. Do not use `$CLAUDE_PLUGIN_ROOT` — it's not set in skill subprocesses.
 
    ```bash
-   PR="${CLAUDE_PLUGIN_ROOT:-$(find ~/.claude/plugins/cache -path '*/conversation-contracts/*/scripts/emit-sentinel.sh' -print -quit 2>/dev/null | sed 's|/scripts/emit-sentinel.sh$||')}" \
-     && id="C-$(date -u +%Y-%m-%d)-$(openssl rand -hex 4)" \
-     && bash "$PR/scripts/emit-sentinel.sh" open "$id" "<one-line statement>"
+   id="C-$(date -u +%Y-%m-%d)-$(openssl rand -hex 4)" \
+     && bash "<this-skill-dir>/../../scripts/emit-sentinel.sh" open "$id" "<one-line statement>"
    ```
-
-   The first line is a fallback for `$CLAUDE_PLUGIN_ROOT` — the harness sets it when invoking hooks, but interactive `Bash` tool calls in skill subprocesses often don't have it. The `find` resolves the install cache; if neither path works, the recipe fails loud with a "No such file or directory" rather than running blind.
 
    The emitted JSON is the **only** line on stdout — that single string becomes the `tool_result.content` the fold parses. Do NOT chain `&& echo "Opened contract $id"` into the same Bash command: the trailing text would concatenate into the same `tool_result.content` string and break the fold's `fromjson?` extraction. The id is in the JSON output already (`"id":"C-..."`); read it from there. The script JSON-escapes the statement, so double-quotes and backslashes in your text are safe.
 

--- a/plugins/conversation-contracts/skills/recipe.bats
+++ b/plugins/conversation-contracts/skills/recipe.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# Tests that every SKILL.md uses the simplified relative-path recipe
+# (<this-skill-dir>/../../scripts/<script>) instead of the prior
+# `${CLAUDE_PLUGIN_ROOT:-$(find ...)}` env-var-with-fallback dance.
+#
+# Why: $CLAUDE_PLUGIN_ROOT is not exported to skill subprocesses, so the
+# original `bash "$CLAUDE_PLUGIN_ROOT/scripts/..."` recipe failed in real use.
+# The fallback `${CLAUDE_PLUGIN_ROOT:-$(find ...)}` worked but was complex,
+# fragile (ordering when multiple cached versions coexist), and unnecessary —
+# the harness already gives the agent the absolute skill directory via the
+# "Base directory" line injected at the top of every SKILL.md. The recipe just
+# needs the agent to substitute that path inline.
+
+setup() {
+  SKILLS_DIR="$BATS_TEST_DIRNAME"
+}
+
+# All four skill SKILL.md files we ship.
+SKILLS=(open-contract close-contract my-contracts close-conversation)
+
+@test "no SKILL.md recipe USES \$CLAUDE_PLUGIN_ROOT to construct a path" {
+  # Mentions in explanatory prose are OK ("Do not use \$CLAUDE_PLUGIN_ROOT,
+  # it's unset in skill subprocesses"). What's NOT OK is a recipe that
+  # actually constructs a path with the env var: `"$CLAUDE_PLUGIN_ROOT/...`.
+  for s in "${SKILLS[@]}"; do
+    run grep -F '"$CLAUDE_PLUGIN_ROOT/' "$SKILLS_DIR/$s/SKILL.md"
+    [ "$status" -ne 0 ] || { echo "$s/SKILL.md still constructs a path with \$CLAUDE_PLUGIN_ROOT:"; echo "$output"; false; }
+  done
+}
+
+@test "no SKILL.md uses the brittle \`find ~/.claude/plugins/cache\` fallback" {
+  for s in "${SKILLS[@]}"; do
+    run grep -F 'find ~/.claude/plugins/cache' "$SKILLS_DIR/$s/SKILL.md"
+    [ "$status" -ne 0 ] || { echo "$s/SKILL.md still uses the find-fallback:"; echo "$output"; false; }
+  done
+}
+
+@test "every recipe-bearing SKILL.md references <this-skill-dir>/../../scripts/" {
+  # open-contract + close-contract emit sentinels; my-contracts + close-
+  # conversation fold. Either way the recipe should reach the scripts/ dir
+  # via the skill's own base directory.
+  for s in "${SKILLS[@]}"; do
+    run grep -F '<this-skill-dir>/../../scripts/' "$SKILLS_DIR/$s/SKILL.md"
+    [ "$status" -eq 0 ] || { echo "$s/SKILL.md missing the simplified recipe shape"; false; }
+  done
+}
+
+@test "every SKILL.md tells the agent to substitute the Base directory" {
+  # The harness injects "Base directory for this skill: <abs path>" at the top
+  # of every SKILL.md it loads. The recipe relies on the agent reading that
+  # and substituting; the SKILL.md must say so explicitly.
+  for s in "${SKILLS[@]}"; do
+    run grep -F 'Base directory' "$SKILLS_DIR/$s/SKILL.md"
+    [ "$status" -eq 0 ] || { echo "$s/SKILL.md does not point the agent at the 'Base directory' line"; false; }
+  done
+}


### PR DESCRIPTION
## Why

The four SKILL.md recipes were doing:

```bash
PR="${CLAUDE_PLUGIN_ROOT:-$(find ~/.claude/plugins/cache -path '*/conversation-contracts/*/scripts/emit-sentinel.sh' -print -quit 2>/dev/null | sed 's|/scripts/emit-sentinel.sh$||')}" \
  && bash "$PR/scripts/emit-sentinel.sh" open "$id" "..."
```

…to work around the fact that `$CLAUDE_PLUGIN_ROOT` is [documented](https://code.claude.com/docs/en/hooks#plugin-scripts) as exported to **hook** subprocesses but not to **skill** subprocesses. The fallback worked, but it was:

- ugly (3-line dance for what should be a one-liner)
- fragile (when multiple cached plugin versions coexist on disk, `find -print -quit` picks one non-deterministically — actually surfaced in the live verification of #672, where the `find` resolved to `0.9.0` while the installed-up-to-date version was `0.9.1`)
- unnecessary

The harness already gives the agent the absolute skill directory by injecting a `Base directory for this skill: <abs path>` line at the top of every loaded SKILL.md. The recipe just needs to instruct the agent to substitute that path inline. Three lines of bash become one; no env vars, no `find`, no fallback, no ordering risk:

```bash
bash "<this-skill-dir>/../../scripts/emit-sentinel.sh" open "$id" "..."
```

…where `<this-skill-dir>` is the agent-substituted literal `Base directory` path.

## Live proof

Opened then closed a dogfood contract via the new recipe shape in the writing session, both calls landed cleanly. The new test suite (`skills/recipe.bats`) also caught a missed `$CLAUDE_PLUGIN_ROOT` usage in `close-conversation/SKILL.md` step 4 — exactly the kind of thing the old recipe shape buried.

## Changes

- All four SKILL.md (`open-contract`, `close-contract`, `my-contracts`, `close-conversation`): drop `${CLAUDE_PLUGIN_ROOT:-$(find ...)}`, replace with the inline-substitute shape.
- New `skills/recipe.bats` with 4 cases asserting the simplification:
  - no SKILL.md recipe USES `$CLAUDE_PLUGIN_ROOT` to construct a path (prose mentions saying "do not use" are fine; bash code is not)
  - no SKILL.md uses the `find ~/.claude/plugins/cache` fallback
  - every recipe-bearing SKILL.md references `<this-skill-dir>/../../scripts/`
  - every SKILL.md tells the agent to substitute the `Base directory`
- Version bump `0.9.1 -> 0.9.2` so `claude plugin update` lifts users to the patched recipes (same lesson as [#672](https://github.com/drewdrewthis/git-orchard-rs/pull/672)).

44 plugin bats green (was 40). Scripts bats unchanged.

## Related wisdom

[`2026-05-28-script-not-template.md`](https://github.com/drewdrewthis/orchard-codex/blob/main/wisdom/2026-05-28-script-not-template.md) — same principle applied one level up. The `$CLAUDE_PLUGIN_ROOT/scripts/...` path was being templated through env-var indirection when it could have been a literal value derived from the skill's own injected location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)