### PR TITLE
fix(contracts): v0.11.2 — dumb stop hook + honest symlink test + tab/CRLF in collapse

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "author": {
         "name": "drewdrewthis"
       },
-      "version": "0.11.1",
+      "version": "0.11.2",
       "source": "./plugins/conversation-contracts",
       "homepage": "https://github.com/drewdrewthis/git-orchard-rs/tree/main/plugins/conversation-contracts"
     }

--- a/plugins/conversation-contracts/.claude-plugin/plugin.json
+++ b/plugins/conversation-contracts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "conversation-contracts",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Contracts as jsonl sentinels: open/close named commitments that block Stop until closed. Auto-opens a conversation contract on SessionStart whose statement is the discipline gateway — it points the agent at /i-am-done as the universal close gate (evidence, failure-mode self-audit, common-mistake patterns, wisdom updates). Closing requires user consent: /close-contract and /close-conversation gate agent-initiated closes behind AskUserQuestion; user-typed close paths (/exit, /quit, /bye, /close-conversation) bypass the gate since the typing is the consent. /open-contract, /close-contract, /my-contracts manage arbitrary contracts; the Stop hook folds open-minus-close and blocks. No MCP server, no daemon, no per-id files — the session jsonl is the durable store.",
   "author": {
     "name": "drewdrewthis",

--- a/plugins/conversation-contracts/hooks/on-session-start.bats
+++ b/plugins/conversation-contracts/hooks/on-session-start.bats
@@ -82,25 +82,31 @@ print(json.loads(sys.stdin.read().strip()).get('$2', ''))
   [[ "$(_field "$output" statement)" == *"/i-am-done"* ]]
 }
 
-@test "BASH_SOURCE fallback resolves symlinked plugin paths via cd -P" {
-  # Exercises the cd -P / pwd -P hardening on the self-locating fallback path.
-  # Without -P, a symlinked install would resolve PLUGIN_ROOT to the symlink's
-  # parent (or fail to find the helper scripts). With -P, we follow the link
-  # to the real install dir and load the statement file from there.
+@test "BASH_SOURCE fallback smoke-tests a symlinked plugin install" {
+  # SMOKE check, not a `cd -P` regression lock — I tried twice to write one
+  # and failed because file reads through symlinks are kernel-transparent:
+  # both `cd` and `cd -P` resolve to the same statement file when the
+  # symlink points at the real install. (Two parallel-trees variants both
+  # passed without `-P` because the read followed the same physical inode.)
+  # The `cd -P` in the hook is defensive — it makes `$PLUGIN_ROOT` the
+  # physical path for any future use that compares the value, but no
+  # current code path is sensitive to that.
+  #
+  # This test verifies the smoke path: a symlinked install can still load
+  # the statement and emit a well-formed sentinel. It does NOT regression-
+  # lock `cd -P`. If you drop `-P` from the hook, this test will still
+  # pass — that's by design.
   tmp_root="$(mktemp -d)"
   cp -r "$CLAUDE_PLUGIN_ROOT/scripts" "$tmp_root/"
   cp -r "$CLAUDE_PLUGIN_ROOT/hooks" "$tmp_root/"
   cp -r "$CLAUDE_PLUGIN_ROOT/references" "$tmp_root/"
 
-  # Install a symlink that points at the real plugin dir; invoke the hook
-  # via the symlinked path with CLAUDE_PLUGIN_ROOT unset.
   link_root="$(mktemp -d)/plugin-link"
   ln -s "$tmp_root" "$link_root"
   unset CLAUDE_PLUGIN_ROOT
   run bash "$link_root/hooks/on-session-start.sh"
   [ "$status" -eq 0 ]
   [ "$(_field "$output" orchard_contract)" = "open" ]
-  # Statement file was found via the resolved real path, not the symlink.
   [[ "$(_field "$output" statement)" == *"/i-am-done"* ]]
 
   rm -rf "$tmp_root" "$(dirname "$link_root")"

--- a/plugins/conversation-contracts/hooks/on-stop.bats
+++ b/plugins/conversation-contracts/hooks/on-stop.bats
@@ -62,17 +62,29 @@ _run_hook() {
 
 # ---- open with no close → block ---------------------------------------------
 
-@test "open contract with no close blocks Stop and names the verbs" {
+@test "open contract with no close blocks Stop with the contract verbatim" {
+  # v0.11.2: hook is DUMB by design. It re-injects the open contract
+  # statements verbatim, no procedural commentary about close mechanics.
+  # The discipline lives in each contract's statement (the conversation
+  # contract points at /i-am-done; work contracts carry their own done-
+  # conditions). Procedural reminders in the hook duplicated and
+  # contradicted that design.
   local id="C-2026-05-27-aaaa1111"
-  _write_jsonl "S-STOP-OPEN" "$(_open_line "$id" "ship the X refactor")"
+  local stmt="ship the X refactor"
+  _write_jsonl "S-STOP-OPEN" "$(_open_line "$id" "$stmt")"
   _run_hook "S-STOP-OPEN"
 
   [ -n "$output" ]
   [ "$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin)["decision"])')" = "block" ]
   reason="$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin)["reason"])')"
+  # The reason MUST contain the open contract id and statement.
   [[ "$reason" == *"$id"* ]]
-  [[ "$reason" == *"/close-contract"* ]]      # self-documenting: names the close verb
-  [[ "$reason" == *"/my-contracts"* ]]        # ... and the list verb
+  [[ "$reason" == *"$stmt"* ]]
+  # The reason MUST NOT contain procedural commentary about close mechanics.
+  # (Hook is dumb; discipline lives in the contract statement.)
+  [[ "$reason" != *"deliver with /close-contract"* ]]
+  [[ "$reason" != *"abandon (reason"* ]]
+  [[ "$reason" != *"List them with /my-contracts"* ]]
 }
 
 # ---- open + matching close → allow ------------------------------------------

--- a/plugins/conversation-contracts/hooks/on-stop.sh
+++ b/plugins/conversation-contracts/hooks/on-stop.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 # on-stop.sh — Stop hook. Folds open contracts from the session jsonl and
-# HARD-BLOCKS Stop while any is open. The block reason is self-documenting
-# (names /close-contract and /my-contracts), so the block is the discovery
-# surface. Block convention: emit {"decision":"block","reason":...} + exit 0;
+# blocks Stop while any is open. The hook is DUMB by design: it throws the
+# open contracts back at the agent verbatim. The discipline lives in each
+# contract's statement (the conversation contract's statement points at
+# /i-am-done; work-contract statements carry their own done-conditions).
+#
+# Procedural reminders about close mechanics ("deliver with /close-contract
+# <id>", etc.) are NOT the hook's job — they were carried in v0.9.x but
+# duplicated and contradicted the statement-as-discipline design landed in
+# v0.10.0+. Hook is mechanism; statement is policy.
+#
+# Block convention: emit {"decision":"block","reason":...} + exit 0;
 # emit nothing + exit 0 to allow Stop.
 
 set -uo pipefail
@@ -15,10 +23,7 @@ session_id=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null)
 open_contracts=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/fold-contracts.sh" --session "$session_id" "${PWD:-}" 2>/dev/null || true)
 [ -n "$open_contracts" ] || exit 0
 
-count=$(printf '%s\n' "$open_contracts" | grep -c .)
-reason="You own ${count} open contract(s). Close each before stopping: deliver with /close-contract <id> (cite evidence) or abandon (reason 'abandoned: ...'). List them with /my-contracts.
-
-Open contracts:
+reason="Open contracts:
 ${open_contracts}"
 
 jq -n --arg reason "$reason" '{decision:"block", reason:$reason}'

--- a/plugins/conversation-contracts/scripts/collapse-statement.bats
+++ b/plugins/conversation-contracts/scripts/collapse-statement.bats
@@ -50,6 +50,26 @@ teardown() {
   [ "$output" = "leading garbage" ]
 }
 
+@test "normalizes tabs into spaces" {
+  # A statement file with tabs would otherwise ship tab characters in the
+  # sentinel JSON value. The shape lock catches some structural starters but
+  # not embedded tabs — the collapse helper must normalize them.
+  printf 'word1\tword2\t\tword3\n' > "$TMP_FILE"
+  run bash "$SCRIPT" "$TMP_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "word1 word2 word3" ]
+}
+
+@test "normalizes CRLF line endings" {
+  # A Windows-edited statement file would otherwise leak \r control chars
+  # into the sentinel JSON. Strip \r before the newline collapse so the
+  # round-trip is clean.
+  printf 'line one\r\nline two\r\n' > "$TMP_FILE"
+  run bash "$SCRIPT" "$TMP_FILE"
+  [ "$status" -eq 0 ]
+  [ "$output" = "line one line two" ]
+}
+
 @test "fails with usage when file argument is missing" {
   run bash "$SCRIPT"
   [ "$status" -eq 1 ]

--- a/plugins/conversation-contracts/scripts/collapse-statement.sh
+++ b/plugins/conversation-contracts/scripts/collapse-statement.sh
@@ -17,9 +17,9 @@ if [ -z "$file" ] || [ ! -r "$file" ]; then
   exit 1
 fi
 
-# Collapse: newlines → spaces, runs of whitespace → single space, strip leading
-# AND trailing. A statement file starting with a blank line would otherwise
-# produce a leading-space sentinel, which the single-line shape lock in
-# on-session-start.bats does NOT catch (awk counts content lines, not
-# leading whitespace).
-tr '\n' ' ' < "$file" | sed 's/  */ /g; s/^ *//; s/ *$//'
+# Normalize all whitespace shapes to spaces, then collapse runs and strip ends.
+# Handles: CRLF (strip \r first), tabs (tr maps to space), newlines (tr maps
+# to space), runs (sed collapses), leading + trailing space (sed strips).
+# Without these, a statement file with Windows line endings or leading tabs
+# would leak control characters into the sentinel JSON.
+sed 's/\r$//' "$file" | tr '\n\t' '  ' | sed 's/  */ /g; s/^ *//; s/ *$//'


### PR DESCRIPTION
## Summary

Three corrections to the conversation-contracts plugin perfecting work — one structural (hook), one honest (test name), one robustness (collapse).

User surfaced (1) and (2) by pushback: "isn't the contract about perfecting it?" + "that's not what we agreed the stop should be."

## What changed

### 1. `on-stop.sh` is DUMB now
The hook was still emitting procedural commentary in its block reason:
> "You own 1 open contract(s). Close each before stopping: deliver with /close-contract <id> (cite evidence) or abandon (reason 'abandoned: ...'). List them with /my-contracts."

That contradicts the v0.10.0+ design we landed earlier in this arc — **discipline lives in each contract's statement**. The conversation contract points at `/i-am-done`; work-contract statements carry their own done-conditions. The hook should be pure mechanism.

Now the reason is exactly:
```
Open contracts:
- C-...: <statement>
```
`on-stop.bats` asserts the procedural strings are NOT present.

### 2. Symlink test honestly downgraded
The test claimed to regression-lock `cd -P` / `pwd -P`. I tried twice to make it actually catch the regression (the v0.10.3 shape and a two-parallel-trees variant in this PR) — both kept passing without `-P` because file reads through symlinks are kernel-transparent. The hardening is defensive, not load-bearing.

Renamed to "smoke-tests a symlinked plugin install" with a comment documenting the failed-attempt history and why no regression lock exists.

### 3. `collapse-statement.sh` handles tabs and CRLF
Prior pipeline `tr '\n' ' ' | sed ...` leaked tab characters and `\r` from Windows-line-ended files. Now: `sed 's/\r$//' | tr '\n\t' '  ' | sed ...`. Two new bats cases lock both.

Closes #681.

## Test plan

- [x] `bats plugins/conversation-contracts/` — 68/68 green (was 66 on v0.11.1).
- [x] `on-stop.bats` asserts NO procedural strings ("deliver with /close-contract", "abandon (reason", "List them with /my-contracts") in the block reason.
- [x] Tab normalization: `"a\tb\t\tc\n"` → `"a b c"`.
- [x] CRLF normalization: `"line one\r\nline two\r\n"` → `"line one line two"`.
- [ ] CI green on this PR.
- [ ] 0 unresolved CodeRabbit threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


# Related issue

- #0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated conversation-contracts plugin to version 0.11.2

* **Bug Fixes**
  * Enhanced text processing to reliably handle various whitespace formats and line-ending styles in statements
  * Improved contract status messaging by streamlining content to provide clearer, more direct communication without unnecessary procedural details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/drewdrewthis/git-orchard-rs/pull/684?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #0