### PR TITLE
fix(contracts): v0.10.1 — address /review findings on the v0.10.0 ship

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,11 +10,11 @@
   "plugins": [
     {
       "name": "conversation-contracts",
-      "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on the first user message; /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon. Hooks: UserPromptSubmit, Stop.",
+      "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on SessionStart whose statement is the discipline gateway — it points the agent at /i-am-done as the universal close gate. /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon. Hooks: SessionStart, Stop.",
       "author": {
         "name": "drewdrewthis"
       },
-      "version": "0.10.0",
+      "version": "0.10.1",
       "source": "./plugins/conversation-contracts",
       "homepage": "https://github.com/drewdrewthis/git-orchard-rs/tree/main/plugins/conversation-contracts"
     }

--- a/plugins/conversation-contracts/.claude-plugin/plugin.json
+++ b/plugins/conversation-contracts/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "conversation-contracts",
-  "version": "0.10.0",
-  "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on the first user message; /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon, no per-id files — the session jsonl is the durable store.",
+  "version": "0.10.1",
+  "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on SessionStart whose statement is the discipline gateway — it points the agent at /i-am-done as the universal close gate (evidence, failure-mode self-audit, common-mistake patterns, wisdom updates). /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon, no per-id files — the session jsonl is the durable store.",
   "author": {
     "name": "drewdrewthis",
     "url": "https://github.com/drewdrewthis/git-orchard-rs"

--- a/plugins/conversation-contracts/hooks/on-session-start.bats
+++ b/plugins/conversation-contracts/hooks/on-session-start.bats
@@ -69,6 +69,45 @@ print(json.loads(sys.stdin.read().strip()).get('$2', ''))
   rm -rf "$tmp_root"
 }
 
+@test "falls back when CLAUDE_PLUGIN_ROOT is unset (self-locates via BASH_SOURCE)" {
+  # The hook must work end-to-end even without the env var — old installs,
+  # test harnesses, smoke checks. It should resolve PLUGIN_ROOT from its own
+  # path and still emit a well-formed sentinel.
+  unset CLAUDE_PLUGIN_ROOT
+  run bash "$HOOK"
+  [ "$status" -eq 0 ]
+  [ "$(_field "$output" orchard_contract)" = "open" ]
+  # Statement file lives next to the hook, so the gateway statement still loads.
+  [[ "$(_field "$output" statement)" == *"/i-am-done"* ]]
+}
+
+@test "collapses a multi-line statement file into a single sentinel line" {
+  tmp_root="$(mktemp -d)"
+  cp -r "$CLAUDE_PLUGIN_ROOT/scripts" "$tmp_root/"
+  cp -r "$CLAUDE_PLUGIN_ROOT/hooks" "$tmp_root/"
+  mkdir -p "$tmp_root/references"
+  # Write a 3-line statement; the hook should collapse runs of whitespace to
+  # a single space and strip the trailing newline.
+  printf 'line one\nline two\n   line three\n' \
+    > "$tmp_root/references/conversation-contract-statement.md"
+  CLAUDE_PLUGIN_ROOT="$tmp_root" run bash "$tmp_root/hooks/on-session-start.sh"
+  [ "$status" -eq 0 ]
+  [ "$(_field "$output" statement)" = "line one line two line three" ]
+  rm -rf "$tmp_root"
+}
+
+@test "statement file is single-line prose (no markdown structural chars)" {
+  # Lock the shape: the hook's tr-and-sed collapse turns ANY content into one
+  # line, so a stray `#` heading or `- ` list item would concatenate inline
+  # with the prose and ship an ugly JSON string into every session jsonl.
+  # If you want structured content, teach the hook to skip / strip it first.
+  line_count=$(wc -l < "$STATEMENT_FILE")
+  # Either one line + trailing newline (= 1) or one line + no trailing newline (= 0).
+  [ "$line_count" -le 1 ]
+  # No markdown structural chars at the start of a line.
+  ! grep -qE '^(#|-|\*|>|\|)' "$STATEMENT_FILE"
+}
+
 @test "the fold script picks up the sentinel when it appears in a stdout-attachment line" {
   # Real Claude Code records the hook's stdout in the jsonl as a hook_success
   # attachment whose `stdout` field is the literal string the hook printed.
@@ -91,7 +130,7 @@ print(json.loads(sys.stdin.read().strip()).get('$2', ''))
 
   id="$(_field "$hook_stdout" id)"
   [[ "$fold_out" == *"$id"* ]]
-  # Fold output truncates long statements at the first sentence; just verify
-  # the conversation-contract closure deliverable prefix appears.
-  [[ "$fold_out" == *"user agrees conversation has come to a close"* ]]
+  # The full statement must round-trip through the open→record→fold path. If
+  # this ever fails, fix fold-contracts.sh — do not relax the assertion.
+  [[ "$fold_out" == *"$DELIVERABLE"* ]]
 }

--- a/plugins/conversation-contracts/hooks/on-session-start.sh
+++ b/plugins/conversation-contracts/hooks/on-session-start.sh
@@ -14,13 +14,26 @@
 # The conversation contract's statement is the discipline gateway: it embeds
 # the failure-mode self-audit and the /i-am-done invocation. Statement is read
 # from references/conversation-contract-statement.md so the discipline is
-# editable without touching the hook. If the file is missing or empty (e.g.
-# in an old install), fall back to the minimal closure-deliverable string.
+# editable without touching the hook. If the file is missing or empty, fall
+# back to the minimal closure-deliverable string.
+#
+# Plugin root resolution: prefer $CLAUDE_PLUGIN_ROOT (what real Claude Code
+# exports to hook subprocesses); fall back to $(BASH_SOURCE[0])/.. so the
+# hook still works when invoked directly (tests, smoke checks, harness
+# misconfig). The fallback covers BOTH the statement-file path and the
+# emit-sentinel.sh exec path.
 
 set -uo pipefail
 
 FALLBACK="user agrees conversation has come to a close and there are no loose ends"
-STATEMENT_FILE="${CLAUDE_PLUGIN_ROOT}/references/conversation-contract-statement.md"
+
+# Resolve the plugin root: env var first, then the hook's own parent dir.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+if [ -z "$PLUGIN_ROOT" ]; then
+  PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+STATEMENT_FILE="$PLUGIN_ROOT/references/conversation-contract-statement.md"
 
 if [ -r "$STATEMENT_FILE" ]; then
   # Collapse the file to a single line: contract statements live one-per-jsonl-line.
@@ -30,4 +43,4 @@ DELIVERABLE="${DELIVERABLE:-$FALLBACK}"
 
 id="C-$(date -u +%Y-%m-%d)-$(openssl rand -hex 4 2>/dev/null || printf '%08x' "$RANDOM$RANDOM")"
 
-exec bash "${CLAUDE_PLUGIN_ROOT}/scripts/emit-sentinel.sh" open "$id" "$DELIVERABLE"
+exec bash "$PLUGIN_ROOT/scripts/emit-sentinel.sh" open "$id" "$DELIVERABLE"

--- a/plugins/conversation-contracts/scaffold.bats
+++ b/plugins/conversation-contracts/scaffold.bats
@@ -51,11 +51,11 @@ _jq() {
 
 # ---- plugin.json ------------------------------------------------------------
 
-@test "plugin.json is valid JSON with name, description, version 0.10.0, author" {
+@test "plugin.json is valid JSON with name, description, version 0.10.1, author" {
   local f=plugins/conversation-contracts/.claude-plugin/plugin.json
   [ -n "$(_jq "$f" '.name')" ]
   [ -n "$(_jq "$f" '.description')" ]
-  [ "$(_jq "$f" '.version')" = "0.10.0" ]
+  [ "$(_jq "$f" '.version')" = "0.10.1" ]
   [ -n "$(_jq "$f" '.author.name')" ]
 }
 


### PR DESCRIPTION
## Summary

Address `/review` findings on the v0.10.0 ship (PR #675).

`/review` (run retroactively on the merged diff after I missed invoking `/i-am-done` at close time) surfaced two real bugs and three coverage gaps. This patch lands the must-fix items; two follow-ups are filed as separate issues.

## What changed

| File | Change |
|---|---|
| `hooks/on-session-start.bats` | Restored strict round-trip assertion `[[ "$fold_out" == *"$DELIVERABLE"* ]]` — the prior relaxation cited "fold truncates long statements" but `fold-contracts.sh` does NOT truncate; the relaxation was based on a false premise. |
| `hooks/on-session-start.sh` | Hardened the fallback path. `CLAUDE_PLUGIN_ROOT` was unguarded under `set -u`; an unset env var aborted before any fallback fired. Now: prefer `$CLAUDE_PLUGIN_ROOT`, fall back to `$(BASH_SOURCE[0])/..` so the hook still emits a sentinel when invoked directly. |
| `hooks/on-session-start.bats` | 3 new tests (8 total, was 5) covering: self-locating fallback when env var unset; multi-line-collapse normalization shape; statement file is single-line prose (no markdown structural chars). |
| `plugin.json` + `marketplace.json` | Bumped to 0.10.1; expanded `description` to surface the discipline-gateway role of the conversation contract — was undocumented in 0.10.0. |
| `scaffold.bats` | Version pin → 0.10.1. |

## Why this is its own PR

I missed invoking `/i-am-done` when closing the v0.10.0 contract (the very discipline I shipped). Running `/i-am-done` retroactively forced me to also run `/review` retroactively, which produced findings on artifacts already merged. Landing the fixes in a follow-up PR rather than reopening the merged one keeps the trail honest — v0.10.0 shipped imperfect; v0.10.1 acknowledges and patches.

## Follow-up issues (not in this PR)

- scaffold.bats version-pin rot: every release edits a test title. Should be a semver regex.
- Real-runtime drive: `claude --plugin-dir ... --print` + jsonl assertion that the open sentinel carries the discipline statement. The bats tests still mock the runtime contract.

## Test plan

- [x] `bats plugins/conversation-contracts/` — 52/52 green on `orchardist-backup` (was 49 on v0.10.0; +3 new tests in on-session-start.bats).
- [x] Fallback when `CLAUDE_PLUGIN_ROOT` unset: hook self-locates via `BASH_SOURCE`, emits sentinel containing `/i-am-done`.
- [x] Multi-line statement file: `tr | sed` collapse produces single line.
- [x] Statement file shape lock: `wc -l ≤ 1` and no markdown structural chars at line start.
- [ ] CI green on this PR.
- [ ] 0 unresolved CodeRabbit threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #0