### PR TITLE
feat(contracts): v0.11.0 — consent gate on agent-initiated contract close

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,11 +10,11 @@
   "plugins": [
     {
       "name": "conversation-contracts",
-      "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on SessionStart whose statement is the discipline gateway — it points the agent at /i-am-done as the universal close gate. /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon. Hooks: SessionStart, Stop.",
+      "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on SessionStart whose statement is the discipline gateway — points the agent at /i-am-done as the close gate. Closing requires user consent: agent-initiated closes go through AskUserQuestion; user-typed close paths (/exit, /quit, /bye, /close-conversation) bypass. /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon. Hooks: SessionStart, Stop.",
       "author": {
         "name": "drewdrewthis"
       },
-      "version": "0.10.3",
+      "version": "0.11.0",
       "source": "./plugins/conversation-contracts",
       "homepage": "https://github.com/drewdrewthis/git-orchard-rs/tree/main/plugins/conversation-contracts"
     }

--- a/plugins/conversation-contracts/.claude-plugin/plugin.json
+++ b/plugins/conversation-contracts/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "conversation-contracts",
-  "version": "0.10.3",
-  "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on SessionStart whose statement is the discipline gateway — it points the agent at /i-am-done as the universal close gate (evidence, failure-mode self-audit, common-mistake patterns, wisdom updates). /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon, no per-id files — the session jsonl is the durable store.",
+  "version": "0.11.0",
+  "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on SessionStart whose statement is the discipline gateway — it points the agent at /i-am-done as the universal close gate (evidence, failure-mode self-audit, common-mistake patterns, wisdom updates). Closing requires user consent: /close-contract and /close-conversation gate agent-initiated closes behind AskUserQuestion; user-typed close paths (/exit, /quit, /bye, /close-conversation) bypass the gate since the typing is the consent. /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon, no per-id files — the session jsonl is the durable store.",
   "author": {
     "name": "drewdrewthis",
     "url": "https://github.com/drewdrewthis/git-orchard-rs"

--- a/plugins/conversation-contracts/scaffold.bats
+++ b/plugins/conversation-contracts/scaffold.bats
@@ -62,6 +62,17 @@ _jq() {
   [ -n "$(_jq "$f" '.author.name')" ]
 }
 
+@test "plugin.json and marketplace.json versions stay in lockstep" {
+  # Without this assertion, the per-release shotgun-surgery surface for #677
+  # would silently let plugin.json and marketplace.json drift apart — semver-
+  # shape testing alone catches malformed strings, not version mismatches.
+  # Surfaced by CodeRabbit on PR #682.
+  local plugin_v marketplace_v
+  plugin_v=$(_jq plugins/conversation-contracts/.claude-plugin/plugin.json '.version')
+  marketplace_v=$(_jq .claude-plugin/marketplace.json '.plugins[0].version')
+  [ "$plugin_v" = "$marketplace_v" ]
+}
+
 # ---- hooks.json -------------------------------------------------------------
 
 @test "hooks.json declares SessionStart and Stop hooks" {

--- a/plugins/conversation-contracts/scaffold.bats
+++ b/plugins/conversation-contracts/scaffold.bats
@@ -51,11 +51,14 @@ _jq() {
 
 # ---- plugin.json ------------------------------------------------------------
 
-@test "plugin.json is valid JSON with name, description, version 0.10.3, author" {
+@test "plugin.json is valid JSON with name, description, current semver, author" {
   local f=plugins/conversation-contracts/.claude-plugin/plugin.json
   [ -n "$(_jq "$f" '.name')" ]
   [ -n "$(_jq "$f" '.description')" ]
-  [ "$(_jq "$f" '.version')" = "0.10.3" ]
+  # Semver shape — current release pins live in plugin.json + marketplace.json,
+  # not in this test. Avoids the per-release test edit shotgun-surgery flagged
+  # as #677.
+  [[ "$(_jq "$f" '.version')" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
   [ -n "$(_jq "$f" '.author.name')" ]
 }
 

--- a/plugins/conversation-contracts/skills/close-contract/SKILL.md
+++ b/plugins/conversation-contracts/skills/close-contract/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: close-contract
-description: Close an open contract by id — deliver it (with evidence) or abandon it (with reason). Use when a committed deliverable is done or being dropped ("close contract C-...", "mark X delivered", "/close-contract <id>"). Writes an orchard_contract close sentinel so the Stop hook stops blocking on it.
+description: Close an open contract by id — deliver it (with evidence) or abandon it (with reason). When the agent initiates the close (not a user-typed close path), gate the close sentinel behind an AskUserQuestion confirmation — the user owns the close decision. Use when a committed deliverable is done or being dropped ("close contract C-...", "mark X delivered", "/close-contract <id>"). Writes an orchard_contract close sentinel so the Stop hook stops blocking on it.
 ---
 
 # /close-contract
@@ -11,15 +11,33 @@ A close is one of two things:
 - **delivered** — the work is done; cite the evidence in the reason.
 - **abandoned** — the work is being dropped; say why (prefix the reason with `abandoned:`).
 
+## Authority: the user owns the close
+
+The agent produces evidence (via `/i-am-done`) but does NOT close on its own authority. Every agent-initiated close must be gated behind explicit user consent — the user is the closer; the agent is the proposer.
+
+The four user-typed close paths (`/exit`, `/quit`, `/bye`, `/close-conversation`) bypass the consent gate because the typing IS the consent.
+
 ## Flow
 
 1. Identify the **id** to close. If the user didn't give one, run `/my-contracts` to list open contracts and pick/confirm the id.
 
-2. Compose the **reason**:
+2. Run `/i-am-done` to produce the evidence block for the proposed close. The skill produces quoted evidence per claim and a decision (done / partial / not-done). Only `done` justifies proposing a delivered close — `partial` or `not-done` means either complete the missing gate or propose `abandoned` with reason.
+
+3. Compose the **reason**:
    - delivered → `delivered: <one-line evidence>` (a command output, a PR link, a test result — what proves it).
    - abandoned → `abandoned: <why it's being dropped>`.
 
-3. Emit the close sentinel with a single `Bash` call to the shared `scripts/emit-sentinel.sh` — the same script `/open-contract` and the SessionStart auto-open hook use, so the on-disk shape stays consistent.
+4. **If you are the agent and the user did NOT type a close path** — gate the close sentinel behind an `AskUserQuestion` confirmation. Present the proposed close with the evidence and the three real options:
+
+   - "Yes — close `<id>` as `<delivered|abandoned>` with reason: `<reason>`"
+   - "Keep open — there's more to do"
+   - "Edit the reason and re-ask"
+
+   Only emit the close sentinel on the "Yes" selection. On "Keep open" do nothing and continue. On "Edit" re-prompt with the revised reason.
+
+5. **If the user typed a close path** (`/exit`, `/quit`, `/bye`, `/close-conversation`, or explicit `/close-contract <id>` with a clear directive) — skip the AskUserQuestion. The typing IS the consent.
+
+6. Emit the close sentinel with a single `Bash` call to the shared `scripts/emit-sentinel.sh` — the same script `/open-contract` and the SessionStart auto-open hook use, so the on-disk shape stays consistent.
 
    The script lives at `<this-skill-dir>/../../scripts/emit-sentinel.sh`. The "Base directory" line at the top of this SKILL.md gives you the absolute skill directory; substitute that literal path for `<this-skill-dir>` when you construct the Bash call. Do not use `$CLAUDE_PLUGIN_ROOT` — it's not set in skill subprocesses.
 
@@ -29,10 +47,11 @@ A close is one of two things:
 
    The script JSON-escapes the reason, so double-quotes and backslashes in your evidence text are safe — you do not need to escape them by hand.
 
-4. Report: "Closed `<id>` (<delivered|abandoned>): <reason>."
+7. Report: "Closed `<id>` (<delivered|abandoned>): <reason>."
 
 ## Notes
 
 - The id must match an open contract's id exactly, or the fold won't cancel it.
 - Closing an already-closed or unknown id is harmless (the fold just sees an extra close); prefer `/my-contracts` first if unsure.
 - For the conversation-level contract specifically, prefer `/close-conversation` — it runs the loose-ends inventory before closing. `/close-contract` is the direct, generic closer for any contract by id.
+- The consent gate distinguishes "agent proposes" from "user authorizes" — the agent's job is to produce evidence and propose; the user's job is to accept or redirect.

--- a/plugins/conversation-contracts/skills/close-conversation/SKILL.md
+++ b/plugins/conversation-contracts/skills/close-conversation/SKILL.md
@@ -29,26 +29,35 @@ Contracts are `orchard_contract` sentinels in the session jsonl (open minus clos
    - Open child contracts: every open contract that is NOT the conversation contract.
    - Open TodoWrite items: scan the session jsonl for pending TodoWrite entries (best-effort).
 
-4. **If the inventory is empty** (only the conversation contract is open): close it as **delivered**. Emit a close sentinel for the conversation contract's id via the shared `scripts/emit-sentinel.sh` (the same script `/close-contract` uses), folding the session summary into the reason. Same `<this-skill-dir>/../../scripts/...` shape as step 1 — substitute the "Base directory" path inline:
+4. **If the inventory is empty** (only the conversation contract is open) AND the user typed a close path (`/exit`, `/quit`, `/bye`, `/close-conversation`) — the typing IS the consent. Emit a close sentinel for the conversation contract's id via the shared `scripts/emit-sentinel.sh` (the same script `/close-contract` uses), folding the session summary into the reason. Same `<this-skill-dir>/../../scripts/...` shape as step 1 — substitute the "Base directory" path inline:
 
    ```bash
    bash "<this-skill-dir>/../../scripts/emit-sentinel.sh" close "<conversation-contract-id>" "delivered: <inventory summary>"
    ```
    Report: "Conversation contract closed as delivered."
 
-5. **If the user names items that are still open:** file a child contract for each via `/open-contract` (one open sentinel per named item). Do NOT close the conversation contract — it stays open. Report: "Conversation contract remains open. Filed child contracts for: <items>."
+5. **If the inventory is empty but the user did NOT type a close path** (e.g. they said "this is done?" or the agent decided the conversation is winding down) — gate the close behind an `AskUserQuestion` confirmation. Present the loose-ends inventory summary and the three options:
 
-6. **If the user confirms everything is resolved** (non-empty inventory but they accept it): close the conversation contract as delivered (step 4), folding the inventory summary into the reason for auditability.
+   - "Yes — close the conversation contract as delivered"
+   - "Keep open — there's more I want to do"
+   - "Abandon with reason: `<reason>`"
+
+   Only emit the close sentinel on "Yes". On "Keep open" report the inventory and continue. On "Abandon" emit with `reason: "abandoned: <reason>"`.
+
+6. **If the user names items that are still open:** file a child contract for each via `/open-contract` (one open sentinel per named item). Do NOT close the conversation contract — it stays open. Report: "Conversation contract remains open. Filed child contracts for: <items>."
+
+7. **If the user explicitly confirms everything is resolved** (non-empty inventory but they accept it): close the conversation contract as delivered (step 4 emit-sentinel call), folding the inventory summary into the reason for auditability. The explicit confirmation IS the consent.
 
 ## Close paths
 
-| Trigger | Result |
-|---------|--------|
-| User confirms (empty inventory) | close sentinel, reason `delivered`, conversation contract CLOSED |
-| User confirms (non-empty inventory) | close sentinel `delivered` with inventory note, conversation contract CLOSED |
-| User names open items | one open sentinel per item (child contracts), conversation contract stays open |
-| `/exit`, `/quit`, `/bye` | host treats these as user-accepts-close; close the conversation contract delivered |
-| Direct `/close-contract <id>` | closes immediately by id, no inventory prompt (escape hatch) |
+| Trigger | Consent gate | Result |
+|---------|--------------|--------|
+| User types `/exit`, `/quit`, `/bye`, `/close-conversation` | typing IS consent — bypass | close sentinel, reason `delivered`, conversation contract CLOSED |
+| User explicitly confirms close (empty inventory) | typed confirmation IS consent — bypass | close sentinel, reason `delivered`, conversation contract CLOSED |
+| User explicitly confirms close (non-empty inventory, accepted) | typed confirmation IS consent — bypass | close sentinel `delivered` with inventory note, conversation contract CLOSED |
+| Agent infers conversation is winding down | AskUserQuestion gate required | close ONLY on "Yes" selection |
+| User names open items | (no close happening) | one open sentinel per item (child contracts), conversation contract stays open |
+| Direct `/close-contract <id>` (escape hatch) | AskUserQuestion gate if agent-initiated | closes immediately by id on consent, no inventory prompt |
 
 ## Notes
 

--- a/plugins/conversation-contracts/skills/recipe.bats
+++ b/plugins/conversation-contracts/skills/recipe.bats
@@ -54,3 +54,22 @@ SKILLS=(open-contract close-contract my-contracts close-conversation)
     [ "$status" -eq 0 ] || { echo "$s/SKILL.md does not point the agent at the 'Base directory' line"; false; }
   done
 }
+
+@test "v0.11: /close-contract documents the consent gate (AskUserQuestion)" {
+  # Closing requires user consent. The skill must instruct the agent to gate
+  # the close sentinel behind an AskUserQuestion when the user has not typed
+  # a close path. The four user-typed close paths bypass the gate (typing
+  # IS the consent).
+  run grep -F 'AskUserQuestion' "$SKILLS_DIR/close-contract/SKILL.md"
+  [ "$status" -eq 0 ] || { echo "close-contract/SKILL.md missing AskUserQuestion consent gate"; false; }
+  run grep -F 'consent' "$SKILLS_DIR/close-contract/SKILL.md"
+  [ "$status" -eq 0 ] || { echo "close-contract/SKILL.md does not mention consent"; false; }
+}
+
+@test "v0.11: /close-conversation documents the consent gate" {
+  # The conversation contract has the four user-typed bypass paths, but when
+  # the agent infers the conversation is winding down it must gate the close
+  # behind AskUserQuestion.
+  run grep -F 'AskUserQuestion' "$SKILLS_DIR/close-conversation/SKILL.md"
+  [ "$status" -eq 0 ] || { echo "close-conversation/SKILL.md missing AskUserQuestion consent gate"; false; }
+}


### PR DESCRIPTION
## Summary

Wire user consent into agent-initiated contract closes. `/i-am-done` provides the **evidence**; the user provides the **authority**. Closing on self-graded evidence alone was producing report cards, not closure.

## Discipline

| Trigger | Consent gate | Result |
|---|---|---|
| User types `/exit`, `/quit`, `/bye`, `/close-conversation` | typing IS consent — bypass | close sentinel emitted |
| User explicitly typed `/close-contract <id>` with clear directive | typing IS consent — bypass | close sentinel emitted |
| Agent infers a close is warranted | **AskUserQuestion gate required** | close sentinel ONLY on user "Yes" |

The `AskUserQuestion` presents three real options:
- "Yes — close `<id>` as `<delivered|abandoned>` with reason: `<reason>`"
- "Keep open — there's more to do"
- "Edit reason and re-ask"

## What changed

| File | Change |
|---|---|
| `skills/close-contract/SKILL.md` | New "Authority: the user owns the close" section. Step 2 explicitly invokes `/i-am-done` for evidence. Step 4 gates agent-initiated closes behind `AskUserQuestion`. Step 5 names the user-typed bypass paths. |
| `skills/close-conversation/SKILL.md` | Step 4 splits into "typed close path (bypass)" vs "agent-inferred (AskUserQuestion gate)". Close paths table gains a **Consent gate** column. |
| `skills/recipe.bats` | +2 tests (12 in this file): both `close-{contract,conversation}` SKILL.md must mention `AskUserQuestion`. |
| `scaffold.bats` | Plugin.json version assertion is now a semver regex (`^[0-9]+\.[0-9]+\.[0-9]+$`) instead of a literal pin. Folds in #677 — eliminates the per-release test-title shotgun-surgery. |
| `plugin.json` + `marketplace.json` | Bumped to 0.11.0; descriptions name the consent gate. |

## Why this needed a behavior version (0.11.0, not 0.10.4)

The contract-closure semantics change in a user-visible way. Before: agent could emit a close sentinel after producing evidence. After: agent must surface the evidence to the user and wait for their "Yes" before emitting. Existing /close-contract callers (agents) will see a different flow.

## What this was driven by

The 2026-05-28 session shipping v0.10.0–v0.10.3 closed seven contracts without explicit user consent — each cited `/i-am-done` evidence and was closed unilaterally. The user surfaced the rule explicitly: "closing a contract requires specific consent from me." This patch encodes that rule into the SKILL.md flow.

## Test plan

- [x] `bats plugins/conversation-contracts/` — 63/63 green on `orchardist-backup` (was 61 on v0.10.3; +2 in `recipe.bats`).
- [x] All four recipe-verbatim bash blocks intact (close-contract emits the same `bash "<this-skill-dir>/../../scripts/emit-sentinel.sh" close ...` shape; the consent gate is prose around it).
- [x] scaffold.bats semver-regex check passes against `0.11.0`.
- [ ] CI green on this PR.
- [ ] 0 unresolved CodeRabbit threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified conversation close behavior: agent-initiated close proposals now require user confirmation, while direct close commands (`/exit`, `/quit`, `/bye`, `/close-conversation`) bypass the gate and close immediately.
  * Enhanced close-contract and close-conversation skill documentation with explicit consent requirements and structured close reasons (delivered vs. abandoned).

* **Chores**
  * Bumped plugin version to 0.11.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #0

# Related issue

- #0