### PR TITLE
fix(orchard-sidebar): width-aware render with grouped hierarchy

### DIFF
--- a/cmd/orchard-sidebar/line_test.go
+++ b/cmd/orchard-sidebar/line_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// line() must never exceed width, even at pathological widths where the
+// 1-cell floors on avail/pad would otherwise overshoot (review finding on
+// PR #725: line(3, "sessionname", "12m") rendered 5 cells and soft-wrapped,
+// skewing the lineToRow mouse mapping).
+func TestLineNeverExceedsWidth(t *testing.T) {
+	cases := []struct {
+		width       int
+		left, right string
+	}{
+		{3, "sessionname", "12m"},
+		{1, "sessionname", "12m"},
+		{2, "x", "longright"},
+		{5, "abc", "12m"},
+		{10, "⏎ jump · j/k · q", "PR#725"},
+		{42, "some-session-name", "3h"},
+		{42, "left-only", ""},
+	}
+	for _, c := range cases {
+		got := line(c.width, c.left, c.right)
+		if w := ansi.StringWidth(got); w > c.width {
+			t.Errorf("line(%d, %q, %q) = %q — %d cells, exceeds width", c.width, c.left, c.right, got, w)
+		}
+	}
+}

--- a/cmd/orchard-sidebar/main.go
+++ b/cmd/orchard-sidebar/main.go
@@ -594,7 +594,9 @@ func line(width int, left, right string) string {
 	if right == "" {
 		return left
 	}
-	return left + strings.Repeat(" ", pad) + right
+	// final clamp: at pathological widths the 1-cell floors on avail/pad can
+	// still overshoot; a soft-wrapped line would skew the lineToRow map
+	return trunc(left+strings.Repeat(" ", pad)+right, width)
 }
 
 // detail renders the worktree line of a row: branch ±ahead/behind, PR state,

--- a/cmd/orchard-sidebar/main.go
+++ b/cmd/orchard-sidebar/main.go
@@ -34,6 +34,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 const graphqlURL = "http://127.0.0.1:7777/graphql"
@@ -507,18 +508,37 @@ var (
 	styMsg     = lipgloss.NewStyle().Foreground(lipgloss.Color("13"))
 )
 
+// glyph returns the one-cell state marker; the state *word* lives in the
+// group header only, so it isn't repeated on every row.
 func glyph(state string) (string, lipgloss.Style) {
 	switch state {
 	case "input":
-		return "● INPUT", styInput
+		return "●", styInput
 	case "stalled":
-		return "✖ STALL", styStalled
+		return "✖", styStalled
 	case "working":
-		return "◐ work ", styWorking
+		return "◐", styWorking
 	case "idle":
-		return "○ idle ", styIdle
+		return "○", styIdle
 	default:
-		return "· shell", styShell
+		return "·", styShell
+	}
+}
+
+// groupLabel is the section header shown once above each run of same-state
+// rows (rows are already sorted by stateRank, so runs are contiguous).
+func groupLabel(state string) string {
+	switch state {
+	case "input":
+		return "NEEDS INPUT"
+	case "stalled":
+		return "STALLED"
+	case "working":
+		return "WORKING"
+	case "idle":
+		return "IDLE"
+	default:
+		return "SHELL"
 	}
 }
 
@@ -549,12 +569,32 @@ func age(t time.Time) string {
 	return fmt.Sprintf("%dd", int(d.Hours()/24))
 }
 
+// trunc clips to n terminal cells (ANSI- and wide-rune-aware), first line only.
 func trunc(s string, n int) string {
 	s = strings.SplitN(s, "\n", 2)[0]
-	if len(s) > n {
-		return s[:n] + "…"
+	if n < 1 {
+		return ""
 	}
-	return s
+	return ansi.Truncate(s, n, "…")
+}
+
+// line lays out left + right-aligned right within width cells, truncating
+// left (never right) when they don't both fit.
+func line(width int, left, right string) string {
+	rw := ansi.StringWidth(right)
+	avail := width - rw
+	if rw > 0 {
+		avail-- // one-cell gap
+	}
+	left = trunc(left, max(1, avail))
+	pad := width - ansi.StringWidth(left) - rw
+	if pad < 1 {
+		pad = 1
+	}
+	if right == "" {
+		return left
+	}
+	return left + strings.Repeat(" ", pad) + right
 }
 
 // detail renders the worktree line of a row: branch ±ahead/behind, PR state,
@@ -563,7 +603,7 @@ func detail(r row) string {
 	if r.branch == "" {
 		return ""
 	}
-	s := "  " + r.branch
+	s := r.branch
 	if r.ahead != nil && *r.ahead > 0 {
 		s += fmt.Sprintf(" ↑%d", *r.ahead)
 	}
@@ -591,20 +631,32 @@ func detail(r row) string {
 	return s
 }
 
+// View layout (everything clipped to the live pane width):
+//
+//	header   — counts of attention-worthy states + fetch stamp
+//	sections — one dim header per contiguous state group (rows are sorted by
+//	           state, so groups are runs); rows are ONE line each:
+//	           cursor/attached bar + glyph + name … right-aligned age
+//	           input/stalled rows add their attention message (that's the
+//	           actionable bit); everything else (mission, model, repo,
+//	           branch/PR/CI) expands under the CURSOR row only.
+//	footer   — key hints
 func (m *model) View() string {
+	w := m.width
+	if w <= 0 {
+		w = 42
+	}
 	var b bytes.Buffer
 	lineMap := []int{}
 	emit := func(s string, rowIdx int) {
 		b.WriteString(s + "\n")
 		lineMap = append(lineMap, rowIdx)
 	}
-	sep := styDim.Render(strings.Repeat("─", 40))
+	sep := styDim.Render(strings.Repeat("─", w))
 
 	if m.err != nil {
-		emit(styErr.Render("⚠ DAEMON OFFLINE"), -1)
-		emit(styDim.Render(trunc(m.err.Error(), 38)), -1)
-		emit(styDim.Render("hook states still live"), -1)
-		emit("", -1)
+		emit(styErr.Render(trunc("⚠ DAEMON OFFLINE — hook states live", w)), -1)
+		emit(styDim.Render(trunc(m.err.Error(), w)), -1)
 	}
 
 	counts := map[string]int{}
@@ -615,74 +667,78 @@ func (m *model) View() string {
 	for _, s := range []string{"input", "stalled", "working", "idle"} {
 		if counts[s] > 0 {
 			g, sty := glyph(s)
-			hdr = append(hdr, sty.Render(fmt.Sprintf("%d %s", counts[s], strings.TrimSpace(g))))
+			hdr = append(hdr, sty.Render(fmt.Sprintf("%d%s", counts[s], g)))
 		}
 	}
-	if len(hdr) > 0 {
-		emit(strings.Join(hdr, styDim.Render("  ")), -1)
+	stamp := ""
+	if !m.fastAt.IsZero() {
+		stamp = styDim.Render(m.fastAt.Format("15:04:05"))
 	}
+	emit(line(w, strings.Join(hdr, " "), stamp), -1)
 	emit(sep, -1)
 
+	prev := ""
 	for i, r := range m.rows {
+		if r.state != prev {
+			if prev != "" {
+				emit("", -1)
+			}
+			emit(styDim.Render(trunc(groupLabel(r.state), w)), -1)
+			prev = r.state
+		}
+
 		g, sty := glyph(r.state)
-		bar, name := "  ", r.session
+		bar, name := " ", r.session
 		if r.attached {
-			bar = stySelBar.Render("▎ ")
+			bar = stySelBar.Render("▎")
 			name = stySelName.Render(r.session)
 		}
 		if i == m.cursor && !r.attached {
-			bar = stySelBar.Render("› ")
+			bar = stySelBar.Render("›")
 		}
-		line1 := fmt.Sprintf("%s%s %s", bar, sty.Render(g), name)
-		if r.attached {
-			line1 += styDim.Render(" ⌖")
-		}
+		left := fmt.Sprintf("%s%s %s", bar, sty.Render(g), name)
 		if !r.hooked && r.state != "shell" {
-			line1 += styDim.Render(" (inferred)")
+			left += styDim.Render("?")
 		}
-		emit(line1, i)
+		emit(line(w, left, styDim.Render(age(r.lastAct))), i)
 
-		if r.state == "input" && r.message != "" {
-			emit(styMsg.Render("    ↳ "+trunc(r.message, 36)), i)
-		}
-		if r.mission != "" {
-			emit(styDim.Render("    “"+trunc(r.mission, 34)+"”"), i)
+		if (r.state == "input" || r.state == "stalled") && r.message != "" {
+			emit(styMsg.Render(trunc("   ↳ "+r.message, w)), i)
 		}
 
-		meta := "    "
-		if r.model != "" {
-			meta += r.model + " · "
+		// detail-on-selection: context lines for the cursor row only
+		if i == m.cursor {
+			if r.mission != "" {
+				emit(styDim.Render(trunc("   “"+r.mission+"”", w)), i)
+			}
+			meta := ""
+			if r.model != "" {
+				meta = r.model
+			}
+			if r.repo != "" {
+				if meta != "" {
+					meta += " · "
+				}
+				meta += r.repo
+			}
+			if meta != "" {
+				emit(styDim.Render(trunc("   "+meta, w)), i)
+			}
+			if d := detail(r); d != "" {
+				emit(styMeta.Render(trunc("   "+d, w)), i)
+			}
 		}
-		if a := age(r.lastAct); a != "" {
-			meta += a
-		} else {
-			meta += "—"
-		}
-		if r.repo != "" {
-			meta += " · " + r.repo
-		}
-		emit(styDim.Render(meta), i)
-
-		if d := detail(r); d != "" {
-			emit(styMeta.Render(d), i)
-		}
-		emit(sep, -1)
 	}
 
+	emit(sep, -1)
 	if !m.stateDirOK {
-		emit(styDim.Render("no state dir — install the"), -1)
-		emit(styDim.Render("claude-session-state plugin"), -1)
+		emit(styDim.Render(trunc("no state dir — install claude-session-state", w)), -1)
 	}
-	prNote := "pr:–"
+	prNote := "pr –"
 	if !m.slowAt.IsZero() {
-		prNote = "pr:" + m.slowAt.Format("15:04")
+		prNote = "pr " + m.slowAt.Format("15:04")
 	}
-	stamp := "—"
-	if !m.fastAt.IsZero() {
-		stamp = m.fastAt.Format("15:04:05")
-	}
-	emit(styDim.Render(fmt.Sprintf("%d sessions · %s · %s", len(m.rows), stamp, prNote)), -1)
-	emit(styDim.Render("click/enter jump · j/k · q quit"), -1)
+	emit(line(w, styDim.Render("⏎ jump · j/k · q"), styDim.Render(prNote)), -1)
 
 	m.lineToRow = lineMap
 	return b.String()

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ go 1.25.0
 
 require (
 	github.com/99designs/gqlgen v0.17.90
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/fsnotify/fsnotify v1.10.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
@@ -16,10 +19,7 @@ require (
 require (
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/vektah/gqlparser/v2 v2.5.33/go.mod h1:c1I28gSOVNzlfc4WuDlqU7voQnsqI6O
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=


### PR DESCRIPTION
Closes #724.

## What changed

- **No more overflow**: every emitted line is truncated to the live pane width with `charmbracelet/x/ansi` (cell- and ANSI-aware — the old `trunc()` counted bytes, and the row line and branch/PR detail line were never truncated at all).
- **Hierarchy from grouping, not chrome**: rows were already sorted by state, so one dim group header per contiguous run (NEEDS INPUT / STALLED / WORKING / IDLE / SHELL) replaces the per-row `────` separators and the per-row state word.
- **One line per row**: bar + one-cell state glyph + name, age right-aligned; `(inferred)` collapses to a dim `?`.
- **Information priority**: the attention message renders only on input/stalled rows (the actionable bit); mission, model·repo, and branch/PR/CI detail expand under the cursor row only (detail-on-selection).
- CI rollup is still rendered as its raw string, never a verdict (false-green incident guard unchanged).

## How I can prove I was successful

Rendered in a real 42-col tmux split pane and captured:

```
1● 2◐ 1○                          11:38:02
──────────────────────────────────────────
NEEDS INPUT
›● titw proto                          18h
   ↳ Claude is waiting for your input
   “did they get a proper review? next st…
   opus · titw
   fix/cli-bin-symlink-entrypoint · #9 OP…

WORKING
▎◐ orchard-sidebar                     now
▎◐ access sweatshop                    now

IDLE
 ○ aws increase space?                  3d

SHELL
▎· commander
──────────────────────────────────────────
⏎ jump · j/k · q                  pr 11:38
```

- Cell-width audit of the capture (Python `east_asian_width`): **no line exceeds 42 cells**.
- `j`/`k` moves the cursor and the detail expansion follows the cursor row (verified with a second capture).
- Coverage note: the render layer has no unit tests before or after this change; evidence is the live capture above. `go build` + `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Related issue

- #724

# Related issue

- #724

## Human verification

<!-- no-ui-surface -->
Terminal TUI (tmux sidebar pane) — no browser surface, so no boxd-browser-test recording applies. Visual proof is the 42-column `tmux capture-pane` output embedded above (header, group sections, right-aligned ages, cursor-expanded detail), plus a cell-width audit showing no line exceeds 42 cells and a `j`/`k` navigation check. To verify by hand after merge: rebuild and restart the sidebar pane, resize it narrow, and confirm no line wraps.


# Related issue

- #724