### PR TITLE
fix(daemon): ClaudeInstance identity = claude pid, not shell wrapper (#711)

### DIFF
--- a/internal/server/providers/ps/proctree.go
+++ b/internal/server/providers/ps/proctree.go
@@ -1,0 +1,74 @@
+package ps
+
+import "strings"
+
+// maxDescendantDepth bounds the descendant-tree walk. Mirrors the depth-6
+// bound in ~/.claude/scripts/session-truth: claude sits one to two levels
+// under the pane's shell in every launch style live on the box, so 6 is
+// generous headroom while still capping the walk on a large process table.
+const maxDescendantDepth = 6
+
+// ProcTree indexes a ps snapshot by parentage so callers can walk a process's
+// descendants without re-shelling. Build it once per request from
+// Provider.List(); it is read-only after construction.
+type ProcTree struct {
+	childrenByPPID map[int][]int
+	commandByPID   map[int]string
+}
+
+// NewProcTree builds a ProcTree from a process snapshot. Safe to call with a
+// nil or empty slice — the resulting tree resolves every pid to itself.
+func NewProcTree(procs []Process) *ProcTree {
+	t := &ProcTree{
+		childrenByPPID: make(map[int][]int, len(procs)),
+		commandByPID:   make(map[int]string, len(procs)),
+	}
+	for _, p := range procs {
+		t.childrenByPPID[p.PPID] = append(t.childrenByPPID[p.PPID], p.ID.PID)
+		t.commandByPID[p.ID.PID] = p.Command
+	}
+	return t
+}
+
+// ResolveClaudePid returns the pid of the foreground claude process associated
+// with rootPid — the pane's root process (tmux pane_pid).
+//
+//   - If rootPid is itself claude (claude exec'd directly), rootPid is returned.
+//   - Otherwise it BFS-walks rootPid's descendants (bounded depth) and returns
+//     the first — i.e. shallowest — claude pid found (the `bash -> claude`
+//     shell-wrapped launch every worker uses).
+//   - If no claude is found, or the tree is unknown, rootPid is returned
+//     unchanged, preserving prior behavior rather than dropping the instance.
+//
+// This is schema.graphql's identity contract ("the foreground claude pid scoped
+// to a host") and mirrors session-truth's resolve_claude_pid descendant walk.
+func (t *ProcTree) ResolveClaudePid(rootPid int) int {
+	if t == nil || rootPid <= 0 {
+		return rootPid
+	}
+	if isClaudeCommand(t.commandByPID[rootPid]) {
+		return rootPid
+	}
+	frontier := []int{rootPid}
+	for depth := 0; depth <= maxDescendantDepth && len(frontier) > 0; depth++ {
+		var next []int
+		for _, pid := range frontier {
+			for _, child := range t.childrenByPPID[pid] {
+				if isClaudeCommand(t.commandByPID[child]) {
+					return child
+				}
+				next = append(next, child)
+			}
+		}
+		frontier = next
+	}
+	return rootPid
+}
+
+// isClaudeCommand reports whether a process command basename identifies a
+// Claude CLI process. Mirrors paneCommandMatchesClaude in the tmux provider
+// (case-insensitive substring) so the two claude detectors agree — one source
+// of truth for "is this a claude process".
+func isClaudeCommand(command string) bool {
+	return strings.Contains(strings.ToLower(command), "claude")
+}

--- a/internal/server/providers/ps/proctree_test.go
+++ b/internal/server/providers/ps/proctree_test.go
@@ -1,0 +1,101 @@
+package ps
+
+import "testing"
+
+// proc is a tiny constructor for test snapshots.
+func proc(pid, ppid int, command string) Process {
+	return Process{ID: ProcessID{Host: "local", PID: pid}, PPID: ppid, Command: command}
+}
+
+func TestProcTree_ResolveClaudePid(t *testing.T) {
+	tests := []struct {
+		name  string
+		procs []Process
+		root  int
+		want  int
+	}{
+		{
+			name: "shell-wrapped: bash -> claude resolves to the claude child (#711)",
+			procs: []Process{
+				proc(806301, 1, "-bash"),
+				proc(806825, 806301, "claude"),
+			},
+			root: 806301,
+			want: 806825,
+		},
+		{
+			name: "exec'd claude keeps its own pid",
+			procs: []Process{
+				proc(1648, 1, "claude"),
+				proc(2902, 1648, "bun"), // a child that must be ignored
+			},
+			root: 1648,
+			want: 1648,
+		},
+		{
+			name: "deep: bash -> sh -> claude found via BFS below depth 1",
+			procs: []Process{
+				proc(100, 1, "-bash"),
+				proc(200, 100, "sh"),
+				proc(300, 200, "claude"),
+			},
+			root: 100,
+			want: 300,
+		},
+		{
+			name: "shallowest claude wins over a deeper claude subagent",
+			procs: []Process{
+				proc(100, 1, "-bash"),
+				proc(200, 100, "claude"), // foreground
+				proc(300, 200, "claude"), // a subagent, deeper — must not win
+			},
+			root: 100,
+			want: 200,
+		},
+		{
+			name: "no claude in tree: falls back to root unchanged",
+			procs: []Process{
+				proc(100, 1, "-bash"),
+				proc(200, 100, "vim"),
+			},
+			root: 100,
+			want: 100,
+		},
+		{
+			name:  "unknown root: returned unchanged",
+			procs: []Process{proc(100, 1, "-bash")},
+			root:  999,
+			want:  999,
+		},
+		{
+			name: "node-wrapped claude basename does not match (falls back to root)",
+			procs: []Process{
+				proc(100, 1, "-bash"),
+				proc(200, 100, "node"),
+			},
+			root: 100,
+			want: 100,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := NewProcTree(tc.procs)
+			if got := tree.ResolveClaudePid(tc.root); got != tc.want {
+				t.Errorf("ResolveClaudePid(%d) = %d, want %d", tc.root, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestProcTree_NilSafe guards the nil-receiver and non-positive-pid paths the
+// resolver relies on when r.PS is absent.
+func TestProcTree_NilSafe(t *testing.T) {
+	var tree *ProcTree
+	if got := tree.ResolveClaudePid(123); got != 123 {
+		t.Errorf("nil tree: ResolveClaudePid(123) = %d, want 123", got)
+	}
+	empty := NewProcTree(nil)
+	if got := empty.ResolveClaudePid(0); got != 0 {
+		t.Errorf("empty tree: ResolveClaudePid(0) = %d, want 0", got)
+	}
+}

--- a/internal/server/resolvers/pane_claude.go
+++ b/internal/server/resolvers/pane_claude.go
@@ -70,12 +70,21 @@ func (r *queryResolver) projectPanesToClaudeInstances(ctx context.Context, panes
 		}
 	}
 
+	// #711: build the process tree ONCE so each pane's shell-wrapper pane_pid
+	// can be resolved to the real foreground claude pid via a descendant walk.
+	// Mirrors the cwdToSession one-shot index above — O(procs) instead of a
+	// full ps snapshot per pane.
+	var procTree *psprovider.ProcTree
+	if r.PS != nil {
+		procTree = psprovider.NewProcTree(r.PS.List())
+	}
+
 	out := make([]*graphql1.ClaudeInstance, 0, len(panes))
 	for _, pane := range panes {
 		if pane == nil {
 			continue
 		}
-		inst := r.buildClaudeInstanceFromPane(ctx, pane, host, account, snapshotReader, cwdToSession)
+		inst := r.buildClaudeInstanceFromPane(ctx, pane, host, account, snapshotReader, cwdToSession, procTree)
 		out = append(out, inst)
 	}
 
@@ -95,10 +104,27 @@ func (r *queryResolver) buildClaudeInstanceFromPane(
 	account *graphql1.ClaudeAccount,
 	snapshotReader claudeinstance.SnapshotReader,
 	cwdToSession map[string]string,
+	procTree *psprovider.ProcTree,
 ) *graphql1.ClaudeInstance {
 	var pid int
 	if pane.CurrentPid != nil {
 		pid = int(*pane.CurrentPid)
+	}
+
+	// #711: pane.CurrentPid is tmux's pane_pid — the pane's ROOT process, which
+	// is the bash wrapper for every `bash -> claude` launch. Resolve the real
+	// foreground claude pid by walking descendants so id / process / cwd key on
+	// claude (schema.graphql's identity contract), not the shell. The hot-path
+	// caller passes a shared procTree; the single-pane caller passes nil and we
+	// build a one-off tree here.
+	if pid > 0 {
+		tree := procTree
+		if tree == nil && r.PS != nil {
+			tree = psprovider.NewProcTree(r.PS.List())
+		}
+		if tree != nil {
+			pid = tree.ResolveClaudePid(pid)
+		}
 	}
 
 	id := buildClaudeIDFromPane(host, pid, pane)

--- a/internal/server/resolvers/pane_claude_identity_test.go
+++ b/internal/server/resolvers/pane_claude_identity_test.go
@@ -1,0 +1,135 @@
+package resolvers
+
+// Tests for issue #711 — ClaudeInstance identity must be the real claude pid,
+// not the pane's shell-wrapper pid.
+//
+// Every worker on the box launches `bash -> claude` (via `tmux send-keys`), so
+// tmux's pane_pid is the BASH wrapper. schema.graphql defines a ClaudeInstance's
+// identity as "the foreground claude pid scoped to a host", yet the projection
+// keyed id / process / cwd off the wrapper pid. These tests address the pane by
+// the exact shape production hands the resolver (a pane row selected by
+// pane_current_command) and assert identity resolves through the descendant tree
+// to claude — the falsifying case for #711.
+
+import (
+	"context"
+	"testing"
+
+	graphql1 "github.com/drewdrewthis/orchardist/internal/server/graphql"
+)
+
+// TestClaudeInstances_IdentityResolvesToClaudePid_NotWrapper is the #711
+// regression. A pane rooted at a bash wrapper (pane_pid) with a claude child
+// must yield a ClaudeInstance whose id and process.pid are the CHILD claude pid.
+// Pids are the real ones from the live box (#706/#711): 806301 bash, 806825 claude.
+func TestClaudeInstances_IdentityResolvesToClaudePid_NotWrapper(t *testing.T) {
+	const wrapperPid = 806301 // bash — the pane's root process (tmux pane_pid)
+	const claudePid = 806825  // claude — a child of the wrapper
+	const paneID = "%21"
+
+	tmuxProv := buildTmuxProvider(t, []string{
+		paneRowWithCommand("orchard_issue711", paneID, wrapperPid, "claude"),
+	})
+	psProv := buildPsProvider(t, []psRow{
+		{pid: wrapperPid, ppid: 1, cmd: "-bash"},
+		{pid: claudePid, ppid: wrapperPid, cmd: "claude"},
+	})
+
+	r := &queryResolver{&Resolver{Tmux: tmuxProv, PS: psProv}}
+	insts, err := r.ClaudeInstances(context.Background())
+	if err != nil {
+		t.Fatalf("ClaudeInstances() error: %v", err)
+	}
+	if len(insts) != 1 {
+		t.Fatalf("want exactly 1 instance, got %d: %+v", len(insts), insts)
+	}
+	got := insts[0]
+
+	const wantID = "ClaudeInstance:local:806825"
+	if got.ID != wantID {
+		t.Errorf("id = %q, want %q — identity must key on the claude pid (%d), not the bash wrapper (%d)",
+			got.ID, wantID, claudePid, wrapperPid)
+	}
+	if got.Process == nil {
+		t.Fatalf("process = nil, want the claude process (pid %d)", claudePid)
+	}
+	if got.Process.Pid != claudePid {
+		t.Errorf("process.pid = %d, want %d (the claude pid, not the wrapper %d)",
+			got.Process.Pid, claudePid, wrapperPid)
+	}
+	if got.Process.Command != "claude" {
+		t.Errorf("process.command = %q, want %q", got.Process.Command, "claude")
+	}
+}
+
+// TestClaudeInstances_ExecdClaudeKeepsOwnPid covers the other launch shape:
+// claude exec'd directly, so the pane_pid IS claude. Identity must be that pid
+// unchanged — the descendant walk must not wander off to some grandchild.
+func TestClaudeInstances_ExecdClaudeKeepsOwnPid(t *testing.T) {
+	const claudePid = 1648 // real exec'd claude pid from the live box
+	const paneID = "%0"
+
+	tmuxProv := buildTmuxProvider(t, []string{
+		paneRowWithCommand("assistant", paneID, claudePid, "claude"),
+	})
+	psProv := buildPsProvider(t, []psRow{
+		{pid: claudePid, ppid: 1, cmd: "claude"},
+		// a bun child, as claude actually has on the box — must be ignored
+		{pid: 2902, ppid: claudePid, cmd: "bun"},
+	})
+
+	r := &queryResolver{&Resolver{Tmux: tmuxProv, PS: psProv}}
+	insts, err := r.ClaudeInstances(context.Background())
+	if err != nil {
+		t.Fatalf("ClaudeInstances() error: %v", err)
+	}
+	if len(insts) != 1 {
+		t.Fatalf("want exactly 1 instance, got %d: %+v", len(insts), insts)
+	}
+	got := insts[0]
+	const wantID = "ClaudeInstance:local:1648"
+	if got.ID != wantID {
+		t.Errorf("id = %q, want %q (exec'd claude keeps its own pid)", got.ID, wantID)
+	}
+	if got.Process == nil || got.Process.Pid != claudePid {
+		t.Errorf("process.pid = %v, want %d", got.Process, claudePid)
+	}
+}
+
+// TestTmuxPaneClaudeInstance_IdentityResolvesToClaudePid covers the SUBSCRIPTION
+// surface: attend.js reads pane.claudeInstance.state via the single-pane
+// tmuxPane.claudeInstance resolver (not Query.claudeInstances). That resolver
+// shares buildClaudeInstanceFromPane, so identity must resolve to the claude pid
+// here too — otherwise the fleet-attention feed keys on the wrong node id (#711).
+func TestTmuxPaneClaudeInstance_IdentityResolvesToClaudePid(t *testing.T) {
+	const wrapperPid = 806301
+	const claudePid = 806825
+	const paneID = "%21"
+
+	tmuxProv := buildTmuxProvider(t, []string{
+		paneRowWithCommand("orchard_issue711", paneID, wrapperPid, "claude"),
+	})
+	psProv := buildPsProvider(t, []psRow{
+		{pid: wrapperPid, ppid: 1, cmd: "-bash"},
+		{pid: claudePid, ppid: wrapperPid, cmd: "claude"},
+	})
+
+	r := &tmuxPaneResolver{&Resolver{Tmux: tmuxProv, PS: psProv}}
+	obj := &graphql1.TmuxPane{ID: paneGQLID(testHost, paneID)}
+
+	got, err := r.ClaudeInstance(context.Background(), obj)
+	if err != nil {
+		t.Fatalf("ClaudeInstance() error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ClaudeInstance() = nil for a shell-wrapped claude pane")
+	}
+	const wantID = "ClaudeInstance:local:806825"
+	if got.ID != wantID {
+		t.Errorf("id = %q, want %q (subscription surface must key on the claude pid, not the wrapper %d)",
+			got.ID, wantID, wrapperPid)
+	}
+	if got.Process == nil || got.Process.Pid != claudePid {
+		t.Errorf("process.pid = %v, want %d", got.Process, claudePid)
+	}
+}

--- a/internal/server/resolvers/schema.resolvers.go
+++ b/internal/server/resolvers/schema.resolvers.go
@@ -1474,7 +1474,8 @@ func (r *tmuxPaneResolver) ClaudeInstance(ctx context.Context, obj *graphql1.Tmu
 		return nil, nil
 	}
 	qr := &queryResolver{r.Resolver}
-	inst := qr.buildClaudeInstanceFromPane(ctx, projectPaneRich(p), host, nil, nil, nil)
+	// nil procTree: the single-pane path builds a one-off tree internally (#711).
+	inst := qr.buildClaudeInstanceFromPane(ctx, projectPaneRich(p), host, nil, nil, nil, nil)
 	return inst, nil
 }
 

--- a/internal/server/resolvers/tmux_pane_process_test.go
+++ b/internal/server/resolvers/tmux_pane_process_test.go
@@ -113,10 +113,13 @@ func paneRowWithCommand(sessionName, paneID string, pid int, currentCommand stri
 // Fake ps CommandRunner
 // --------------------------------------------------------------------------
 
-// psRow holds a single (pid, command) pair for the fake ps runner.
+// psRow holds a single process row for the fake ps runner. ppid is optional:
+// when 0 it defaults to 1 (init), so single-process rows need not set it;
+// descendant-tree tests (#711) set it to build a real bash -> claude parentage.
 type psRow struct {
-	pid int
-	cmd string
+	pid  int
+	ppid int
+	cmd  string
 }
 
 // fakePsRunnerProcess drives the ps adapter with a fixed single-process list.
@@ -133,10 +136,14 @@ func (f *fakePsRunnerProcess) Run(_ context.Context, name string, args ...string
 	}
 	lines := []string{psHeaderTest}
 	for _, r := range f.rows {
+		ppid := r.ppid
+		if ppid == 0 {
+			ppid = 1
+		}
 		// Columns: PID PPID USER TTY %CPU RSS STARTED COMMAND
 		lines = append(lines, fmt.Sprintf(
-			"%d 1 root ?? 0.0 1024 Sun May  4 10:00:00 2026 %s",
-			r.pid, r.cmd,
+			"%d %d root ?? 0.0 1024 Sun May  4 10:00:00 2026 %s",
+			r.pid, ppid, r.cmd,
 		))
 	}
 	return []byte(strings.Join(lines, "\n") + "\n"), nil


### PR DESCRIPTION
## Reviewer cockpit
- **Scariest thing** — this changes ClaudeInstance **node ids** (`ClaudeInstance:local:<pid>` now carries the *claude* pid, not the shell wrapper). If `node(id:)` or the `tmuxSessionsChanged` subscription (which `attend.js` reads for `pane.claudeInstance.state`) diverged from the query projection, the fleet-attention feed would go blind. It does not: `node(id:)` re-derives via `findClaudeInstanceByID` → the same projection, and the single-pane subscription resolver shares `buildClaudeInstanceFromPane`. Both are covered by tests.
- **Start here** — `internal/server/providers/ps/proctree.go` (`ResolveClaudePid`, the pure descendant walk) and its single wiring point in `internal/server/resolvers/pane_claude.go`.

## Why
Closes #711. Every worker launches `bash -> claude` via `tmux send-keys`, so tmux's `pane_pid` is the **bash wrapper**. `buildClaudeInstanceFromPane` keyed `id`, `process`, and `cwd` off that wrapper pid — violating `schema.graphql`'s "the foreground claude pid scoped to a host" identity contract, and reading the *shell's* cwd (which can `cd`-drift) instead of claude's fixed-at-exec cwd. Net effect the owner hit: **a busy session reported `state: idle`** because identity was wrong.

## What changed
- **Resolve the real claude pid by walking the wrapper's descendant process tree** (`ps.ProcTree`, a BFS mirroring `~/.claude/scripts/session-truth`'s depth-6 walk) → alternative was plumbing a new axis through `tmux.PanePsGetter`; keeping it in the projection layer where `id`/`LoadCwd` already live is the minimal change and leaves the pane-matching interface untouched. Blast radius: node-id shape for shell-wrapped instances (see cockpit).
- **Build the tree once per request** (mirrors the existing `cwdToSession` one-shot index) → alternative was a `ps` snapshot per pane (O(N·M)); the shared `ProcTree` is O(procs).
- **Exec'd-claude panes and no-claude-found panes are unchanged** → the walk returns the root pid when the root is already claude or no claude descendant exists, so this strictly improves shell-wrapped identity without regressing the exec'd path or dropping instances.

## How it works
```
internal/server/providers/ps/proctree.go   NEW — ProcTree: index ps snapshot by ppid;
                                                  ResolveClaudePid(rootPid) BFS→ claude pid (pure)
internal/server/resolvers/pane_claude.go    build ProcTree once in projectPanesToClaudeInstances;
                                                  resolve pane.CurrentPid → claude pid before it
                                                  drives id / Process / LoadCwd
internal/server/resolvers/schema.resolvers  single-pane tmuxPane.claudeInstance passes nil tree
                                                  (builds a one-off) — the subscription surface
```
`node(id:)` needs no change: `findClaudeInstanceByID` re-derives instances via the same projection and matches on `inst.ID`, so a changed id stays internally consistent.

## Human verification (if you don't trust me)
1. On a box with a `bash -> claude` worker: `session-truth --all` shows the real claude pid (a child) while the *old* daemon's `claudeInstances{id process{pid}}` shows the bash pid.
2. Build + run this branch's daemon; re-query `claudeInstances{id state process{pid command}}` — the shell-wrapped instance's `process.command` is now `claude`, not `-bash`, and `id` carries the claude pid.
3. Make that claude genuinely busy (a real tool call); confirm `state` reports `working`, not `idle`.

## How I can prove I was successful

**1. Falsifying test — RED before, GREEN after (proven).** Resolver-level, exercises `Query.claudeInstances` and the `tmuxPane.claudeInstance` subscription surface with a seeded `bash(806301) -> claude(806825)` tree.

RED (before the fix):
```
--- FAIL: TestClaudeInstances_IdentityResolvesToClaudePid_NotWrapper
    id = "ClaudeInstance:local:806301", want "ClaudeInstance:local:806825"
    process.pid = 806301, want 806825
    process.command = "-bash", want "claude"
```
GREEN (after the fix):
```
--- PASS: TestClaudeInstances_IdentityResolvesToClaudePid_NotWrapper
--- PASS: TestClaudeInstances_ExecdClaudeKeepsOwnPid
--- PASS: TestTmuxPaneClaudeInstance_IdentityResolvesToClaudePid   (subscription surface)
ok   github.com/drewdrewthis/orchardist/internal/server/resolvers
--- PASS: TestProcTree_ResolveClaudePid            (7 subtests: shell-wrapped, exec'd, deep, shallowest-wins, no-claude, unknown, node-wrapped)
--- PASS: TestProcTree_NilSafe
ok   github.com/drewdrewthis/orchardist/internal/server/providers/ps
```

**2. Live before/after on a genuinely-busy shell-wrapped session (proven).** No natural session on the box has a divergent shell/claude cwd (workers `cd` into the worktree first), so I constructed the exact failure case: a tmux pane whose **bash wrapper sits at `/tmp`** while its **claude child runs busy** (a real `sha256sum` workload, tool_use open) at `/tmp/or711-proof-claudecwd`. Queried the deployed (old) daemon on `:7777` and this branch's daemon on `:7778` at the same instant:

```
:7777 OLD/deployed  ClaudeInstance:local:221557  STATE=idle     process.pid=221557 (-bash)   sessionUuid=fef66409… (stray, matched via bash cwd=/tmp)
:7778 NEW/this-PR   ClaudeInstance:local:222069  STATE=working  process.pid=222069 (claude)  sessionUuid=7392ff9e… (the claude's real session)
```

Same pane (`pane.currentPid=221557` on both). Identity `-bash → claude`, and **state `idle → working`** — the owner's original pain (busy session shows idle), gone.

## Anything surprising?
- The old daemon didn't just show idle — it matched a **wrong** `sessionUuid` via the wrapper's `/tmp` cwd, the cwd-drift / 1:many hazard #711 describes. The fix keys on claude's own cwd.
- **Go CI (#712) still does not exist** — `ci.yml` runs only the Rust suite; the Makefile's `test-go` target is not wired into any workflow. So these Go tests are verified locally (above), not in GitHub CI. Adding a `go test ./...` job is non-trivial because several pre-existing daemon e2e tests fail without a real tmux/env; leaving that to #712 per the issue's scope note. Noted for #712.


# Related issue

- #711