### PR TITLE
fix(daemon): resolve cwd on Linux for ClaudeInstance enrichment

### DIFF
--- a/internal/server/providers/claudeinstance/state_derive_test.go
+++ b/internal/server/providers/claudeinstance/state_derive_test.go
@@ -1,0 +1,120 @@
+package claudeinstance
+
+// Tests for DeriveInstanceState — the pane-first state-derivation entrypoint
+// (ADR-022 Phase 4). These pin down the causal core of orchardist#710: a live,
+// actively-working claude is reported "idle" whenever its cwd (or the session
+// it resolves to) is empty. On Linux the ps adapter's cwd resolver was stubbed
+// to return "" for every pid (fixed in this PR by reading /proc/<pid>/cwd), so
+// `Cwd` arrived empty here and EVERY instance fell through to the idle branch
+// below — regardless of what the process was actually doing.
+//
+// TestDeriveInstanceState_EmptyCwdPinsWorkingClaudeToIdle is the linchpin: it
+// feeds a snapshot that unambiguously classifies as Working, yet asserts idle,
+// because Cwd is empty. That is exactly the symptom #710 reported on the live
+// box. The companion "resolved cwd -> working" test is the fix's payoff.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drewdrewthis/orchardist/internal/server/graphql"
+)
+
+// stubSnapshotReader returns a fixed set of records, letting a test drive
+// DeriveInstanceState without touching the filesystem.
+type stubSnapshotReader struct {
+	records []Record
+	ok      bool
+}
+
+func (s stubSnapshotReader) ReadSnapshot(_ context.Context, _, _ string) ([]Record, bool) {
+	return s.records, s.ok
+}
+
+// stubLiveness reports a fixed liveness verdict for any pid.
+type stubLiveness struct{ alive bool }
+
+func (s stubLiveness) IsAlive(int) bool { return s.alive }
+
+// workingSnapshot classifies as InstanceStateWorking: an assistant turn ended
+// on tool_use with one open tool and no matching result.
+func workingSnapshot() stubSnapshotReader {
+	return stubSnapshotReader{ok: true, records: []Record{
+		userRecord(ts(0), nil),
+		assistantRecord(ts(1), "tool_use", []ContentItem{toolUseContent("toolu_X", "Bash")}),
+	}}
+}
+
+// idleSnapshot classifies as InstanceStateIdle: the turn ended (end_turn) and a
+// turn_duration system record followed.
+func idleSnapshot() stubSnapshotReader {
+	return stubSnapshotReader{ok: true, records: []Record{
+		userRecord(ts(0), nil),
+		assistantRecord(ts(1), "end_turn", nil),
+		systemRecord(ts(2), "turn_duration"),
+	}}
+}
+
+func deriveWith(cwd, sessionUUID string, pid int, alive bool, snap SnapshotReader) graphql.InstanceState {
+	state, _ := DeriveInstanceState(context.Background(), DeriveState{
+		Cwd:         cwd,
+		SessionUUID: sessionUUID,
+		Pid:         pid,
+		Snapshot:    snap,
+		Liveness:    stubLiveness{alive: alive},
+		Clock:       func() time.Time { return testNow },
+	})
+	return state
+}
+
+// TestDeriveInstanceState_EmptyCwdPinsWorkingClaudeToIdle is the #710 core:
+// with an empty cwd, an actively-working claude is misreported as idle because
+// derivation short-circuits before it ever reads the (working) snapshot. This
+// is what the Linux cwd stub produced for every instance.
+func TestDeriveInstanceState_EmptyCwdPinsWorkingClaudeToIdle(t *testing.T) {
+	got := deriveWith("", "sess-uuid", 4242, true /*alive*/, workingSnapshot())
+	if got != graphql.InstanceStateIdle {
+		t.Fatalf("state = %s, want idle (empty cwd must short-circuit to idle — the #710 symptom)", got)
+	}
+}
+
+// TestDeriveInstanceState_EmptySessionUUIDYieldsIdle covers the other half of
+// the short-circuit: a resolvable cwd that matches no conversation (sessionUUID
+// empty) also falls back to idle.
+func TestDeriveInstanceState_EmptySessionUUIDYieldsIdle(t *testing.T) {
+	got := deriveWith("/home/ubuntu/.claude", "", 4242, true, workingSnapshot())
+	if got != graphql.InstanceStateIdle {
+		t.Fatalf("state = %s, want idle (empty sessionUUID must short-circuit to idle)", got)
+	}
+}
+
+// TestDeriveInstanceState_ResolvedCwdYieldsWorking is the fix's payoff: once cwd
+// AND sessionUUID resolve (which they now do on Linux), a working snapshot
+// derives InstanceStateWorking for a live claude — matching what session-truth
+// reports for an actively-working process.
+func TestDeriveInstanceState_ResolvedCwdYieldsWorking(t *testing.T) {
+	got := deriveWith("/home/ubuntu/.claude", "sess-uuid", 4242, true, workingSnapshot())
+	if got != graphql.InstanceStateWorking {
+		t.Fatalf("state = %s, want working (resolved cwd+sessionUUID + working snapshot)", got)
+	}
+}
+
+// TestDeriveInstanceState_ResolvedCwdIdleSnapshotYieldsIdle proves derivation
+// distinguishes a genuinely idle-at-prompt claude from a working one — the
+// "distinct state for a stalled/idle one" half of the DoD.
+func TestDeriveInstanceState_ResolvedCwdIdleSnapshotYieldsIdle(t *testing.T) {
+	got := deriveWith("/home/ubuntu/.claude", "sess-uuid", 4242, true, idleSnapshot())
+	if got != graphql.InstanceStateIdle {
+		t.Fatalf("state = %s, want idle (resolved cwd + idle snapshot)", got)
+	}
+}
+
+// TestDeriveInstanceState_DeadPidYieldsNoClaude verifies a dead pid is reported
+// no_claude before any snapshot read, independent of cwd resolution.
+func TestDeriveInstanceState_DeadPidYieldsNoClaude(t *testing.T) {
+	got := deriveWith("/home/ubuntu/.claude", "sess-uuid", 4242, false /*dead*/, workingSnapshot())
+	if got != graphql.InstanceStateNoClaude {
+		t.Fatalf("state = %s, want no_claude (dead pid)", got)
+	}
+}

--- a/internal/server/providers/ps/adapter.go
+++ b/internal/server/providers/ps/adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -150,19 +151,44 @@ func (a *PsAdapter) FetchArgs(ctx context.Context, pids []int) (map[int][]string
 }
 
 // FetchCwds returns cwd for the given pids. macOS uses lsof per pid;
-// Linux reads /proc/<pid>/cwd. v1 ships macOS only — Linux returns an
-// empty map and no error so resolvers degrade gracefully.
+// Linux reads the /proc/<pid>/cwd symlink. Both paths return a partial map
+// (missing/dead pids simply absent) and no error, so a single unresolvable
+// pid never blanks out the batch.
 func (a *PsAdapter) FetchCwds(ctx context.Context, pids []int) (map[int]string, error) {
 	if len(pids) == 0 {
 		return map[int]string{}, nil
 	}
-	if runtime.GOOS != "darwin" {
-		// Linux fallback lives in a future PR. Surface "not implemented"
-		// as an empty result rather than an error so a worktree on
-		// Linux can still serve everything else.
-		return map[int]string{}, nil
+	if runtime.GOOS == "darwin" {
+		return a.fetchCwdsDarwin(ctx, pids)
 	}
-	return a.fetchCwdsDarwin(ctx, pids)
+	return fetchCwdsLinux(ctx, pids)
+}
+
+// fetchCwdsLinux resolves each pid's cwd by reading the /proc/<pid>/cwd
+// symlink — the Linux counterpart to fetchCwdsDarwin's lsof shellout. It
+// reads procfs directly (no fork), so a batch of N pids costs N cheap
+// readlink syscalls on the request goroutine.
+//
+// Partial-result contract mirrors the Darwin path: a pid that has exited,
+// or whose cwd is unreadable (permission, race), is simply absent from the
+// map rather than failing the whole batch. Never returns a non-nil error so
+// one unreadable pid can't blank out the others. Without this the daemon's
+// pane→ClaudeInstance enrichment gets an empty cwd for every pid on Linux,
+// no conversation matches, and DeriveInstanceState pins every instance at
+// "idle" (orchardist#710).
+func fetchCwdsLinux(ctx context.Context, pids []int) (map[int]string, error) {
+	out := make(map[int]string, len(pids))
+	for _, pid := range pids {
+		if err := ctx.Err(); err != nil {
+			return out, nil
+		}
+		target, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+		if err != nil || target == "" {
+			continue
+		}
+		out[pid] = target
+	}
+	return out, nil
 }
 
 // fetchCwdsDarwin issues a single `lsof -a -d cwd -p <pids>` shellout for

--- a/internal/server/providers/ps/goos.go
+++ b/internal/server/providers/ps/goos.go
@@ -1,7 +1,0 @@
-package ps
-
-import "runtime"
-
-// osGOOS exposes runtime.GOOS through a package-level seam. Centralised
-// here so tests and the cwd path agree on the same value.
-func osGOOS() string { return runtime.GOOS }

--- a/internal/server/providers/ps/provider_test.go
+++ b/internal/server/providers/ps/provider_test.go
@@ -63,9 +63,6 @@ func TestProvider_ListSnapshotIncludesSelf(t *testing.T) {
 // against the test process, proving the batch loader plumbs through to
 // the adapter and back.
 func TestProvider_LoadCwdResolvesSelf(t *testing.T) {
-	if !isDarwin() {
-		t.Skip("cwd loader test is darwin-only for v1")
-	}
 	p := New(NewAdapter("local").WithPollInterval(time.Hour), nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -148,19 +145,3 @@ func TestProvider_SubscribeReceivesInvalidations(t *testing.T) {
 		}
 	}
 }
-
-// isDarwin is a tiny helper rather than importing runtime in every test.
-func isDarwin() bool {
-	return runtimeGOOS() == "darwin"
-}
-
-// runtimeGOOS exists so the compiler doesn't optimise the runtime read
-// into a constant — keeps the cwd test guarded at runtime instead of
-// at build time, which matters when GOOS-cross-compiling for review.
-func runtimeGOOS() string {
-	return goosValue
-}
-
-// goosValue is wired by an init in goos_*.go (or here directly). Using
-// a package-level variable keeps the test file independent of build tags.
-var goosValue = osGOOS()


### PR DESCRIPTION
> **Reviewer cockpit**
> - **Scariest thing** — the new Linux path reads `/proc/<pid>/cwd` for arbitrary pids the resolver hands it. It's read-only (`os.Readlink`), never errors the batch (unreadable/dead pid → simply absent, mirroring the Darwin lsof contract), and touches nothing outside procfs. No write, no fork.
> - **Start here** — `internal/server/providers/ps/adapter.go` `FetchCwds` / `fetchCwdsLinux` (the whole fix). Then `state_derive_test.go` for why an empty cwd manifested as "idle".

## Why

Closes #710.

On Linux the ps adapter's `FetchCwds` was a **stub that returned an empty map for every pid** ("Linux fallback lives in a future PR"). The daemon runs on Linux, so `LoadCwd(pid)` yielded `""` for every ClaudeInstance → no conversation matched by cwd → `sessionUUID` stayed empty → `DeriveInstanceState` hit its `Cwd==""` short-circuit and returned `InstanceStateIdle` for **every** instance, with `sessionUuid`/`worktree`/`conversation` all `null`. #709 made instances visible; this makes their enrichment resolve.

## What changed

- **Implement `fetchCwdsLinux` reading `/proc/<pid>/cwd`** → the Darwin path (lsof) stays; Linux stops returning empty. Alternative not taken: shelling out to `pwdx`/`readlink` via the `runner` seam — rejected because a direct `os.Readlink` is fork-free and the procfs symlink is the canonical source. Blast radius: `LoadCwd`/`LoadCwds` now return real data on Linux where they returned `""`; every caller strictly gains (empty → populated).
- **Un-skip `TestProvider_LoadCwdResolvesSelf`** (was `darwin-only`) so it runs on Linux — the RED→GREEN falsifier for this exact defect — and delete the now-dead darwin-gating apparatus (`isDarwin`/`runtimeGOOS`/`goosValue`/`goos.go`).
- **Add `state_derive_test.go`** covering the previously-untested `DeriveInstanceState` entrypoint: empty cwd pins a working claude to idle (the #710 symptom), resolved cwd + working snapshot → `working`, plus distinct `idle`/`no_claude`.

## How it works

```
Query.claudeInstances
  → buildClaudeInstanceFromPane (pane_claude.go)
      → r.PS.LoadCwd(pid) ─► ps.Provider.cwdLoader ─► PsAdapter.FetchCwds
                                                        └─ darwin: lsof   (unchanged)
                                                        └─ linux : /proc/<pid>/cwd  ◄── THE FIX
      → cwdToSession[cwd]  → sessionUUID
      → DeriveInstanceState{Cwd, SessionUUID, Pid}
          └─ Cwd=="" || SessionUUID=="" ─► InstanceStateIdle   (the fallback that made #710 visible)
          └─ else ClassifyState(jsonl)  ─► working | idle | input | stalled
```

## Test plan

**Falsifiability — RED before / GREEN after (Linux):**
```
# before (current main): FetchCwds returns empty map on Linux
--- FAIL: TestProvider_LoadCwdResolvesSelf
    provider_test.go:79: LoadCwd(self) = "", want "…/providers/ps"
# after (this PR): reads /proc/self/cwd
--- PASS: TestProvider_LoadCwdResolvesSelf (0.03s)
```

**State derivation (new `state_derive_test.go`, all PASS):**
```
PASS TestDeriveInstanceState_EmptyCwdPinsWorkingClaudeToIdle   ← the #710 symptom, proven
PASS TestDeriveInstanceState_ResolvedCwdYieldsWorking          ← the fix's payoff (working claude → working)
PASS TestDeriveInstanceState_ResolvedCwdIdleSnapshotYieldsIdle ← distinct idle
PASS TestDeriveInstanceState_EmptySessionUUIDYieldsIdle
PASS TestDeriveInstanceState_DeadPidYieldsNoClaude
```
`go test ./internal/server/providers/ps/... ./internal/server/providers/claudeinstance/...` → `ok`. `go vet` clean, `go build ./...` clean.

**Live on the box — enrichment resolves (verified after `make daemon` + `sudo install` + `systemctl --user restart`, MainPID 4128024, exe `/usr/local/bin/orchard-daemon`):**

Before (every field null, every state idle):
```json
{"id":"ClaudeInstance:local:1733","state":"idle","sessionUuid":null,"worktree":null,"conversation":null}
```
After (identity fields now resolve):
```
local:1648      state=idle  sess=d6879ede  worktree=/home/ubuntu/langwatch-assistant
local:1733      state=idle  sess=fe3993e6  worktree=/home/ubuntu/.claude
local:4059118   state=idle  sess=b14a87e1  worktree=/home/ubuntu/workspace/…/issue710-…
```
`sessionUuid` + `worktree` + `conversation` went `null → resolved` for every instance. **Claim status:** enrichment-resolves = **proven** (live + tests); working-claude→working derivation = **proven** (hermetic test); live per-instance `state` correctness = **NOT fixed here** — see below.

## Anything surprising?

**Live `state` is still `idle` for co-located / shell-wrapped agents — this is #711, not closed here.** Fixing the cwd stub exposed the next layer, exactly as #710 warned ("don't stop at one story that fits half the evidence"):

- Three live agents — `orchardist` (1733), `support` (1804), `technician` (1869) — **share `cwd=/home/ubuntu/.claude`** among **239 historical sessions** there. `cwdToSession` is cwd→session **1:many, last-wins**, so all three collapse onto one arbitrary (dead, 1.2 KB) session `fe3993e6` → idle.
- Orchardist's real live session (`95bb9884`, 27 MB, actively growing, 1629 "orchardist" refs) has `agentName`/`customTitle`/`lastSeenAt` = **null** in the daemon — there is **no clean pid→session signal** (no session-UUID in `/proc/<pid>/environ`, no held-open jsonl fd).
- Many instances also report the **bash wrapper pid**, not the claude pid (e.g. this worktree's own worker is `local:4059118` = `bash`, real claude is child `4059422`) — the #711 identity defect, whose Knock-on section already claims "conversation-by-cwd matching can bind to the wrong cwd".

Correct per-instance `state` needs resolving the real claude pid (descendant walk, as `session-truth` does) **and** mapping that pid → its specific session — i.e. **#711 identity work** ("larger blast radius, changes node ids", deliberately kept separate). Filed to #711.

**CI note (#712):** `.github/workflows/ci.yml` runs **no Go tests** — the tests added here are runnable (`go test ./...`) but won't gate CI until #712 wires `make test-go`. Not fixed here per scope.


# Related issue

- #710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved working-directory detection for processes on Linux.
  * Instance states now correctly reflect missing directories, sessions, idle snapshots, and terminated processes.

* **Tests**
  * Added coverage for instance-state resolution across working, idle, and unavailable process scenarios.
  * Expanded working-directory resolution tests to run consistently across supported operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #710