### PR TITLE
fix(contracts): v0.10.3 — polish from /review on v0.10.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "author": {
         "name": "drewdrewthis"
       },
-      "version": "0.10.2",
+      "version": "0.10.3",
       "source": "./plugins/conversation-contracts",
       "homepage": "https://github.com/drewdrewthis/git-orchard-rs/tree/main/plugins/conversation-contracts"
     }

--- a/plugins/conversation-contracts/.claude-plugin/plugin.json
+++ b/plugins/conversation-contracts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conversation-contracts",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on SessionStart whose statement is the discipline gateway — it points the agent at /i-am-done as the universal close gate (evidence, failure-mode self-audit, common-mistake patterns, wisdom updates). /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon, no per-id files — the session jsonl is the durable store.",
   "author": {
     "name": "drewdrewthis",

--- a/plugins/conversation-contracts/hooks/on-session-start.bats
+++ b/plugins/conversation-contracts/hooks/on-session-start.bats
@@ -82,6 +82,30 @@ print(json.loads(sys.stdin.read().strip()).get('$2', ''))
   [[ "$(_field "$output" statement)" == *"/i-am-done"* ]]
 }
 
+@test "BASH_SOURCE fallback resolves symlinked plugin paths via cd -P" {
+  # Exercises the cd -P / pwd -P hardening on the self-locating fallback path.
+  # Without -P, a symlinked install would resolve PLUGIN_ROOT to the symlink's
+  # parent (or fail to find the helper scripts). With -P, we follow the link
+  # to the real install dir and load the statement file from there.
+  tmp_root="$(mktemp -d)"
+  cp -r "$CLAUDE_PLUGIN_ROOT/scripts" "$tmp_root/"
+  cp -r "$CLAUDE_PLUGIN_ROOT/hooks" "$tmp_root/"
+  cp -r "$CLAUDE_PLUGIN_ROOT/references" "$tmp_root/"
+
+  # Install a symlink that points at the real plugin dir; invoke the hook
+  # via the symlinked path with CLAUDE_PLUGIN_ROOT unset.
+  link_root="$(mktemp -d)/plugin-link"
+  ln -s "$tmp_root" "$link_root"
+  unset CLAUDE_PLUGIN_ROOT
+  run bash "$link_root/hooks/on-session-start.sh"
+  [ "$status" -eq 0 ]
+  [ "$(_field "$output" orchard_contract)" = "open" ]
+  # Statement file was found via the resolved real path, not the symlink.
+  [[ "$(_field "$output" statement)" == *"/i-am-done"* ]]
+
+  rm -rf "$tmp_root" "$(dirname "$link_root")"
+}
+
 @test "collapses a multi-line statement file into a single sentinel line" {
   tmp_root="$(mktemp -d)"
   cp -r "$CLAUDE_PLUGIN_ROOT/scripts" "$tmp_root/"

--- a/plugins/conversation-contracts/scaffold.bats
+++ b/plugins/conversation-contracts/scaffold.bats
@@ -13,7 +13,7 @@
 #       "./plugins/conversation-contracts" (NOT a {source:"github",url:"."} object)
 #
 #   plugins/conversation-contracts/.claude-plugin/plugin.json
-#     - name (the only required field), description, version "0.9.0",
+#     - name (the only required field), description, current semver version,
 #       author as an object with a name
 #
 #   plugins/conversation-contracts/hooks/hooks.json
@@ -51,11 +51,11 @@ _jq() {
 
 # ---- plugin.json ------------------------------------------------------------
 
-@test "plugin.json is valid JSON with name, description, version 0.10.2, author" {
+@test "plugin.json is valid JSON with name, description, version 0.10.3, author" {
   local f=plugins/conversation-contracts/.claude-plugin/plugin.json
   [ -n "$(_jq "$f" '.name')" ]
   [ -n "$(_jq "$f" '.description')" ]
-  [ "$(_jq "$f" '.version')" = "0.10.2" ]
+  [ "$(_jq "$f" '.version')" = "0.10.3" ]
   [ -n "$(_jq "$f" '.author.name')" ]
 }
 

--- a/plugins/conversation-contracts/scripts/collapse-statement.bats
+++ b/plugins/conversation-contracts/scripts/collapse-statement.bats
@@ -40,6 +40,16 @@ teardown() {
   [ "$output" = "sentence with trailing" ]
 }
 
+@test "strips leading whitespace (newlines and spaces)" {
+  # A statement file starting with a blank line would otherwise produce a
+  # leading-space sentinel — the single-line shape lock in on-session-start.bats
+  # does NOT catch this (awk counts content lines, not leading whitespace).
+  printf '\n\n   leading garbage\n' > "$TMP_FILE"
+  run bash "$SCRIPT" "$TMP_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "leading garbage" ]
+}
+
 @test "fails with usage when file argument is missing" {
   run bash "$SCRIPT"
   [ "$status" -eq 1 ]

--- a/plugins/conversation-contracts/scripts/collapse-statement.sh
+++ b/plugins/conversation-contracts/scripts/collapse-statement.sh
@@ -17,5 +17,9 @@ if [ -z "$file" ] || [ ! -r "$file" ]; then
   exit 1
 fi
 
-# Collapse: newlines → spaces, runs of whitespace → single space, strip trailing.
-tr '\n' ' ' < "$file" | sed 's/  */ /g; s/ *$//'
+# Collapse: newlines → spaces, runs of whitespace → single space, strip leading
+# AND trailing. A statement file starting with a blank line would otherwise
+# produce a leading-space sentinel, which the single-line shape lock in
+# on-session-start.bats does NOT catch (awk counts content lines, not
+# leading whitespace).
+tr '\n' ' ' < "$file" | sed 's/  */ /g; s/^ *//; s/ *$//'


### PR DESCRIPTION
## Summary

Polish from `/review` on the v0.10.2 patch (PR #679 / `8edb3b0`). 3 minor concerns addressed; nothing critical.

## What changed

| File | Change |
|---|---|
| `scripts/collapse-statement.sh` | Strip leading whitespace too (was already stripping trailing). A statement file with a leading blank line would otherwise emit a leading-space sentinel that the single-line shape lock does NOT catch. |
| `scripts/collapse-statement.bats` | +1 test (8 total): leading-whitespace case (newlines + spaces → no leading space in output). |
| `hooks/on-session-start.bats` | +1 test (9 total): real symlinked-plugin-path case. Without this, the v0.10.2 `cd -P` / `pwd -P` hardening was code-review-only. |
| `scaffold.bats` | Stale comment block referenced `version "0.9.0"` — dropped the literal version from the comment block (test title carries the live pin). |
| `plugin.json` + `marketplace.json` + `scaffold.bats` | 0.10.2 → 0.10.3. |

## Test plan

- [x] `bats plugins/conversation-contracts/` — 61/61 green on `orchardist-backup` (was 59 on v0.10.2; +2 new).
- [x] Symlinked-plugin-path test exercises real `cd -P`/`pwd -P` behavior.
- [x] Leading-whitespace test: `"\n\n   foo\n"` → `"foo"`.
- [ ] CI green on this PR.
- [ ] 0 unresolved CodeRabbit threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #0