### PR TITLE
fix(daemon): see shell-wrapped claude sessions — claudeInstance null for every worker (#706)

### DIFF
--- a/internal/server/providers/tmux/axes_test.go
+++ b/internal/server/providers/tmux/axes_test.go
@@ -171,6 +171,50 @@ func TestPanesByCommand_FallbackToCurrentCommand(t *testing.T) {
 	}
 }
 
+func TestPanesByCommand_ShellWrappedClaudeIsNotShadowedByPs(t *testing.T) {
+	// Regression for #706. tmux's pane_pid is the pane's ROOT process, not its
+	// foreground process. A session launched as `bash -> claude` reports
+	// pane_pid = the bash pid, while tmux's own pane_current_command still
+	// resolves the foreground correctly to "claude".
+	//
+	// Asking ps about the root pid answers "bash". That answer is non-empty, so
+	// it must not shadow tmux's: the two signals are complementary, not ranked.
+	// Both pids below are copied from the live box (#706): 1648 is an exec'd
+	// claude (found today), 806301 is a shell-wrapped worker (missed today).
+	panes := []Pane{
+		{Key: PaneKey{Host: "local", PaneID: "%1"}, CurrentPid: 1648, CurrentCommand: "claude"},
+		{Key: PaneKey{Host: "local", PaneID: "%2"}, CurrentPid: 806301, CurrentCommand: "claude"},
+	}
+	ps := &stubPsGetter{commands: map[int]string{
+		1648:   "claude",
+		806301: "-bash",
+	}}
+	p := buildTestProvider(panes)
+
+	got := p.PanesByCommand("local", "claude", ps)
+	if len(got) != 2 {
+		t.Fatalf("PanesByCommand: want 2 claude panes (exec'd + shell-wrapped), got %d — "+
+			"a shell-wrapped claude is invisible, so the concurrency cap counts 0 workers "+
+			"while workers are running", len(got))
+	}
+}
+
+func TestPanesByCommand_ShellWithoutClaudeStillExcluded(t *testing.T) {
+	// Guards the fix above from over-matching: a pane running a plain shell with
+	// no claude anywhere must stay excluded. Without this, "trust tmux too"
+	// could degrade into "match everything".
+	panes := []Pane{
+		{Key: PaneKey{Host: "local", PaneID: "%3"}, CurrentPid: 13036, CurrentCommand: "bash"},
+	}
+	ps := &stubPsGetter{commands: map[int]string{13036: "-bash"}}
+	p := buildTestProvider(panes)
+
+	got := p.PanesByCommand("local", "claude", ps)
+	if len(got) != 0 {
+		t.Errorf("PanesByCommand: plain shell must not match claude, got %d", len(got))
+	}
+}
+
 func TestPanesByCommand_CaseInsensitive(t *testing.T) {
 	panes := []Pane{
 		{Key: PaneKey{Host: "local", PaneID: "%7"}, CurrentPid: 700, CurrentCommand: "Claude"},

--- a/internal/server/providers/tmux/provider.go
+++ b/internal/server/providers/tmux/provider.go
@@ -299,17 +299,29 @@ func (p *Provider) PanesBySession(host, sessionName string) []Pane {
 	return out
 }
 
-// paneCommandMatchesClaude checks whether a pane's foreground command
-// (by ps basename) contains needle (lower-case). Falls back to the raw
-// tmux CurrentCommand when ps cannot resolve the pid.
+// paneCommandMatchesClaude reports whether a pane is running needle
+// (lower-case), consulting two independent signals.
+//
+// CurrentPid is tmux's pane_pid — the pane's ROOT process, NOT its foreground
+// process. A session started as `bash -> claude` has a bash root pid, so asking
+// ps about it answers "bash" even though claude is very much running. tmux's own
+// pane_current_command resolves the foreground through the shell and answers
+// "claude" correctly.
+//
+// So the two signals are complementary, not ranked: ps sees through wrapper
+// processes tmux reports verbatim, and tmux sees through shells ps cannot.
+// Either one matching is a match. Previously a non-empty ps answer returned
+// early and shadowed tmux's, which made every shell-wrapped claude session
+// invisible to Query.claudeInstances — and the concurrency cap that reads it
+// counted 0 workers while workers were running (#706).
 func paneCommandMatchesClaude(pn Pane, host string, ps PanePsGetter, needle string) bool {
 	if ps != nil && pn.CurrentPid > 0 {
 		cmd := ps.CommandForPid(host, pn.CurrentPid)
-		if cmd != "" {
-			return strings.Contains(strings.ToLower(filepath.Base(cmd)), needle)
+		if cmd != "" && strings.Contains(strings.ToLower(filepath.Base(cmd)), needle) {
+			return true
 		}
 	}
-	// Fallback to tmux pane_current_command (may be version string on macOS).
+	// tmux pane_current_command (may be a version string on macOS, hence ps above).
 	return strings.Contains(strings.ToLower(filepath.Base(pn.CurrentCommand)), needle)
 }
 

--- a/internal/server/providers/tmux/provider.go
+++ b/internal/server/providers/tmux/provider.go
@@ -276,6 +276,18 @@ func (p *Provider) PanesByCommand(host, basenameContains string, ps PanePsGetter
 	return out
 }
 
+// PaneRunsCommand reports whether pn is running needle, matched
+// case-insensitively against the command basename. It is the same detection
+// PanesByCommand applies, exported so a resolver holding a single already-known
+// pane can ask the question without re-deriving it — one source of truth for
+// "is this pane running claude".
+func PaneRunsCommand(pn Pane, host string, ps PanePsGetter, needle string) bool {
+	if needle == "" {
+		return false
+	}
+	return paneCommandMatchesClaude(pn, host, ps, strings.ToLower(needle))
+}
+
 // PanesBySession returns every pane whose tmux session name equals
 // sessionName on the given host. Returns [] (never nil).
 func (p *Provider) PanesBySession(host, sessionName string) []Pane {

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -1456,13 +1456,25 @@ func (r *tmuxPaneResolver) ClaudeInstance(ctx context.Context, obj *graphql1.Tmu
 	if r.Tmux == nil || obj == nil {
 		return nil, nil
 	}
-	// Only project panes running claude.
-	if obj.CurrentCommand != "claude" {
+	// obj is a thin handle: tmuxWindowResolver.Panes projects panes through
+	// projectPane(), which sets {ID, PaneID} and nothing else. Every sibling
+	// field resolver (currentCommand, currentPid, process) therefore looks the
+	// pane up in the provider rather than reading obj. This one used to read
+	// obj.CurrentCommand, which compared "" against "claude" and so returned
+	// nil for EVERY pane, always — attend.js reads this field and treats null
+	// as healthy, leaving the attention feed blind to every worker (#706).
+	p, ok := r.lookupPane(obj.ID)
+	if !ok {
 		return nil, nil
 	}
 	host := string(r.Tmux.Host())
+	// Only project panes running claude — same two-signal detection as
+	// Query.claudeInstances, so both surfaces agree on what "running claude" means.
+	if !tmux.PaneRunsCommand(p, host, newResolverPanePsGetter(r.PS), "claude") {
+		return nil, nil
+	}
 	qr := &queryResolver{r.Resolver}
-	inst := qr.buildClaudeInstanceFromPane(ctx, obj, host, nil, nil, nil)
+	inst := qr.buildClaudeInstanceFromPane(ctx, projectPaneRich(p), host, nil, nil, nil)
 	return inst, nil
 }
 

--- a/internal/server/resolvers/tmux_pane_claude_instance_test.go
+++ b/internal/server/resolvers/tmux_pane_claude_instance_test.go
@@ -2,56 +2,110 @@ package resolvers
 
 // Tests for tmuxPaneResolver.ClaudeInstance (ADR-022 Phase 5).
 //
-// Scenarios covered:
-//  1. Pane with CurrentCommand=="claude" → resolver returns a non-nil instance.
-//  2. Pane with CurrentCommand!="claude" → resolver returns (nil, nil).
-//  3. r.Tmux is nil → resolver returns (nil, nil).
+// These tests address the pane by node id ONLY — `&graphql1.TmuxPane{ID: ...}`
+// — because that is the exact object production hands the resolver:
+// tmuxWindowResolver.Panes projects via projectPane(), which sets {ID, PaneID}
+// and nothing else.
+//
+// An earlier version of this file constructed obj with CurrentCommand
+// pre-populated. No production path produces that shape, so the suite passed
+// while `TmuxPane.claudeInstance` returned null for every pane on the live box
+// — attend.js reads that field and treats null as healthy, leaving the
+// attention feed blind to every worker (#706). Seed the provider and address
+// panes by id; never hand the resolver a field production would not set.
 
 import (
 	"context"
 	"testing"
 
 	graphql1 "github.com/drewdrewthis/orchardist/internal/server/graphql"
-	tmuxprovider "github.com/drewdrewthis/orchardist/internal/server/providers/tmux"
 )
 
-// TestTmuxPaneClaudeInstance_ClaudePaneReturnsInstance verifies that a pane
-// whose CurrentCommand is "claude" produces a non-nil ClaudeInstance.
-func TestTmuxPaneClaudeInstance_ClaudePaneReturnsInstance(t *testing.T) {
-	prov := tmuxprovider.New(tmuxprovider.NewAdapter(tmuxprovider.HostID("local")), nil)
-	r := &tmuxPaneResolver{&Resolver{Tmux: prov}}
-	obj := &graphql1.TmuxPane{
-		ID:             "TmuxPane:local:%59",
-		PaneID:         "%59",
-		CurrentCommand: "claude",
-	}
+// TestTmuxPaneClaudeInstance_ShellWrappedClaudeByNodeID is the #706 regression.
+// A worker launched as `bash -> claude` has pane_pid = the bash pid, so ps
+// answers "-bash" while tmux's pane_current_command answers "claude". The pane
+// is addressed by node id, exactly as Window.panes does.
+func TestTmuxPaneClaudeInstance_ShellWrappedClaudeByNodeID(t *testing.T) {
+	const pid = 806301 // real bash wrapper pid from the live box (#706)
+	const paneID = "%21"
+
+	tmuxProv := buildTmuxProvider(t, []string{
+		paneRowWithCommand("orchard_issue706", paneID, pid, "claude"),
+	})
+	psProv := buildPsProvider(t, []psRow{{pid: pid, cmd: "-bash"}})
+
+	r := &tmuxPaneResolver{&Resolver{Tmux: tmuxProv, PS: psProv}}
+	obj := &graphql1.TmuxPane{ID: paneGQLID(testHost, paneID)}
 
 	got, err := r.ClaudeInstance(context.Background(), obj)
 	if err != nil {
 		t.Fatalf("ClaudeInstance() unexpected error: %v", err)
 	}
 	if got == nil {
-		t.Fatal("ClaudeInstance() returned nil, want non-nil *graphql1.ClaudeInstance for claude pane")
+		t.Fatal("ClaudeInstance() = nil for a live claude pane addressed by node id; " +
+			"attend.js reads this field and treats null as healthy, so every worker is invisible (#706)")
 	}
 }
 
-// TestTmuxPaneClaudeInstance_NonClaudePaneReturnsNil verifies that a pane
-// whose CurrentCommand is not "claude" returns (nil, nil).
-func TestTmuxPaneClaudeInstance_NonClaudePaneReturnsNil(t *testing.T) {
-	prov := tmuxprovider.New(tmuxprovider.NewAdapter(tmuxprovider.HostID("local")), nil)
-	r := &tmuxPaneResolver{&Resolver{Tmux: prov}}
-	obj := &graphql1.TmuxPane{
-		ID:             "TmuxPane:local:%99",
-		PaneID:         "%99",
-		CurrentCommand: "vim",
+// TestTmuxPaneClaudeInstance_ExecdClaudeByNodeID covers the other launch shape:
+// claude exec'd directly, so the pane's root process IS claude and ps agrees.
+func TestTmuxPaneClaudeInstance_ExecdClaudeByNodeID(t *testing.T) {
+	const pid = 1648 // real exec'd claude pid from the live box (#706)
+	const paneID = "%0"
+
+	tmuxProv := buildTmuxProvider(t, []string{
+		paneRowWithCommand("assistant", paneID, pid, "claude"),
+	})
+	psProv := buildPsProvider(t, []psRow{{pid: pid, cmd: "claude"}})
+
+	r := &tmuxPaneResolver{&Resolver{Tmux: tmuxProv, PS: psProv}}
+	obj := &graphql1.TmuxPane{ID: paneGQLID(testHost, paneID)}
+
+	got, err := r.ClaudeInstance(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("ClaudeInstance() unexpected error: %v", err)
 	}
+	if got == nil {
+		t.Fatal("ClaudeInstance() = nil for an exec'd claude pane addressed by node id")
+	}
+}
+
+// TestTmuxPaneClaudeInstance_NonClaudePaneReturnsNil guards against
+// over-matching: a plain shell pane with no claude must still resolve to nil.
+func TestTmuxPaneClaudeInstance_NonClaudePaneReturnsNil(t *testing.T) {
+	const pid = 13036
+	const paneID = "%4"
+
+	tmuxProv := buildTmuxProvider(t, []string{
+		paneRowWithCommand("agents-view", paneID, pid, "bash"),
+	})
+	psProv := buildPsProvider(t, []psRow{{pid: pid, cmd: "-bash"}})
+
+	r := &tmuxPaneResolver{&Resolver{Tmux: tmuxProv, PS: psProv}}
+	obj := &graphql1.TmuxPane{ID: paneGQLID(testHost, paneID)}
 
 	got, err := r.ClaudeInstance(context.Background(), obj)
 	if err != nil {
 		t.Fatalf("ClaudeInstance() unexpected error: %v", err)
 	}
 	if got != nil {
-		t.Errorf("ClaudeInstance() = %+v, want nil (non-claude pane)", got)
+		t.Errorf("ClaudeInstance() = %+v, want nil (plain shell pane)", got)
+	}
+}
+
+// TestTmuxPaneClaudeInstance_UnknownPaneReturnsNil covers a node id the
+// provider has no pane for (e.g. the pane died between resolution steps).
+func TestTmuxPaneClaudeInstance_UnknownPaneReturnsNil(t *testing.T) {
+	tmuxProv := buildTmuxProvider(t, nil)
+	r := &tmuxPaneResolver{&Resolver{Tmux: tmuxProv}}
+	obj := &graphql1.TmuxPane{ID: paneGQLID(testHost, "%404")}
+
+	got, err := r.ClaudeInstance(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("ClaudeInstance() unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("ClaudeInstance() = %+v, want nil (unknown pane)", got)
 	}
 }
 
@@ -59,7 +113,7 @@ func TestTmuxPaneClaudeInstance_NonClaudePaneReturnsNil(t *testing.T) {
 // is nil the resolver returns (nil, nil) without panicking.
 func TestTmuxPaneClaudeInstance_NilTmuxReturnsNil(t *testing.T) {
 	r := &tmuxPaneResolver{&Resolver{Tmux: nil}}
-	obj := &graphql1.TmuxPane{ID: "TmuxPane:local:%42", CurrentCommand: "claude"}
+	obj := &graphql1.TmuxPane{ID: paneGQLID(testHost, "%42")}
 
 	got, err := r.ClaudeInstance(context.Background(), obj)
 	if err != nil {

--- a/internal/server/resolvers/tmux_pane_process_test.go
+++ b/internal/server/resolvers/tmux_pane_process_test.go
@@ -25,7 +25,13 @@ type fakeTmuxRunner struct {
 	paneLines []string
 }
 
-const fieldSepTest = "\x01"
+// fieldSepTest must match the tmux adapter's fieldSep. #662 changed the real
+// separator from \x01 to \t (tmux 3.x discovery fix) without updating these
+// fakes, so every seeded pane row silently failed the 18-field parse and the
+// providers came up empty — the tests here have been asserting against an empty
+// provider ever since. CI never caught it: .github/workflows/ci.yml runs only
+// `cargo test -p orchard`, so no Go test in this repo runs in CI.
+const fieldSepTest = "\t"
 
 func (f *fakeTmuxRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
 	if name != "tmux" {
@@ -73,6 +79,14 @@ func (f *fakeTmuxRunner) Run(_ context.Context, name string, args ...string) ([]
 // listAll consolidated list-sessions + list-panes into one call (#511 follow-up),
 // so every pane row carries its session metadata too.
 func paneRow(sessionName, paneID string, pid int) string {
+	return paneRowWithCommand(sessionName, paneID, pid, "zsh")
+}
+
+// paneRowWithCommand is paneRow with an explicit pane_current_command — the
+// field tmux fills with the pane's FOREGROUND process, which differs from the
+// pane's root process (pane_pid) whenever a session is launched via a shell
+// wrapper (#706).
+func paneRowWithCommand(sessionName, paneID string, pid int, currentCommand string) string {
 	return strings.Join([]string{
 		sessionName,                   // 0  session_name
 		"1700000000",                  // 1  session_created
@@ -87,7 +101,7 @@ func paneRow(sessionName, paneID string, pid int) string {
 		paneID,                        // 10 window_active_pane
 		paneID,                        // 11 pane_id
 		"",                            // 12 pane_title
-		"zsh",                         // 13 pane_current_command
+		currentCommand,                // 13 pane_current_command
 		fmt.Sprintf("%d", pid),        // 14 pane_pid
 		"80",                          // 15 pane_width
 		"24",                          // 16 pane_height


### PR DESCRIPTION
**Scariest thing** — `TmuxPane.claudeInstance` goes from "always null" to "non-null for any pane running claude". `attend.js` reads exactly this field, so the attention feed wakes up: sessions that silently read as healthy will now start emitting events. That is the point of the fix, but it is a live behaviour change to the orchardist's supervision loop, and the blast radius is every consumer of that field.
**Start here** — `internal/server/resolvers/schema.resolvers.go`, `tmuxPaneResolver.ClaudeInstance`. The old body's `if obj.CurrentCommand != "claude"` is the whole bug: production never populates that struct field.

## Why

Closes #706

The daemon could not see worker sessions. Two independent defects, both confirmed on the live box, both fixed here.

The live consumer is the **attention feed** (`attend.js`), which reads per-pane `claudeInstance.state` and treats null as healthy — so the orchardist was blind to the very worker sessions it supervises. That is this issue's stated symptom, and it is what this fix repairs.

> **Correction to my own first draft of this body.** I originally led with "the launch concurrency pre-flight computes 0 workers while 2 run — a false all-clear on the cap". That framing is **stale**: the pre-flight (`fleet-session/lifecycle` Step 0) was independently remediated earlier the same day and now counts via `session-truth --all`, explicitly banning a daemon-sourced count *because of this bug*. **The cap is enforced today with or without this fix.** What this fix does is remove the product defect that forced that workaround — it does not rescue the cap. Overstating impact is the same sin as overstating evidence, so it is corrected here rather than left standing.

## What changed

- **`paneCommandMatchesClaude` now treats ps and tmux as complementary signals, not ranked** → alternative was to trust ps alone and walk the process tree ourselves (as `session-truth` does to depth 6). Not needed: tmux's `pane_current_command` *already* resolves the foreground through the shell and was correct for all 6 panes. Consequence if wrong: a pane whose tmux command string is a macOS version string still relies on the ps signal, which is retained.
- **`TmuxPane.claudeInstance` resolves from the provider instead of the thin `obj`** → alternative was to make `Window.panes` use `projectPaneRich`, populating the field. Rejected: every *sibling* resolver (`currentCommand`, `currentPid`, `process`) already looks the pane up; matching them keeps one convention. Consequence: one extra snapshot lookup per pane.
- **Detection is shared via the new exported `tmux.PaneRunsCommand`** → alternative was duplicating the match in the resolver. Rejected — `Query.claudeInstances` and `TmuxPane.claudeInstance` would drift apart, which is the "same data served through two paths" smell.
- **Repaired the fake-runner test harness** (`fieldSepTest` `\x01` → `\t`) → not optional: without it these tests cannot fail for the right reason (see Anything surprising).

## How it works

```
internal/server/providers/tmux/provider.go
  paneCommandMatchesClaude   — either signal matches ⇒ match (was: ps answer shadows tmux)
  PaneRunsCommand (new, exported) — single source of truth for "is this pane claude"

internal/server/resolvers/schema.resolvers.go
  tmuxPaneResolver.ClaudeInstance — lookupPane(obj.ID) → PaneRunsCommand → projectPaneRich
```

**Defect A — shell-wrapped claude invisible.** tmux's `pane_pid` is the pane's **root** process, not its foreground process. A session launched `bash -> claude` reports `pane_pid` = the bash pid; `ps` answers `"bash"`. The old code returned on any non-empty ps answer, so `"bash"` shadowed tmux's correct `"claude"`. Sessions that **exec** claude directly (pane root *is* claude) were found; **shell-wrapped** ones never were.

This is launch method, not session age — and it explains the issue's own 2026-07-13 evidence ("only 4 claude instances… the 4 counted are the standing sessions"): the standing sessions are exec'd, the workers are shell-wrapped.

| pane_pid | ps says | tmux says | before | after |
|---|---|---|---|---|
| 1648 assistant, 1733 orchardist, 1804 support, 1869 technician | `claude` | `claude` | found | found |
| 600362 saas_social_scribe, 806301 orchard_issue706 | `bash` | `claude` | **missed** | found |

**Defect B — `TmuxPane.claudeInstance` null for every pane, always.** `Window.panes` projects panes via `projectPane()`, which sets `{ID, PaneID}` and nothing else. The resolver guarded on `obj.CurrentCommand`, comparing `""` against `"claude"` — never true in production. This is the issue's headline symptom: the feed reads null and treats every worker as healthy.

## Test plan

Falsifiability, both defects, red-before / green-after:

**Defect A** (`TestPanesByCommand_ShellWrappedClaudeIsNotShadowedByPs`) — before:
```
--- FAIL: TestPanesByCommand_ShellWrappedClaudeIsNotShadowedByPs
    axes_test.go:196: PanesByCommand: want 2 claude panes (exec'd + shell-wrapped), got 1
```
after: `ok github.com/drewdrewthis/orchardist/internal/server/providers/tmux`

**Defect B** — with the harness repaired and **only the resolver fix reverted**:
```
--- FAIL: TestTmuxPaneClaudeInstance_ShellWrappedClaudeByNodeID
    ClaudeInstance() = nil for a live claude pane addressed by node id
--- FAIL: TestTmuxPaneClaudeInstance_ExecdClaudeByNodeID
--- PASS: TestTmuxPaneClaudeInstance_NonClaudePaneReturnsNil
--- PASS: TestTmuxPaneClaudeInstance_UnknownPaneReturnsNil
```
fix restored: `ok ... internal/server/resolvers 0.046s` (all 5 pass)

The guard tests pass in **both** states, so they are real guards and not free passes.

Package baseline: pristine HEAD has **7** failing tests in `internal/server/resolvers`; with this branch there are **6** — no new failures, and `TestTmuxPaneProcess_MatchingPid` is *fixed* by the harness repair.

## How I can prove I was successful

**Claim 1 — the daemon missed live workers. `proven`.** Freshly built HEAD daemon on an isolated port vs. tmux truth:
```
HEAD count:    4     RUNNING count: 4     tmux claude panes: 6
```
Missing: 600362 (saas_social_scribe, launched 14:56), 806301 (orchard_issue706, launched 15:22). Both shell-wrapped.

**Claim 2 — with the fix the daemon agrees with reality. `proven`.** Same box, daemon rebuilt with both fixes:
```
FIXED count:      6
PROD (7777, old): 4
tmux claude panes: 6
```

**Claim 3 — the issue's own repro passes. `proven`.** `{tmuxSessions{name windows{panes{claudeInstance{state}}}}}`:
```
SESSION                    PROD(old)   FIXED
assistant                  null        idle
drewdrewthis_technician    null        idle
orchard_issue706           null        idle     <- worker, was invisible
saas_social_scribe         null        idle     <- worker, was invisible
support                    null        idle
orchardist                 null        idle
agents-view                null        null     <- correctly no claude
ubuntu_orchardist          null        null     <- correctly no claude
```

**Claim 4 — matches the reference implementation. `proven`.** `session-truth --all` (descendant-tree walk, depth 6) finds a live claude in exactly 6 sessions — assistant(1648), technician(1869), orchard_issue706, orchardist(1733), saas_social_scribe, support — and none in `agents-view` / `ubuntu_orchardist` (`pid=n/a`, "no claude in its descendant tree"). The fixed daemon returns exactly that set. Its `tmuxSessions` also `diff`s clean against `tmux list-sessions`.

> Note on `session-truth` verdicts: `NO-PANE` is overloaded. For `orchardist` it means "no parseable ⏱ statusline", not "no claude" — that session reports `pid=1733`, ACTIVELY-WORKING. Presence must be read from the `pid=` field.

**Claim 5 — the real consumer's surface, not just the query path. `proven`.** `attend.js` does not use `Query.tmuxSessions`; it subscribes to **`tmuxSessionsChanged`** and does `const inst = pane.claudeInstance; if (!inst) continue;`. Query-path evidence would have been the wrong surface, so I drove the subscription on the wire (via attend.js's own `ws` module) against the restarted production daemon:

```
--- data frame #1: 9 sessions ---
  assistant                  cmd=claude  claudeInstance=idle
  orchardist                 cmd=claude  claudeInstance=idle
  drewdrewthis_technician    cmd=claude  claudeInstance=idle
  saas_social_scribe         cmd=claude  claudeInstance=idle
  support                    cmd=claude  claudeInstance=idle
  orchard_issue706           cmd=claude  claudeInstance=idle
  => attend.js would CLASSIFY 6, SKIP 0
```

Before the fix every pane carried `claudeInstance: null`, so that `continue` skipped all six — **CLASSIFY 0, SKIP 6**, which is exactly the blindness #706 describes. The feed now sees every worker.

**Honest boundary on Claim 5.** Seeing them is not yet *reacting* to them: `attend.js` emits only on a state **flip** (`emitDiff`), and `state` is pinned at `idle` for every instance (see the enrichment follow-up). Running the real `attend.js` for 25s emitted no lines. So this fix moves the feed from *blind* to *sighted*, not to *fully reactive* — the latter needs the enrichment issue fixed.

**Visual evidence — `deviation, declared`.** Policy A.5 asks for a screenshot. The proof here is terminal output, reproduced verbatim above; the only way to embed a real image would be committing a PNG that then lives in the repo forever. Every block above is copy-pasteable and re-runnable (see Human verification). Flagging rather than silently skipping.

## Human verification

1. `go test ./internal/server/providers/tmux/ ./internal/server/resolvers/ -run 'TestPanesByCommand|TestTmuxPaneClaudeInstance'` → passes.
2. Revert `paneCommandMatchesClaude` to `return strings.Contains(...)` on the ps branch → `TestPanesByCommand_ShellWrappedClaudeIsNotShadowedByPs` fails. Restore.
3. Live box, with a **shell-wrapped** worker running (`tmux new-session -d -s probe` then type `claude` in it — do **not** `exec` it):
   ```bash
   go build -o /tmp/d ./cmd/orchard-daemon
   XDG_STATE_HOME=/tmp/probe-state /tmp/d daemon start --addr localhost:7799 &
   curl -s -X POST http://127.0.0.1:7799/graphql -H 'Content-Type: application/json' \
     -d '{"query":"{claudeInstances{id}}"}' | jq '.data.claudeInstances|length'
   tmux list-panes -a -F '#{pane_current_command}' | grep -c claude
   ```
   The two numbers must match. On the old binary they do not.

## Anything surprising?

**Yes — three things a reviewer should know.**

1. **No Go test in this repo runs in CI.** `.github/workflows/ci.yml` runs only `cargo test -p orchard`. That is why 7 Go tests sit red on `main` unnoticed, and why a green CI badge on this PR proves nothing about the daemon. The falsifiability output above is the real gate. Follow-up worth filing.

2. **The test harness was broken and the tests were asserting a fiction.** #662 changed the tmux adapter's `fieldSep` from `\x01` to `\t` without updating the fakes, so every seeded pane row failed the 18-field parse and the providers came up **empty**. Separately, the old `ClaudeInstance` tests hand-built `obj` with `CurrentCommand:"claude"` pre-populated — a shape no production path produces. Both had to be fixed before these tests could fail for the right reason.

3. **Known limitations, deliberately not fixed here** (both pre-existing, neither a regression):
   - **Instance identity for shell-wrapped panes is the wrapper's pid.** `ClaudeInstance:local:806301` is bash; the real claude is 806825. The schema says identity is "the foreground claude pid". Fixing it needs a descendant walk through `PanePsGetter` and changes node ids, so it is its own change.
   - **Instance enrichment does not resolve.** `sessionUuid`, `model`, `worktree`, `conversation` are null and `state` is therefore always `idle` — on the **old daemon too**, for the 4 it did see (hence the issue's "idle=4"). So the feed can now *see* workers but cannot yet distinguish working/input/stall. #706's stated symptom (null ⇒ treated healthy) is fixed; full state fidelity needs that follow-up.

**Not fixed here because it is not a code defect:** the reported "daemon lists killed sessions / omits live ones" does **not** reproduce against the daemon. Its GraphQL `tmuxSessions` matches `tmux list-sessions` exactly. That symptom came from `orchard sessions --json` on a **2.5-month-old installed CLI** (`~/.cargo/bin/orchard`, Apr 26) that reads a stale `~/.cache/orchard/tmux_sessions.json` and never refreshes it. Current `main` already calls `refresh_and_build` there and does a live read — proven: running the old binary leaves the cache mtime untouched, running a HEAD build rewrites it. The remedy is reinstalling the CLI, not a code change. (That surface is also already deprecated in favour of GraphQL, #438.)


# Related issue

- #706