### PR TITLE
feat: publish recall as the orchardist plugin + rename repo refs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,11 +1,20 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "orchard",
-  "description": "The orchard marketplace. Companion plugins for the orchard worktree/session dashboard. The conversation-contracts plugin was retired 2026-05-29 in favor of a single Stop hook (audit-promise-stop.sh) + native TaskList — see codex research/2028. This marketplace is currently empty.",
+  "name": "orchardist",
+  "description": "The orchardist marketplace — companion plugins for the orchardist worktree/session dashboard. Hosts the orchardist plugin, which provides the `recall` skill for searching and synthesizing context from past Claude Code conversations.",
   "owner": {
     "name": "drewdrewthis",
     "email": "andrew@langwatch.ai",
     "url": "https://github.com/drewdrewthis"
   },
-  "plugins": []
+  "plugins": [
+    {
+      "name": "orchardist",
+      "description": "Recall: search and synthesize context from past Claude Code conversations across all projects.",
+      "author": { "name": "drewdrewthis" },
+      "category": "agent-orchestration",
+      "source": "./plugin-sources/orchardist",
+      "homepage": "https://github.com/drewdrewthis/orchardist/tree/main/plugin-sources/orchardist"
+    }
+  ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Plugin code (Claude Code plugins, hooks, MCP servers) verified by an actual `cla
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **git-orchard-rs** (2984 symbols, 7553 relationships, 259 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **orchardist** (2984 symbols, 7553 relationships, 259 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 
@@ -110,7 +110,7 @@ This project is indexed by GitNexus as **git-orchard-rs** (2984 symbols, 7553 re
 
 1. `gitnexus_query({query: "<error or symptom>"})` — find execution flows related to the issue
 2. `gitnexus_context({name: "<suspect function>"})` — see all callers, callees, and process participation
-3. `READ gitnexus://repo/git-orchard-rs/process/{processName}` — trace the full execution flow step by step
+3. `READ gitnexus://repo/orchardist/process/{processName}` — trace the full execution flow step by step
 4. For regressions: `gitnexus_detect_changes({scope: "compare", base_ref: "main"})` — see what your branch changed
 
 ## When Refactoring
@@ -149,10 +149,10 @@ This project is indexed by GitNexus as **git-orchard-rs** (2984 symbols, 7553 re
 
 | Resource | Use for |
 |----------|---------|
-| `gitnexus://repo/git-orchard-rs/context` | Codebase overview, check index freshness |
-| `gitnexus://repo/git-orchard-rs/clusters` | All functional areas |
-| `gitnexus://repo/git-orchard-rs/processes` | All execution flows |
-| `gitnexus://repo/git-orchard-rs/process/{name}` | Step-by-step execution trace |
+| `gitnexus://repo/orchardist/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/orchardist/clusters` | All functional areas |
+| `gitnexus://repo/orchardist/processes` | All execution flows |
+| `gitnexus://repo/orchardist/process/{name}` | Step-by-step execution trace |
 
 ## Self-Check Before Finishing
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at https://github.com/drewdrewthis/git-orchard-rs/issues. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at https://github.com/drewdrewthis/orchardist/issues. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ Thanks for your interest in contributing! This guide covers everything you need 
 1. Fork and clone the repository:
 
    ```bash
-   gh repo fork drewdrewthis/git-orchard-rs --clone
-   cd git-orchard-rs
+   gh repo fork drewdrewthis/orchardist --clone
+   cd orchardist
    ```
 
 2. Build the project:
@@ -103,11 +103,11 @@ Read [docs/architecture.md](docs/architecture.md) for the full picture. Key prin
 
 ## Reporting Bugs
 
-Use the [bug report template](https://github.com/drewdrewthis/git-orchard-rs/issues/new?template=bug_report.md) to file bugs with steps to reproduce, expected/actual behavior, and your environment.
+Use the [bug report template](https://github.com/drewdrewthis/orchardist/issues/new?template=bug_report.md) to file bugs with steps to reproduce, expected/actual behavior, and your environment.
 
 ## Requesting Features
 
-Use the [feature request template](https://github.com/drewdrewthis/git-orchard-rs/issues/new?template=feature_request.md) to propose new functionality.
+Use the [feature request template](https://github.com/drewdrewthis/orchardist/issues/new?template=feature_request.md) to propose new functionality.
 
 ## License
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Top-level Makefile for the polyglot git-orchard-rs repo.
+# Top-level Makefile for the polyglot orchardist repo.
 #
 # Three binaries coexist (per ADR-013):
 #   - `orchard` (Rust)        — thin dispatcher; routes verbs to helpers.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ binary `orchard` dispatches to helper binaries under the hood:
   CLI. Dispatched as `orchard worktree …` and via bare-verb shortcuts
   (`orchard new <issue>`, `orchard rm <id>`, etc.).
 
-The repo name still ends in `-rs` because URL stability is worth more
-than the suffix. See `scripts/init/` for launchd / systemd units.
+Renamed from `git-orchard-rs` to `orchardist` on 2026-06-09; the old URL
+redirects. The repo is polyglot (Rust + Go) — the binaries are `orchard`,
+`orchard-tui`, `orchard-daemon`, and `orchard-worktree`. See `scripts/init/`
+for launchd / systemd units.
 
 The schema lives in `schema.graphql` at the repo root — schema-first.
 Run `make generate` to regenerate Go types from it. The Rust TUI client
@@ -69,7 +71,7 @@ Orchard gives you a single dashboard showing everything happening across your re
 ### From source
 
 ```bash
-cargo install --git https://github.com/drewdrewthis/git-orchard-rs orchard --bin orchard-tui
+cargo install --git https://github.com/drewdrewthis/orchardist orchard --bin orchard-tui
 
 # Or from a local checkout:
 cargo install --path crates/orchard --bin orchard-tui

--- a/crates/chat-core/Cargo.toml
+++ b/crates/chat-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Cross-machine chat substrate: append-only JSONL rooms + tmux send-keys fanout with Level 2 receipts"
 license = "MIT"
-repository = "https://github.com/drewdrewthis/git-orchard-rs"
+repository = "https://github.com/drewdrewthis/orchardist"
 
 [lib]
 name = "chat_core"

--- a/crates/orchard-chat/Cargo.toml
+++ b/crates/orchard-chat/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Agent-to-agent chat CLI: thin clap wrapper on chat-core (orchard send/chat verbs)"
 license = "MIT"
-repository = "https://github.com/drewdrewthis/git-orchard-rs"
+repository = "https://github.com/drewdrewthis/orchardist"
 
 [[bin]]
 name = "orchard-chat"

--- a/crates/orchard-dispatcher/Cargo.toml
+++ b/crates/orchard-dispatcher/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Thin dispatcher for the orchard CLI ecosystem (routes to orchard-tui, orchard-daemon, orchard-worktree, etc.)"
 license = "MIT"
-repository = "https://github.com/drewdrewthis/git-orchard-rs"
+repository = "https://github.com/drewdrewthis/orchardist"
 
 [[bin]]
 name = "orchard"

--- a/crates/orchard-worktree/Cargo.toml
+++ b/crates/orchard-worktree/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Worktree mutation CLI: thin clap wrapper on worktree-core (orchard new/rm/prune/ls/path)"
 license = "MIT"
-repository = "https://github.com/drewdrewthis/git-orchard-rs"
+repository = "https://github.com/drewdrewthis/orchardist"
 
 [[bin]]
 name = "orchard-worktree"

--- a/crates/orchard/Cargo.toml
+++ b/crates/orchard/Cargo.toml
@@ -4,8 +4,8 @@ version = "1.1.0"
 edition = "2024"
 description = "Interactive TUI for managing git worktrees, PR status, and tmux sessions"
 license = "MIT"
-repository = "https://github.com/drewdrewthis/git-orchard-rs"
-homepage = "https://github.com/drewdrewthis/git-orchard-rs"
+repository = "https://github.com/drewdrewthis/orchardist"
+homepage = "https://github.com/drewdrewthis/orchardist"
 keywords = ["git", "worktree", "tui", "tmux", "terminal"]
 categories = ["command-line-utilities", "development-tools"]
 

--- a/crates/worktree-core/Cargo.toml
+++ b/crates/worktree-core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 description = "Core git worktree operations: list, parse, create, remove, conflict detection"
 license = "MIT"
-repository = "https://github.com/drewdrewthis/git-orchard-rs"
+repository = "https://github.com/drewdrewthis/orchardist"
 
 [lib]
 name = "worktree_core"

--- a/npm/package.json
+++ b/npm/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/drewdrewthis/git-orchard-rs.git"
+    "url": "git+https://github.com/drewdrewthis/orchardist.git"
   },
   "bin": {
     "git-orchard": "run.js",

--- a/plugin-sources/orchardist/.claude-plugin/plugin.json
+++ b/plugin-sources/orchardist/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "orchardist",
+  "description": "Recall: search past Claude Code conversations across all projects and synthesize context into the current session.",
+  "version": "0.1.0",
+  "author": { "name": "drewdrewthis", "email": "andrew@langwatch.ai", "url": "https://github.com/drewdrewthis" }
+}

--- a/plugin-sources/orchardist/scripts/session-index.py
+++ b/plugin-sources/orchardist/scripts/session-index.py
@@ -14,6 +14,7 @@ Usage:
 import sqlite3
 import json
 import os
+import re
 import sys
 import glob
 import time
@@ -108,7 +109,11 @@ def build_index():
         project = os.path.basename(os.path.dirname(f))
         try:
             messages = extract_user_messages(f)
-        except Exception:
+        except (OSError, UnicodeDecodeError) as exc:
+            print(
+                json.dumps({"warning": "index_skip", "file_path": f, "error": str(exc)}),
+                file=sys.stderr,
+            )
             continue
 
         combined = "\n".join(messages)
@@ -162,26 +167,30 @@ def search(query, limit=10):
         sys.exit(1)
 
     results = []
-    rows = db.execute("""
-        SELECT
-            f.session_id,
-            s.project,
-            s.file_path,
-            s.mtime,
-            s.message_count,
-            s.first_prompt,
-            s.last_prompt,
-            snippet(sessions_fts, 2, '>>>', '<<<', '...', 24) as snippet,
-            rank
-        FROM sessions_fts f
-        JOIN sessions s ON s.session_id = f.session_id
-        WHERE sessions_fts MATCH ?
-        ORDER BY rank
-        LIMIT ?
-    """, (query, limit)).fetchall()
+    try:
+        rows = db.execute("""
+            SELECT
+                f.session_id,
+                s.project,
+                s.file_path,
+                s.mtime,
+                s.message_count,
+                s.first_prompt,
+                s.last_prompt,
+                snippet(sessions_fts, 2, '>>>', '<<<', '...', 24) as snippet,
+                rank
+            FROM sessions_fts f
+            JOIN sessions s ON s.session_id = f.session_id
+            WHERE sessions_fts MATCH ?
+            ORDER BY rank
+            LIMIT ?
+        """, (query, limit)).fetchall()
+    except sqlite3.OperationalError as exc:
+        print(json.dumps({"error": "Invalid search query", "details": str(exc)}))
+        sys.exit(1)
 
     for row in rows:
-        proj = row["project"].replace("-Users-hope-", "~/").replace("-", "/")
+        proj = re.sub(r"^-Users-[^-]+-", "~/", row["project"])
         results.append({
             "session_id": row["session_id"],
             "project": proj,
@@ -226,7 +235,7 @@ def context(jsonl_path, tail=10):
                 if text.startswith("<local-command"):
                     continue
                 idx = text.find("<system-reminder>")
-                if idx > 0:
+                if idx >= 0:
                     text = text[:idx]
                 messages.append({"role": msg_type, "text": text[:400]})
             except (json.JSONDecodeError, KeyError):
@@ -253,7 +262,11 @@ if __name__ == "__main__":
         limit = 10
         if "--limit" in sys.argv:
             idx = sys.argv.index("--limit")
-            limit = int(sys.argv[idx + 1])
+            try:
+                limit = int(sys.argv[idx + 1])
+            except (IndexError, ValueError):
+                print(json.dumps({"error": "--limit requires an integer value"}))
+                sys.exit(1)
         search(query, limit)
     elif cmd == "context":
         if len(sys.argv) < 3:
@@ -263,7 +276,11 @@ if __name__ == "__main__":
         tail = 10
         if "--tail" in sys.argv:
             idx = sys.argv.index("--tail")
-            tail = int(sys.argv[idx + 1])
+            try:
+                tail = int(sys.argv[idx + 1])
+            except (IndexError, ValueError):
+                print(json.dumps({"error": "--tail requires an integer value"}))
+                sys.exit(1)
         context(path, tail)
     else:
         print(f"Unknown command: {cmd}")

--- a/plugin-sources/orchardist/scripts/session-index.py
+++ b/plugin-sources/orchardist/scripts/session-index.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+Session search index for Claude Code conversations.
+
+Builds and queries a SQLite FTS5 index over all session JSONL files.
+Supports incremental updates (only re-parses changed files).
+
+Usage:
+    session-index.py build                        # Build/update the index
+    session-index.py search <query> [--limit N]   # Search sessions, output JSON
+    session-index.py context <path.jsonl> [--tail N]  # Extract recent messages from a session
+"""
+
+import sqlite3
+import json
+import os
+import sys
+import glob
+import time
+
+DB_PATH = os.path.expanduser("~/.claude/sessions.db")
+PROJECTS_DIR = os.path.expanduser("~/.claude/projects")
+
+
+def get_db():
+    db = sqlite3.connect(DB_PATH)
+    db.row_factory = sqlite3.Row
+    db.execute("PRAGMA journal_mode=WAL")
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS sessions (
+            session_id TEXT PRIMARY KEY,
+            project TEXT,
+            file_path TEXT,
+            mtime REAL,
+            message_count INTEGER,
+            first_prompt TEXT,
+            last_prompt TEXT
+        )
+    """)
+    db.execute("""
+        CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts USING fts5(
+            session_id,
+            project,
+            user_text,
+            tokenize='porter unicode61'
+        )
+    """)
+    return db
+
+
+def extract_user_messages(jsonl_path):
+    """Parse a JSONL session file and extract user message text."""
+    messages = []
+    for line in open(jsonl_path):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+            if obj.get("type") != "user":
+                continue
+            content = obj.get("message", {}).get("content", "")
+            text = ""
+            if isinstance(content, list):
+                for c in content:
+                    if isinstance(c, dict) and c.get("type") == "text":
+                        text += c["text"] + " "
+            else:
+                text = str(content)
+            text = text.strip()
+            if len(text) < 10:
+                continue
+            if text.startswith("Base directory for this skill:"):
+                continue
+            if text.startswith("<local-command"):
+                continue
+            messages.append(text)
+        except (json.JSONDecodeError, KeyError):
+            continue
+    return messages
+
+
+def build_index():
+    db = get_db()
+    files = glob.glob(os.path.join(PROJECTS_DIR, "*", "*.jsonl"))
+    files = [f for f in files if "/subagents/" not in f]
+
+    # Load existing mtimes
+    existing = {}
+    for row in db.execute("SELECT session_id, mtime FROM sessions"):
+        existing[row["session_id"]] = row["mtime"]
+
+    # Track which session IDs are still on disk
+    on_disk = set()
+    indexed = 0
+    skipped = 0
+    start = time.time()
+
+    for f in files:
+        session_id = os.path.basename(f).replace(".jsonl", "")
+        on_disk.add(session_id)
+        mtime = os.path.getmtime(f)
+
+        if session_id in existing and existing[session_id] == mtime:
+            skipped += 1
+            continue
+
+        project = os.path.basename(os.path.dirname(f))
+        try:
+            messages = extract_user_messages(f)
+        except Exception:
+            continue
+
+        combined = "\n".join(messages)
+        first_prompt = messages[0][:200] if messages else ""
+        last_prompt = messages[-1][:200] if len(messages) > 1 else first_prompt
+
+        # Upsert metadata
+        db.execute("""
+            INSERT INTO sessions (session_id, project, file_path, mtime, message_count, first_prompt, last_prompt)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(session_id) DO UPDATE SET
+                project=excluded.project, file_path=excluded.file_path,
+                mtime=excluded.mtime, message_count=excluded.message_count,
+                first_prompt=excluded.first_prompt, last_prompt=excluded.last_prompt
+        """, (session_id, project, f, mtime, len(messages), first_prompt, last_prompt))
+
+        # Upsert FTS (delete old entry first)
+        db.execute("DELETE FROM sessions_fts WHERE session_id = ?", (session_id,))
+        db.execute("INSERT INTO sessions_fts (session_id, project, user_text) VALUES (?, ?, ?)",
+                   (session_id, project, combined))
+
+        indexed += 1
+
+    # Remove sessions whose files no longer exist
+    removed = 0
+    for sid in existing:
+        if sid not in on_disk:
+            db.execute("DELETE FROM sessions WHERE session_id = ?", (sid,))
+            db.execute("DELETE FROM sessions_fts WHERE session_id = ?", (sid,))
+            removed += 1
+
+    db.commit()
+    elapsed = time.time() - start
+    total = db.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    print(json.dumps({
+        "indexed": indexed,
+        "skipped": skipped,
+        "removed": removed,
+        "total": total,
+        "elapsed_seconds": round(elapsed, 2)
+    }))
+
+
+def search(query, limit=10):
+    db = get_db()
+
+    # Check if index exists
+    total = db.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    if total == 0:
+        print(json.dumps({"error": "Index is empty. Run: session-index.py build"}))
+        sys.exit(1)
+
+    results = []
+    rows = db.execute("""
+        SELECT
+            f.session_id,
+            s.project,
+            s.file_path,
+            s.mtime,
+            s.message_count,
+            s.first_prompt,
+            s.last_prompt,
+            snippet(sessions_fts, 2, '>>>', '<<<', '...', 24) as snippet,
+            rank
+        FROM sessions_fts f
+        JOIN sessions s ON s.session_id = f.session_id
+        WHERE sessions_fts MATCH ?
+        ORDER BY rank
+        LIMIT ?
+    """, (query, limit)).fetchall()
+
+    for row in rows:
+        proj = row["project"].replace("-Users-hope-", "~/").replace("-", "/")
+        results.append({
+            "session_id": row["session_id"],
+            "project": proj,
+            "file_path": row["file_path"],
+            "mtime": row["mtime"],
+            "message_count": row["message_count"],
+            "first_prompt": row["first_prompt"],
+            "last_prompt": row["last_prompt"],
+            "snippet": row["snippet"],
+            "score": row["rank"],
+        })
+
+    print(json.dumps(results, indent=2))
+
+
+def context(jsonl_path, tail=10):
+    """Extract recent user/assistant messages from a session for context."""
+    messages = []
+    with open(jsonl_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                msg_type = obj.get("type")
+                if msg_type not in ("user", "assistant"):
+                    continue
+                content = obj.get("message", {}).get("content", "")
+                text = ""
+                if isinstance(content, list):
+                    for c in content:
+                        if isinstance(c, dict) and c.get("type") == "text":
+                            text += c["text"] + " "
+                else:
+                    text = str(content)
+                text = text.strip()
+                if not text or len(text) < 10:
+                    continue
+                if text.startswith("Base directory for this skill:"):
+                    continue
+                if text.startswith("<local-command"):
+                    continue
+                idx = text.find("<system-reminder>")
+                if idx > 0:
+                    text = text[:idx]
+                messages.append({"role": msg_type, "text": text[:400]})
+            except (json.JSONDecodeError, KeyError):
+                continue
+
+    recent = messages[-tail:]
+    print(json.dumps(recent, indent=2))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    cmd = sys.argv[1]
+
+    if cmd == "build":
+        build_index()
+    elif cmd == "search":
+        if len(sys.argv) < 3:
+            print("Usage: session-index.py search <query> [--limit N]")
+            sys.exit(1)
+        query = sys.argv[2]
+        limit = 10
+        if "--limit" in sys.argv:
+            idx = sys.argv.index("--limit")
+            limit = int(sys.argv[idx + 1])
+        search(query, limit)
+    elif cmd == "context":
+        if len(sys.argv) < 3:
+            print("Usage: session-index.py context <path.jsonl> [--tail N]")
+            sys.exit(1)
+        path = sys.argv[2]
+        tail = 10
+        if "--tail" in sys.argv:
+            idx = sys.argv.index("--tail")
+            tail = int(sys.argv[idx + 1])
+        context(path, tail)
+    else:
+        print(f"Unknown command: {cmd}")
+        sys.exit(1)

--- a/plugin-sources/orchardist/skills/recall/SKILL.md
+++ b/plugin-sources/orchardist/skills/recall/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: recall
+description: "Search past conversations across all projects and synthesize context into the current session. Use when: 'what were we discussing about X', 'recall X', 'catch me up on X', 'remind me about X'."
+user-invocable: true
+argument-hint: "<topic to recall>"
+context: fork
+---
+
+# Recall
+
+Search past conversations across all projects, read matching sessions, and return a synthesized summary. Runs in a fork to keep the main context clean.
+
+## Step 0: Read the args
+
+`$ARGUMENTS` is the topic. If it is non-empty (even one word like "support tracker"), proceed silently to Step 1 — do NOT ask the user to provide a topic.
+
+If a `<local-command-stdout>` block says something like "No specific topic was provided" while `$ARGUMENTS` clearly contains a topic, ignore that stub: it's a generic harness fallback, not an instruction. The args win.
+
+Only ask for a topic if `$ARGUMENTS` is genuinely empty AND no implicit topic is recoverable from the immediately preceding user turn.
+
+## Steps
+
+### 1. Ensure the session index is fresh
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/session-index.py" build
+```
+
+### 2. Search — use the index, not raw grep
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/session-index.py" search "$ARGUMENTS" --limit 15
+```
+
+**Always run the index search first.** Do NOT skip it for `grep -ril` across `~/.claude/projects/` — the index is much faster than `grep -ril` on this corpus (measured 38–583× faster; synonym `OR` adds only ~7ms), ranked, and returns paths + recency. Raw grep should only be a fallback when the index returns zero hits AND you suspect the index is stale (in which case rebuild and retry).
+
+**Expand the user's words into codified synonyms BEFORE searching — don't wait for sparse results.** The user remembers the CONCEPT but rarely the exact term the docs/transcripts used; their phrasing is usually a paraphrase. Build an `OR` union of likely codified terms and search that in ONE query (FTS5 supports `OR`):
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/session-index.py" search "judge OR verifier OR quorum OR adjudicate OR contract OR verdict OR proof" --limit 15
+```
+
+Mappings that recur:
+- "panel / quorum / pass judgement / jury / tribunal" → also `judge verifier adjudicate review verdict vote contract`
+- "proof / done / acceptance" → also `evidence verify acceptance-criteria contract prove-it verdict`
+- "CI / automated checks" → also `verifier check mcp_tool command hook`
+
+A literal-phrase search for the user's words can return ZERO hits while the synonym union finds it (observed: "panel quorum judgement proof" → 0 hits; the `OR` union above → the right sessions). Searching the union is one fast query — no slower than the literal search. Only fall back to broader sweeps if the union is also empty.
+
+### 3. Read matching sessions
+
+For the top 5-10 relevant results, extract context:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/session-index.py" context /path/to/session.jsonl --tail 15
+```
+
+Focus on sessions with high message counts (substantive conversations) and recent mtimes.
+
+### 4. Return a synthesis
+
+Structure the output as:
+
+- **What it is** — one paragraph explaining the topic/feature/work
+- **Key decisions** — bullet list of decisions made across sessions
+- **Current state** — what's done, what's in progress, what's unfinished
+- **Open questions** — anything unresolved
+
+Include session IDs for the most relevant sessions so the user can resume them if needed: `claude --continue <id>`.

--- a/scripts/ac9-federated-orchard-e2e.sh
+++ b/scripts/ac9-federated-orchard-e2e.sh
@@ -96,12 +96,12 @@ boxd cp "$BINARY" "$VM_NAME:/home/boxd/.local/bin/orchard-tui"
 boxd exec "$VM_NAME" "chmod +x /home/boxd/.local/bin/orchard-tui"
 
 log "creating test worktree on VM (branch $TEST_BRANCH)"
-boxd exec "$VM_NAME" "cd /home/boxd/workspace/git-orchard-rs \
+boxd exec "$VM_NAME" "cd /home/boxd/workspace/orchardist \
     && git worktree add .worktrees/ac9-smoke -b $TEST_BRANCH origin/main"
 
 log "creating test tmux session on VM ($TEST_SESSION)"
 boxd exec "$VM_NAME" "tmux new-session -d -s $TEST_SESSION \
-    -c /home/boxd/workspace/git-orchard-rs/.worktrees/ac9-smoke"
+    -c /home/boxd/workspace/orchardist/.worktrees/ac9-smoke"
 
 # ---------------------------------------------------------------------------
 # 2. Configure VM as OrchardProxy remote locally
@@ -115,12 +115,12 @@ EVENTS_LOG="$HOME/.local/state/git-orchard/events.jsonl"
 cat > "$HOME/.config/orchard/config.json" <<EOF
 {
   "repos": [{
-    "slug": "drewdrewthis/git-orchard-rs",
+    "slug": "drewdrewthis/orchardist",
     "path": "$REPO_ROOT",
     "remotes": [{
       "name": "ac9-vm",
       "host": "$VM_HOST",
-      "path": "/home/boxd/workspace/git-orchard-rs",
+      "path": "/home/boxd/workspace/orchardist",
       "type": "orchard-proxy",
       "fallback_kind": "remmy"
     }]


### PR DESCRIPTION
## What

Renamed the repo to `orchardist` and published the `recall` skill as an official, installable plugin.

### Recall plugin (`plugin-sources/orchardist/`)
- `skills/recall/SKILL.md` + bundled `scripts/session-index.py` (referenced via `${CLAUDE_PLUGIN_ROOT}`)
- Codex-only material (boxd/fleet fallback, internal doc links) stripped — self-contained for any installer
- Marketplace renamed `orchard` -> `orchardist`; installs as `/plugin install orchardist@orchardist`, skill is `/orchardist:recall`

### Rename refs
- 6x `Cargo.toml` repository/homepage, `npm/package.json`, marketplace homepage
- Install/contrib docs: README (cargo-install cmd + rewritten `-rs` stability note), CONTRIBUTING, CODE_OF_CONDUCT, Makefile, CLAUDE.md GitNexus slugs, ac9 e2e script
- Historical changelog links left to the GitHub redirect

## Verification
- `recall` loads as `orchardist:recall` in a real `claude --plugin-dir ... --print` drive
- Bundled `session-index.py` builds the index + returns ranked results via `${CLAUDE_PLUGIN_ROOT}` expansion
- All manifests parse (cargo/tomllib, npm, marketplace JSON)
- Zero `git-orchard-rs` slug remains in the correctness-critical + doc files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session indexing and full‑text search for past conversations via a new CLI tool
  * Introduced a "recall" skill for searching and synthesizing conversation context

* **Documentation**
  * Updated docs, README, contribution and policy links to reflect the repository rename and new index name

* **Chores**
  * Updated package and crate metadata to new repository URL
  * Added plugin manifest for the orchardist plugin
<!-- end of auto-generated comment: release notes by coderabbit.ai -->