### PR TITLE
fix(claude-session-state): idle-nag Notification no longer maps to input

### DIFF
--- a/plugin-sources/claude-session-state/docs/STATE_SCHEMA.md
+++ b/plugin-sources/claude-session-state/docs/STATE_SCHEMA.md
@@ -12,7 +12,7 @@ Override the directory with `CLAUDE_SESSION_STATE_DIR`.
 | `pid` | every event | hook parent pid; consumers MUST `kill -0` it — a stale file with a dead pid is a crashed session |
 | `pane` | when in tmux (sticky) | `$TMUX_PANE` id, joinable to tmux |
 | `started_at` | set-once | first event's timestamp |
-| `state` | event-mapped | `working` (UserPromptSubmit/Pre/PostToolUse) \| `idle` (SessionStart/Stop) \| `input` (Notification) |
+| `state` | event-mapped | `working` (UserPromptSubmit/Pre/PostToolUse) \| `idle` (SessionStart/Stop) \| `input` (Notification, except the idle-nag "waiting for your input" → `idle`; never downgrades a pending `input`) |
 | `last_event` / `ts` | every event | latest event name + UTC timestamp |
 | `message` | Notification; cleared on prompt/Stop | why the session needs attention |
 | `first_prompt` | set-once, ≤500 chars | the session's mission |

--- a/plugin-sources/claude-session-state/scripts/fold-state.bats
+++ b/plugin-sources/claude-session-state/scripts/fold-state.bats
@@ -37,6 +37,27 @@ field() { jq -r ".$1 // \"null\"" "$CLAUDE_SESSION_STATE_DIR/t.json"; }
   [ "$(field first_prompt)" = "the actual mission" ]
 }
 
+notify() { jq -nc --arg m "$2" '{session_id: $ARGS.positional[0], hook_event_name: "Notification", message: $m}' --args "$1" | "$REDUCER"; }
+
+@test "permission notification sets state=input with message" {
+  notify t "Claude needs your permission to use Bash"
+  [ "$(field state)" = "input" ]
+  [ "$(field message)" = "Claude needs your permission to use Bash" ]
+}
+
+@test "idle-nag notification stays idle, no message stored" {
+  notify t "Claude is waiting for your input"
+  [ "$(field state)" = "idle" ]
+  [ "$(field message)" = "null" ]
+}
+
+@test "idle-nag does not downgrade a pending permission request" {
+  notify t "Claude needs your permission to use Bash"
+  notify t "Claude is waiting for your input"
+  [ "$(field state)" = "input" ]
+  [ "$(field message)" = "Claude needs your permission to use Bash" ]
+}
+
 @test "a real prompt merely containing the marker mid-text is kept" {
   send t 'the side bar says "<task-notification>", which is weird?'
   [ "$(field last_prompt)" = 'the side bar says "<task-notification>", which is weird?' ]

--- a/plugin-sources/claude-session-state/scripts/fold-state.bats
+++ b/plugin-sources/claude-session-state/scripts/fold-state.bats
@@ -51,6 +51,14 @@ notify() { jq -nc --arg m "$2" '{session_id: $ARGS.positional[0], hook_event_nam
   [ "$(field message)" = "null" ]
 }
 
+@test "idle-nag after an answered permission clears the stale message" {
+  notify t "Claude needs your permission to use Bash"
+  jq -nc '{session_id: "t", hook_event_name: "PreToolUse", tool_name: "Bash"}' | "$REDUCER"
+  notify t "Claude is waiting for your input"
+  [ "$(field state)" = "idle" ]
+  [ "$(field message)" = "null" ]
+}
+
 @test "idle-nag does not downgrade a pending permission request" {
   notify t "Claude needs your permission to use Bash"
   notify t "Claude is waiting for your input"

--- a/plugin-sources/claude-session-state/scripts/fold-state.sh
+++ b/plugin-sources/claude-session-state/scripts/fold-state.sh
@@ -96,7 +96,7 @@ STATE_DIR="${CLAUDE_SESSION_STATE_DIR:-$HOME/.local/state/claude-sessions/state}
       # the idle nag ("waiting for your input") is not a real input request —
       # keep it out of state=input, but never downgrade a pending permission ask
       if (($ev.message // "") | test("waiting for your input"; "i")) then
-        (if .state == "input" then . else .state = "idle" end)
+        (if .state == "input" then . else .state = "idle" | .message = null end)
       else
         .state = "input" | .message = ($ev.message | trunc(500))
       end

--- a/plugin-sources/claude-session-state/scripts/fold-state.sh
+++ b/plugin-sources/claude-session-state/scripts/fold-state.sh
@@ -93,7 +93,13 @@ STATE_DIR="${CLAUDE_SESSION_STATE_DIR:-$HOME/.local/state/claude-sessions/state}
     elif $event == "PostToolUse" then
       .state = "working" | .last_tool = $ev.tool_name
     elif $event == "Notification" then
-      .state = "input" | .message = ($ev.message | trunc(500))
+      # the idle nag ("waiting for your input") is not a real input request —
+      # keep it out of state=input, but never downgrade a pending permission ask
+      if (($ev.message // "") | test("waiting for your input"; "i")) then
+        (if .state == "input" then . else .state = "idle" end)
+      else
+        .state = "input" | .message = ($ev.message | trunc(500))
+      end
     elif $event == "Stop" then
       .state = "idle"
       | .message = null


### PR DESCRIPTION
Closes #721.

The reducer mapped every `Notification` hook event to `state=input`, so the harness's idle nag ("Claude is waiting for your input") ranked idle sessions as NEEDS INPUT in the sidebar and `orchard status`.

Now classified by message:
- idle-nag pattern (`waiting for your input`, case-insensitive) → `state=idle`, message not stored, and never downgrades an already-pending `input` (permission ask)
- everything else → `state=input` + message (unchanged)

## How I can prove I was successful

- `bats plugin-sources/claude-session-state/scripts/fold-state.bats` — 8/8 pass, including 3 new cases: permission→input+message, idle-nag→idle/no-message, idle-nag-after-permission stays input
- STATE_SCHEMA.md contract updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session status handling for notifications indicating that the session is waiting.
  * Prevented idle notifications from overwriting pending input or permission requests.
  * Continued recording relevant input-request messages while ignoring idle notices.

* **Tests**
  * Added coverage for permission and idle notification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Related issue

- #721

# Related issue

- #721

## Human verification

<!-- no-ui-surface -->
Backend-only change: a jq reducer branch in `fold-state.sh` (hook state machine) — no UI surface. Proof is the bats suite (9/9 green, including the fail-first regression cases for the idle-nag Notification). To verify by hand: send an idle-nag notification to a session and confirm the sidebar shows it as idle with no stale message.


# Related issue

- #721