### PR TITLE
feat(contracts): v0.10.0 — conversation contract carries discipline via /i-am-done

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "author": {
         "name": "drewdrewthis"
       },
-      "version": "0.9.2",
+      "version": "0.10.0",
       "source": "./plugins/conversation-contracts",
       "homepage": "https://github.com/drewdrewthis/git-orchard-rs/tree/main/plugins/conversation-contracts"
     }

--- a/plugins/conversation-contracts/.claude-plugin/plugin.json
+++ b/plugins/conversation-contracts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conversation-contracts",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on the first user message; /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon, no per-id files — the session jsonl is the durable store.",
   "author": {
     "name": "drewdrewthis",

--- a/plugins/conversation-contracts/hooks/on-session-start.bats
+++ b/plugins/conversation-contracts/hooks/on-session-start.bats
@@ -4,15 +4,26 @@
 # The hook writes one `orchard_contract` open sentinel to stdout. The Claude
 # Code harness records hook stdout in the session jsonl as a `hook_success`
 # attachment whose `stdout` field is the literal string we emit; fold-contracts.sh
-# extracts the sentinel via its strings-via-fromjson path. Stateless: no file
-# IO, no path resolution, no idempotency check needed (SessionStart fires once).
+# extracts the sentinel via its strings-via-fromjson path.
+#
+# v0.10.0: the conversation contract's statement is read from
+# references/conversation-contract-statement.md (the discipline gateway), with
+# a fallback to the minimal closure-deliverable string when the file is missing.
 
 setup() {
   HOOK="$BATS_TEST_DIRNAME/on-session-start.sh"
   # Real Claude Code sets CLAUDE_PLUGIN_ROOT so the hook can `exec` the shared
   # emit-sentinel.sh; mirror that in the test environment.
   export CLAUDE_PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
-  DELIVERABLE="user agrees conversation has come to a close and there are no loose ends"
+  STATEMENT_FILE="$CLAUDE_PLUGIN_ROOT/references/conversation-contract-statement.md"
+  FALLBACK="user agrees conversation has come to a close and there are no loose ends"
+  # The expected statement is the file collapsed to one line (matching the hook's
+  # tr-and-sed normalization).
+  if [ -r "$STATEMENT_FILE" ]; then
+    DELIVERABLE=$(tr '\n' ' ' < "$STATEMENT_FILE" | sed 's/  */ /g; s/ *$//')
+  else
+    DELIVERABLE="$FALLBACK"
+  fi
 }
 
 # _field <hook-stdout> <key> — parse the emitted sentinel and print the value.
@@ -32,10 +43,12 @@ print(json.loads(sys.stdin.read().strip()).get('$2', ''))
   [ "$(_field "$output" orchard_contract)" = "open" ]
 }
 
-@test "the sentinel's statement is the fixed deliverable" {
+@test "the sentinel's statement is read from the statement file" {
   run bash "$HOOK"
   [ "$status" -eq 0 ]
   [ "$(_field "$output" statement)" = "$DELIVERABLE" ]
+  # The statement file should reference /i-am-done as the close gate.
+  [[ "$DELIVERABLE" == *"/i-am-done"* ]]
 }
 
 @test "the sentinel id has the C-YYYY-MM-DD-<8hex> shape" {
@@ -43,6 +56,17 @@ print(json.loads(sys.stdin.read().strip()).get('$2', ''))
   [ "$status" -eq 0 ]
   id="$(_field "$output" id)"
   [[ "$id" =~ ^C-[0-9]{4}-[0-9]{2}-[0-9]{2}-[a-f0-9]{8}$ ]]
+}
+
+@test "falls back to the minimal deliverable string when the statement file is missing" {
+  tmp_root="$(mktemp -d)"
+  cp -r "$CLAUDE_PLUGIN_ROOT/scripts" "$tmp_root/"
+  cp -r "$CLAUDE_PLUGIN_ROOT/hooks" "$tmp_root/"
+  # No references/ in the temp root — simulates a missing statement file.
+  CLAUDE_PLUGIN_ROOT="$tmp_root" run bash "$tmp_root/hooks/on-session-start.sh"
+  [ "$status" -eq 0 ]
+  [ "$(_field "$output" statement)" = "$FALLBACK" ]
+  rm -rf "$tmp_root"
 }
 
 @test "the fold script picks up the sentinel when it appears in a stdout-attachment line" {
@@ -67,5 +91,7 @@ print(json.loads(sys.stdin.read().strip()).get('$2', ''))
 
   id="$(_field "$hook_stdout" id)"
   [[ "$fold_out" == *"$id"* ]]
-  [[ "$fold_out" == *"$DELIVERABLE"* ]]
+  # Fold output truncates long statements at the first sentence; just verify
+  # the conversation-contract closure deliverable prefix appears.
+  [[ "$fold_out" == *"user agrees conversation has come to a close"* ]]
 }

--- a/plugins/conversation-contracts/hooks/on-session-start.sh
+++ b/plugins/conversation-contracts/hooks/on-session-start.sh
@@ -6,14 +6,28 @@
 # script (scripts/fold-contracts.sh) finds it via its strings-via-fromjson path
 # and treats it identically to a tool_result sentinel.
 #
-# Stateless: no file IO, no path resolution. SessionStart fires once per
-# session, so the open is naturally one-per-conversation. The sentinel itself
-# is rendered by scripts/emit-sentinel.sh — the single source of truth for the
-# on-disk shape, shared with /open-contract and /close-contract.
+# Stateless: no file IO except reading the statement file. SessionStart fires
+# once per session, so the open is naturally one-per-conversation. The sentinel
+# itself is rendered by scripts/emit-sentinel.sh — the single source of truth
+# for the on-disk shape, shared with /open-contract and /close-contract.
+#
+# The conversation contract's statement is the discipline gateway: it embeds
+# the failure-mode self-audit and the /i-am-done invocation. Statement is read
+# from references/conversation-contract-statement.md so the discipline is
+# editable without touching the hook. If the file is missing or empty (e.g.
+# in an old install), fall back to the minimal closure-deliverable string.
 
 set -uo pipefail
 
-DELIVERABLE="user agrees conversation has come to a close and there are no loose ends"
+FALLBACK="user agrees conversation has come to a close and there are no loose ends"
+STATEMENT_FILE="${CLAUDE_PLUGIN_ROOT}/references/conversation-contract-statement.md"
+
+if [ -r "$STATEMENT_FILE" ]; then
+  # Collapse the file to a single line: contract statements live one-per-jsonl-line.
+  DELIVERABLE=$(tr '\n' ' ' < "$STATEMENT_FILE" | sed 's/  */ /g; s/ *$//')
+fi
+DELIVERABLE="${DELIVERABLE:-$FALLBACK}"
+
 id="C-$(date -u +%Y-%m-%d)-$(openssl rand -hex 4 2>/dev/null || printf '%08x' "$RANDOM$RANDOM")"
 
 exec bash "${CLAUDE_PLUGIN_ROOT}/scripts/emit-sentinel.sh" open "$id" "$DELIVERABLE"

--- a/plugins/conversation-contracts/references/conversation-contract-statement.md
+++ b/plugins/conversation-contracts/references/conversation-contract-statement.md
@@ -1,0 +1,1 @@
+user agrees conversation has come to a close and there are no loose ends. To close, /i-am-done must pass — it is the single source of truth for what "done" requires (evidence, failure-mode self-audit, common-mistake patterns, wisdom updates, skill-vs-freehand check).

--- a/plugins/conversation-contracts/scaffold.bats
+++ b/plugins/conversation-contracts/scaffold.bats
@@ -51,11 +51,11 @@ _jq() {
 
 # ---- plugin.json ------------------------------------------------------------
 
-@test "plugin.json is valid JSON with name, description, version 0.9.2, author" {
+@test "plugin.json is valid JSON with name, description, version 0.10.0, author" {
   local f=plugins/conversation-contracts/.claude-plugin/plugin.json
   [ -n "$(_jq "$f" '.name')" ]
   [ -n "$(_jq "$f" '.description')" ]
-  [ "$(_jq "$f" '.version')" = "0.9.2" ]
+  [ "$(_jq "$f" '.version')" = "0.10.0" ]
   [ -n "$(_jq "$f" '.author.name')" ]
 }
 


### PR DESCRIPTION
## Summary

- Conversation contract carries the discipline now. Its statement points at `/i-am-done` as the close gate — the existing universal-done skill is the single source of truth for evidence shape, common-mistake patterns, wisdom updates, skill-vs-freehand check. No duplication, no new clause directory.
- Hook factoring: statement is read from `references/conversation-contract-statement.md`, editable without touching the bash heredoc. Falls back to the minimal closure-deliverable when the file is missing (backcompat).
- Stop hook stays dumb. It folds open contracts and lists statements verbatim. Policy lives in the contract statement; hook is pure mechanism.

## What changed

| File | Change |
|---|---|
| `plugins/conversation-contracts/references/conversation-contract-statement.md` | **new** — gateway text. One-sentence reminder that `/i-am-done` is the close gate. |
| `plugins/conversation-contracts/hooks/on-session-start.sh` | Reads statement from file (above). Falls back to const if missing. |
| `plugins/conversation-contracts/hooks/on-session-start.bats` | 5 tests (was 4). Adds fallback-when-file-missing case. |
| `plugins/conversation-contracts/scaffold.bats` | Version assertion `0.9.2 → 0.10.0`. |
| `plugins/conversation-contracts/.claude-plugin/plugin.json` | `0.9.2 → 0.10.0`. |
| `.claude-plugin/marketplace.json` | `0.9.2 → 0.10.0`. |

## Design conversation that produced this

User and assistant iterated through three layers of simplification this session:
1. First sketch: a `references/clauses/` directory with per-work-shape templates (pr.md, issue.md, etc.) the contract could compose from.
2. Simpler: keep clauses, but no template-at-open-time; contracts stay free-form text, clauses are optional reference the model consults when the work matches.
3. **Landed here**: no clauses at all. `/i-am-done` already references everything associated with being done; the conversation contract just routes through it. One file added. Hook reads it.

The hook deliberately doesn't enforce — it just hands the contract back on Stop. The statement's `/i-am-done must pass` line is the reminder; the model walks the gate when it tries to close.

## Test plan

- [x] `bats plugins/conversation-contracts/` — 49/49 green on `orchardist-backup`.
- [x] `on-session-start.bats` fallback test: statement file missing → minimal deliverable.
- [x] `on-session-start.bats` happy path: statement file present → statement contains `/i-am-done`.
- [ ] CI green on this PR.
- [ ] 0 unresolved CodeRabbit threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version from 0.9.2 to 0.10.0

* **New Features**
  * Conversation contract statement now requires the `/i-am-done` command to mark completion as the official source of truth for done conditions.

* **Improvements**
  * Plugin now dynamically loads the contract statement from a configurable reference file, enabling easier requirement updates without code changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #0