### PR TITLE
fix(contracts): v0.10.2 — address /review findings on v0.10.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "author": {
         "name": "drewdrewthis"
       },
-      "version": "0.10.1",
+      "version": "0.10.2",
       "source": "./plugins/conversation-contracts",
       "homepage": "https://github.com/drewdrewthis/git-orchard-rs/tree/main/plugins/conversation-contracts"
     }

--- a/plugins/conversation-contracts/.claude-plugin/plugin.json
+++ b/plugins/conversation-contracts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conversation-contracts",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on SessionStart whose statement is the discipline gateway — it points the agent at /i-am-done as the universal close gate (evidence, failure-mode self-audit, common-mistake patterns, wisdom updates). /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon, no per-id files — the session jsonl is the durable store.",
   "author": {
     "name": "drewdrewthis",

--- a/plugins/conversation-contracts/hooks/on-session-start.bats
+++ b/plugins/conversation-contracts/hooks/on-session-start.bats
@@ -6,7 +6,7 @@
 # attachment whose `stdout` field is the literal string we emit; fold-contracts.sh
 # extracts the sentinel via its strings-via-fromjson path.
 #
-# v0.10.0: the conversation contract's statement is read from
+# The conversation contract's statement is read from
 # references/conversation-contract-statement.md (the discipline gateway), with
 # a fallback to the minimal closure-deliverable string when the file is missing.
 
@@ -17,10 +17,11 @@ setup() {
   export CLAUDE_PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
   STATEMENT_FILE="$CLAUDE_PLUGIN_ROOT/references/conversation-contract-statement.md"
   FALLBACK="user agrees conversation has come to a close and there are no loose ends"
-  # The expected statement is the file collapsed to one line (matching the hook's
-  # tr-and-sed normalization).
+  # Compute the expected statement via the same shared collapse helper the
+  # hook uses — this prevents the test and the hook from co-drifting if the
+  # normalization shape ever changes (e.g. tabs, CRLF).
   if [ -r "$STATEMENT_FILE" ]; then
-    DELIVERABLE=$(tr '\n' ' ' < "$STATEMENT_FILE" | sed 's/  */ /g; s/ *$//')
+    DELIVERABLE=$(bash "$CLAUDE_PLUGIN_ROOT/scripts/collapse-statement.sh" "$STATEMENT_FILE")
   else
     DELIVERABLE="$FALLBACK"
   fi
@@ -96,16 +97,20 @@ print(json.loads(sys.stdin.read().strip()).get('$2', ''))
   rm -rf "$tmp_root"
 }
 
-@test "statement file is single-line prose (no markdown structural chars)" {
-  # Lock the shape: the hook's tr-and-sed collapse turns ANY content into one
-  # line, so a stray `#` heading or `- ` list item would concatenate inline
-  # with the prose and ship an ugly JSON string into every session jsonl.
-  # If you want structured content, teach the hook to skip / strip it first.
-  line_count=$(wc -l < "$STATEMENT_FILE")
-  # Either one line + trailing newline (= 1) or one line + no trailing newline (= 0).
-  [ "$line_count" -le 1 ]
-  # No markdown structural chars at the start of a line.
-  ! grep -qE '^(#|-|\*|>|\|)' "$STATEMENT_FILE"
+@test "statement file is single-line prose (no markdown structural starters)" {
+  # Lock the shape: the hook collapses ANY content to one line, so a stray
+  # `#` heading, `- ` list item, or `1.` numbered item would concatenate
+  # inline with the prose and ship an ugly JSON string into every session
+  # jsonl. If you want structured content later, teach the hook (or the
+  # collapse helper) to skip / strip it first.
+  #
+  # Real single-line check: count lines with content (not trailing-newline
+  # sensitive). `wc -l` would lie on a "foo\nbar" file (1 newline = 1 line).
+  non_empty_lines=$(awk 'NF > 0 {n++} END {print n+0}' "$STATEMENT_FILE")
+  [ "$non_empty_lines" -eq 1 ]
+  # No common markdown structural starters at line start: heading, bullet,
+  # asterisk-list, blockquote, table, numbered-list, fenced-code opener.
+  ! grep -qE '^(#|-|\*|>|\||[0-9]+\.|```)' "$STATEMENT_FILE"
 }
 
 @test "the fold script picks up the sentinel when it appears in a stdout-attachment line" {
@@ -129,8 +134,9 @@ print(json.loads(sys.stdin.read().strip()).get('$2', ''))
   rm -f "$jsonl"
 
   id="$(_field "$hook_stdout" id)"
-  [[ "$fold_out" == *"$id"* ]]
-  # The full statement must round-trip through the open→record→fold path. If
-  # this ever fails, fix fold-contracts.sh — do not relax the assertion.
-  [[ "$fold_out" == *"$DELIVERABLE"* ]]
+  # Equality, not substring. Fold output shape is exactly `- <id>: <statement>`
+  # (scripts/fold-contracts.sh:115-116). Substring would let trailing or
+  # leading garbage hide regressions. If this ever fails: fix fold-contracts.sh
+  # or the statement file — do NOT relax this assertion.
+  [ "$fold_out" = "- $id: $DELIVERABLE" ]
 }

--- a/plugins/conversation-contracts/hooks/on-session-start.sh
+++ b/plugins/conversation-contracts/hooks/on-session-start.sh
@@ -28,16 +28,19 @@ set -uo pipefail
 FALLBACK="user agrees conversation has come to a close and there are no loose ends"
 
 # Resolve the plugin root: env var first, then the hook's own parent dir.
+# Use `cd -P` / `pwd -P` to match scripts/fold-contracts.sh — both resolve
+# symlinks so the plugin works under symlinked install paths consistently.
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
 if [ -z "$PLUGIN_ROOT" ]; then
-  PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  PLUGIN_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 fi
 
 STATEMENT_FILE="$PLUGIN_ROOT/references/conversation-contract-statement.md"
 
 if [ -r "$STATEMENT_FILE" ]; then
-  # Collapse the file to a single line: contract statements live one-per-jsonl-line.
-  DELIVERABLE=$(tr '\n' ' ' < "$STATEMENT_FILE" | sed 's/  */ /g; s/ *$//')
+  # Single source of truth for the normalization shape lives in
+  # scripts/collapse-statement.sh — keeps hook and test in sync.
+  DELIVERABLE=$(bash "$PLUGIN_ROOT/scripts/collapse-statement.sh" "$STATEMENT_FILE")
 fi
 DELIVERABLE="${DELIVERABLE:-$FALLBACK}"
 

--- a/plugins/conversation-contracts/scaffold.bats
+++ b/plugins/conversation-contracts/scaffold.bats
@@ -51,11 +51,11 @@ _jq() {
 
 # ---- plugin.json ------------------------------------------------------------
 
-@test "plugin.json is valid JSON with name, description, version 0.10.1, author" {
+@test "plugin.json is valid JSON with name, description, version 0.10.2, author" {
   local f=plugins/conversation-contracts/.claude-plugin/plugin.json
   [ -n "$(_jq "$f" '.name')" ]
   [ -n "$(_jq "$f" '.description')" ]
-  [ "$(_jq "$f" '.version')" = "0.10.1" ]
+  [ "$(_jq "$f" '.version')" = "0.10.2" ]
   [ -n "$(_jq "$f" '.author.name')" ]
 }
 

--- a/plugins/conversation-contracts/scripts/collapse-statement.bats
+++ b/plugins/conversation-contracts/scripts/collapse-statement.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# Tests for collapse-statement.sh — the shared normalization helper used by
+# both the SessionStart hook and the bats tests. Single source of truth: if
+# this script changes, hook and tests get the new behavior together.
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/collapse-statement.sh"
+  TMP_FILE="$(mktemp)"
+}
+
+teardown() {
+  rm -f "$TMP_FILE"
+}
+
+@test "collapses a single-line file to itself (no trailing newline drift)" {
+  printf 'hello world' > "$TMP_FILE"
+  run bash "$SCRIPT" "$TMP_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello world" ]
+}
+
+@test "collapses multi-line into space-separated single line" {
+  printf 'line one\nline two\nline three\n' > "$TMP_FILE"
+  run bash "$SCRIPT" "$TMP_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "line one line two line three" ]
+}
+
+@test "collapses runs of whitespace to a single space" {
+  printf 'a     b\n\n\n   c\n' > "$TMP_FILE"
+  run bash "$SCRIPT" "$TMP_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "a b c" ]
+}
+
+@test "strips trailing whitespace" {
+  printf 'sentence with trailing   \n' > "$TMP_FILE"
+  run bash "$SCRIPT" "$TMP_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "sentence with trailing" ]
+}
+
+@test "fails with usage when file argument is missing" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"usage"* ]]
+}
+
+@test "fails with usage when file does not exist" {
+  run bash "$SCRIPT" "/nonexistent/path/$$"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"usage"* ]]
+}
+
+@test "hook and tests share this collapse helper (no co-drift surface)" {
+  # The hook and the bats test setup both shell out to this script.
+  # Verify they both reference it so a future edit doesn't accidentally
+  # reintroduce inline `tr | sed` and reopen the co-drift gap.
+  hook="$BATS_TEST_DIRNAME/../hooks/on-session-start.sh"
+  test_file="$BATS_TEST_DIRNAME/../hooks/on-session-start.bats"
+  grep -q 'collapse-statement.sh' "$hook"
+  grep -q 'collapse-statement.sh' "$test_file"
+}

--- a/plugins/conversation-contracts/scripts/collapse-statement.sh
+++ b/plugins/conversation-contracts/scripts/collapse-statement.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# collapse-statement.sh — collapse a statement file into the one-line shape
+# the conversation-contracts jsonl expects. Single source of truth shared by
+# the SessionStart hook (which writes the sentinel) and the bats tests
+# (which compute the expected value). Extracting this prevents co-drift:
+# if the normalization rules ever change (e.g. add tab/CRLF handling), the
+# hook and the test cannot disagree because they share this script.
+#
+# Usage: bash collapse-statement.sh <path-to-statement-file>
+# Prints the collapsed statement to stdout. Exits 1 if the file is missing.
+
+set -uo pipefail
+
+file="${1:-}"
+if [ -z "$file" ] || [ ! -r "$file" ]; then
+  echo "collapse-statement.sh: usage: $0 <readable-file>" >&2
+  exit 1
+fi
+
+# Collapse: newlines → spaces, runs of whitespace → single space, strip trailing.
+tr '\n' ' ' < "$file" | sed 's/  */ /g; s/ *$//'


### PR DESCRIPTION
## Summary

Address `/review` findings on the v0.10.1 patch (PR #676 / `0611c71`).

`/review --since 911c0cc` surfaced 8 concerns; 4 must-fix, 2 decide-calls (both tightened), 2 folded into existing follow-up issues #677/#678.

## What changed

| File | Change | Concern # |
|---|---|---|
| `scripts/collapse-statement.sh` (new) | Single source of truth for the statement normalization shape. Hook + tests both shell out to it. | #3 (co-drift) |
| `scripts/collapse-statement.bats` (new) | 7 tests for the helper, including a "no co-drift" assertion that the hook and the bats setup both reference the script. | — |
| `hooks/on-session-start.sh` | Calls collapse-statement.sh instead of inlining `tr \| sed`. `cd`/`pwd` → `cd -P`/`pwd -P` to match `fold-contracts.sh:47`. | #3, #8 |
| `hooks/on-session-start.bats` | Setup uses the shared helper. `wc -l ≤ 1` → `awk 'NF > 0 {n++}'` (real per-line count; wc -l counts newlines and `"foo\nbar"` had 1 newline = passed but is 2 lines). Markdown regex extended for numbered lists + fenced-code openers. Round-trip assertion tightened from substring to exact equality against the fold output shape `- <id>: <statement>`. Stale `v0.10.0:` comment dropped. | #1, #2, #4, #6 |
| `plugin.json` + `marketplace.json` + `scaffold.bats` | Bumped to 0.10.2. | — |

## Deferred into existing follow-up issues

- **#678** (real-runtime drive) also gets the tab/CRLF/BOM normalization hardening concern (#5 from the review).
- **#677** (version-pin rot) now also covers the description-drift surface (#7) — `description` fields in both manifest files mention `discipline-gateway` and will need re-thinking each release.

## Test plan

- [x] `bats plugins/conversation-contracts/` — 59/59 green on `orchardist-backup` (was 52 on v0.10.1; +7 new in `collapse-statement.bats`).
- [x] Co-drift assertion: both hook and bats reference `scripts/collapse-statement.sh`.
- [x] Round-trip is now exact-equality, not substring; statement contains `/i-am-done` and round-trips through open→record→fold byte-for-byte.
- [x] Statement file shape lock uses a real single-line check, not `wc -l`.
- [ ] CI green on this PR.
- [ ] 0 unresolved CodeRabbit threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #0